### PR TITLE
fix: handle large request bodies in admin profiles CSV upload

### DIFF
--- a/lapis/routes/tax-admin-profiles.lua
+++ b/lapis/routes/tax-admin-profiles.lua
@@ -116,8 +116,20 @@ local CATEGORY_MAP = {
 
 local function parseJSON(self)
     local ok, result = pcall(function()
-        local body = ngx.req.read_body()
+        ngx.req.read_body()
         local data = ngx.req.get_body_data()
+        -- When body exceeds client_body_buffer_size, OpenResty writes
+        -- it to a temp file and get_body_data() returns nil.
+        if not data or data == "" then
+            local file = ngx.req.get_body_file()
+            if file then
+                local f = io.open(file, "r")
+                if f then
+                    data = f:read("*a")
+                    f:close()
+                end
+            end
+        end
         if not data or data == "" then return {} end
         return cjson.decode(data)
     end)


### PR DESCRIPTION
## Summary
CSV uploads to `/api/v2/tax/admin/profiles/:uuid/upload-csv` fail with `"csv_content is required"` for any file larger than ~16KB.

**Root cause**: OpenResty's `client_body_buffer_size` defaults to 8-16KB. When the POST body exceeds this, it's written to a temp file and `ngx.req.get_body_data()` returns `nil`. The `parseJSON` function returned `{}`, so `csv_content` was always missing.

**Fix**: Fall back to `ngx.req.get_body_file()` and read from disk when `get_body_data()` returns nil.

## Test plan
- [ ] Upload 40KB+ CSV via admin profiles API → parses successfully
- [ ] Small payloads (<16KB) still work via get_body_data()

🤖 Generated with [Claude Code](https://claude.com/claude-code)