### PR TITLE
feat: production-hardened multi-project namespace setup

### DIFF
--- a/.github/workflows/build-and-deploy-opsapi.yml
+++ b/.github/workflows/build-and-deploy-opsapi.yml
@@ -37,14 +37,10 @@ on:
           - opsapi
           - opsapi-kisaan
       PROJECT_CODE:
-        type: choice
-        description: "Please select the project Code"
-        default: "opsapi"
+        type: string
+        description: "Project code(s) for migrations. Single (tax_copilot) or comma-separated (ecommerce,collaboration)"
+        default: "all"
         required: true
-        options:
-          - opsapi
-          - kisaan
-          - tax-copilot
 
 env:
   PROJECT_NAME: ${{ github.event.inputs.PROJECT_NAME || 'opsapi' }}

--- a/.github/workflows/deploy-docker-self-hosted.yml
+++ b/.github/workflows/deploy-docker-self-hosted.yml
@@ -53,17 +53,10 @@ on:
         required: false
 
       PROJECT_CODE:
-        type: choice
-        description: "Project code for conditional migrations"
-        default: "tax_copilot"
+        type: string
+        description: "Project code(s) for migrations. Single (tax_copilot) or comma-separated (ecommerce,collaboration)"
+        default: "all"
         required: true
-        options:
-          - all
-          - tax_copilot
-          - ecommerce
-          - collaboration
-          - hospital
-          - core_only
 
       ADMIN_EMAIL:
         type: string
@@ -138,7 +131,7 @@ jobs:
           TARGET_ENV="int"
           PROTOCOL="${{ github.event.inputs.PROTOCOL || 'https' }}"
           RESET_DB="${{ github.event.inputs.RESET_DB || 'false' }}"
-          PROJECT_CODE="${{ github.event.inputs.PROJECT_CODE || 'tax_copilot' }}"
+          PROJECT_CODE="${{ github.event.inputs.PROJECT_CODE || 'all' }}"
           APEX_DOMAIN="${{ github.event.inputs.APEX_DOMAIN || 'diytaxreturn.co.uk' }}"
           API_URL="${PROTOCOL}://${TARGET_ENV}-api.${APEX_DOMAIN}"
 
@@ -326,7 +319,7 @@ jobs:
           TARGET_ENV="test"
           PROTOCOL="${{ github.event.inputs.PROTOCOL || 'https' }}"
           RESET_DB="${{ github.event.inputs.RESET_DB || 'false' }}"
-          PROJECT_CODE="${{ github.event.inputs.PROJECT_CODE || 'tax_copilot' }}"
+          PROJECT_CODE="${{ github.event.inputs.PROJECT_CODE || 'all' }}"
           APEX_DOMAIN="${{ github.event.inputs.APEX_DOMAIN || 'diytaxreturn.co.uk' }}"
           API_URL="${PROTOCOL}://${TARGET_ENV}-api.${APEX_DOMAIN}"
 

--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -24,9 +24,9 @@ on:
         type: boolean
         default: false
       PROJECT_CODE:
-        description: "Project code for migrations (e.g. tax_copilot, kisaan)"
+        description: "Project code(s) for migrations. Single (tax_copilot) or comma-separated (ecommerce,collaboration)"
         required: true
-        default: "tax_copilot"
+        default: "all"
         type: string
       ADMIN_EMAIL:
         description: "Super admin email for namespace setup"
@@ -239,7 +239,7 @@ jobs:
             --set image.repository=${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }} \
             --set image.tag=latest \
             --set env=${{ steps.env.outputs.TARGET_ENV }} \
-            --set projectCode=${{ github.event.inputs.PROJECT_CODE || 'tax_copilot' }} \
+            --set projectCode=${{ github.event.inputs.PROJECT_CODE || 'all' }} \
             --set setup.adminEmail=${{ github.event.inputs.ADMIN_EMAIL || '' }} \
             --set setup.adminPassword=${{ github.event.inputs.ADMIN_PASSWORD || '' }} \
             --set setup.namespaceSlug=${{ github.event.inputs.NAMESPACE_SLUG || '' }}

--- a/devops/helm-charts/diytaxreturn-lapis/templates/configmaps.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/templates/configmaps.yaml
@@ -6,6 +6,10 @@ metadata:
 data:
     bootstrap-nginx.sh: |
         #!/bin/bash
