### PR TITLE
Fix dashboard healthcheck IPv6 resolution

### DIFF
--- a/lapis/docker-compose.yml
+++ b/lapis/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       opsapi-network:
         ipv4_address: 172.71.0.19
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8039"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:8039"]
       interval: 30s
       timeout: 20s
       retries: 3


### PR DESCRIPTION
## Summary
- Dashboard container was permanently marked `unhealthy` despite the app running fine
- `wget` resolved `localhost` to IPv6 `[::1]` but Next.js listens on IPv4 `0.0.0.0`
- Changed healthcheck URL from `http://localhost:8039` to `http://127.0.0.1:8039`

## Test plan
- [ ] Run `docker compose up -d dashboard` and verify container becomes `healthy`
- [ ] Confirm dashboard is accessible at `http://localhost:8039`

🤖 Generated with [Claude Code](https://claude.com/claude-code)