### PR TITLE
fix: Lua gsub multi-return crashes CSV parser with quoted fields

### DIFF
--- a/lapis/routes/tax-admin-profiles.lua
+++ b/lapis/routes/tax-admin-profiles.lua
@@ -482,7 +482,7 @@ return function(app)
                             closing = line:find('"', closing + 2)
                         end
                         if closing then
-                            table.insert(fields, line:sub(pos + 1, closing - 1):gsub('""', '"'))
+                            table.insert(fields, (line:sub(pos + 1, closing - 1):gsub('""', '"')))
                             pos = closing + 2 -- skip closing quote + comma
                         else
                             table.insert(fields, line:sub(pos + 1))


### PR DESCRIPTION
## Summary
`string.gsub` returns two values `(replaced_string, count)`. As the last argument to `table.insert`, Lua expands both — `table.insert(t, string, count)` is read as `table.insert(t, pos, value)`, causing `"number expected, got string"` on any CSV with quoted fields containing `""`.

One-character fix: wrap in parens `(line:sub(...):gsub(...))` to truncate the multi-return.

## Test plan
- [ ] Upload NatWest CSV with quoted fields → parses successfully (no 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)