+        # Fail fast on any error so readiness probe keeps failing until bootstrap succeeds.
+        # pipefail: catch failures piped through tee/etc. nounset disabled (-x instead) —
+        # some upstream images reference optional vars we do not want to mask.
+        set -eo pipefail
         set -x
 
         FILE=/app/config.lua
@@ -18,11 +22,34 @@ data:
           echo "[bootstrap] Patched nginx resolver with K8s DNS: ${KUBE_DNS}"
         fi
 
-        lapis migrate
+        echo "[bootstrap] PROJECT_CODE=${PROJECT_CODE:-<unset>}"
+        echo "[bootstrap] Running migrations..."
+        # Retry migrations up to 5 times — Postgres may not be fully ready at postStart time.
+        MIGRATE_RETRIES=5
+        MIGRATE_DELAY=6
+        attempt=1
+        while [ $attempt -le $MIGRATE_RETRIES ]; do
+          if lapis migrate; then
+            break
+          fi
+          echo "[bootstrap] Migration attempt $attempt/$MIGRATE_RETRIES failed. Retrying in ${MIGRATE_DELAY}s..."
+          attempt=$((attempt + 1))
+          sleep $MIGRATE_DELAY
+        done
+        if [ $attempt -gt $MIGRATE_RETRIES ]; then
+          echo "[bootstrap] Migrations failed after $MIGRATE_RETRIES attempts. Aborting bootstrap." >&2
+          exit 1
+        fi
         echo "==========================="
 
-        echo "[bootstrap] Running namespace setup..."
-        lapis exec "require('scripts.setup-namespace').run({})"
+        echo "[bootstrap] Running namespace setup (supports multi-project codes)..."
+        # runMulti() validates every project code, isolates per-code failures with pcall,
+        # and re-raises on partial failure so this script exits non-zero and the pod
+        # readiness probe keeps failing until an operator intervenes.
+        if ! lapis exec "require('scripts.setup-namespace').runMulti({})"; then
+          echo "[bootstrap] Namespace setup failed — check above for which project code failed." >&2
+          exit 1
+        fi
         echo "[bootstrap] Namespace setup complete."
         echo "==========================="
 

--- a/devops/helm-charts/diytaxreturn-lapis/templates/deployment.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
             - name: LAPIS_ENVIRONMENT
               value: "production"
             - name: PROJECT_CODE
-              value: {{ .Values.projectCode | default "tax_copilot" | quote }}
+              value: {{ .Values.projectCode | default "all" | quote }}
             {{- if and .Values.setup .Values.setup.adminEmail }}
             - name: ADMIN_EMAIL
               value: {{ .Values.setup.adminEmail | quote }}

--- a/devops/helm-charts/diytaxreturn-lapis/values-acc.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/values-acc.yaml
@@ -1,6 +1,6 @@
 env: acc
 app: diytaxreturn-lapis
-projectCode: tax_copilot
+projectCode: all
 
 image:
   repository: bwalia/opsapi

--- a/devops/helm-charts/diytaxreturn-lapis/values-dev.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/values-dev.yaml
@@ -1,6 +1,6 @@
 env: dev
 app: diytaxreturn-lapis
-projectCode: tax_copilot
+projectCode: all
 
 image:
   repository: bwalia/opsapi

--- a/devops/helm-charts/diytaxreturn-lapis/values-int.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/values-int.yaml
@@ -1,6 +1,6 @@
 env: int
 app: diytaxreturn-lapis
-projectCode: tax_copilot
+projectCode: all
 
 image:
   repository: bwalia/opsapi

--- a/devops/helm-charts/diytaxreturn-lapis/values-prod.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/values-prod.yaml
@@ -1,6 +1,6 @@
 env: prod
 app: diytaxreturn-lapis
-projectCode: tax_copilot
+projectCode: all
 
 image:
   repository: bwalia/opsapi

--- a/lapis/app.lua
+++ b/lapis/app.lua
@@ -112,6 +112,43 @@ app:get("/live", function(self)
     }
 end)
 
