### PR TITLE
Fix: FCM token is_active bug and delete on logout

### DIFF
--- a/lapis/queries/DeviceTokenQueries.lua
+++ b/lapis/queries/DeviceTokenQueries.lua
@@ -29,7 +29,7 @@ function DeviceTokenQueries.register(data, user_uuid)
         -- Update existing token
         db.query([[
             UPDATE device_tokens
-            SET is_active = true,
+            SET is_active = TRUE,
                 device_type = COALESCE(?, device_type),
                 device_name = COALESCE(?, device_name),
                 updated_at = NOW()
@@ -55,7 +55,7 @@ function DeviceTokenQueries.register(data, user_uuid)
         fcm_token = data.fcm_token,
         device_type = device_type,
         device_name = device_name,
-        is_active = true
+        is_active = db.TRUE
     }
 
     local token = DeviceTokens:create(token_data, { returning = "*" })
@@ -111,11 +111,10 @@ function DeviceTokenQueries.getActiveTokensForUsers(user_uuids)
     return tokens or {}
 end
 
--- Deactivate a token (logout)
+-- Delete a token (logout)
 function DeviceTokenQueries.deactivate(fcm_token, user_uuid)
     local result = db.query([[
-        UPDATE device_tokens
-        SET is_active = false, updated_at = NOW()
+        DELETE FROM device_tokens
         WHERE fcm_token = ? AND user_uuid = ?
         RETURNING *
     ]], fcm_token, user_uuid)
@@ -123,11 +122,10 @@ function DeviceTokenQueries.deactivate(fcm_token, user_uuid)
     return result and #result > 0
 end
 
--- Deactivate all tokens for a user (logout from all devices)
+-- Delete all tokens for a user (logout from all devices)
 function DeviceTokenQueries.deactivateAll(user_uuid)
-    local result = db.query([[
-        UPDATE device_tokens
-        SET is_active = false, updated_at = NOW()
+    db.query([[
+        DELETE FROM device_tokens
         WHERE user_uuid = ?
     ]], user_uuid)
 

--- a/lapis/routes/auth.lua
+++ b/lapis/routes/auth.lua
@@ -430,13 +430,10 @@ return function(app)
                 db.delete("cart_items", "user_id = ?", user_result[1].id)
             end
 
-            -- Deactivate all FCM device tokens so stale tokens don't linger
-            local ok, err = pcall(function()
-                DeviceTokenQueries.deactivateAll(user_uuid)
-            end)
-            if not ok then
-                ngx.log(ngx.WARN, "Failed to deactivate device tokens on logout: " .. tostring(err))
-            end
+            -- Device token cleanup is handled by the iOS app calling
+            -- DELETE /api/v2/device-tokens with the specific fcm_token
+            -- before this endpoint. We don't delete all tokens here
+            -- because the user may be logged in on other devices.
         end
 
         return {


### PR DESCRIPTION
## Summary
- `register()` used Lua `true` for `is_active` which wasn't properly stored as PostgreSQL `TRUE` — changed to `db.TRUE`
- `deactivate()` now DELETEs the token row instead of soft-deactivating (`is_active = false`), so re-login creates a clean fresh row
- Removed `deactivateAll()` from logout endpoint to support multi-device — iOS app already calls `DELETE /api/v2/device-tokens` with the specific FCM token before logout

## Test plan
- [ ] Login on device → verify token row created with `is_active = true` in DB
- [ ] Logout → verify token row is deleted from DB
- [ ] Re-login → verify new token row created and push notifications work
- [ ] Login on 2 devices, logout on one → verify only that device's token is deleted