### PR TITLE
Add restart policy to lapis service

### DIFF
--- a/lapis/docker-compose.yml
+++ b/lapis/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       interval: 30s
       timeout: 20s
       retries: 3
+    restart: unless-stopped
 
   # Next.js Dashboard
   dashboard:


### PR DESCRIPTION
The opsapi container had no restart policy, so it stayed down after receiving SIGTERM. Added restart: unless-stopped to match the dashboard service.