+-- System info endpoint — reports the project configuration this pod was started with.
+-- Lets operators (and the dashboard) verify which features/routes are live without
+-- shelling into the container. Public because the dashboard may call it pre-login
+-- to render the correct menu; contains no tenant-specific data.
+app:get("/api/v2/system/info", function(self)
+    local ok_cfg, ProjectConfig = pcall(require, "helper.project-config")
+    if not ok_cfg then
+        ngx.log(ngx.ERR, "system/info: failed to load project-config: ", tostring(ProjectConfig))
+        return {
+            status = 500,
+            json = { error = "Project configuration unavailable" }
+        }
+    end
+
+    local ok_info, info_or_err = pcall(ProjectConfig.getProjectInfo)
+    if not ok_info then
+        ngx.log(ngx.ERR, "system/info: getProjectInfo failed: ", tostring(info_or_err))
+        return {
+            status = 500,
+            json = { error = "Failed to read project info" }
+        }
+    end
+
+    ngx.header["Access-Control-Allow-Origin"] = "*"
+    return {
+        status = 200,
+        json = {
+            project_code = info_or_err.project_code,
+            parsed_codes = info_or_err.project_codes,
+            enabled_features = info_or_err.enabled_features,
+            environment = os.getenv("LAPIS_ENVIRONMENT") or "development",
+            version = "1.0.0",
+            timestamp = ngx.time(),
+        }
+    }
+end)
+
 app:get("/swagger", function(self)
     return { render = "swagger" }
 end)
@@ -208,7 +245,8 @@ app:before_filter(function(self)
     -- Skip auth for public routes
     if uri == "/" or uri == "/health" or uri == "/ready" or uri == "/live" or
         uri == "/swagger" or uri == "/api-docs" or uri == "/openapi.json" or
-        uri == "/swagger/swagger.json" or uri == "/metrics" or public_auth_routes[uri] or
+        uri == "/swagger/swagger.json" or uri == "/metrics" or
+        uri == "/api/v2/system/info" or public_auth_routes[uri] or
         uri:match("^/api/v2/public/") or
         uri:match("^/api/v2/projects$") or
         uri:match("^/api/v2/projects/[^/]+/theme") or

--- a/lapis/scripts/setup-namespace.lua
+++ b/lapis/scripts/setup-namespace.lua
@@ -4,6 +4,11 @@
   Automatically creates a namespace from PROJECT_CODE with a super admin user.
   This script is idempotent — safe to re-run on every deployment.
 
+  Supports multi-project codes:
+    - Single code:  PROJECT_CODE=tax_copilot      → creates one namespace
+    - Multi code:   PROJECT_CODE=ecommerce,chat    → creates one namespace per code
+    - All:          PROJECT_CODE=all               → creates "system" namespace
+
   Configuration priority: function args > environment variables > defaults
 
   Usage (via lapis exec — pass config inline to bypass nginx env limitation):
@@ -15,6 +20,10 @@
         namespace_name='UK Tax Return',
         namespace_slug='uk-tax-return'
       })"
+
+  Multi-project usage (recommended for combined project codes):
+    docker exec opsapi lapis exec \
+      "require('scripts.setup-namespace').runMulti({})"
 ]]
 
 local SetupNamespace = {}
@@ -31,6 +40,43 @@ local function resolve(config, key, env_key, default)
     return default
 end
 
+--- Validate a project code against the registered list in ProjectConfig.
+--- Returns true if known, or false + list of valid codes.
+local function isKnownProjectCode(code)
+    local ProjectConfig = require("helper.project-config")
+    if not code or code == "" then
+        return false, {}
+    end
+    local valid = {}
+    for k, _ in pairs(ProjectConfig.PROJECT_FEATURES) do
+        table.insert(valid, k)
+    end
+    table.sort(valid)
+    return ProjectConfig.PROJECT_FEATURES[code] ~= nil, valid
+end
+
+--- Parse a potentially comma-separated project_code string.
+--- Returns two lists: valid codes, invalid codes (for error reporting).
+local function parseAndValidateCodes(project_code)
+    local valid_codes, invalid_codes = {}, {}
+    local seen = {}
+
+    for raw in tostring(project_code or ""):gmatch("[^,]+") do
+        local trimmed = raw:match("^%s*(.-)%s*$")
+        if trimmed and #trimmed > 0 and not seen[trimmed] then
+            seen[trimmed] = true
+            local known, _ = isKnownProjectCode(trimmed)
+            if known then
+                table.insert(valid_codes, trimmed)
+            else
+                table.insert(invalid_codes, trimmed)
+            end
+        end
+    end
+
+    return valid_codes, invalid_codes
+end
+
 function SetupNamespace.run(config)
     config = config or {}
 
@@ -41,6 +87,26 @@ function SetupNamespace.run(config)
     local project_code = resolve(config, "project_code", "PROJECT_CODE", "all")
     local admin_email = resolve(config, "admin_email", "ADMIN_EMAIL", "admin@opsapi.com")
     local admin_password = resolve(config, "admin_password", "ADMIN_PASSWORD", "Admin@123")
