### PR TITLE
fix: IFS bug in validate_project_code breaks all Docker Compose deploys

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -337,10 +337,12 @@ validate_project_code() {
     local input="$1"
     local VALID_CODES="all tax_copilot ecommerce ecommerce_chat collaboration hospital business core_only"
 
-    # Split on commas and validate each individual code
-    local IFS=','
-    local codes
-    read -ra codes <<< "$input"
+    # Split input on commas (save/restore IFS so the inner loop still
+    # splits VALID_CODES on spaces)
+    local saved_ifs="$IFS"
+    IFS=',' read -ra codes <<< "$input"
+    IFS="$saved_ifs"
+
     for code in "${codes[@]}"; do
         # Trim whitespace
         code=$(echo "$code" | xargs)


### PR DESCRIPTION
## Summary
`local IFS=','` in `validate_project_code()` persisted into the inner loop that checks each code against VALID_CODES. Since VALID_CODES is space-separated, the entire string became one token with IFS=comma, so nothing ever matched — including `"all"`.

**Impact**: All Docker Compose deploys since the multi-project refactor have been failing. Migrations never ran, causing downstream failures (e.g., missing `profile_type` column breaking classification in diy-tax-return-uk).

**Fix**: Use `IFS=',' read -ra` inline and immediately restore IFS.

## Test plan
- [ ] `./start.sh -j all` → passes validation
- [ ] `./start.sh -j tax_copilot` → passes
- [ ] `./start.sh -j tax_copilot,ecommerce` → passes
- [ ] `./start.sh -j invalid` → rejects
- [ ] Deploy pipeline succeeds, migration [54] runs, `profile_type` column created

🤖 Generated with [Claude Code](https://claude.com/claude-code)