### PR TITLE
fix: register tax-copilot migrations [44] and [45] in migration runner

### DIFF
--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -1202,6 +1202,8 @@ local _migrations = {
     ['438_tax_namespace_backfill'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 42),
     ['439_profile_client_questions'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, profile_builder_migrations, 35),
     ['441_create_classification_training_data'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 43),
+    ['458_tax_seed_accountant_categories'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 44),
+    ['459_tax_merge_overlapping_categories'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 45),
 
     -- =========================================================================
     -- CRM SYSTEM (500-509)


### PR DESCRIPTION
Migrations [44] (seed accountant categories) and [45] (merge overlapping categories) existed in tax-copilot-system.lua but were never registered in migrations.lua, so the runner never executed them.

Registers as:
- 458_tax_seed_accountant_categories → tax_copilot_migrations[44]
- 459_tax_merge_overlapping_categories → tax_copilot_migrations[45]