### PR TITLE
feat: add profession/industry fields to tax_user_profiles

### DIFF
--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -1206,6 +1206,7 @@ local _migrations = {
     ['459_tax_merge_overlapping_categories'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 45),
     ['460_tax_create_classification_reference_data'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 46),
     ['461_tax_seed_accountant_reference_data'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 47),
+    ['462_tax_add_profile_profession'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 48),
 
     -- =========================================================================
     -- CRM SYSTEM (500-509)

--- a/lapis/migrations/tax-copilot-system.lua
+++ b/lapis/migrations/tax-copilot-system.lua
@@ -1775,4 +1775,15 @@ return {
         count = result and result[1] and result[1].cnt or 0
         print("[Tax Copilot] Seeded " .. count .. " accountant reference transactions (Client C + D)")
     end,
+
+    -- 48. Add profession/industry fields to tax_user_profiles
+    -- Needed so the AI classifier can factor in the user's business type
+    -- (e.g., "Shell £45" is deductible for a taxi driver but personal for a dev).
+    [48] = function()
+        db.query("ALTER TABLE tax_user_profiles ADD COLUMN IF NOT EXISTS profession VARCHAR(255)")
+        db.query("ALTER TABLE tax_user_profiles ADD COLUMN IF NOT EXISTS industry VARCHAR(255)")
+        db.query("ALTER TABLE tax_user_profiles ADD COLUMN IF NOT EXISTS business_description TEXT")
+        db.query("CREATE INDEX IF NOT EXISTS idx_tax_user_profiles_profession ON tax_user_profiles (profession)")
+        print("[Tax Copilot] Added profession, industry, business_description to tax_user_profiles")
+    end,
 }


### PR DESCRIPTION
## Summary
- Migration **[48]**: Adds `profession`, `industry`, `business_description` columns to `tax_user_profiles`
- Registered as `462_tax_add_profile_profession` in `migrations.lua`
- Index on `profession` for query performance

## Test plan
- [ ] Run Lapis migrations — verify columns exist: `\d tax_user_profiles`
- [ ] Verify existing profiles are unaffected (new columns are nullable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)