### PR TITLE
feat: Add document linking to bank transactions and reduce upload limit

### DIFF
--- a/lapis/helper/minio.lua
+++ b/lapis/helper/minio.lua
@@ -32,7 +32,7 @@ MinioClient.__index = MinioClient
 
 -- Configuration defaults
 local DEFAULT_REGION = "us-east-1"
-local MAX_FILE_SIZE = 50 * 1024 * 1024  -- 50MB default max
+local MAX_FILE_SIZE = 10 * 1024 * 1024  -- 10MB default max
 local ALLOWED_MIME_TYPES = {
     -- Images
     ["image/jpeg"] = { extensions = { "jpg", "jpeg" }, category = "image" },
@@ -42,6 +42,8 @@ local ALLOWED_MIME_TYPES = {
     ["image/svg+xml"] = { extensions = { "svg" }, category = "image" },
     ["image/bmp"] = { extensions = { "bmp" }, category = "image" },
     ["image/tiff"] = { extensions = { "tiff", "tif" }, category = "image" },
+    ["image/heic"] = { extensions = { "heic" }, category = "image" },
+    ["image/heif"] = { extensions = { "heif" }, category = "image" },
 
     -- Documents
     ["application/pdf"] = { extensions = { "pdf" }, category = "document" },

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -659,6 +659,7 @@ return {
     -- Bank Transactions System
     ['290_create_bank_transactions_table'] = bank_transaction_migrations[1],
     ['291_add_bank_transactions_indexes'] = bank_transaction_migrations[2],
+    ['294_add_document_uuid_to_bank_transactions'] = bank_transaction_migrations[3],
 
     -- Push Notifications (FCM Device Tokens)
     ['292_create_device_tokens_table'] = push_notification_migrations[1],

--- a/lapis/migrations/bank-transactions.lua
+++ b/lapis/migrations/bank-transactions.lua
@@ -60,4 +60,19 @@ return {
             ]])
         end)
     end,
+
+    -- ========================================
+    -- [3] Add document_uuid foreign key
+    -- ========================================
+    [3] = function()
+        -- Add document_uuid column
+        pcall(function()
+            schema.add_column("bank_transactions", "document_uuid", "VARCHAR REFERENCES documents(uuid) ON DELETE SET NULL")
+        end)
+
+        -- Create index for document_uuid
+        pcall(function()
+            schema.create_index("bank_transactions", "document_uuid")
+        end)
+    end,
 }