+
+    -- Validate project code when run directly with a single code.
+    -- Multi-code inputs are handled by runMulti(); if one slips through here, fail fast.
+    if project_code:find(",") then
+        error("SetupNamespace.run() received a multi-code project_code '" .. project_code
+            .. "'. Use SetupNamespace.runMulti() for comma-separated codes.")
+    end
+    local known, valid = isKnownProjectCode(project_code)
+    if not known then
+        error("Unknown project_code '" .. tostring(project_code)
+            .. "'. Valid codes: " .. table.concat(valid, ", "))
+    end
+
+    -- Basic sanity checks on admin inputs (fail early, not mid-DB insert)
+    if type(admin_email) ~= "string" or not admin_email:find("@") then
+        error("Invalid admin_email '" .. tostring(admin_email) .. "' — must be a valid email address")
+    end
+    if type(admin_password) ~= "string" or #admin_password < 6 then
+        error("Invalid admin_password — must be at least 6 characters")
+    end
 
     -- Derive default namespace name/slug from project code
     local default_slug = project_code:gsub("_", "-")
@@ -345,6 +411,123 @@ function SetupNamespace.run(config)
     print("Modules:   " .. #project_modules .. " (" .. project_code .. ")")
     print("======================")
     print("")
+end
+
+--- Run namespace setup for one or more project codes.
+--- Parses comma-separated PROJECT_CODE and creates one namespace per code.
+--- For single codes (including "all"), delegates to run() directly.
+--- This is the recommended entry point for Kubernetes bootstrap and CI/CD.
+---
+--- Error handling:
+---  - Unknown codes are rejected up front. If ALL codes are invalid, aborts with error.
+---  - If SOME codes are invalid, warns and continues with the valid ones.
+---  - Each code's setup runs in an isolated pcall so one failure does not abort the rest.
+---  - Prints a structured summary of successes + failures at the end.
+---  - Re-raises with a consolidated error if any code failed, so CI/CD sees a non-zero exit.
+---
+--- @param config table Optional config overrides (admin_email, admin_password, etc.)
+--- @return table Summary { total, succeeded, failed, failures = { {code, error} } }
+function SetupNamespace.runMulti(config)
+    config = config or {}
+
+    local project_code = resolve(config, "project_code", "PROJECT_CODE", "all")
+
+    -- Single code — delegate to run() (which also does its own validation)
+    if not project_code:find(",") then
+        SetupNamespace.run(config)
+        return { total = 1, succeeded = 1, failed = 0, failures = {} }
+    end
+
+    local valid_codes, invalid_codes = parseAndValidateCodes(project_code)
+
+    print("")
+    print("=== Multi-Project Namespace Setup ===")
+    print("PROJECT_CODE: " .. project_code)
+    print("Valid codes:  " .. (#valid_codes > 0 and table.concat(valid_codes, ", ") or "(none)"))
+    if #invalid_codes > 0 then
+        print("INVALID codes (will be skipped): " .. table.concat(invalid_codes, ", "))
+    end
+    print("======================================")
+    print("")
+
+    if #valid_codes == 0 then
+        local _, all_valid = isKnownProjectCode("all")
+        error("No valid project codes in '" .. project_code .. "'. Known codes: "
+            .. table.concat(all_valid, ", "))
+    end
+
+    local admin_email = resolve(config, "admin_email", "ADMIN_EMAIL", "admin@opsapi.com")
+    local admin_password = resolve(config, "admin_password", "ADMIN_PASSWORD", "Admin@123")
+
+    local failures = {}
+    local succeeded = 0
+
+    for i, code in ipairs(valid_codes) do
+        local code_slug = code:gsub("_", "-")
+        local code_name = code:gsub("_", " "):gsub("(%a)([%w_']*)", function(a, b)
+            return a:upper() .. b
+        end)
+
+        print("--- [" .. i .. "/" .. #valid_codes .. "] Setting up namespace: "
+            .. code_name .. " (" .. code_slug .. ") [project: " .. code .. "] ---")
+
+        local per_code_config = {
+            project_code = code,
+            admin_email = admin_email,
+            admin_password = admin_password,
+            namespace_slug = code_slug,
+            namespace_name = code_name,
+        }
+
+        local ok, err = pcall(SetupNamespace.run, per_code_config)
+        if ok then
+            succeeded = succeeded + 1
+        else
+            print("  !! FAILED setting up '" .. code .. "': " .. tostring(err))
+            table.insert(failures, { code = code, error = tostring(err) })
+        end
+    end
+
+    print("")
+    print("=== Multi-Project Setup Summary ===")
+    print("Total codes:  " .. #valid_codes)
+    print("Succeeded:    " .. succeeded)
+    print("Failed:       " .. #failures)
+    if #invalid_codes > 0 then
+        print("Skipped (unknown): " .. table.concat(invalid_codes, ", "))
+    end
+    if #failures > 0 then
+        print("Failures:")
+        for _, f in ipairs(failures) do
+            print("  - " .. f.code .. ": " .. f.error)
+        end
+    end
+    print("====================================")
+    print("")
+
+    local summary = {
+        total = #valid_codes,
+        succeeded = succeeded,
+        failed = #failures,
+        failures = failures,
+        skipped = invalid_codes,
+    }
+
+    -- Re-raise if ANY code failed — so CI/CD pipelines fail loudly rather than silently.
+    -- Unknown codes alone do NOT cause a failure (they were filtered up front with a warning).
+    if #failures > 0 then
+        error(string.format(
+            "Multi-project setup failed for %d of %d codes: %s",
+            #failures, #valid_codes,
+            table.concat((function()
+                local names = {}
+                for _, f in ipairs(failures) do table.insert(names, f.code) end
+                return names
+            end)(), ", ")
+        ))
+    end
+
+    return summary
 end
 
 return SetupNamespace

--- a/start.sh
+++ b/start.sh
@@ -57,28 +57,38 @@ show_help() {
     echo "  Example: -e staging -P http   -> http://staging-api.${BASE_DOMAIN}"
     echo ""
     echo -e "${BLUE}Project Codes (for conditional migrations):${NC}"
-    echo "  all          - All features (default, backward compatible)"
-    echo "  tax_copilot  - UK Tax Return AI Agent (core + tax tables only)"
-    echo "  ecommerce    - E-commerce platform (core + stores, products, orders)"
-    echo "  collaboration - Chat + Kanban + Services"
-    echo "  hospital     - Hospital CRM"
-    echo "  core_only    - Just authentication tables"
+    echo "  all            - All features (default, backward compatible)"
+    echo "  tax_copilot    - UK Tax Return AI Agent (core + tax tables only)"
+    echo "  ecommerce      - E-commerce platform (core + stores, products, orders)"
+    echo "  ecommerce_chat - E-commerce + Chat"
+    echo "  collaboration  - Chat + Kanban + Services"
+    echo "  hospital       - Hospital CRM"
+    echo "  business       - CRM + Timesheets + Invoicing + Accounting + Kanban"
+    echo "  core_only      - Just authentication tables"
+    echo ""
+    echo -e "${BLUE}Multi-Project (comma-separated):${NC}"
+    echo "  Combine multiple project codes to enable features from each:"
+    echo "  ecommerce,collaboration   - E-commerce + Chat + Kanban + Vault"
+    echo "  tax_copilot,business      - Tax filing + CRM + Invoicing"
+    echo "  Each code creates its own namespace with appropriate roles/modules."
     echo ""
     echo -e "${BLUE}Examples:${NC}"
-    echo "  ./start.sh                    # Interactive mode (prompts)"
-    echo "  ./start.sh -e local           # Local development environment"
-    echo "  ./start.sh -e dev -a          # Dev environment, auto git (https)"
-    echo "  ./start.sh -e dev -P http     # Dev environment with HTTP"
-    echo "  ./start.sh -e remote -n       # Remote environment, no git ops"
-    echo "  ./start.sh -e staging -a      # Custom 'staging' environment"
-    echo "  ./start.sh --env=prod -a      # Prod environment, auto mode"
-    echo "  ./start.sh -c -e dev          # Just check/update .env for dev"
-    echo "  ./start.sh -r                 # Reset database (fresh start)"
-    echo "  ./start.sh -e remote -n -C    # CI/CD deployment (no dev mounts)"
-    echo "  ./start.sh -j tax_copilot     # Only create tax-related tables"
-    echo "  ./start.sh -e local -j tax_copilot -r  # Fresh tax_copilot setup"
-    echo "  ./start.sh -d myapp.com -e prod -n  # Deploy with custom apex domain"
-    echo "  ./start.sh -d kisaan.com -e dev -a  # Dev environment on kisaan.com"
+    echo "  ./start.sh                              # Interactive mode (prompts)"
+    echo "  ./start.sh -e local           	         # Local development environment"
+    echo "  ./start.sh -e dev -a                     # Dev environment, auto git (https)"
+    echo "  ./start.sh -e dev -P http                # Dev environment with HTTP"
+    echo "  ./start.sh -e remote -n                  # Remote environment, no git ops"
+    echo "  ./start.sh -e staging -a                 # Custom 'staging' environment"
+    echo "  ./start.sh --env=prod -a                 # Prod environment, auto mode"
+    echo "  ./start.sh -c -e dev                     # Just check/update .env for dev"
+    echo "  ./start.sh -r                            # Reset database (fresh start)"
+    echo "  ./start.sh -e remote -n -C               # CI/CD deployment (no dev mounts)"
+    echo "  ./start.sh -j tax_copilot                # Only create tax-related tables"
+    echo "  ./start.sh -j ecommerce,collaboration    # Multi-project: combined features"
+    echo "  ./start.sh -j business                   # Business/Professional Services"
+    echo "  ./start.sh -e local -j tax_copilot -r    # Fresh tax_copilot setup"
+    echo "  ./start.sh -d myapp.com -e prod -n       # Deploy with custom apex domain"
+    echo "  ./start.sh -d kisaan.com -e dev -a       # Dev environment on kisaan.com"
     echo ""
 }
 
@@ -322,29 +332,52 @@ validate_protocol() {
     esac
 }
 
-# Function to validate project code
+# Function to validate project code (supports comma-separated multi-project codes)
 validate_project_code() {
-    local code="$1"
-    case "$code" in
-        all|tax_copilot|ecommerce|ecommerce_chat|collaboration|hospital|core_only) return 0 ;;
-        *) return 1 ;;
-    esac
+    local input="$1"
+    local VALID_CODES="all tax_copilot ecommerce ecommerce_chat collaboration hospital business core_only"
+
+    # Split on commas and validate each individual code
+    local IFS=','
+    local codes
+    read -ra codes <<< "$input"
+    for code in "${codes[@]}"; do
+        # Trim whitespace
+        code=$(echo "$code" | xargs)
+        if [[ -z "$code" ]]; then
+            continue
+        fi
+        local found=false
+        for valid in $VALID_CODES; do
+            if [[ "$code" == "$valid" ]]; then
+                found=true
+                break
+            fi
+        done
+        if ! $found; then
+            echo -e "${RED}[!] Unknown project code: '$code'${NC}" >&2
+            return 1
+        fi
+    done
+    return 0
 }
 
 # Function to prompt for project code selection
 prompt_project_code() {
     echo -e "${CYAN}Select project code for conditional migrations:${NC}" >&2
-    echo "  1) all          - All features (default, backward compatible)" >&2
-    echo "  2) tax_copilot  - UK Tax Return AI Agent (core + tax tables only)" >&2
-    echo "  3) ecommerce    - E-commerce platform (core + stores, products, orders)" >&2
-    echo "  4) collaboration - Chat + Kanban + Services" >&2
-    echo "  5) hospital     - Hospital CRM" >&2
-    echo "  6) core_only    - Just authentication tables" >&2
+    echo "  1) all            - All features (default, backward compatible)" >&2
+    echo "  2) tax_copilot    - UK Tax Return AI Agent (core + tax tables only)" >&2
+    echo "  3) ecommerce      - E-commerce platform (core + stores, products, orders)" >&2
+    echo "  4) collaboration  - Chat + Kanban + Services" >&2
+    echo "  5) hospital       - Hospital CRM" >&2
+    echo "  6) core_only      - Just authentication tables" >&2
+    echo "  7) business       - CRM + Timesheets + Invoicing + Accounting + Kanban" >&2
+    echo "  8) custom combo   - Enter comma-separated codes (e.g. ecommerce,collaboration)" >&2
     echo "" >&2
 
     local choice
     while true; do
-        read -p "Enter choice [1-6] or press Enter for default (all): " choice
+        read -p "Enter choice [1-8] or press Enter for default (all): " choice
         case "$choice" in
             ""|1|all)
                 echo "all"
@@ -370,8 +403,31 @@ prompt_project_code() {
                 echo "core_only"
                 return 0
                 ;;
+            7|business)
+                echo "business"
+                return 0
+                ;;
+            8|custom)
+                echo -e "${CYAN}Enter comma-separated project codes:${NC}" >&2
+                echo -e "${BLUE}  Valid codes: all, tax_copilot, ecommerce, ecommerce_chat, collaboration, hospital, business, core_only${NC}" >&2
+                echo -e "${BLUE}  Example: ecommerce,collaboration${NC}" >&2
+                local custom_codes
+                read -p "Project codes: " custom_codes
+                if validate_project_code "$custom_codes"; then
+                    echo "$custom_codes"
+                    return 0
+                else
+                    echo -e "${YELLOW}Invalid project code(s). Please try again.${NC}" >&2
+                fi
+                ;;
             *)
-                echo -e "${YELLOW}Invalid choice. Please enter 1-6 or a valid project code.${NC}" >&2
+                # Allow direct entry of valid code(s) including comma-separated
+                if validate_project_code "$choice"; then
+                    echo "$choice"
+                    return 0
+                else
+                    echo -e "${YELLOW}Invalid choice. Please enter 1-8 or valid project code(s).${NC}" >&2
+                fi
                 ;;
         esac
     done
@@ -701,7 +757,8 @@ if [[ -n "$PROJECT_CODE" ]]; then
         echo -e "${BLUE}[i] Project code from argument: ${CYAN}${PROJECT_CODE}${NC}"
     else
         echo -e "${RED}[!] Invalid project code: '$PROJECT_CODE'${NC}"
-        echo -e "${YELLOW}[!] Valid options: all, tax_copilot, ecommerce, ecommerce_chat, collaboration, hospital, core_only${NC}"
+        echo -e "${YELLOW}[!] Valid options: all, tax_copilot, ecommerce, ecommerce_chat, collaboration, hospital, business, core_only${NC}"
+        echo -e "${YELLOW}[!] Combine with commas: ecommerce,collaboration${NC}"
         exit 1
     fi
 else
@@ -760,13 +817,14 @@ echo -e "${GREEN}[+] Namespace Configuration${NC}"
 echo ""
 
 # Derive defaults from project code
-DEFAULT_NS_SLUG=$(echo "$PROJECT_CODE" | sed 's/_/-/g')
-DEFAULT_NS_NAME=$(echo "$PROJECT_CODE" | sed 's/_/ /g' | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) tolower(substr($i,2))}1')
-
-# For "all" project code, use "system" namespace
-if [[ "$PROJECT_CODE" == "all" ]]; then
+# For multi-project (comma-separated) or "all", use "system" namespace as the default
+# Each individual code will get its own namespace during the setup phase
+if [[ "$PROJECT_CODE" == "all" ]] || [[ "$PROJECT_CODE" == *","* ]]; then
     DEFAULT_NS_SLUG="system"
     DEFAULT_NS_NAME="System"
