### PR TITLE
fix(ci): prevent /docs SSG build hang on unreachable API

### DIFF
--- a/opsapi-dashboard/app/docs/api/[tag]/page.tsx
+++ b/opsapi-dashboard/app/docs/api/[tag]/page.tsx
@@ -23,6 +23,8 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
   };
 }
 
+export const dynamic = 'force-dynamic';
+
 export default async function TagPage({ params }: Params) {
   const { tag } = await params;
   const doc = await loadOpenApi();

--- a/opsapi-dashboard/app/docs/api/page.tsx
+++ b/opsapi-dashboard/app/docs/api/page.tsx
@@ -8,6 +8,8 @@ export const metadata: Metadata = {
   title: 'API Reference — OpsAPI Docs',
 };
 
+export const dynamic = 'force-dynamic';
+
 export default async function ApiIndexPage() {
   const doc = await loadOpenApi();
   const domains = parseOpenApi(doc);

--- a/opsapi-dashboard/app/docs/guides/page.tsx
+++ b/opsapi-dashboard/app/docs/guides/page.tsx
@@ -20,6 +20,8 @@ const firstCallJs = `const res = await fetch('${baseUrl}/api/v2/users', {
 });
 const users = await res.json();`;
 
+export const dynamic = 'force-dynamic';
+
 export default function GuidesPage() {
   return (
     <div className="space-y-10">

--- a/opsapi-dashboard/app/docs/layout.tsx
+++ b/opsapi-dashboard/app/docs/layout.tsx
@@ -9,6 +9,8 @@ export const metadata: Metadata = {
     'Developer documentation for OpsAPI — automated REST APIs on PostgreSQL.',
 };
 
+export const dynamic = 'force-dynamic';
+
 export default async function DocsRootLayout({
   children,
 }: {

--- a/opsapi-dashboard/app/docs/page.tsx
+++ b/opsapi-dashboard/app/docs/page.tsx
@@ -48,6 +48,8 @@ TOKEN=$(curl -sX POST ${baseUrl}/api/v2/auth/login \\
 curl ${baseUrl}/api/v2/users?page=1 \\
   -H "Authorization: Bearer $TOKEN"`;
 
+export const dynamic = 'force-dynamic';
+
 export default function DocsHomePage() {
   return (
     <div className="space-y-14">

--- a/opsapi-dashboard/app/docs/use-cases/[slug]/page.tsx
+++ b/opsapi-dashboard/app/docs/use-cases/[slug]/page.tsx
@@ -20,6 +20,8 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
   return { title: uc ? `${uc.title} — OpsAPI Docs` : 'OpsAPI Docs' };
 }
 
+export const dynamic = 'force-dynamic';
+
 export default async function UseCasePage({ params }: Params) {
   const { slug } = await params;
   const uc = useCases.find((u) => u.slug === slug);

--- a/opsapi-dashboard/app/docs/use-cases/page.tsx
+++ b/opsapi-dashboard/app/docs/use-cases/page.tsx
@@ -7,6 +7,8 @@ export const metadata: Metadata = {
   title: 'Use Cases — OpsAPI Docs',
 };
 
+export const dynamic = 'force-dynamic';
+
 export default function UseCasesIndexPage() {
   return (
     <div className="space-y-6">

--- a/opsapi-dashboard/lib/openapi/loader.ts
+++ b/opsapi-dashboard/lib/openapi/loader.ts
@@ -25,6 +25,7 @@ export async function loadOpenApi(): Promise<OpenApiDoc> {
   try {
     const res = await fetch(`${base}/swagger/swagger.json`, {
       next: { revalidate: 300 },
+      signal: AbortSignal.timeout(3000),
     });
     if (res.ok) {
       return (await res.json()) as OpenApiDoc;

--- a/start.sh
+++ b/start.sh
@@ -923,7 +923,11 @@ fi
 # This ensures nginx workers have PROJECT_CODE for feature-gated route loading
 export PROJECT_CODE
 
-$COMPOSE_CMD up --build -d
+if ! $COMPOSE_CMD up --build -d; then
+    echo -e "${RED}[!] docker compose up failed — aborting.${NC}"
+    $COMPOSE_CMD logs --tail=100
+    exit 1
+fi
 
 # Wait for PostgreSQL to be ready (healthcheck-based)
 echo -e "${GREEN}[+] Waiting for PostgreSQL to be ready...${NC}"


### PR DESCRIPTION
## Summary

The `Deploy OPSAPI via Docker Compose (Self-Hosted)` workflow was failing with a misleading "PostgreSQL failed to start after 60 attempts" error. The real failure is earlier in the log: the `opsapi-dashboard` Next.js build hangs exporting `/docs/api/page` because the root `/docs` layout unconditionally fetches `${NEXT_PUBLIC_API_URL}/swagger/swagger.json` during SSG, and the build network can't reach `int-api.diytaxreturn.co.uk`. Next aborts each page after 60s × 3 retries, compose never creates the Postgres container, and `start.sh`'s pg_isready loop burns its retries on a container that doesn't exist.

- **Fix 1** — `export const dynamic = 'force-dynamic'` on `app/docs/layout.tsx` and all six `app/docs/**/page.tsx` files so /docs routes render at request time rather than build time.
- **Fix 2** — Add `signal: AbortSignal.timeout(3000)` to the fetch in `lib/openapi/loader.ts` so a blip in production falls through to the file fallback / `EMPTY_DOC` instead of hanging 60s per page.
- **Fix 3** — Wrap `$COMPOSE_CMD up --build -d` in `start.sh` with an exit-code check that dumps `compose logs --tail=100` and exits 1, so compose-build failures surface immediately instead of cascading into the Postgres wait loop.

Context: reproducibly failing run `24444148579` on commit `e7c1d4a`. Commit `b01b207` (pgvector image, PR #362) is a red herring and is not reverted.

## Test plan

- [ ] `Deploy OPSAPI via Docker Compose (Self-Hosted)` workflow goes green on this branch
- [ ] Local: `NEXT_PUBLIC_API_URL=http://127.0.0.1:1 next build` completes in normal time and `/docs/**` routes show as `λ Dynamic` (not `○ Static` or `◐ Partial`)
- [ ] `/docs` pages still render and read the live spec at request time when the API is reachable
- [ ] File fallback (`lapis/api-docs/swagger.json`) still works in local dev where the sibling directory exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)