### PR TITLE
feat: enable push notifications for tax_copilot

### DIFF
--- a/lapis/helper/project-config.lua
+++ b/lapis/helper/project-config.lua
@@ -61,6 +61,7 @@ ProjectConfig.PROJECT_FEATURES = {
     tax_copilot = {
         ProjectConfig.FEATURES.CORE,
         ProjectConfig.FEATURES.TAX_COPILOT,
+        ProjectConfig.FEATURES.NOTIFICATIONS,
     },
 
     -- Ecommerce platform


### PR DESCRIPTION
## Summary

- Add `ProjectConfig.FEATURES.NOTIFICATIONS` to the `tax_copilot` project feature list
- This enables the `device_tokens` table migration and push notification routes when running with `PROJECT_CODE=tax_copilot`

### Context

The DIY Tax Return FastAPI backend needs to send push notifications via Firebase Admin SDK. It reads FCM tokens from the shared `device_tokens` table in the opsapi PostgreSQL database. This change ensures the table and routes are available when running the tax_copilot project.

### Related PRs
- **diy-tax-return-uk**: https://github.com/bwalia/diy-tax-return-uk/pull/25
- **iOS app**: See `bwalia/diytaxreturn` feature/fcm-push-notifications

## Test plan
- [x] `lapis migrate` shows notifications feature enabled for tax_copilot
- [x] `device_tokens` table created and accessible
- [x] Device token CRUD routes load at `/api/v2/device-tokens`

🤖 Generated with [Claude Code](https://claude.com/claude-code)