+else
+    DEFAULT_NS_SLUG=$(echo "$PROJECT_CODE" | sed 's/_/-/g')
+    DEFAULT_NS_NAME=$(echo "$PROJECT_CODE" | sed 's/_/ /g' | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) tolower(substr($i,2))}1')
 fi
 
 if [[ -n "$NAMESPACE_NAME" ]]; then
@@ -983,32 +1041,74 @@ else
     docker exec -e "PROJECT_CODE=$PROJECT_CODE" -it "$CONTAINER_NAME" lapis migrate
 fi
 
-# Run namespace setup - creates namespace with admin user
+# Run namespace setup - creates namespace(s) with admin user
 # Seeds project-specific modules and creates default roles
+# For multi-project codes (comma-separated), creates one namespace per code
 # Note: config is passed inline as a Lua table because lapis exec runs inside
 # an nginx worker process which does not inherit docker exec -e environment vars.
-echo -e "${GREEN}[+] Setting up namespace '${NAMESPACE_NAME}' (${NAMESPACE_SLUG}) for ${PROJECT_CODE}...${NC}"
 
-# Escape single quotes in password for safe Lua string embedding
-ESCAPED_PASSWORD=$(echo "$ADMIN_PASSWORD" | sed "s/'/\\\\'/g")
+# Escape single quotes in strings for safe Lua string embedding
+lua_escape() {
+    printf '%s' "$1" | sed "s/'/\\\\'/g"
+}
+ESCAPED_PASSWORD=$(lua_escape "$ADMIN_PASSWORD")
+ESCAPED_EMAIL=$(lua_escape "$ADMIN_EMAIL")
+ESCAPED_NS_NAME=$(lua_escape "$NAMESPACE_NAME")
+ESCAPED_NS_SLUG=$(lua_escape "$NAMESPACE_SLUG")
+ESCAPED_PROJECT_CODE=$(lua_escape "$PROJECT_CODE")
 
