### PR TITLE
feat: add tax copilot dashboard UI and menu items migration

### DIFF
--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -86,6 +86,9 @@ local hospital_crm_migrations = load_if_enabled(ProjectConfig.FEATURES.HOSPITAL,
 local hospital_care_mgmt_migrations = load_if_enabled(ProjectConfig.FEATURES.HOSPITAL, "migrations.hospital-care-management") or {}
 local hospital_menu_items_migrations = load_if_enabled(ProjectConfig.FEATURES.HOSPITAL, "migrations.hospital-menu-items") or {}
 
+-- Tax Copilot menu items
+local tax_copilot_menu_items_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.tax-copilot-menu-items") or {}
+
 -- Notifications
 local notification_migrations = load_if_enabled(ProjectConfig.FEATURES.NOTIFICATIONS, "migrations.notifications") or {}
 local push_notification_migrations = load_if_enabled(ProjectConfig.FEATURES.NOTIFICATIONS,
@@ -1212,6 +1215,12 @@ local _migrations = {
     ['465_seed_error_catalog_english'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 51),
     ['466_seed_notification_catalog_codes'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 52),
     ['467_seed_classify_partial_code'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 53),
+
+    -- Tax Copilot menu items (468-471)
+    ['468_seed_tax_menu_items'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_menu_items_migrations, 1),
+    ['469_seed_tax_modules'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_menu_items_migrations, 2),
+    ['470_grant_tax_permissions'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_menu_items_migrations, 3),
+    ['471_enable_tax_menu_per_namespace'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_menu_items_migrations, 4),
 
     -- =========================================================================
     -- CRM SYSTEM (500-509)

--- a/lapis/migrations/tax-copilot-menu-items.lua
+++ b/lapis/migrations/tax-copilot-menu-items.lua
@@ -1,0 +1,233 @@
+--[[
+    Tax Copilot Menu Items Seeding Migration
+
+    Adds Tax dashboard menu items to the backend-driven menu,
+    registers the corresponding modules, grants owner-role permissions, and enables
+    them for all existing namespaces so they appear in the sidebar.
+]]
+
+local db = require("lapis.db")
+
+return {
+    -- =========================================================================
+    -- [1] Insert menu items for tax copilot
+    -- =========================================================================
+    [1] = function()
+        local MigrationUtils = require("helper.migration-utils")
+        local timestamp = MigrationUtils.getCurrentTimestamp()
+
+        -- Create a parent menu item for Tax
+        local parent_key = "tax"
+        local parent_existing = db.select("* FROM menu_items WHERE key = ?", parent_key)
+        local parent_id = nil
+
+        if #parent_existing == 0 then
+            db.insert("menu_items", {
+                uuid = MigrationUtils.generateUUID(),
+                key = parent_key,
+                name = "Tax Returns",
+                icon = "Calculator",
+                path = "/dashboard/tax",
+                module = "tax_transactions",
+                required_action = "read",
+                priority = 30,
+                is_active = true,
+                is_admin_only = false,
+                always_show = false,
+                settings = "{}",
+                created_at = timestamp,
+                updated_at = timestamp,
+            })
+            local inserted = db.select("* FROM menu_items WHERE key = ?", parent_key)
+            if #inserted > 0 then
+                parent_id = inserted[1].id
+            end
+        else
+            parent_id = parent_existing[1].id
+        end
+
+        local items = {
+            {
+                key = "tax_bank_accounts",
+                name = "Bank Accounts",
+                icon = "Landmark",
+                path = "/dashboard/tax/bank-accounts",
+                module = "tax_bank_accounts",
+                required_action = "read",
+                priority = 31,
+            },
+            {
+                key = "tax_statements",
+                name = "Statements",
+                icon = "FileUp",
+                path = "/dashboard/tax/statements",
+                module = "tax_statements",
+                required_action = "read",
+                priority = 32,
+            },
+            {
+                key = "tax_transactions",
+                name = "Transactions",
+                icon = "ArrowLeftRight",
+                path = "/dashboard/tax/transactions",
+                module = "tax_transactions",
+                required_action = "read",
+                priority = 33,
+            },
+            {
+                key = "tax_reports",
+                name = "Reports",
+                icon = "BarChart3",
+                path = "/dashboard/tax/reports",
+                module = "tax_transactions",
+                required_action = "read",
+                priority = 34,
+            },
+        }
+
+        for _, item in ipairs(items) do
+            local existing = db.select("* FROM menu_items WHERE key = ?", item.key)
+            if #existing == 0 then
+                db.insert("menu_items", {
+                    uuid = MigrationUtils.generateUUID(),
+                    key = item.key,
+                    name = item.name,
+                    icon = item.icon,
+                    path = item.path,
+                    module = item.module,
+                    required_action = item.required_action,
+                    priority = item.priority,
+                    parent_id = parent_id,
+                    is_active = true,
+                    is_admin_only = false,
+                    always_show = false,
+                    settings = "{}",
+                    created_at = timestamp,
+                    updated_at = timestamp,
+                })
+            end
+        end
+    end,
+
+    -- =========================================================================
+    -- [2] Register modules (tax_bank_accounts, tax_statements, tax_transactions, etc.)
+    -- =========================================================================
+    [2] = function()
+        local MigrationUtils = require("helper.migration-utils")
+        local timestamp = MigrationUtils.getCurrentTimestamp()
+
+        local modules = {
+            { machine_name = "tax_bank_accounts", name = "Tax Bank Accounts", description = "Bank account management for tax returns", priority = 30 },
+            { machine_name = "tax_statements",    name = "Tax Statements",    description = "Bank statement uploads and extraction", priority = 31 },
+            { machine_name = "tax_transactions",   name = "Tax Transactions",  description = "Transaction tracking and classification", priority = 32 },
+            { machine_name = "tax_categories",     name = "Tax Categories",    description = "Transaction category management", priority = 33 },
+            { machine_name = "tax_support",        name = "Tax Support",       description = "Tax support conversations", priority = 34 },
+            { machine_name = "tax_file",           name = "HMRC Filing",       description = "Submit tax returns to HMRC", priority = 35 },
+        }
+
+        for _, mod in ipairs(modules) do
+            local existing = db.select("* FROM modules WHERE machine_name = ?", mod.machine_name)
+            if #existing == 0 then
+                db.insert("modules", {
+                    uuid = MigrationUtils.generateUUID(),
+                    machine_name = mod.machine_name,
+                    name = mod.name,
+                    description = mod.description,
+                    priority = mod.priority,
+                    created_at = timestamp,
+                    updated_at = timestamp,
+                })
+            end
+        end
+    end,
+
+    -- =========================================================================
+    -- [3] Grant permissions to namespace owner roles
+    -- =========================================================================
+    [3] = function()
+        local cjson_ok, cjson = pcall(require, "cjson")
+        if not cjson_ok then return end
+
+        -- Find all owner roles across namespaces
+        local owner_roles = db.select(
+            "* FROM namespace_roles WHERE role_name IN ('Owner', 'owner', 'Namespace Owner')"
+        )
+
+        local tax_modules = {
+            "tax_bank_accounts", "tax_statements", "tax_transactions",
+            "tax_categories", "tax_support", "tax_file"
+        }
+        local actions = { "create", "read", "update", "delete", "manage" }
+
+        for _, role in ipairs(owner_roles) do
+            local perms = {}
+            if role.permissions and role.permissions ~= "" then
+                local ok, decoded = pcall(cjson.decode, role.permissions)
+                if ok and type(decoded) == "table" then perms = decoded end
+            end
+
+            for _, mod_name in ipairs(tax_modules) do
+                perms[mod_name] = actions
+            end
+
+            db.update("namespace_roles", {
+                permissions = cjson.encode(perms),
+            }, { id = role.id })
+        end
+
+        -- Also grant to admin roles
+        local admin_roles = db.select(
+            "* FROM namespace_roles WHERE role_name IN ('Admin', 'admin', 'Namespace Admin')"
+        )
+
+        local admin_actions = { "create", "read", "update", "delete" }
+        for _, role in ipairs(admin_roles) do
+            local perms = {}
+            if role.permissions and role.permissions ~= "" then
+                local ok, decoded = pcall(cjson.decode, role.permissions)
+                if ok and type(decoded) == "table" then perms = decoded end
+            end
+
+            for _, mod_name in ipairs(tax_modules) do
+                perms[mod_name] = admin_actions
+            end
+
+            db.update("namespace_roles", {
+                permissions = cjson.encode(perms),
+            }, { id = role.id })
+        end
+    end,
+
+    -- =========================================================================
+    -- [4] Enable menu items in namespace_menu_config for all existing namespaces
+    -- =========================================================================
+    [4] = function()
+        local MigrationUtils = require("helper.migration-utils")
+        local timestamp = MigrationUtils.getCurrentTimestamp()
+
+        local keys = { "tax", "tax_bank_accounts", "tax_statements", "tax_transactions", "tax_reports" }
+        for _, key in ipairs(keys) do
+            local menu_rows = db.select("* FROM menu_items WHERE key = ?", key)
+            if #menu_rows > 0 then
+                local menu_item = menu_rows[1]
+                local namespaces = db.select("* FROM namespaces")
+                for _, ns in ipairs(namespaces) do
+                    local exists = db.select([[
+                        * FROM namespace_menu_config
+                        WHERE namespace_id = ? AND menu_item_id = ?
+                    ]], ns.id, menu_item.id)
+                    if #exists == 0 then
+                        db.insert("namespace_menu_config", {
+                            uuid = MigrationUtils.generateUUID(),
+                            namespace_id = ns.id,
+                            menu_item_id = menu_item.id,
+                            is_enabled = true,
+                            created_at = timestamp,
+                            updated_at = timestamp,
+                        })
+                    end
+                end
+            end
+        end
+    end,
+}

--- a/opsapi-dashboard/app/dashboard/tax/bank-accounts/page.tsx
+++ b/opsapi-dashboard/app/dashboard/tax/bank-accounts/page.tsx
@@ -1,0 +1,334 @@
+'use client';
+
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import {
+  Search,
+  Plus,
+  Landmark,
+  Trash2,
+  Edit2,
+  RefreshCw,
+} from 'lucide-react';
+import { Input, Table, Card, Modal } from '@/components/ui';
+import { ProtectedPage } from '@/components/permissions';
+import { taxService, type TaxBankAccount } from '@/services/tax.service';
+import { formatDate } from '@/lib/utils';
+import type { TableColumn } from '@/types';
+import toast from 'react-hot-toast';
+
+function BankAccountsContent() {
+  const [accounts, setAccounts] = useState<TaxBankAccount[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [editingAccount, setEditingAccount] = useState<TaxBankAccount | null>(null);
+  const fetchIdRef = useRef(0);
+
+  // Form state
+  const [formData, setFormData] = useState({
+    bank_name: '',
+    account_number: '',
+    sort_code: '',
+    account_type: 'current',
+    currency: 'GBP',
+  });
+  const [isSaving, setIsSaving] = useState(false);
+
+  const fetchAccounts = useCallback(async () => {
+    const fetchId = ++fetchIdRef.current;
+    setIsLoading(true);
+    try {
+      const data = await taxService.getBankAccounts();
+      if (fetchId === fetchIdRef.current) {
+        setAccounts(data);
+      }
+    } catch {
+      toast.error('Failed to load bank accounts');
+    } finally {
+      if (fetchId === fetchIdRef.current) {
+        setIsLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAccounts();
+  }, [fetchAccounts]);
+
+  const filteredAccounts = accounts.filter((a) =>
+    !searchQuery ||
+    a.bank_name?.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    a.account_number?.includes(searchQuery)
+  );
+
+  const handleCreate = async () => {
+    if (!formData.bank_name.trim()) {
+      toast.error('Bank name is required');
+      return;
+    }
+    setIsSaving(true);
+    try {
+      await taxService.createBankAccount(formData);
+      toast.success('Bank account created');
+      setShowCreateModal(false);
+      resetForm();
+      fetchAccounts();
+    } catch {
+      toast.error('Failed to create bank account');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleUpdate = async () => {
+    if (!editingAccount) return;
+    setIsSaving(true);
+    try {
+      await taxService.updateBankAccount(editingAccount.uuid, formData);
+      toast.success('Bank account updated');
+      setEditingAccount(null);
+      resetForm();
+      fetchAccounts();
+    } catch {
+      toast.error('Failed to update bank account');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async (account: TaxBankAccount) => {
+    if (!confirm(`Delete bank account "${account.bank_name}"? This cannot be undone.`)) return;
+    try {
+      await taxService.deleteBankAccount(account.uuid);
+      toast.success('Bank account deleted');
+      fetchAccounts();
+    } catch {
+      toast.error('Failed to delete bank account');
+    }
+  };
+
+  const openEdit = (account: TaxBankAccount) => {
+    setFormData({
+      bank_name: account.bank_name || '',
+      account_number: account.account_number || '',
+      sort_code: account.sort_code || '',
+      account_type: account.account_type || 'current',
+      currency: account.currency || 'GBP',
+    });
+    setEditingAccount(account);
+  };
+
+  const resetForm = () => {
+    setFormData({ bank_name: '', account_number: '', sort_code: '', account_type: 'current', currency: 'GBP' });
+  };
+
+  const columns: TableColumn<TaxBankAccount>[] = [
+    {
+      key: 'bank_name',
+      header: 'Bank Name',
+      sortable: true,
+      render: (item) => (
+        <div className="flex items-center gap-2">
+          <Landmark className="w-4 h-4 text-secondary-400" />
+          <span className="font-medium">{item.bank_name}</span>
+        </div>
+      ),
+    },
+    {
+      key: 'account_number',
+      header: 'Account Number',
+      render: (item) => item.account_number ? `****${item.account_number.slice(-4)}` : '-',
+    },
+    {
+      key: 'sort_code',
+      header: 'Sort Code',
+      render: (item) => item.sort_code || '-',
+    },
+    {
+      key: 'account_type',
+      header: 'Type',
+      render: (item) => (
+        <span className="capitalize">{item.account_type || 'current'}</span>
+      ),
+    },
+    {
+      key: 'created_at',
+      header: 'Added',
+      render: (item) => formatDate(item.created_at),
+    },
+    {
+      key: 'actions',
+      header: '',
+      width: 'w-24',
+      render: (item) => (
+        <div className="flex items-center gap-1">
+          <button
+            onClick={(e) => { e.stopPropagation(); openEdit(item); }}
+            className="p-1.5 rounded-lg hover:bg-secondary-100 text-secondary-500 hover:text-secondary-700"
+          >
+            <Edit2 className="w-4 h-4" />
+          </button>
+          <button
+            onClick={(e) => { e.stopPropagation(); handleDelete(item); }}
+            className="p-1.5 rounded-lg hover:bg-red-50 text-secondary-500 hover:text-red-600"
+          >
+            <Trash2 className="w-4 h-4" />
+          </button>
+        </div>
+      ),
+    },
+  ];
+
+  const renderForm = () => (
+    <div className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium text-secondary-700 mb-1">Bank Name *</label>
+        <input
+          type="text"
+          value={formData.bank_name}
+          onChange={(e) => setFormData({ ...formData, bank_name: e.target.value })}
+          placeholder="e.g., Barclays, HSBC, Lloyds"
+          className="w-full px-3 py-2 border border-secondary-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+        />
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium text-secondary-700 mb-1">Account Number</label>
+          <input
+            type="text"
+            value={formData.account_number}
+            onChange={(e) => setFormData({ ...formData, account_number: e.target.value })}
+            placeholder="12345678"
+            maxLength={8}
+            className="w-full px-3 py-2 border border-secondary-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-secondary-700 mb-1">Sort Code</label>
+          <input
+            type="text"
+            value={formData.sort_code}
+            onChange={(e) => setFormData({ ...formData, sort_code: e.target.value })}
+            placeholder="20-00-00"
+            className="w-full px-3 py-2 border border-secondary-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          />
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium text-secondary-700 mb-1">Account Type</label>
+          <select
+            value={formData.account_type}
+            onChange={(e) => setFormData({ ...formData, account_type: e.target.value })}
+            className="w-full px-3 py-2 border border-secondary-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          >
+            <option value="current">Current</option>
+            <option value="savings">Savings</option>
+            <option value="business">Business</option>
+            <option value="credit_card">Credit Card</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-secondary-700 mb-1">Currency</label>
+          <select
+            value={formData.currency}
+            onChange={(e) => setFormData({ ...formData, currency: e.target.value })}
+            className="w-full px-3 py-2 border border-secondary-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          >
+            <option value="GBP">GBP</option>
+            <option value="EUR">EUR</option>
+            <option value="USD">USD</option>
+          </select>
+        </div>
+      </div>
+      <div className="flex justify-end gap-3 pt-2">
+        <button
+          onClick={() => { setShowCreateModal(false); setEditingAccount(null); resetForm(); }}
+          className="px-4 py-2 text-secondary-600 hover:bg-secondary-100 rounded-lg"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={editingAccount ? handleUpdate : handleCreate}
+          disabled={isSaving}
+          className="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50"
+        >
+          {isSaving ? 'Saving...' : editingAccount ? 'Update' : 'Create'}
+        </button>
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-secondary-900">Bank Accounts</h1>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={fetchAccounts}
+            className="p-2 text-secondary-600 hover:bg-secondary-100 rounded-lg"
+          >
+            <RefreshCw className="w-4 h-4" />
+          </button>
+          <button
+            onClick={() => { resetForm(); setShowCreateModal(true); }}
+            className="flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700"
+          >
+            <Plus className="w-4 h-4" />
+            Add Account
+          </button>
+        </div>
+      </div>
+
+      {/* Search */}
+      <Card padding="md">
+        <Input
+          placeholder="Search bank accounts..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          leftIcon={<Search className="w-4 h-4" />}
+        />
+      </Card>
+
+      {/* Table */}
+      <Table
+        columns={columns}
+        data={filteredAccounts}
+        keyExtractor={(item) => item.uuid || String(item.id)}
+        isLoading={isLoading}
+        emptyMessage="No bank accounts yet. Click 'Add Account' to get started."
+      />
+
+      {/* Create Modal */}
+      {showCreateModal && (
+        <Modal
+          isOpen={showCreateModal}
+          onClose={() => { setShowCreateModal(false); resetForm(); }}
+          title="Add Bank Account"
+        >
+          {renderForm()}
+        </Modal>
+      )}
+
+      {/* Edit Modal */}
+      {editingAccount && (
+        <Modal
+          isOpen={!!editingAccount}
+          onClose={() => { setEditingAccount(null); resetForm(); }}
+          title="Edit Bank Account"
+        >
+          {renderForm()}
+        </Modal>
+      )}
+    </div>
+  );
+}
+
+export default function BankAccountsPage() {
+  return (
+    <ProtectedPage module="tax_bank_accounts" title="Tax Bank Accounts">
+      <BankAccountsContent />
+    </ProtectedPage>
+  );
+}

--- a/opsapi-dashboard/app/dashboard/tax/page.tsx
+++ b/opsapi-dashboard/app/dashboard/tax/page.tsx
@@ -1,0 +1,262 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  Calculator,
+  Landmark,
+  FileUp,
+  ArrowLeftRight,
+  BarChart3,
+  TrendingUp,
+  TrendingDown,
+  AlertCircle,
+  CheckCircle,
+  RefreshCw,
+} from 'lucide-react';
+import { Card } from '@/components/ui';
+import { ProtectedPage } from '@/components/permissions';
+import { taxService, type TaxDashboardStats } from '@/services/tax.service';
+import { formatCurrency } from '@/lib/utils';
+import toast from 'react-hot-toast';
+
+interface StatCardProps {
+  title: string;
+  value: string | number;
+  icon: React.ReactNode;
+  color: 'primary' | 'success' | 'warning' | 'danger' | 'info';
+  onClick?: () => void;
+}
+
+const StatCard: React.FC<StatCardProps> = ({ title, value, icon, color, onClick }) => {
+  const colorClasses = {
+    primary: 'bg-primary-50 text-primary-600',
+    success: 'bg-green-50 text-green-600',
+    warning: 'bg-amber-50 text-amber-600',
+    danger: 'bg-red-50 text-red-600',
+    info: 'bg-blue-50 text-blue-600',
+  };
+
+  return (
+    <div
+      className={`bg-white rounded-xl border border-secondary-200 p-5 shadow-sm ${onClick ? 'cursor-pointer hover:border-primary-300 transition-colors' : ''}`}
+      onClick={onClick}
+    >
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm font-medium text-secondary-500">{title}</p>
+          <p className="text-2xl font-bold text-secondary-900 mt-1">{value}</p>
+        </div>
+        <div className={`w-12 h-12 rounded-xl flex items-center justify-center ${colorClasses[color]}`}>
+          {icon}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+function TaxDashboardContent() {
+  const router = useRouter();
+  const [stats, setStats] = useState<TaxDashboardStats | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchStats = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const data = await taxService.getDashboardStats();
+      setStats(data);
+    } catch {
+      // Stats endpoint may not exist yet, use defaults
+      setStats({
+        total_bank_accounts: 0,
+        total_statements: 0,
+        total_transactions: 0,
+        classified_transactions: 0,
+        unclassified_transactions: 0,
+        total_income: 0,
+        total_expenses: 0,
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchStats();
+  }, [fetchStats]);
+
+  const quickActions = [
+    {
+      title: 'Bank Accounts',
+      description: 'Add and manage your bank accounts',
+      icon: <Landmark className="w-6 h-6" />,
+      path: '/dashboard/tax/bank-accounts',
+      color: 'bg-blue-50 text-blue-600',
+    },
+    {
+      title: 'Upload Statement',
+      description: 'Upload a bank statement (PDF, CSV, or image)',
+      icon: <FileUp className="w-6 h-6" />,
+      path: '/dashboard/tax/statements',
+      color: 'bg-purple-50 text-purple-600',
+    },
+    {
+      title: 'Transactions',
+      description: 'View and classify your transactions',
+      icon: <ArrowLeftRight className="w-6 h-6" />,
+      path: '/dashboard/tax/transactions',
+      color: 'bg-amber-50 text-amber-600',
+    },
+    {
+      title: 'Tax Reports',
+      description: 'View category breakdowns and HMRC boxes',
+      icon: <BarChart3 className="w-6 h-6" />,
+      path: '/dashboard/tax/reports',
+      color: 'bg-green-50 text-green-600',
+    },
+  ];
+
+  if (isLoading) {
+    return (
+      <div className="animate-pulse space-y-6 p-6">
+        <div className="h-8 bg-secondary-200 rounded w-1/4"></div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="h-24 bg-secondary-200 rounded-xl"></div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-secondary-900">Tax Returns</h1>
+          <p className="text-secondary-500 mt-1">Manage your UK self-assessment tax return</p>
+        </div>
+        <button
+          onClick={fetchStats}
+          className="flex items-center gap-2 px-3 py-2 text-secondary-600 hover:text-secondary-900 hover:bg-secondary-100 rounded-lg transition-colors"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Refresh
+        </button>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        <StatCard
+          title="Bank Accounts"
+          value={stats?.total_bank_accounts ?? 0}
+          icon={<Landmark className="w-5 h-5" />}
+          color="primary"
+          onClick={() => router.push('/dashboard/tax/bank-accounts')}
+        />
+        <StatCard
+          title="Statements"
+          value={stats?.total_statements ?? 0}
+          icon={<FileUp className="w-5 h-5" />}
+          color="info"
+          onClick={() => router.push('/dashboard/tax/statements')}
+        />
+        <StatCard
+          title="Total Income"
+          value={formatCurrency(stats?.total_income ?? 0, 'GBP', 'en-GB')}
+          icon={<TrendingUp className="w-5 h-5" />}
+          color="success"
+        />
+        <StatCard
+          title="Total Expenses"
+          value={formatCurrency(stats?.total_expenses ?? 0, 'GBP', 'en-GB')}
+          icon={<TrendingDown className="w-5 h-5" />}
+          color="danger"
+        />
+      </div>
+
+      {/* Classification status */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <StatCard
+          title="Total Transactions"
+          value={stats?.total_transactions ?? 0}
+          icon={<ArrowLeftRight className="w-5 h-5" />}
+          color="primary"
+          onClick={() => router.push('/dashboard/tax/transactions')}
+        />
+        <StatCard
+          title="Classified"
+          value={stats?.classified_transactions ?? 0}
+          icon={<CheckCircle className="w-5 h-5" />}
+          color="success"
+        />
+        <StatCard
+          title="Unclassified"
+          value={stats?.unclassified_transactions ?? 0}
+          icon={<AlertCircle className="w-5 h-5" />}
+          color="warning"
+          onClick={() => router.push('/dashboard/tax/transactions')}
+        />
+      </div>
+
+      {/* Quick Actions */}
+      <div>
+        <h2 className="text-lg font-semibold text-secondary-900 mb-4">Quick Actions</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+          {quickActions.map((action) => (
+            <div
+              key={action.path}
+              onClick={() => router.push(action.path)}
+              className="bg-white rounded-xl border border-secondary-200 p-5 shadow-sm cursor-pointer hover:border-primary-300 hover:shadow-md transition-all"
+            >
+              <div className={`w-12 h-12 rounded-xl flex items-center justify-center ${action.color} mb-3`}>
+                {action.icon}
+              </div>
+              <h3 className="font-semibold text-secondary-900">{action.title}</h3>
+              <p className="text-sm text-secondary-500 mt-1">{action.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Workflow guide */}
+      <div className="bg-blue-50 border border-blue-200 rounded-xl p-6">
+        <h3 className="font-semibold text-blue-900 flex items-center gap-2">
+          <Calculator className="w-5 h-5" />
+          How it works
+        </h3>
+        <ol className="mt-3 space-y-2 text-sm text-blue-800">
+          <li className="flex items-start gap-2">
+            <span className="font-bold min-w-[20px]">1.</span>
+            <span>Add your bank accounts under <strong>Bank Accounts</strong></span>
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="font-bold min-w-[20px]">2.</span>
+            <span>Upload bank statements (PDF, CSV, or image) under <strong>Statements</strong></span>
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="font-bold min-w-[20px]">3.</span>
+            <span>AI automatically extracts and classifies your transactions</span>
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="font-bold min-w-[20px]">4.</span>
+            <span>Review classifications under <strong>Transactions</strong> and verify</span>
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="font-bold min-w-[20px]">5.</span>
+            <span>View your tax summary and HMRC box mapping under <strong>Reports</strong></span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  );
+}
+
+export default function TaxDashboardPage() {
+  return (
+    <ProtectedPage module="tax_transactions" title="Tax Returns">
+      <TaxDashboardContent />
+    </ProtectedPage>
+  );
+}

--- a/opsapi-dashboard/app/dashboard/tax/reports/page.tsx
+++ b/opsapi-dashboard/app/dashboard/tax/reports/page.tsx
@@ -1,0 +1,427 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  BarChart3,
+  PieChart,
+  TrendingUp,
+  Calculator,
+  RefreshCw,
+  Loader2,
+  ChevronDown,
+} from 'lucide-react';
+import { Card } from '@/components/ui';
+import { ProtectedPage } from '@/components/permissions';
+import {
+  taxService,
+  type TaxReportCategoryBreakdown,
+  type TaxReportHmrcBoxes,
+  type TaxReportMonthlyTrend,
+  type TaxCalculation,
+} from '@/services/tax.service';
+import { formatCurrency } from '@/lib/utils';
+import toast from 'react-hot-toast';
+
+type TabId = 'categories' | 'hmrc' | 'trends' | 'calculation';
+
+function ReportsContent() {
+  const [activeTab, setActiveTab] = useState<TabId>('categories');
+  const [taxYear, setTaxYear] = useState('2025');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const [categoryBreakdown, setCategoryBreakdown] = useState<TaxReportCategoryBreakdown[]>([]);
+  const [hmrcBoxes, setHmrcBoxes] = useState<TaxReportHmrcBoxes[]>([]);
+  const [monthlyTrend, setMonthlyTrend] = useState<TaxReportMonthlyTrend[]>([]);
+  const [taxCalculation, setTaxCalculation] = useState<TaxCalculation | null>(null);
+
+  const fetchData = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      switch (activeTab) {
+        case 'categories': {
+          const data = await taxService.getCategoryBreakdown(taxYear);
+          setCategoryBreakdown(Array.isArray(data) ? data : []);
+          break;
+        }
+        case 'hmrc': {
+          const data = await taxService.getHmrcBoxes(taxYear);
+          setHmrcBoxes(Array.isArray(data) ? data : []);
+          break;
+        }
+        case 'trends': {
+          const data = await taxService.getMonthlyTrend(taxYear);
+          setMonthlyTrend(Array.isArray(data) ? data : []);
+          break;
+        }
+        case 'calculation': {
+          const data = await taxService.getTaxCalculation(taxYear);
+          setTaxCalculation(data);
+          break;
+        }
+      }
+    } catch {
+      toast.error('Failed to load report data');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [activeTab, taxYear]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const tabs: { id: TabId; label: string; icon: React.ReactNode }[] = [
+    { id: 'categories', label: 'Category Breakdown', icon: <PieChart className="w-4 h-4" /> },
+    { id: 'hmrc', label: 'HMRC Boxes', icon: <BarChart3 className="w-4 h-4" /> },
+    { id: 'trends', label: 'Monthly Trends', icon: <TrendingUp className="w-4 h-4" /> },
+    { id: 'calculation', label: 'Tax Calculation', icon: <Calculator className="w-4 h-4" /> },
+  ];
+
+  const currentYear = new Date().getFullYear();
+  const taxYears = Array.from({ length: 5 }, (_, i) => String(currentYear - i));
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-secondary-900">Tax Reports</h1>
+        <div className="flex items-center gap-3">
+          <select
+            value={taxYear}
+            onChange={(e) => setTaxYear(e.target.value)}
+            className="px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+          >
+            {taxYears.map((y) => (
+              <option key={y} value={y}>Tax Year {y}/{Number(y) + 1}</option>
+            ))}
+          </select>
+          <button
+            onClick={fetchData}
+            className="p-2 text-secondary-600 hover:bg-secondary-100 rounded-lg"
+          >
+            <RefreshCw className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="border-b border-secondary-200">
+        <nav className="flex gap-1 -mb-px">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`flex items-center gap-2 px-4 py-3 text-sm font-medium border-b-2 transition-colors ${
+                activeTab === tab.id
+                  ? 'border-primary-500 text-primary-600'
+                  : 'border-transparent text-secondary-500 hover:text-secondary-700 hover:border-secondary-300'
+              }`}
+            >
+              {tab.icon}
+              {tab.label}
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      {/* Loading */}
+      {isLoading && (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="w-8 h-8 text-primary-500 animate-spin" />
+        </div>
+      )}
+
+      {/* Category Breakdown */}
+      {!isLoading && activeTab === 'categories' && (
+        <div>
+          {categoryBreakdown.length === 0 ? (
+            <div className="text-center py-12 text-secondary-500">
+              No categorised transactions for this tax year. Upload statements and classify transactions first.
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {/* Summary */}
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div className="bg-green-50 rounded-xl p-4 border border-green-200">
+                  <p className="text-sm text-green-700">Total Income</p>
+                  <p className="text-2xl font-bold text-green-800">
+                    {formatCurrency(
+                      categoryBreakdown.filter((c) => c.category_type === 'income').reduce((s, c) => s + Number(c.total_amount), 0),
+                      'GBP', 'en-GB'
+                    )}
+                  </p>
+                </div>
+                <div className="bg-red-50 rounded-xl p-4 border border-red-200">
+                  <p className="text-sm text-red-700">Total Expenses</p>
+                  <p className="text-2xl font-bold text-red-800">
+                    {formatCurrency(
+                      categoryBreakdown.filter((c) => c.category_type === 'expense').reduce((s, c) => s + Number(c.total_amount), 0),
+                      'GBP', 'en-GB'
+                    )}
+                  </p>
+                </div>
+                <div className="bg-blue-50 rounded-xl p-4 border border-blue-200">
+                  <p className="text-sm text-blue-700">Tax Deductible</p>
+                  <p className="text-2xl font-bold text-blue-800">
+                    {formatCurrency(
+                      categoryBreakdown.filter((c) => c.is_deductible).reduce((s, c) => s + Number(c.total_amount), 0),
+                      'GBP', 'en-GB'
+                    )}
+                  </p>
+                </div>
+              </div>
+
+              {/* Table */}
+              <div className="bg-white rounded-xl border border-secondary-200 overflow-hidden">
+                <table className="w-full">
+                  <thead>
+                    <tr className="bg-secondary-50 border-b border-secondary-200">
+                      <th className="px-6 py-3 text-left text-xs font-semibold text-secondary-600 uppercase">Category</th>
+                      <th className="px-6 py-3 text-left text-xs font-semibold text-secondary-600 uppercase">Type</th>
+                      <th className="px-6 py-3 text-right text-xs font-semibold text-secondary-600 uppercase">Amount</th>
+                      <th className="px-6 py-3 text-right text-xs font-semibold text-secondary-600 uppercase">Count</th>
+                      <th className="px-6 py-3 text-center text-xs font-semibold text-secondary-600 uppercase">Deductible</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-secondary-100">
+                    {categoryBreakdown.map((cat, i) => (
+                      <tr key={i} className="hover:bg-secondary-50">
+                        <td className="px-6 py-3 text-sm font-medium">{cat.category_name}</td>
+                        <td className="px-6 py-3">
+                          <span className={`text-xs px-2 py-0.5 rounded-full ${
+                            cat.category_type === 'income' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'
+                          }`}>
+                            {cat.category_type}
+                          </span>
+                        </td>
+                        <td className="px-6 py-3 text-sm text-right font-medium">
+                          {formatCurrency(Number(cat.total_amount), 'GBP', 'en-GB')}
+                        </td>
+                        <td className="px-6 py-3 text-sm text-right text-secondary-500">{cat.transaction_count}</td>
+                        <td className="px-6 py-3 text-center">
+                          {cat.is_deductible ? (
+                            <span className="text-green-600 text-xs">Yes</span>
+                          ) : (
+                            <span className="text-secondary-400 text-xs">No</span>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* HMRC Boxes */}
+      {!isLoading && activeTab === 'hmrc' && (
+        <div>
+          {hmrcBoxes.length === 0 ? (
+            <div className="text-center py-12 text-secondary-500">
+              No HMRC box data available. Classify your transactions first.
+            </div>
+          ) : (
+            <div className="bg-white rounded-xl border border-secondary-200 overflow-hidden">
+              <div className="p-4 border-b border-secondary-200 bg-secondary-50">
+                <h3 className="font-semibold text-secondary-900">SA103F Self-Employment (Full)</h3>
+                <p className="text-sm text-secondary-500">Tax Year {taxYear}/{Number(taxYear) + 1}</p>
+              </div>
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b border-secondary-200">
+                    <th className="px-6 py-3 text-left text-xs font-semibold text-secondary-600 uppercase">Box</th>
+                    <th className="px-6 py-3 text-left text-xs font-semibold text-secondary-600 uppercase">Description</th>
+                    <th className="px-6 py-3 text-right text-xs font-semibold text-secondary-600 uppercase">Amount</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-secondary-100">
+                  {hmrcBoxes.map((box, i) => (
+                    <tr key={i} className="hover:bg-secondary-50">
+                      <td className="px-6 py-3 text-sm font-mono font-bold text-primary-600">{box.box_number}</td>
+                      <td className="px-6 py-3 text-sm">{box.box_name}</td>
+                      <td className="px-6 py-3 text-sm text-right font-medium">
+                        {formatCurrency(Number(box.amount), 'GBP', 'en-GB')}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Monthly Trends */}
+      {!isLoading && activeTab === 'trends' && (
+        <div>
+          {monthlyTrend.length === 0 ? (
+            <div className="text-center py-12 text-secondary-500">
+              No monthly trend data available for this tax year.
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div className="bg-white rounded-xl border border-secondary-200 overflow-hidden">
+                <table className="w-full">
+                  <thead>
+                    <tr className="bg-secondary-50 border-b border-secondary-200">
+                      <th className="px-6 py-3 text-left text-xs font-semibold text-secondary-600 uppercase">Month</th>
+                      <th className="px-6 py-3 text-right text-xs font-semibold text-secondary-600 uppercase">Income</th>
+                      <th className="px-6 py-3 text-right text-xs font-semibold text-secondary-600 uppercase">Expenses</th>
+                      <th className="px-6 py-3 text-right text-xs font-semibold text-secondary-600 uppercase">Net</th>
+                      <th className="px-6 py-3 text-left text-xs font-semibold text-secondary-600 uppercase">Bar</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-secondary-100">
+                    {monthlyTrend.map((month, i) => {
+                      const maxVal = Math.max(...monthlyTrend.map((m) => Math.max(Number(m.income), Number(m.expenses))));
+                      const incomeWidth = maxVal > 0 ? (Number(month.income) / maxVal) * 100 : 0;
+                      const expenseWidth = maxVal > 0 ? (Number(month.expenses) / maxVal) * 100 : 0;
+                      return (
+                        <tr key={i} className="hover:bg-secondary-50">
+                          <td className="px-6 py-3 text-sm font-medium">{month.month}</td>
+                          <td className="px-6 py-3 text-sm text-right text-green-600">
+                            {formatCurrency(Number(month.income), 'GBP', 'en-GB')}
+                          </td>
+                          <td className="px-6 py-3 text-sm text-right text-red-600">
+                            {formatCurrency(Number(month.expenses), 'GBP', 'en-GB')}
+                          </td>
+                          <td className={`px-6 py-3 text-sm text-right font-medium ${Number(month.net) >= 0 ? 'text-green-700' : 'text-red-700'}`}>
+                            {formatCurrency(Number(month.net), 'GBP', 'en-GB')}
+                          </td>
+                          <td className="px-6 py-3 w-48">
+                            <div className="space-y-1">
+                              <div className="h-2 bg-green-200 rounded-full overflow-hidden">
+                                <div className="h-full bg-green-500 rounded-full" style={{ width: `${incomeWidth}%` }} />
+                              </div>
+                              <div className="h-2 bg-red-200 rounded-full overflow-hidden">
+                                <div className="h-full bg-red-500 rounded-full" style={{ width: `${expenseWidth}%` }} />
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Tax Calculation */}
+      {!isLoading && activeTab === 'calculation' && (
+        <div>
+          {!taxCalculation ? (
+            <div className="text-center py-12 text-secondary-500">
+              No tax calculation available. Classify your transactions first.
+            </div>
+          ) : (
+            <div className="space-y-6">
+              {/* Summary cards */}
+              <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+                <div className="bg-white rounded-xl border border-secondary-200 p-5">
+                  <p className="text-sm text-secondary-500">Total Income</p>
+                  <p className="text-2xl font-bold text-secondary-900">
+                    {formatCurrency(Number(taxCalculation.total_income), 'GBP', 'en-GB')}
+                  </p>
+                </div>
+                <div className="bg-white rounded-xl border border-secondary-200 p-5">
+                  <p className="text-sm text-secondary-500">Allowable Expenses</p>
+                  <p className="text-2xl font-bold text-secondary-900">
+                    {formatCurrency(Number(taxCalculation.total_expenses), 'GBP', 'en-GB')}
+                  </p>
+                </div>
+                <div className="bg-white rounded-xl border border-secondary-200 p-5">
+                  <p className="text-sm text-secondary-500">Taxable Income</p>
+                  <p className="text-2xl font-bold text-secondary-900">
+                    {formatCurrency(Number(taxCalculation.taxable_income), 'GBP', 'en-GB')}
+                  </p>
+                </div>
+                <div className="bg-primary-50 rounded-xl border border-primary-200 p-5">
+                  <p className="text-sm text-primary-700">Total Tax Due</p>
+                  <p className="text-2xl font-bold text-primary-900">
+                    {formatCurrency(Number(taxCalculation.total_due), 'GBP', 'en-GB')}
+                  </p>
+                </div>
+              </div>
+
+              {/* Tax bands */}
+              {taxCalculation.tax_bands && taxCalculation.tax_bands.length > 0 && (
+                <div className="bg-white rounded-xl border border-secondary-200 overflow-hidden">
+                  <div className="p-4 border-b border-secondary-200 bg-secondary-50">
+                    <h3 className="font-semibold text-secondary-900">Income Tax Bands</h3>
+                  </div>
+                  <table className="w-full">
+                    <thead>
+                      <tr className="border-b border-secondary-200">
+                        <th className="px-6 py-3 text-left text-xs font-semibold text-secondary-600 uppercase">Band</th>
+                        <th className="px-6 py-3 text-right text-xs font-semibold text-secondary-600 uppercase">Rate</th>
+                        <th className="px-6 py-3 text-right text-xs font-semibold text-secondary-600 uppercase">Taxable Amount</th>
+                        <th className="px-6 py-3 text-right text-xs font-semibold text-secondary-600 uppercase">Tax</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-secondary-100">
+                      {taxCalculation.tax_bands.map((band, i) => (
+                        <tr key={i} className="hover:bg-secondary-50">
+                          <td className="px-6 py-3 text-sm font-medium">{band.band}</td>
+                          <td className="px-6 py-3 text-sm text-right">{band.rate}%</td>
+                          <td className="px-6 py-3 text-sm text-right">
+                            {formatCurrency(Number(band.taxable_amount), 'GBP', 'en-GB')}
+                          </td>
+                          <td className="px-6 py-3 text-sm text-right font-medium">
+                            {formatCurrency(Number(band.tax_amount), 'GBP', 'en-GB')}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                    <tfoot>
+                      <tr className="bg-secondary-50 border-t border-secondary-200">
+                        <td className="px-6 py-3 text-sm font-bold" colSpan={3}>Income Tax</td>
+                        <td className="px-6 py-3 text-sm text-right font-bold">
+                          {formatCurrency(Number(taxCalculation.total_tax), 'GBP', 'en-GB')}
+                        </td>
+                      </tr>
+                      {taxCalculation.national_insurance != null && (
+                        <tr className="bg-secondary-50">
+                          <td className="px-6 py-3 text-sm font-bold" colSpan={3}>National Insurance (Class 4)</td>
+                          <td className="px-6 py-3 text-sm text-right font-bold">
+                            {formatCurrency(Number(taxCalculation.national_insurance), 'GBP', 'en-GB')}
+                          </td>
+                        </tr>
+                      )}
+                      <tr className="bg-primary-50">
+                        <td className="px-6 py-3 text-sm font-bold text-primary-900" colSpan={3}>Total Due</td>
+                        <td className="px-6 py-3 text-sm text-right font-bold text-primary-900">
+                          {formatCurrency(Number(taxCalculation.total_due), 'GBP', 'en-GB')}
+                        </td>
+                      </tr>
+                    </tfoot>
+                  </table>
+                </div>
+              )}
+
+              {/* Disclaimer */}
+              <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 text-sm text-amber-800">
+                <strong>Disclaimer:</strong> This is an estimate based on classified transactions.
+                Always verify with a qualified accountant before filing with HMRC. Personal allowance
+                ({formatCurrency(Number(taxCalculation.personal_allowance), 'GBP', 'en-GB')}) is
+                applied automatically.
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function ReportsPage() {
+  return (
+    <ProtectedPage module="tax_transactions" title="Tax Reports">
+      <ReportsContent />
+    </ProtectedPage>
+  );
+}

--- a/opsapi-dashboard/app/dashboard/tax/statements/page.tsx
+++ b/opsapi-dashboard/app/dashboard/tax/statements/page.tsx
@@ -1,0 +1,427 @@
+'use client';
+
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import {
+  Search,
+  Upload,
+  FileText,
+  Trash2,
+  Play,
+  RefreshCw,
+  CheckCircle,
+  Clock,
+  AlertCircle,
+  Loader2,
+  FileUp,
+} from 'lucide-react';
+import { Input, Table, Card, Modal, Pagination } from '@/components/ui';
+import { ProtectedPage } from '@/components/permissions';
+import {
+  taxService,
+  type TaxStatement,
+  type TaxBankAccount,
+  type TaxStatementFilters,
+} from '@/services/tax.service';
+import { formatDate, formatCurrency } from '@/lib/utils';
+import type { TableColumn } from '@/types';
+import toast from 'react-hot-toast';
+
+const STATUS_CONFIG: Record<string, { label: string; classes: string; icon: React.ReactNode }> = {
+  uploaded: { label: 'Uploaded', classes: 'bg-blue-100 text-blue-700', icon: <FileUp className="w-3 h-3" /> },
+  processing: { label: 'Processing', classes: 'bg-amber-100 text-amber-700', icon: <Loader2 className="w-3 h-3 animate-spin" /> },
+  extracted: { label: 'Extracted', classes: 'bg-purple-100 text-purple-700', icon: <CheckCircle className="w-3 h-3" /> },
+  classified: { label: 'Classified', classes: 'bg-green-100 text-green-700', icon: <CheckCircle className="w-3 h-3" /> },
+  error: { label: 'Error', classes: 'bg-red-100 text-red-700', icon: <AlertCircle className="w-3 h-3" /> },
+};
+
+function StatementsContent() {
+  const [statements, setStatements] = useState<TaxStatement[]>([]);
+  const [bankAccounts, setBankAccounts] = useState<TaxBankAccount[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const perPage = 20;
+
+  const [showUploadModal, setShowUploadModal] = useState(false);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [selectedBankAccountId, setSelectedBankAccountId] = useState<number | ''>('');
+  const [statementDate, setStatementDate] = useState('');
+  const [isUploading, setIsUploading] = useState(false);
+  const [processingId, setProcessingId] = useState<number | null>(null);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const fetchIdRef = useRef(0);
+
+  const fetchStatements = useCallback(async () => {
+    const fetchId = ++fetchIdRef.current;
+    setIsLoading(true);
+    try {
+      const result = await taxService.getStatements({ page, per_page: perPage });
+      if (fetchId === fetchIdRef.current) {
+        setStatements(result.data);
+        setTotal(result.total);
+      }
+    } catch {
+      toast.error('Failed to load statements');
+    } finally {
+      if (fetchId === fetchIdRef.current) setIsLoading(false);
+    }
+  }, [page]);
+
+  const fetchBankAccounts = useCallback(async () => {
+    try {
+      const data = await taxService.getBankAccounts();
+      setBankAccounts(data);
+    } catch {
+      // Silently fail - user can still view statements
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchStatements();
+    fetchBankAccounts();
+  }, [fetchStatements, fetchBankAccounts]);
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const maxSize = 25 * 1024 * 1024; // 25MB
+    if (file.size > maxSize) {
+      toast.error('File size exceeds 25MB limit');
+      return;
+    }
+
+    const allowedTypes = ['application/pdf', 'text/csv', 'image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+    if (!allowedTypes.includes(file.type) && !file.name.endsWith('.csv')) {
+      toast.error('Unsupported file type. Use PDF, CSV, JPG, PNG, GIF, or WebP.');
+      return;
+    }
+
+    setSelectedFile(file);
+  };
+
+  const handleUpload = async () => {
+    if (!selectedFile) {
+      toast.error('Please select a file');
+      return;
+    }
+    if (!selectedBankAccountId) {
+      toast.error('Please select a bank account');
+      return;
+    }
+
+    setIsUploading(true);
+    try {
+      await taxService.uploadStatement(selectedFile, Number(selectedBankAccountId), statementDate || undefined);
+      toast.success('Statement uploaded successfully');
+      setShowUploadModal(false);
+      setSelectedFile(null);
+      setSelectedBankAccountId('');
+      setStatementDate('');
+      if (fileInputRef.current) fileInputRef.current.value = '';
+      fetchStatements();
+    } catch (err: unknown) {
+      const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error || 'Upload failed';
+      toast.error(msg);
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const handleExtract = async (statement: TaxStatement) => {
+    setProcessingId(statement.id);
+    try {
+      const result = await taxService.extractTransactions(statement.id);
+      toast.success(result.message || 'Extraction started');
+      fetchStatements();
+    } catch {
+      toast.error('Failed to extract transactions');
+    } finally {
+      setProcessingId(null);
+    }
+  };
+
+  const handleClassify = async (statement: TaxStatement) => {
+    setProcessingId(statement.id);
+    try {
+      const result = await taxService.classifyTransactions(statement.id);
+      toast.success(result.message || 'Classification started');
+      fetchStatements();
+    } catch {
+      toast.error('Failed to classify transactions');
+    } finally {
+      setProcessingId(null);
+    }
+  };
+
+  const handleDelete = async (statement: TaxStatement) => {
+    if (!confirm('Delete this statement and all its transactions? This cannot be undone.')) return;
+    try {
+      await taxService.deleteStatement(statement.uuid);
+      toast.success('Statement deleted');
+      fetchStatements();
+    } catch {
+      toast.error('Failed to delete statement');
+    }
+  };
+
+  const columns: TableColumn<TaxStatement>[] = [
+    {
+      key: 'file_name',
+      header: 'File',
+      render: (item) => (
+        <div className="flex items-center gap-2">
+          <FileText className="w-4 h-4 text-secondary-400" />
+          <div>
+            <p className="font-medium text-sm">{item.file_name || 'Unknown'}</p>
+            {item.file_size && (
+              <p className="text-xs text-secondary-400">
+                {(item.file_size / 1024).toFixed(1)} KB
+              </p>
+            )}
+          </div>
+        </div>
+      ),
+    },
+    {
+      key: 'bank_name',
+      header: 'Bank',
+      render: (item) => item.bank_name || '-',
+    },
+    {
+      key: 'statement_date',
+      header: 'Statement Date',
+      render: (item) => item.statement_date ? formatDate(item.statement_date) : '-',
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      render: (item) => {
+        const config = STATUS_CONFIG[item.status] || STATUS_CONFIG.uploaded;
+        return (
+          <span className={`inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-medium ${config.classes}`}>
+            {config.icon}
+            {config.label}
+          </span>
+        );
+      },
+    },
+    {
+      key: 'transaction_count',
+      header: 'Transactions',
+      render: (item) => item.transaction_count ?? '-',
+    },
+    {
+      key: 'created_at',
+      header: 'Uploaded',
+      render: (item) => formatDate(item.created_at),
+    },
+    {
+      key: 'actions',
+      header: '',
+      width: 'w-36',
+      render: (item) => (
+        <div className="flex items-center gap-1">
+          {item.status === 'uploaded' && (
+            <button
+              onClick={(e) => { e.stopPropagation(); handleExtract(item); }}
+              disabled={processingId === item.id}
+              className="p-1.5 rounded-lg hover:bg-blue-50 text-blue-600 disabled:opacity-50"
+              title="Extract transactions"
+            >
+              {processingId === item.id ? <Loader2 className="w-4 h-4 animate-spin" /> : <Play className="w-4 h-4" />}
+            </button>
+          )}
+          {item.status === 'extracted' && (
+            <button
+              onClick={(e) => { e.stopPropagation(); handleClassify(item); }}
+              disabled={processingId === item.id}
+              className="px-2 py-1 text-xs rounded-lg bg-purple-50 text-purple-700 hover:bg-purple-100 disabled:opacity-50"
+              title="Classify transactions"
+            >
+              {processingId === item.id ? 'Processing...' : 'Classify'}
+            </button>
+          )}
+          <button
+            onClick={(e) => { e.stopPropagation(); handleDelete(item); }}
+            className="p-1.5 rounded-lg hover:bg-red-50 text-secondary-500 hover:text-red-600"
+          >
+            <Trash2 className="w-4 h-4" />
+          </button>
+        </div>
+      ),
+    },
+  ];
+
+  const totalPages = Math.ceil(total / perPage);
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-secondary-900">Bank Statements</h1>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={fetchStatements}
+            className="p-2 text-secondary-600 hover:bg-secondary-100 rounded-lg"
+          >
+            <RefreshCw className="w-4 h-4" />
+          </button>
+          <button
+            onClick={() => setShowUploadModal(true)}
+            className="flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700"
+          >
+            <Upload className="w-4 h-4" />
+            Upload Statement
+          </button>
+        </div>
+      </div>
+
+      {/* Info banner */}
+      {bankAccounts.length === 0 && !isLoading && (
+        <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 flex items-start gap-3">
+          <AlertCircle className="w-5 h-5 text-amber-600 mt-0.5 shrink-0" />
+          <div>
+            <p className="font-medium text-amber-800">No bank accounts yet</p>
+            <p className="text-sm text-amber-700 mt-1">
+              You need to add a bank account before uploading statements.{' '}
+              <a href="/dashboard/tax/bank-accounts" className="underline font-medium">Add one now</a>
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Table */}
+      <Table
+        columns={columns}
+        data={statements}
+        keyExtractor={(item) => item.uuid || String(item.id)}
+        isLoading={isLoading}
+        emptyMessage="No statements uploaded yet. Click 'Upload Statement' to get started."
+      />
+
+      {totalPages > 1 && (
+        <Pagination
+          currentPage={page}
+          totalPages={totalPages}
+          onPageChange={setPage}
+          totalItems={total}
+          perPage={perPage}
+        />
+      )}
+
+      {/* Upload Modal */}
+      {showUploadModal && (
+        <Modal
+          isOpen={showUploadModal}
+          onClose={() => {
+            setShowUploadModal(false);
+            setSelectedFile(null);
+            setSelectedBankAccountId('');
+            setStatementDate('');
+          }}
+          title="Upload Bank Statement"
+        >
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-secondary-700 mb-1">Bank Account *</label>
+              <select
+                value={selectedBankAccountId}
+                onChange={(e) => setSelectedBankAccountId(e.target.value ? Number(e.target.value) : '')}
+                className="w-full px-3 py-2 border border-secondary-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+              >
+                <option value="">Select a bank account...</option>
+                {bankAccounts.map((acc) => (
+                  <option key={acc.id} value={acc.id}>
+                    {acc.bank_name} {acc.account_number ? `(****${acc.account_number.slice(-4)})` : ''}
+                  </option>
+                ))}
+              </select>
+              {bankAccounts.length === 0 && (
+                <p className="text-xs text-amber-600 mt-1">
+                  No bank accounts found. <a href="/dashboard/tax/bank-accounts" className="underline">Add one first.</a>
+                </p>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-secondary-700 mb-1">Statement Date</label>
+              <input
+                type="date"
+                value={statementDate}
+                onChange={(e) => setStatementDate(e.target.value)}
+                className="w-full px-3 py-2 border border-secondary-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-secondary-700 mb-1">File *</label>
+              <div className="border-2 border-dashed border-secondary-300 rounded-lg p-6 text-center hover:border-primary-400 transition-colors">
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".pdf,.csv,.jpg,.jpeg,.png,.gif,.webp"
+                  onChange={handleFileSelect}
+                  className="hidden"
+                  id="statement-file"
+                />
+                <label htmlFor="statement-file" className="cursor-pointer">
+                  <Upload className="w-8 h-8 text-secondary-400 mx-auto mb-2" />
+                  {selectedFile ? (
+                    <div>
+                      <p className="font-medium text-secondary-900">{selectedFile.name}</p>
+                      <p className="text-xs text-secondary-500">{(selectedFile.size / 1024).toFixed(1)} KB</p>
+                    </div>
+                  ) : (
+                    <div>
+                      <p className="text-secondary-600">Click to select a file</p>
+                      <p className="text-xs text-secondary-400 mt-1">PDF, CSV, JPG, PNG, GIF, WebP (max 25MB)</p>
+                    </div>
+                  )}
+                </label>
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-3 pt-2">
+              <button
+                onClick={() => {
+                  setShowUploadModal(false);
+                  setSelectedFile(null);
+                }}
+                className="px-4 py-2 text-secondary-600 hover:bg-secondary-100 rounded-lg"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleUpload}
+                disabled={isUploading || !selectedFile || !selectedBankAccountId}
+                className="flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50"
+              >
+                {isUploading ? (
+                  <>
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    Uploading...
+                  </>
+                ) : (
+                  <>
+                    <Upload className="w-4 h-4" />
+                    Upload
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+}
+
+export default function StatementsPage() {
+  return (
+    <ProtectedPage module="tax_statements" title="Tax Statements">
+      <StatementsContent />
+    </ProtectedPage>
+  );
+}

--- a/opsapi-dashboard/app/dashboard/tax/transactions/page.tsx
+++ b/opsapi-dashboard/app/dashboard/tax/transactions/page.tsx
@@ -1,0 +1,324 @@
+'use client';
+
+import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import {
+  Search,
+  ArrowLeftRight,
+  Filter,
+  RefreshCw,
+  CheckCircle,
+  XCircle,
+  ChevronDown,
+  TrendingUp,
+  TrendingDown,
+  Loader2,
+} from 'lucide-react';
+import { Input, Table, Card, Pagination } from '@/components/ui';
+import { ProtectedPage } from '@/components/permissions';
+import {
+  taxService,
+  type TaxTransaction,
+  type TaxTransactionFilters,
+  type TaxCategory,
+} from '@/services/tax.service';
+import { formatDate, formatCurrency } from '@/lib/utils';
+import type { TableColumn } from '@/types';
+import toast from 'react-hot-toast';
+
+function TransactionsContent() {
+  const [transactions, setTransactions] = useState<TaxTransaction[]>([]);
+  const [categories, setCategories] = useState<TaxCategory[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [typeFilter, setTypeFilter] = useState<string>('all');
+  const [verifiedFilter, setVerifiedFilter] = useState<string>('all');
+  const [showFilters, setShowFilters] = useState(false);
+  const [editingTxn, setEditingTxn] = useState<string | null>(null);
+  const [editCategory, setEditCategory] = useState<string>('');
+  const perPage = 25;
+  const fetchIdRef = useRef(0);
+
+  const fetchTransactions = useCallback(async () => {
+    const fetchId = ++fetchIdRef.current;
+    setIsLoading(true);
+    try {
+      const filters: TaxTransactionFilters = {
+        page,
+        per_page: perPage,
+        search: searchQuery || undefined,
+        transaction_type: typeFilter !== 'all' ? typeFilter : undefined,
+        is_verified: verifiedFilter !== 'all' ? verifiedFilter === 'true' : undefined,
+      };
+      const result = await taxService.getTransactions(filters);
+      if (fetchId === fetchIdRef.current) {
+        setTransactions(result.data);
+        setTotal(result.total);
+      }
+    } catch {
+      toast.error('Failed to load transactions');
+    } finally {
+      if (fetchId === fetchIdRef.current) setIsLoading(false);
+    }
+  }, [page, searchQuery, typeFilter, verifiedFilter]);
+
+  const fetchCategories = useCallback(async () => {
+    try {
+      const data = await taxService.getCategories();
+      setCategories(data);
+    } catch {
+      // Categories might not be seeded yet
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchTransactions();
+  }, [fetchTransactions]);
+
+  useEffect(() => {
+    fetchCategories();
+  }, [fetchCategories]);
+
+  const handleVerify = async (txn: TaxTransaction) => {
+    try {
+      await taxService.updateTransaction(txn.uuid, { is_verified: !txn.is_verified });
+      toast.success(txn.is_verified ? 'Unverified' : 'Verified');
+      fetchTransactions();
+    } catch {
+      toast.error('Failed to update transaction');
+    }
+  };
+
+  const handleCategoryChange = async (txn: TaxTransaction, categoryId: string) => {
+    try {
+      await taxService.updateTransaction(txn.uuid, { category_id: Number(categoryId) } as Partial<TaxTransaction>);
+      toast.success('Category updated');
+      setEditingTxn(null);
+      fetchTransactions();
+    } catch {
+      toast.error('Failed to update category');
+    }
+  };
+
+  const stats = useMemo(() => {
+    const income = transactions.filter((t) => t.transaction_type === 'credit').reduce((sum, t) => sum + Math.abs(Number(t.amount)), 0);
+    const expenses = transactions.filter((t) => t.transaction_type === 'debit').reduce((sum, t) => sum + Math.abs(Number(t.amount)), 0);
+    const verified = transactions.filter((t) => t.is_verified).length;
+    return { income, expenses, verified, total: transactions.length };
+  }, [transactions]);
+
+  const columns: TableColumn<TaxTransaction>[] = [
+    {
+      key: 'transaction_date',
+      header: 'Date',
+      sortable: true,
+      width: 'w-28',
+      render: (item) => (
+        <span className="text-sm">{formatDate(item.transaction_date)}</span>
+      ),
+    },
+    {
+      key: 'description',
+      header: 'Description',
+      render: (item) => (
+        <div className="max-w-xs">
+          <p className="text-sm font-medium truncate">{item.description}</p>
+          {item.notes && <p className="text-xs text-secondary-400 truncate">{item.notes}</p>}
+        </div>
+      ),
+    },
+    {
+      key: 'amount',
+      header: 'Amount',
+      sortable: true,
+      render: (item) => {
+        const isCredit = item.transaction_type === 'credit';
+        return (
+          <div className="flex items-center gap-1">
+            {isCredit ? (
+              <TrendingUp className="w-3 h-3 text-green-500" />
+            ) : (
+              <TrendingDown className="w-3 h-3 text-red-500" />
+            )}
+            <span className={`font-medium ${isCredit ? 'text-green-700' : 'text-red-700'}`}>
+              {isCredit ? '+' : '-'}{formatCurrency(Math.abs(Number(item.amount)), 'GBP', 'en-GB')}
+            </span>
+          </div>
+        );
+      },
+    },
+    {
+      key: 'category_name',
+      header: 'Category',
+      render: (item) => {
+        if (editingTxn === item.uuid) {
+          return (
+            <select
+              value={editCategory}
+              onChange={(e) => {
+                setEditCategory(e.target.value);
+                handleCategoryChange(item, e.target.value);
+              }}
+              onBlur={() => setEditingTxn(null)}
+              autoFocus
+              className="text-xs px-2 py-1 border rounded focus:ring-1 focus:ring-primary-500 max-w-[150px]"
+            >
+              <option value="">Select...</option>
+              {categories.map((cat) => (
+                <option key={cat.id} value={cat.id}>{cat.name}</option>
+              ))}
+            </select>
+          );
+        }
+
+        return (
+          <button
+            onClick={() => { setEditingTxn(item.uuid); setEditCategory(String(item.category_id || '')); }}
+            className="text-xs px-2 py-1 rounded hover:bg-secondary-100 text-left max-w-[150px] truncate"
+          >
+            {item.category_name || (
+              <span className="text-secondary-400 italic">Unclassified</span>
+            )}
+            {item.confidence != null && (
+              <span className={`ml-1 text-[10px] ${
+                item.confidence > 0.8 ? 'text-green-500' : item.confidence > 0.5 ? 'text-amber-500' : 'text-red-500'
+              }`}>
+                ({(item.confidence * 100).toFixed(0)}%)
+              </span>
+            )}
+          </button>
+        );
+      },
+    },
+    {
+      key: 'is_business',
+      header: 'Business',
+      width: 'w-20',
+      render: (item) => (
+        <span className={`text-xs px-2 py-0.5 rounded-full ${
+          item.is_business ? 'bg-green-100 text-green-700' : 'bg-secondary-100 text-secondary-500'
+        }`}>
+          {item.is_business ? 'Yes' : 'No'}
+        </span>
+      ),
+    },
+    {
+      key: 'is_verified',
+      header: 'Verified',
+      width: 'w-24',
+      render: (item) => (
+        <button
+          onClick={(e) => { e.stopPropagation(); handleVerify(item); }}
+          className={`flex items-center gap-1 text-xs px-2 py-0.5 rounded-full ${
+            item.is_verified ? 'bg-green-100 text-green-700 hover:bg-green-200' : 'bg-secondary-100 text-secondary-500 hover:bg-secondary-200'
+          }`}
+        >
+          {item.is_verified ? <CheckCircle className="w-3 h-3" /> : <XCircle className="w-3 h-3" />}
+          {item.is_verified ? 'Yes' : 'No'}
+        </button>
+      ),
+    },
+  ];
+
+  const totalPages = Math.ceil(total / perPage);
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-secondary-900">Transactions</h1>
+          <p className="text-sm text-secondary-500 mt-1">
+            {total} transactions {stats.verified > 0 && `(${stats.verified} verified)`}
+          </p>
+        </div>
+        <button
+          onClick={fetchTransactions}
+          className="p-2 text-secondary-600 hover:bg-secondary-100 rounded-lg"
+        >
+          <RefreshCw className="w-4 h-4" />
+        </button>
+      </div>
+
+      {/* Stats row */}
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        <div className="bg-white rounded-xl border border-secondary-200 p-4">
+          <p className="text-xs text-secondary-500">Page Income</p>
+          <p className="text-lg font-bold text-green-600">{formatCurrency(stats.income, 'GBP', 'en-GB')}</p>
+        </div>
+        <div className="bg-white rounded-xl border border-secondary-200 p-4">
+          <p className="text-xs text-secondary-500">Page Expenses</p>
+          <p className="text-lg font-bold text-red-600">{formatCurrency(stats.expenses, 'GBP', 'en-GB')}</p>
+        </div>
+        <div className="bg-white rounded-xl border border-secondary-200 p-4">
+          <p className="text-xs text-secondary-500">Verified</p>
+          <p className="text-lg font-bold text-secondary-900">{stats.verified} / {stats.total}</p>
+        </div>
+        <div className="bg-white rounded-xl border border-secondary-200 p-4">
+          <p className="text-xs text-secondary-500">Total Records</p>
+          <p className="text-lg font-bold text-secondary-900">{total}</p>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <Card padding="md">
+        <div className="flex flex-col md:flex-row gap-3">
+          <div className="flex-1">
+            <Input
+              placeholder="Search transactions..."
+              value={searchQuery}
+              onChange={(e) => { setSearchQuery(e.target.value); setPage(1); }}
+              leftIcon={<Search className="w-4 h-4" />}
+            />
+          </div>
+          <select
+            value={typeFilter}
+            onChange={(e) => { setTypeFilter(e.target.value); setPage(1); }}
+            className="px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+          >
+            <option value="all">All Types</option>
+            <option value="credit">Income (Credit)</option>
+            <option value="debit">Expense (Debit)</option>
+          </select>
+          <select
+            value={verifiedFilter}
+            onChange={(e) => { setVerifiedFilter(e.target.value); setPage(1); }}
+            className="px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+          >
+            <option value="all">All Status</option>
+            <option value="true">Verified</option>
+            <option value="false">Unverified</option>
+          </select>
+        </div>
+      </Card>
+
+      {/* Table */}
+      <Table
+        columns={columns}
+        data={transactions}
+        keyExtractor={(item) => item.uuid || String(item.id)}
+        isLoading={isLoading}
+        emptyMessage="No transactions found. Upload and extract a bank statement first."
+      />
+
+      {totalPages > 1 && (
+        <Pagination
+          currentPage={page}
+          totalPages={totalPages}
+          onPageChange={setPage}
+          totalItems={total}
+          perPage={perPage}
+        />
+      )}
+    </div>
+  );
+}
+
+export default function TransactionsPage() {
+  return (
+    <ProtectedPage module="tax_transactions" title="Tax Transactions">
+      <TransactionsContent />
+    </ProtectedPage>
+  );
+}

--- a/opsapi-dashboard/services/tax.service.ts
+++ b/opsapi-dashboard/services/tax.service.ts
@@ -1,0 +1,350 @@
+import apiClient, { buildQueryString } from '@/lib/api-client';
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+export interface TaxBankAccount {
+  id: number;
+  uuid: string;
+  user_id: number;
+  namespace_id: number;
+  bank_name: string;
+  account_number?: string;
+  sort_code?: string;
+  account_type?: string;
+  currency?: string;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TaxStatement {
+  id: number;
+  uuid: string;
+  bank_account_id: number;
+  user_id: number;
+  namespace_id: number;
+  file_url?: string;
+  file_name?: string;
+  file_type?: string;
+  file_size?: number;
+  statement_date?: string;
+  start_date?: string;
+  end_date?: string;
+  status: 'uploaded' | 'processing' | 'extracted' | 'classified' | 'error';
+  transaction_count?: number;
+  error_message?: string;
+  created_at: string;
+  updated_at: string;
+  bank_name?: string;
+  account_number?: string;
+}
+
+export interface TaxTransaction {
+  id: number;
+  uuid: string;
+  statement_id: number;
+  user_id: number;
+  namespace_id: number;
+  transaction_date: string;
+  description: string;
+  amount: number;
+  balance?: number;
+  transaction_type: 'credit' | 'debit';
+  category_id?: number;
+  category_name?: string;
+  hmrc_category?: string;
+  confidence?: number;
+  classification_source?: string;
+  is_business: boolean;
+  is_verified: boolean;
+  notes?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TaxCategory {
+  id: number;
+  uuid: string;
+  name: string;
+  hmrc_box?: string;
+  category_type: 'income' | 'expense';
+  is_deductible: boolean;
+  description?: string;
+}
+
+export interface TaxReportCategoryBreakdown {
+  category_name: string;
+  category_type: string;
+  total_amount: number;
+  transaction_count: number;
+  is_deductible: boolean;
+}
+
+export interface TaxReportHmrcBoxes {
+  box_number: string;
+  box_name: string;
+  amount: number;
+}
+
+export interface TaxReportMonthlyTrend {
+  month: string;
+  income: number;
+  expenses: number;
+  net: number;
+}
+
+export interface TaxCalculation {
+  tax_year: string;
+  total_income: number;
+  total_expenses: number;
+  taxable_income: number;
+  personal_allowance: number;
+  tax_bands: Array<{
+    band: string;
+    rate: number;
+    taxable_amount: number;
+    tax_amount: number;
+  }>;
+  total_tax: number;
+  national_insurance: number;
+  total_due: number;
+}
+
+export interface TaxDashboardStats {
+  total_bank_accounts: number;
+  total_statements: number;
+  total_transactions: number;
+  classified_transactions: number;
+  unclassified_transactions: number;
+  total_income: number;
+  total_expenses: number;
+}
+
+// Filter types
+export interface TaxTransactionFilters {
+  page?: number;
+  per_page?: number;
+  statement_id?: number;
+  category_id?: number;
+  transaction_type?: string;
+  is_verified?: boolean;
+  is_business?: boolean;
+  search?: string;
+  date_from?: string;
+  date_to?: string;
+}
+
+export interface TaxStatementFilters {
+  page?: number;
+  per_page?: number;
+  bank_account_id?: number;
+  status?: string;
+}
+
+// Paginated response
+export interface PaginatedResponse<T> {
+  data: T[];
+  total: number;
+  page: number;
+  per_page: number;
+  total_pages: number;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function buildParams(filters: Record<string, unknown> | object): Record<string, string | number> {
+  const params: Record<string, string | number> = {};
+  Object.entries(filters).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && value !== '' && value !== 'all') {
+      params[key] = value as string | number;
+    }
+  });
+  return params;
+}
+
+function normalizeList<T>(response: { data?: { data?: T[] } & T[] }): T[] {
+  const d = response.data;
+  if (!d) return [];
+  if (Array.isArray(d)) return d;
+  if (d && typeof d === 'object' && 'data' in d && Array.isArray((d as Record<string, unknown>).data)) {
+    return (d as Record<string, unknown>).data as T[];
+  }
+  return [];
+}
+
+// ── Service ───────────────────────────────────────────────────────────────────
+
+const TAX_BASE = '/api/v2/tax';
+
+export const taxService = {
+  // ── Dashboard Stats ─────────────────────────────────────────────────────────
+  async getDashboardStats(): Promise<TaxDashboardStats> {
+    const response = await apiClient.get(`${TAX_BASE}/dashboard/stats`);
+    return response.data?.data || response.data || {};
+  },
+
+  // ── Bank Accounts ───────────────────────────────────────────────────────────
+  async getBankAccounts(): Promise<TaxBankAccount[]> {
+    const response = await apiClient.get(`${TAX_BASE}/bank-accounts`);
+    const d = response.data;
+    if (Array.isArray(d?.data)) return d.data;
+    if (Array.isArray(d)) return d;
+    return [];
+  },
+
+  async getBankAccount(uuid: string): Promise<TaxBankAccount> {
+    const response = await apiClient.get(`${TAX_BASE}/bank-accounts/${uuid}`);
+    return response.data?.data || response.data;
+  },
+
+  async createBankAccount(data: {
+    bank_name: string;
+    account_number?: string;
+    sort_code?: string;
+    account_type?: string;
+    currency?: string;
+  }): Promise<TaxBankAccount> {
+    const params = new URLSearchParams();
+    Object.entries(data).forEach(([k, v]) => {
+      if (v !== undefined && v !== null) params.append(k, String(v));
+    });
+    const response = await apiClient.post(`${TAX_BASE}/bank-accounts`, params.toString());
+    return response.data?.data || response.data;
+  },
+
+  async updateBankAccount(uuid: string, data: Partial<TaxBankAccount>): Promise<TaxBankAccount> {
+    const params = new URLSearchParams();
+    Object.entries(data).forEach(([k, v]) => {
+      if (v !== undefined && v !== null) params.append(k, String(v));
+    });
+    const response = await apiClient.put(`${TAX_BASE}/bank-accounts/${uuid}`, params.toString());
+    return response.data?.data || response.data;
+  },
+
+  async deleteBankAccount(uuid: string): Promise<void> {
+    await apiClient.delete(`${TAX_BASE}/bank-accounts/${uuid}`);
+  },
+
+  // ── Statements ──────────────────────────────────────────────────────────────
+  async getStatements(filters: TaxStatementFilters = {}): Promise<PaginatedResponse<TaxStatement>> {
+    const response = await apiClient.get(`${TAX_BASE}/statements`, { params: buildParams(filters as unknown as Record<string, unknown>) });
+    const d = response.data;
+    return {
+      data: Array.isArray(d?.data) ? d.data : [],
+      total: d?.total || 0,
+      page: d?.page || 1,
+      per_page: d?.per_page || 20,
+      total_pages: d?.total_pages || 0,
+    };
+  },
+
+  async getStatement(uuid: string): Promise<TaxStatement> {
+    const response = await apiClient.get(`${TAX_BASE}/statements/${uuid}`);
+    return response.data?.data || response.data;
+  },
+
+  async uploadStatement(file: File, bankAccountId: number, statementDate?: string): Promise<TaxStatement> {
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('bank_account_id', String(bankAccountId));
+    if (statementDate) formData.append('statement_date', statementDate);
+
+    const response = await apiClient.post(`${TAX_BASE}/upload`, formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+      timeout: 60000,
+    });
+    return response.data?.data || response.data;
+  },
+
+  async deleteStatement(uuid: string): Promise<void> {
+    await apiClient.delete(`${TAX_BASE}/statements/${uuid}`);
+  },
+
+  // ── Extraction ──────────────────────────────────────────────────────────────
+  async extractTransactions(statementId: number): Promise<{ message: string; count?: number }> {
+    const params = new URLSearchParams();
+    params.append('statement_id', String(statementId));
+    const response = await apiClient.post(`${TAX_BASE}/extract`, params.toString());
+    return response.data;
+  },
+
+  async getExtractedTransactions(statementId: number): Promise<TaxTransaction[]> {
+    const response = await apiClient.get(`${TAX_BASE}/extract/${statementId}`);
+    const d = response.data;
+    if (Array.isArray(d?.data)) return d.data;
+    if (Array.isArray(d)) return d;
+    return [];
+  },
+
+  // ── Transactions ────────────────────────────────────────────────────────────
+  async getTransactions(filters: TaxTransactionFilters = {}): Promise<PaginatedResponse<TaxTransaction>> {
+    const response = await apiClient.get(`${TAX_BASE}/transactions`, { params: buildParams(filters as unknown as Record<string, unknown>) });
+    const d = response.data;
+    return {
+      data: Array.isArray(d?.data) ? d.data : [],
+      total: d?.total || 0,
+      page: d?.page || 1,
+      per_page: d?.per_page || 20,
+      total_pages: d?.total_pages || 0,
+    };
+  },
+
+  async updateTransaction(uuid: string, data: Partial<TaxTransaction>): Promise<TaxTransaction> {
+    const params = new URLSearchParams();
+    Object.entries(data).forEach(([k, v]) => {
+      if (v !== undefined && v !== null) params.append(k, String(v));
+    });
+    const response = await apiClient.put(`${TAX_BASE}/transactions/${uuid}`, params.toString());
+    return response.data?.data || response.data;
+  },
+
+  // ── Classification ──────────────────────────────────────────────────────────
+  async classifyTransactions(statementId: number): Promise<{ message: string; classified?: number }> {
+    const params = new URLSearchParams();
+    params.append('statement_id', String(statementId));
+    const response = await apiClient.post(`${TAX_BASE}/classify`, params.toString());
+    return response.data;
+  },
+
+  async getClassificationProviders(): Promise<Array<{ name: string; available: boolean }>> {
+    const response = await apiClient.get(`${TAX_BASE}/classify/providers`);
+    return response.data?.data || response.data || [];
+  },
+
+  // ── Categories ──────────────────────────────────────────────────────────────
+  async getCategories(): Promise<TaxCategory[]> {
+    const response = await apiClient.get(`${TAX_BASE}/categories`);
+    const d = response.data;
+    if (Array.isArray(d?.data)) return d.data;
+    if (Array.isArray(d)) return d;
+    return [];
+  },
+
+  // ── Reports ─────────────────────────────────────────────────────────────────
+  async getCategoryBreakdown(taxYear?: string): Promise<TaxReportCategoryBreakdown[]> {
+    const qs = taxYear ? buildQueryString({ tax_year: taxYear }) : '';
+    const response = await apiClient.get(`${TAX_BASE}/reports/category-breakdown${qs}`);
+    return response.data?.data || response.data || [];
+  },
+
+  async getHmrcBoxes(taxYear?: string): Promise<TaxReportHmrcBoxes[]> {
+    const qs = taxYear ? buildQueryString({ tax_year: taxYear }) : '';
+    const response = await apiClient.get(`${TAX_BASE}/reports/hmrc-boxes${qs}`);
+    return response.data?.data || response.data || [];
+  },
+
+  async getMonthlyTrend(taxYear?: string): Promise<TaxReportMonthlyTrend[]> {
+    const qs = taxYear ? buildQueryString({ tax_year: taxYear }) : '';
+    const response = await apiClient.get(`${TAX_BASE}/reports/monthly-trend${qs}`);
+    return response.data?.data || response.data || [];
+  },
+
+  async getTaxCalculation(taxYear: string): Promise<TaxCalculation> {
+    const params = new URLSearchParams();
+    params.append('tax_year', taxYear);
+    const response = await apiClient.post(`${TAX_BASE}/reports/tax-calculation`, params.toString());
+    return response.data?.data || response.data;
+  },
+};
+
+export default taxService;


### PR DESCRIPTION
- Add tax-copilot-menu-items.lua migration (468-471): registers menu items, RBAC modules, permissions, and namespace configs for tax
- Add tax.service.ts frontend API client for all tax endpoints
- Add 5 dashboard pages: overview, bank-accounts, statements (with file upload), transactions (with inline classification), reports (category breakdown, HMRC SA103F boxes, monthly trends, tax calc)