### PR TITLE
fix: switch deployed postgres to pgvector/pgvector:pg14

### DIFF
--- a/lapis/docker-compose.ci.yml
+++ b/lapis/docker-compose.ci.yml
@@ -96,7 +96,7 @@ services:
   postgres:
     container_name: opsapi-postgres-dev-db
     restart: unless-stopped
-    image: postgres:14-alpine
+    image: pgvector/pgvector:pg14
     ports:
       - "5439:5432"
     volumes:


### PR DESCRIPTION
## Summary
- Changes `docker-compose.ci.yml` postgres image from `postgres:14-alpine` to `pgvector/pgvector:pg14`
- The deployed server is missing pgvector extension, causing migrations [43], [46] to fail with `ERROR: type "vector" does not exist`
- This blocks all classification features (reference data, training data, embeddings)

## Why
- Local dev (`docker-compose.yml`) already uses `pgvector/pgvector:pg14` — this aligns the deployed environment
- `pgvector/pgvector:pg14` is the official pgvector image, based on `postgres:14` with pgvector pre-installed

## Impact
After deploy, pending migrations will run:
- [43] CREATE EXTENSION vector + classification_training_data table
- [46] classification_reference_data table
- [47] 355 accountant reference transactions seeded
- [49] 3 new columns on tax_transactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)