-SETUP_LUA_CMD="require('scripts.setup-namespace').run({ \
-  project_code='${PROJECT_CODE}', \
-  admin_email='${ADMIN_EMAIL}', \
-  admin_password='${ESCAPED_PASSWORD}', \
-  namespace_name='${NAMESPACE_NAME}', \
-  namespace_slug='${NAMESPACE_SLUG}' \
-})"
+# Helper function to run a lapis exec command inside the container.
+# Returns the container's exit code so callers can react to failures.
+run_lapis_exec() {
+    local lua_cmd="$1"
+    if $CI_MODE; then
+        docker exec \
+            -e PROJECT_CODE="$PROJECT_CODE" \
+            "$CONTAINER_NAME" lapis exec "$lua_cmd"
+    else
+        docker exec \
+            -e PROJECT_CODE="$PROJECT_CODE" \
+            -it "$CONTAINER_NAME" lapis exec "$lua_cmd"
+    fi
+}
 
-if $CI_MODE; then
-    docker exec \
-        -e PROJECT_CODE=$PROJECT_CODE \
-        $CONTAINER_NAME lapis exec "$SETUP_LUA_CMD"
+# ============================================
+# Namespace setup
+# ============================================
+# Delegate the single-vs-multi branching to the Lua runMulti() entry point.
+# It validates each code against ProjectConfig, isolates per-code failures
+# with pcall, and re-raises a consolidated error so this shell sees a non-zero
+# exit on partial failure. That keeps CI/CD pipelines honest.
+if [[ "$PROJECT_CODE" == *","* ]]; then
+    echo -e "${GREEN}[+] Multi-project mode detected: ${CYAN}${PROJECT_CODE}${NC}"
+    echo ""
+
+    SETUP_LUA_CMD="require('scripts.setup-namespace').runMulti({ \
+      project_code='${ESCAPED_PROJECT_CODE}', \
+      admin_email='${ESCAPED_EMAIL}', \
+      admin_password='${ESCAPED_PASSWORD}' \
+    })"
 else