--- a/lapis/nginx.conf
+++ b/lapis/nginx.conf
@@ -82,7 +82,7 @@ http {
     tcp_nopush on;
     tcp_nodelay on;
     keepalive_timeout 65;
-    client_max_body_size 100M;
+    client_max_body_size 10M;
     lua_package_path "/app/?.lua;/usr/local/openresty/lualib/?.lua;/opt/nginx-lua-prometheus/?.lua;/opt/nginx-lua-prometheus/lib/?.lua;/opt/lua-resty-jwt/lib/?.lua;/opt/lua-resty-session/lib/?.lua;;";
     lua_package_cpath "/usr/local/openresty/lualib/?.so;;";
 

--- a/lapis/queries/BankTransactionQueries.lua
+++ b/lapis/queries/BankTransactionQueries.lua
@@ -1,5 +1,6 @@
 local Global = require "helper.global"
 local BankTransactions = require "models.BankTransactionModel"
+local db = require("lapis.db")
 
 local BankTransactionQueries = {}
 
@@ -29,7 +30,7 @@ function BankTransactionQueries.all(params, user_id)
         user_id,
         {
             per_page = perPage,
-            fields = 'id as internal_id, uuid as id, user_id, transaction_date, description, money_in, money_out, balance'
+            fields = 'id as internal_id, uuid as id, user_id, transaction_date, description, money_in, money_out, balance, document_uuid'
         }
     )
     return {
@@ -76,6 +77,103 @@ function BankTransactionQueries.destroy(uuid, user_id)
         return false
     end
     return transaction:delete()
+end
+
+-- Get all transactions with document details
+function BankTransactionQueries.allWithDocuments(params, user_id)
+    local page = tonumber(params.page) or 1
+    local perPage = tonumber(params.perPage) or 10
+    local offset = (page - 1) * perPage
+
+    local valid_fields = { transaction_date = true, balance = true, money_in = true, money_out = true }
+    local orderField, orderDir = Global.sanitizeOrderBy(params.orderBy, params.orderDir, valid_fields, "transaction_date", "desc")
+
+    -- Get transactions with document details via LEFT JOIN
+    local transactions = db.query([[
+        SELECT
+            bt.id as internal_id,
+            bt.uuid as id,
+            bt.user_id,
+            bt.transaction_date,
+            bt.description,
+            bt.money_in,
+            bt.money_out,
+            bt.balance,
+            bt.document_uuid,
+            CASE WHEN d.uuid IS NOT NULL THEN
+                json_build_object(
+                    'uuid', d.uuid,
+                    'title', d.title,
+                    'excerpt', d.excerpt,
+                    'status', d.status,
+                    'created_at', d.created_at,
+                    'cover_image', (
+                        SELECT json_build_object('url', i.url, 'alt_text', i.alt_text)
+                        FROM images i
+                        WHERE i.document_id = d.id AND i.is_cover = true
+                        LIMIT 1
+                    )
+                )
+            ELSE NULL END as document
+        FROM bank_transactions bt
+        LEFT JOIN documents d ON bt.document_uuid = d.uuid
+        WHERE bt.user_id = ?
+        ORDER BY bt.]] .. orderField .. " " .. orderDir .. [[
+        LIMIT ? OFFSET ?
+    ]], user_id, perPage, offset)
+
+    -- Get total count
+    local count_result = db.query([[
+        SELECT COUNT(*) as total FROM bank_transactions WHERE user_id = ?
+    ]], user_id)
+    local total = count_result[1] and count_result[1].total or 0
+
+    return {
+        data = transactions,
+        total = total,
+        page = page,
+        per_page = perPage
+    }
+end
+
+-- Get single transaction with document details
+function BankTransactionQueries.showWithDocument(uuid, user_id)
+    local results = db.query([[
+        SELECT
+            bt.id as internal_id,
+            bt.uuid as id,
+            bt.user_id,
+            bt.transaction_date,
+            bt.description,
+            bt.money_in,
+            bt.money_out,
+            bt.balance,
+            bt.document_uuid,
+            CASE WHEN d.uuid IS NOT NULL THEN
+                json_build_object(
+                    'uuid', d.uuid,
+                    'title', d.title,
+                    'excerpt', d.excerpt,
+                    'slug', d.slug,
+                    'status', d.status,
+                    'content', d.content,
+                    'created_at', d.created_at,
+                    'updated_at', d.updated_at,
+                    'cover_image', (
+                        SELECT json_build_object('url', i.url, 'alt_text', i.alt_text)
+                        FROM images i
+                        WHERE i.document_id = d.id AND i.is_cover = true
+                        LIMIT 1
+                    )
+                )
+            ELSE NULL END as document
+        FROM bank_transactions bt
+        LEFT JOIN documents d ON bt.document_uuid = d.uuid
+        WHERE bt.uuid = ? AND bt.user_id = ?
+        LIMIT 1
+    ]], uuid, user_id)
+
+    return results[1]
 end
 
 return BankTransactionQueries

--- a/lapis/routes/bank_transactions.lua
+++ b/lapis/routes/bank_transactions.lua
@@ -10,9 +10,17 @@ local AuthMiddleware = require("middleware.auth")
 
 return function(app)
     -- List all transactions for the current user (with pagination)
+    -- Add ?include=document to get document details
     app:get("/api/v2/bank-transactions", AuthMiddleware.requireAuth(function(self)
         local user_id = self.current_user.uuid
-        local transactions = BankTransactionQueries.all(self.params, user_id)
+        local transactions
+
+        if self.params.include == "document" then
+            transactions = BankTransactionQueries.allWithDocuments(self.params, user_id)
+        else
+            transactions = BankTransactionQueries.all(self.params, user_id)
+        end
+
         return {
             json = transactions,
             status = 200
@@ -52,9 +60,16 @@ return function(app)
     end))
 
     -- Get a single transaction by UUID
+    -- Add ?include=document to get document details
     app:get("/api/v2/bank-transactions/:id", AuthMiddleware.requireAuth(function(self)
         local user_id = self.current_user.uuid
-        local transaction = BankTransactionQueries.show(tostring(self.params.id), user_id)
+        local transaction
+
+        if self.params.include == "document" then
+            transaction = BankTransactionQueries.showWithDocument(tostring(self.params.id), user_id)
+        else
+            transaction = BankTransactionQueries.show(tostring(self.params.id), user_id)
+        end
 
         if not transaction then
             return {

--- a/lapis/routes/documents.lua
+++ b/lapis/routes/documents.lua
@@ -32,7 +32,7 @@ local MinioClient = require("helper.minio")
 local AuthMiddleware = require("middleware.auth")
 
 -- Configuration
-local MAX_FILE_SIZE = 50 * 1024 * 1024  -- 50MB
+local MAX_FILE_SIZE = 10 * 1024 * 1024  -- 10MB
 local ALLOWED_CATEGORIES = { "image", "document" }  -- Allowed file categories
 
 return function(app)


### PR DESCRIPTION
- Add document_uuid foreign key to bank_transactions table
- Add API to fetch transactions with linked document details (?include=document)
- Reduce max upload file size from 100MB/50MB to 10MB
- Update queries to join with documents table for embedded document data