### PR TITLE
feat: add profile_type column to classification_training_data

### DIFF
--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -1221,6 +1221,7 @@ local _migrations = {
     ['469_seed_tax_modules'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_menu_items_migrations, 2),
     ['470_grant_tax_permissions'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_menu_items_migrations, 3),
     ['471_enable_tax_menu_per_namespace'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_menu_items_migrations, 4),
+    ['472_tax_training_data_profile_type'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 54),
 
     -- =========================================================================
     -- CRM SYSTEM (500-509)

--- a/lapis/migrations/tax-copilot-system.lua
+++ b/lapis/migrations/tax-copilot-system.lua
@@ -1649,4 +1649,13 @@ return {
         ]])
         print("[Tax Copilot] Seeded CLASSIFY_003 partial-success notice code")
     end,
+
+    -- 54. Add profile_type to classification_training_data
+    -- Records which business profile was active during classification,
+    -- enabling per-profile accuracy analysis and RAG boosting.
+    [54] = function()
+        db.query("ALTER TABLE classification_training_data ADD COLUMN IF NOT EXISTS profile_type VARCHAR(100)")
+        db.query("CREATE INDEX IF NOT EXISTS idx_ctd_profile_type ON classification_training_data (profile_type)")
+        print("[Tax Copilot] Added profile_type to classification_training_data")
+    end,
 }


### PR DESCRIPTION
## Summary
- Migration [54]: Adds `profile_type VARCHAR(100)` to `classification_training_data` with index
- Registered as `472_tax_training_data_profile_type` in `migrations.lua`

## Test plan
- [ ] Run Lapis migrations — column and index created
- [ ] Existing rows unaffected (`profile_type = NULL`)

> Companion PR in diy-tax-return-uk (Python model + wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)