-    docker exec \
-        -e PROJECT_CODE=$PROJECT_CODE \
-        -it $CONTAINER_NAME lapis exec "$SETUP_LUA_CMD"
+    echo -e "${GREEN}[+] Setting up namespace '${NAMESPACE_NAME}' (${NAMESPACE_SLUG}) for ${PROJECT_CODE}...${NC}"
+
+    SETUP_LUA_CMD="require('scripts.setup-namespace').run({ \
+      project_code='${ESCAPED_PROJECT_CODE}', \
+      admin_email='${ESCAPED_EMAIL}', \
+      admin_password='${ESCAPED_PASSWORD}', \
+      namespace_name='${ESCAPED_NS_NAME}', \
+      namespace_slug='${ESCAPED_NS_SLUG}' \
+    })"
 fi
+
+if ! run_lapis_exec "$SETUP_LUA_CMD"; then
+    echo ""
+    echo -e "${RED}[!] Namespace setup failed. Inspect container logs:${NC}"
+    echo -e "${YELLOW}    docker logs ${CONTAINER_NAME}${NC}"
+    exit 1
+fi
+
+echo ""
+echo -e "${GREEN}[+] Namespace setup completed successfully${NC}"
 
 sleep 5
 


### PR DESCRIPTION
Make comma-separated PROJECT_CODE a first-class input across local Docker and Kubernetes so the platform can scale to any number of vertical modules.

- setup-namespace.lua: validate every code against ProjectConfig; reject unknown codes with the valid list in the error; fail-fast on bad email or short password; runMulti() isolates per-code failures with pcall and re-raises a consolidated error so CI exits non-zero on partial failure.
- start.sh: delegate single/multi branching to runMulti() (one Lua call, one validation path); escape email/name/slug for safe Lua embedding; explicit failure handling with actionable hint on non-zero exit.
- helm configmap: set -eo pipefail in bootstrap; retry migrations up to 5 times (Postgres may not be ready at postStart); check runMulti exit so the readiness probe keeps failing until an operator intervenes.
- helm values: default projectCode=all across dev/int/acc/prod.
- workflows: PROJECT_CODE changed from choice to free-text string so comma-separated combos (ecommerce,collaboration) are accepted.
- app.lua: new public /api/v2/system/info endpoint reports project_code, parsed_codes, enabled_features, and environment so ops (and the dashboard) can verify what is live without exec'ing into the pod.