### PR TITLE
feat: migration [49] add classification metadata to tax_transactions

### DIFF
--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -1207,6 +1207,7 @@ local _migrations = {
     ['460_tax_create_classification_reference_data'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 46),
     ['461_tax_seed_accountant_reference_data'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 47),
     ['462_tax_add_profile_profession'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 48),
+    ['463_tax_add_classification_fields'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 49),
 
     -- =========================================================================
     -- CRM SYSTEM (500-509)

--- a/lapis/migrations/tax-copilot-system.lua
+++ b/lapis/migrations/tax-copilot-system.lua
@@ -1786,4 +1786,15 @@ return {
         db.query("CREATE INDEX IF NOT EXISTS idx_tax_user_profiles_profession ON tax_user_profiles (profession)")
         print("[Tax Copilot] Added profession, industry, business_description to tax_user_profiles")
     end,
+
+    -- 49. Add classification metadata fields to tax_transactions
+    -- Tracks how each transaction was classified (source), its cleaned merchant name
+    -- (for pattern matching / RAG lookup), and whether it's a business expense.
+    [49] = function()
+        db.query("ALTER TABLE tax_transactions ADD COLUMN IF NOT EXISTS classification_source VARCHAR(100)")
+        db.query("ALTER TABLE tax_transactions ADD COLUMN IF NOT EXISTS cleaned_merchant_name VARCHAR(500)")
+        db.query("ALTER TABLE tax_transactions ADD COLUMN IF NOT EXISTS is_business_expense BOOLEAN DEFAULT TRUE")
+        db.query("CREATE INDEX IF NOT EXISTS idx_tax_txn_cleaned_merchant ON tax_transactions (cleaned_merchant_name)")
+        print("[Tax Copilot] Added classification_source, cleaned_merchant_name, is_business_expense to tax_transactions")
+    end,
 }


### PR DESCRIPTION
## Summary
- Migration [49]: adds `classification_source`, `cleaned_merchant_name`, `is_business_expense` to `tax_transactions`
- Registered as `463_tax_add_classification_fields` in migrations.lua
- Index on `cleaned_merchant_name` for fast pattern matching lookups

## Test plan
- [ ] Run migration → `\d tax_transactions` shows 3 new columns
- [ ] Deploy alongside diy-tax-return-uk PR for Python model update

🤖 Generated with [Claude Code](https://claude.com/claude-code)