### PR TITLE
feat: app settings + user-created custom categories admin moderation …

### DIFF
--- a/lapis/app.lua
+++ b/lapis/app.lua
@@ -459,6 +459,8 @@ load_if("tax_copilot", "routes.tax-training-data")
 load_if("tax_copilot", "routes.tax-admin")
 load_if("tax_copilot", "routes.tax-admin-categories")
 load_if("tax_copilot", "routes.tax-admin-profiles")
+load_if("tax_copilot", "routes.tax-app-settings")
+load_if("tax_copilot", "routes.tax-admin-custom-categories")
 load_if("tax_copilot", "routes.tax-support")
 
 -- ============================================

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -1242,6 +1242,26 @@ local _migrations = {
     ['480_tax_create_classification_profiles']  = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 62),
 
     -- =========================================================================
+    -- Issue #308 — User-created custom categories + audit trail (April 2026)
+    -- =========================================================================
+    -- Schema (tax_copilot_migrations[63]-[66]):
+    --   481  → tax_app_settings table + seed allow_user_category_editing /
+    --          allow_user_custom_categories flags (both default false)
+    --   482  → tax_user_custom_categories table (user-scoped customs with
+    --          status enum + mapping/promotion FK columns)
+    --   483  → tax_transaction_audit table (append-only history)
+    --   484  → modified_by_*, custom_category_uuid columns on tax_transactions
+    --
+    -- Permissions (tax_copilot_menu_items_migrations[5]):
+    --   485  → register tax_app_settings + tax_custom_categories modules and
+    --          grant access to admin/owner/accountant roles
+    ['481_tax_create_app_settings']                  = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 63),
+    ['482_tax_create_user_custom_categories']        = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 64),
+    ['483_tax_create_transaction_audit']             = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 65),
+    ['484_tax_add_transaction_audit_columns']        = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 66),
+    ['485_tax_grant_custom_categories_permissions']  = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_menu_items_migrations, 5),
+
+    -- =========================================================================
     -- CRM SYSTEM (500-509)
     -- =========================================================================
     ['500_crm_create_pipelines'] = conditional_array(ProjectConfig.FEATURES.CRM, crm_system_migrations, 1),

--- a/lapis/migrations/tax-copilot-menu-items.lua
+++ b/lapis/migrations/tax-copilot-menu-items.lua
@@ -230,4 +230,101 @@ return {
             end
         end
     end,
+
+    -- =========================================================================
+    -- [5] Issue #308 — Register new permission modules for app settings + custom
+    -- categories moderation. Slots into the existing RBAC pattern (modules
+    -- table + namespace_roles.permissions JSONB).
+    --
+    -- After this migration runs, the admin/roles UI auto-picks up:
+    --   - tax_app_settings    — global settings (the two #308 flags + future)
+    --   - tax_custom_categories — user-created custom category moderation
+    --
+    -- Owner/admin roles automatically get full access; tax_accountant gets
+    -- read+update on custom categories (can moderate) but not on settings
+    -- (can't change global toggles).
+    -- =========================================================================
+    [5] = function()
+        local cjson_ok, cjson = pcall(require, "cjson")
+        if not cjson_ok then return end
+
+        local MigrationUtils = require("helper.migration-utils")
+        local timestamp = MigrationUtils.getCurrentTimestamp()
+
+        local modules = {
+            { machine_name = "tax_app_settings",      name = "Tax App Settings",      description = "Global tax-copilot settings (feature flags, retention, etc.)", priority = 36 },
+            { machine_name = "tax_custom_categories", name = "Tax Custom Categories", description = "Moderation of user-created custom categories (issue #308)",  priority = 37 },
+        }
+        for _, mod in ipairs(modules) do
+            local existing = db.select("* FROM modules WHERE machine_name = ?", mod.machine_name)
+            if #existing == 0 then
+                db.insert("modules", {
+                    uuid = MigrationUtils.generateUUID(),
+                    machine_name = mod.machine_name,
+                    name = mod.name,
+                    description = mod.description,
+                    priority = mod.priority,
+                    created_at = timestamp,
+                    updated_at = timestamp,
+                })
+                print("[Tax Copilot] Registered module: " .. mod.machine_name)
+            end
+        end
+
+        -- Grant full access to owner + admin roles. Pattern matches phase [3].
+        local privileged_roles = db.select([[
+            * FROM namespace_roles
+            WHERE role_name IN ('Owner', 'owner', 'Namespace Owner',
+                                'admin', 'Admin', 'administrative', 'tax_admin')
+        ]])
+        local full_actions = { "create", "read", "update", "delete", "manage" }
+
+        for _, role in ipairs(privileged_roles) do
+            local perms = {}
+            if role.permissions and role.permissions ~= "" then
+                local ok, decoded = pcall(cjson.decode, role.permissions)
+                if ok and type(decoded) == "table" then perms = decoded end
+            end
+
+            -- Only grant if not already explicitly set, so admins who
+            -- pruned a role's permissions don't have them silently re-added.
+            if not perms.tax_app_settings then
+                perms.tax_app_settings = full_actions
+            end
+            if not perms.tax_custom_categories then
+                perms.tax_custom_categories = full_actions
+            end
+
+            db.update("namespace_roles", {
+                permissions = cjson.encode(perms),
+            }, { id = role.id })
+        end
+
+        -- Grant accountant roles read + update on customs (moderation), but
+        -- NOT on app_settings — accountants shouldn't be able to flip the
+        -- global feature flags that control whether users can edit categories.
+        local accountant_roles = db.select([[
+            * FROM namespace_roles
+            WHERE role_name IN ('tax_accountant', 'accountant', 'Tax Accountant')
+        ]])
+        local moderate_actions = { "read", "update" }
+
+        for _, role in ipairs(accountant_roles) do
+            local perms = {}
+            if role.permissions and role.permissions ~= "" then
+                local ok, decoded = pcall(cjson.decode, role.permissions)
+                if ok and type(decoded) == "table" then perms = decoded end
+            end
+
+            if not perms.tax_custom_categories then
+                perms.tax_custom_categories = moderate_actions
+            end
+
+            db.update("namespace_roles", {
+                permissions = cjson.encode(perms),
+            }, { id = role.id })
+        end
+
+        print("[Tax Copilot] Granted permissions for tax_app_settings + tax_custom_categories")
+    end,
 }

--- a/lapis/migrations/tax-copilot-system.lua
+++ b/lapis/migrations/tax-copilot-system.lua
@@ -2065,4 +2065,215 @@ return {
         db.query("CREATE INDEX IF NOT EXISTS idx_cp_namespace_id ON classification_profiles (namespace_id)")
         print("[Tax Copilot] Created classification_profiles table")
     end,
+
+    -- ===========================================================================
+    -- Issue #308 — User-created custom categories + audit trail (April 2026)
+    --
+    -- Adds the schema needed for two connected features:
+    --
+    --   1. Two global flags admin can toggle:
+    --        - allow_user_category_editing  (gate the classify-page picker for
+    --                                        non-admin users)
+    --        - allow_user_custom_categories (further gate "+ Add custom" entry)
+    --      Both default OFF — the system is admin-only until an admin flips
+    --      them on. Settings live in a key/value table so future toggles are
+    --      data, not migrations.
+    --
+    --   2. User-scoped custom categories ("Bee Supplies", "Restoration Parts"):
+    --      created by users on the classify page, moderated by admin via the
+    --      admin dashboard, optionally promoted to system-wide categories
+    --      when multiple users keep creating the same name.
+    --
+    --   3. Append-only audit log on every category change so admin can see
+    --      who changed what and when. Retention is enforced server-side
+    --      (tax_transaction_audit_retention_days config) so the table stays
+    --      bounded.
+    --
+    --   4. Denormalised "who last touched this" pointers on tax_transactions
+    --      for cheap classify-page badge rendering (no JOIN to the audit log
+    --      on every page render).
+    -- ===========================================================================
+
+    -- 63. Create tax_app_settings table (key/value store for global toggles)
+    [63] = function()
+        db.query([[
+            CREATE TABLE IF NOT EXISTS tax_app_settings (
+                id              SERIAL PRIMARY KEY,
+                setting_key     VARCHAR(100) UNIQUE NOT NULL,
+                setting_value   JSONB NOT NULL,
+                setting_type    VARCHAR(20) NOT NULL
+                                CHECK (setting_type IN ('boolean','integer','string','object','array')),
+                description     TEXT NOT NULL,
+                category        VARCHAR(50) NOT NULL DEFAULT 'general',
+                is_admin_only   BOOLEAN NOT NULL DEFAULT TRUE,
+                updated_by_user_uuid VARCHAR(255),
+                updated_at      TIMESTAMP NOT NULL DEFAULT NOW(),
+                created_at      TIMESTAMP NOT NULL DEFAULT NOW()
+            )
+        ]])
+        db.query("CREATE INDEX IF NOT EXISTS idx_tas_category ON tax_app_settings(category)")
+        db.query("CREATE INDEX IF NOT EXISTS idx_tas_is_admin_only ON tax_app_settings(is_admin_only)")
+
+        -- Seed the two flags introduced by issue #308. ON CONFLICT DO NOTHING so
+        -- re-running the migration is idempotent; admin's value (if changed)
+        -- is never overwritten.
+        local seeds = {
+            {
+                key  = "allow_user_category_editing",
+                val  = "false",
+                type = "boolean",
+                cat  = "classification",
+                desc = "When true, non-admin users can change a transaction's category on the classify page. When false, only admins can edit categories.",
+                public = true,
+            },
+            {
+                key  = "allow_user_custom_categories",
+                val  = "false",
+                type = "boolean",
+                cat  = "classification",
+                desc = "When true, users can additionally create their own custom category names on the classify page. Requires allow_user_category_editing to also be true. Custom categories are user-scoped until an admin moderates them.",
+                public = true,
+            },
+        }
+        for _, s in ipairs(seeds) do
+            db.query([[
+                INSERT INTO tax_app_settings
+                    (setting_key, setting_value, setting_type, description, category, is_admin_only)
+                VALUES (?, ?::jsonb, ?, ?, ?, ?)
+                ON CONFLICT (setting_key) DO NOTHING
+            ]], s.key, s.val, s.type, s.desc, s.cat, not s.public)
+        end
+        print("[Tax Copilot] Created tax_app_settings table and seeded #308 flags")
+    end,
+
+    -- 64. Create tax_user_custom_categories table
+    [64] = function()
+        db.query([[
+            CREATE TABLE IF NOT EXISTS tax_user_custom_categories (
+                id              SERIAL PRIMARY KEY,
+                uuid            VARCHAR(255) UNIQUE NOT NULL DEFAULT gen_random_uuid()::text,
+                user_uuid       VARCHAR(255) NOT NULL,
+                namespace_id    INTEGER NOT NULL DEFAULT 0,
+
+                name            VARCHAR(100) NOT NULL,
+                key_normalized  VARCHAR(120) NOT NULL,
+
+                status          VARCHAR(20) NOT NULL DEFAULT 'pending'
+                                CHECK (status IN ('pending','approved','rejected','promoted')),
+
+                mapped_to_category_id      INTEGER NULL,
+                mapped_to_hmrc_category_id INTEGER NULL,
+
+                admin_notes        TEXT NULL,
+                reviewed_by_user_uuid VARCHAR(255) NULL,
+                reviewed_at        TIMESTAMP NULL,
+
+                promoted_to_category_id INTEGER NULL,
+                promoted_at        TIMESTAMP NULL,
+                promoted_by_user_uuid VARCHAR(255) NULL,
+
+                usage_count        INTEGER NOT NULL DEFAULT 0,
+
+                is_active          BOOLEAN NOT NULL DEFAULT TRUE,
+                created_at         TIMESTAMP NOT NULL DEFAULT NOW(),
+                updated_at         TIMESTAMP NOT NULL DEFAULT NOW(),
+
+                UNIQUE (user_uuid, key_normalized),
+
+                CONSTRAINT fk_tucc_mapped_category
+                    FOREIGN KEY (mapped_to_category_id)
+                    REFERENCES tax_categories(id) ON DELETE SET NULL,
+                CONSTRAINT fk_tucc_mapped_hmrc
+                    FOREIGN KEY (mapped_to_hmrc_category_id)
+                    REFERENCES tax_hmrc_categories(id) ON DELETE SET NULL,
+                CONSTRAINT fk_tucc_promoted_category
+                    FOREIGN KEY (promoted_to_category_id)
+                    REFERENCES tax_categories(id) ON DELETE SET NULL
+            )
+        ]])
+        db.query("CREATE INDEX IF NOT EXISTS idx_tucc_user_uuid ON tax_user_custom_categories(user_uuid)")
+        db.query("CREATE INDEX IF NOT EXISTS idx_tucc_namespace_id ON tax_user_custom_categories(namespace_id)")
+        db.query("CREATE INDEX IF NOT EXISTS idx_tucc_status ON tax_user_custom_categories(status)")
+        db.query("CREATE INDEX IF NOT EXISTS idx_tucc_mapped_to ON tax_user_custom_categories(mapped_to_category_id)")
+        db.query("CREATE INDEX IF NOT EXISTS idx_tucc_key_normalized ON tax_user_custom_categories(key_normalized)")
+        -- Composite index supporting "find duplicate names across users" admin query
+        db.query("CREATE INDEX IF NOT EXISTS idx_tucc_key_status ON tax_user_custom_categories(key_normalized, status)")
+        print("[Tax Copilot] Created tax_user_custom_categories table")
+    end,
+
+    -- 65. Create tax_transaction_audit table (append-only history)
+    [65] = function()
+        db.query([[
+            CREATE TABLE IF NOT EXISTS tax_transaction_audit (
+                id              BIGSERIAL PRIMARY KEY,
+                transaction_uuid VARCHAR(255) NOT NULL,
+                user_uuid       VARCHAR(255) NOT NULL,
+                user_role       VARCHAR(20) NOT NULL
+                                CHECK (user_role IN ('user','admin','accountant','ai','system')),
+
+                action          VARCHAR(50) NOT NULL,
+
+                old_value       JSONB,
+                new_value       JSONB,
+
+                source          VARCHAR(20) NOT NULL DEFAULT 'web'
+                                CHECK (source IN ('web','ios','admin','api','classifier','reconciler')),
+                ip_address      VARCHAR(64) NULL,
+                user_agent      VARCHAR(500) NULL,
+                correlation_id  VARCHAR(255) NULL,
+
+                namespace_id    INTEGER NOT NULL DEFAULT 0,
+                created_at      TIMESTAMP NOT NULL DEFAULT NOW()
+            )
+        ]])
+        db.query("CREATE INDEX IF NOT EXISTS idx_tta_transaction_uuid ON tax_transaction_audit(transaction_uuid)")
+        db.query("CREATE INDEX IF NOT EXISTS idx_tta_user_uuid ON tax_transaction_audit(user_uuid)")
+        db.query("CREATE INDEX IF NOT EXISTS idx_tta_created_at ON tax_transaction_audit(created_at DESC)")
+        db.query("CREATE INDEX IF NOT EXISTS idx_tta_action ON tax_transaction_audit(action)")
+        db.query("CREATE INDEX IF NOT EXISTS idx_tta_namespace_id ON tax_transaction_audit(namespace_id)")
+        print("[Tax Copilot] Created tax_transaction_audit table (append-only)")
+    end,
+
+    -- 66. Add denormalised pointers + custom category FK to tax_transactions
+    [66] = function()
+        db.query([[
+            ALTER TABLE tax_transactions
+                ADD COLUMN IF NOT EXISTS modified_by_user_uuid VARCHAR(255) NULL,
+                ADD COLUMN IF NOT EXISTS modified_by_role      VARCHAR(20) NULL,
+                ADD COLUMN IF NOT EXISTS modified_at           TIMESTAMP NULL,
+                ADD COLUMN IF NOT EXISTS custom_category_uuid  VARCHAR(255) NULL
+        ]])
+        -- Constraint added separately so the migration succeeds even when the
+        -- column already exists from a prior partial run (ALTER ... ADD CHECK
+        -- without a column name).
+        local check_exists = db.select([[
+            1 FROM information_schema.check_constraints
+            WHERE constraint_name = 'chk_tax_transactions_modified_by_role'
+        ]])
+        if not check_exists or #check_exists == 0 then
+            db.query([[
+                ALTER TABLE tax_transactions
+                ADD CONSTRAINT chk_tax_transactions_modified_by_role
+                CHECK (modified_by_role IS NULL
+                       OR modified_by_role IN ('user','admin','accountant','ai','system'))
+            ]])
+        end
+
+        local fk_exists = db.select([[
+            1 FROM information_schema.table_constraints
+            WHERE constraint_name = 'fk_tax_transactions_custom_category'
+        ]])
+        if not fk_exists or #fk_exists == 0 then
+            db.query([[
+                ALTER TABLE tax_transactions
+                ADD CONSTRAINT fk_tax_transactions_custom_category
+                FOREIGN KEY (custom_category_uuid)
+                REFERENCES tax_user_custom_categories(uuid) ON DELETE SET NULL
+            ]])
+        end
+
+        db.query("CREATE INDEX IF NOT EXISTS idx_tx_modified_by_user ON tax_transactions(modified_by_user_uuid)")
+        db.query("CREATE INDEX IF NOT EXISTS idx_tx_custom_category ON tax_transactions(custom_category_uuid)")
+        print("[Tax Copilot] Added modified_by_* + custom_category_uuid columns to tax_transactions")
+    end,
 }

--- a/lapis/queries/AppSettingsQueries.lua
+++ b/lapis/queries/AppSettingsQueries.lua
@@ -1,0 +1,250 @@
+-- App Settings Queries — issue #308
+--
+-- Read/write helpers for the tax_app_settings key/value table. The two
+-- toggles introduced by issue #308 (allow_user_category_editing,
+-- allow_user_custom_categories) live here, and any future global
+-- settings can be added without a migration — just INSERT a new row.
+--
+-- A small in-process cache (60s TTL) sits in front of the read path
+-- because the classify page hits get_public() on every render and
+-- reading from Postgres on each request would be wasteful. The cache
+-- is invalidated on every successful PUT, so admin changes propagate
+-- immediately on the same node and within at most 60s on other nodes.
+--
+-- Cross-setting validation lives here, not in the route layer, so the
+-- invariant ("you can't enable custom categories unless editing is
+-- enabled too") is enforced regardless of which surface (Lapis,
+-- FastAPI, internal call) sets the value.
+
+local db = require("lapis.db")
+local cjson = require("cjson")
+
+local AppSettingsQueries = {}
+
+-- ---------------------------------------------------------------------------
+-- In-process cache
+-- ---------------------------------------------------------------------------
+
+local _cache = nil          -- { [key] = row } where row.setting_value is decoded
+local _cache_loaded_at = 0
+local CACHE_TTL_SECONDS = 60
+
+local function decode_value(raw, setting_type)
+    -- setting_value is stored as JSONB in Postgres. Lapis returns it as a
+    -- string for many JSONB columns; defensively decode and coerce.
+    if raw == nil then return nil end
+    if type(raw) == "string" then
+        local ok, decoded = pcall(cjson.decode, raw)
+        if ok then return decoded end
+        -- Some clients return the literal text already (booleans / numbers).
+        if setting_type == "boolean" then
+            return raw == "true"
+        elseif setting_type == "integer" then
+            return tonumber(raw)
+        end
+        return raw
+    end
+    return raw
+end
+
+local function load_all()
+    local rows = db.select("* FROM tax_app_settings ORDER BY category, setting_key")
+    local cache = {}
+    for _, row in ipairs(rows) do
+        cache[row.setting_key] = {
+            id = row.id,
+            setting_key = row.setting_key,
+            setting_value = decode_value(row.setting_value, row.setting_type),
+            setting_type = row.setting_type,
+            description = row.description,
+            category = row.category,
+            is_admin_only = row.is_admin_only,
+            updated_by_user_uuid = row.updated_by_user_uuid,
+            updated_at = row.updated_at,
+            created_at = row.created_at,
+        }
+    end
+    _cache = cache
+    _cache_loaded_at = os.time()
+end
+
+local function ensure_cache()
+    if _cache == nil or (os.time() - _cache_loaded_at) > CACHE_TTL_SECONDS then
+        load_all()
+    end
+end
+
+function AppSettingsQueries.invalidate()
+    _cache = nil
+end
+
+-- ---------------------------------------------------------------------------
+-- Reads
+-- ---------------------------------------------------------------------------
+
+-- Return all settings (admin-facing — includes admin-only ones).
+function AppSettingsQueries.list(params)
+    params = params or {}
+    ensure_cache()
+
+    local result = {}
+    for _, row in pairs(_cache) do
+        local include = true
+        if params.category and row.category ~= params.category then
+            include = false
+        end
+        if include then
+            table.insert(result, row)
+        end
+    end
+    -- Stable order
+    table.sort(result, function(a, b)
+        if a.category ~= b.category then return a.category < b.category end
+        return a.setting_key < b.setting_key
+    end)
+    return result
+end
+
+-- Return settings safe to expose to non-admin users (is_admin_only = false).
+-- The classify page calls this to learn whether the two #308 flags are on.
+function AppSettingsQueries.list_public()
+    ensure_cache()
+    local result = {}
+    for _, row in pairs(_cache) do
+        if not row.is_admin_only then
+            -- Strip admin metadata from the public payload — frontend doesn't
+            -- need (and shouldn't see) who last changed it.
+            table.insert(result, {
+                setting_key = row.setting_key,
+                setting_value = row.setting_value,
+                setting_type = row.setting_type,
+                description = row.description,
+                category = row.category,
+            })
+        end
+    end
+    table.sort(result, function(a, b) return a.setting_key < b.setting_key end)
+    return result
+end
+
+function AppSettingsQueries.get(key)
+    ensure_cache()
+    return _cache[key]
+end
+
+-- Convenience: typed boolean read for hot-path callers (classify page,
+-- transaction PATCH endpoint). Returns the explicit default if the row
+-- is missing rather than nil — never let a missing row enable a feature.
+function AppSettingsQueries.get_bool(key, default_value)
+    local row = AppSettingsQueries.get(key)
+    if not row then return default_value end
+    if type(row.setting_value) == "boolean" then return row.setting_value end
+    return default_value
+end
+
+-- ---------------------------------------------------------------------------
+-- Writes
+-- ---------------------------------------------------------------------------
+
+-- Cross-setting invariants enforced in code so every write path
+-- (REST, internal, future MCP/CLI) goes through the same gate.
+local function validate_cross_setting(key, new_value)
+    if key == "allow_user_custom_categories" and new_value == true then
+        local editing_enabled = AppSettingsQueries.get_bool(
+            "allow_user_category_editing", false
+        )
+        if not editing_enabled then
+            return false,
+                "Cannot enable allow_user_custom_categories while " ..
+                "allow_user_category_editing is false. Enable category " ..
+                "editing first."
+        end
+    end
+    if key == "allow_user_category_editing" and new_value == false then
+        -- Disabling editing should also disable custom categories — they're
+        -- meaningless without editing. Don't block the write; the route
+        -- layer will cascade the change.
+    end
+    return true
+end
+
+-- Validate that `value` matches the declared setting_type. Returns
+-- (ok, error_message). Strict — callers that pass strings for boolean
+-- columns are rejected so shapes stay consistent across the system.
+local function validate_type(setting_type, value)
+    if setting_type == "boolean" then
+        if type(value) ~= "boolean" then
+            return false, "Expected boolean, got " .. type(value)
+        end
+    elseif setting_type == "integer" then
+        if type(value) ~= "number" or value ~= math.floor(value) then
+            return false, "Expected integer, got " .. type(value)
+        end
+    elseif setting_type == "string" then
+        if type(value) ~= "string" then
+            return false, "Expected string, got " .. type(value)
+        end
+    elseif setting_type == "object" then
+        if type(value) ~= "table" then
+            return false, "Expected object, got " .. type(value)
+        end
+    elseif setting_type == "array" then
+        if type(value) ~= "table" then
+            return false, "Expected array, got " .. type(value)
+        end
+    end
+    return true
+end
+
+-- Update a setting. Returns (row, error). On success returns
+-- (updated_row, nil). On validation failure returns (nil, error_message).
+-- Wraps the cascade (disabling editing also disables customs) in a
+-- single transaction so partial state can never leak.
+function AppSettingsQueries.set(key, new_value, updated_by_user_uuid)
+    -- Read current row to know its setting_type
+    local existing = db.select(
+        "* FROM tax_app_settings WHERE setting_key = ? LIMIT 1", key
+    )
+    if not existing or #existing == 0 then
+        return nil, "Setting '" .. key .. "' does not exist"
+    end
+    local row = existing[1]
+
+    local ok, type_err = validate_type(row.setting_type, new_value)
+    if not ok then return nil, type_err end
+
+    local ok2, cross_err = validate_cross_setting(key, new_value)
+    if not ok2 then return nil, cross_err end
+
+    db.query("BEGIN")
+    local txn_ok, txn_err = pcall(function()
+        db.update("tax_app_settings", {
+            setting_value = db.raw(db.escape_literal(cjson.encode(new_value)) .. "::jsonb"),
+            updated_by_user_uuid = updated_by_user_uuid,
+            updated_at = db.raw("NOW()"),
+        }, { setting_key = key })
+
+        -- Cascade: if editing is being disabled, also force custom
+        -- categories OFF. They're meaningless without editing and leaving
+        -- them ON would be confusing for the next admin.
+        if key == "allow_user_category_editing" and new_value == false then
+            db.update("tax_app_settings", {
+                setting_value = db.raw("'false'::jsonb"),
+                updated_by_user_uuid = updated_by_user_uuid,
+                updated_at = db.raw("NOW()"),
+            }, { setting_key = "allow_user_custom_categories" })
+        end
+    end)
+
+    if not txn_ok then
+        db.query("ROLLBACK")
+        return nil, "Transaction failed: " .. tostring(txn_err)
+    end
+    db.query("COMMIT")
+
+    AppSettingsQueries.invalidate()
+
+    return AppSettingsQueries.get(key), nil
+end
+
+return AppSettingsQueries

--- a/lapis/queries/CustomCategoryQueries.lua
+++ b/lapis/queries/CustomCategoryQueries.lua
@@ -1,0 +1,388 @@
+-- Custom Category Queries — issue #308 (admin moderation side)
+--
+-- This module owns reads and admin-side writes on
+-- tax_user_custom_categories. The user-side CRUD (a user creating
+-- their own custom on the classify page) lives in a sibling module
+-- and is the other developer's territory; nothing here writes the
+-- "pending" rows users create — only reads + moderation actions.
+--
+-- Moderation actions:
+--   - approve(uuid, mapped_to_category_id, mapped_to_hmrc_category_id?, notes?)
+--       Sets status='approved' and links the custom to a system category.
+--       The classification pipeline can now resolve the custom through
+--       the mapping for HMRC aggregation.
+--
+--   - reject(uuid, notes)
+--       Sets status='rejected'. Transactions tagged with this custom
+--       stay tagged but won't affect HMRC aggregation (the aggregator
+--       skips non-approved customs).
+--
+--   - promote(uuid, opts) — the heaviest operation
+--       Creates a new system tax_categories row and migrates every
+--       transaction across all users that referenced this custom (or
+--       any custom with the same key_normalized, optionally) to point
+--       at the new system category. Wraps in a DB transaction so
+--       partial migrations are impossible.
+--
+-- All writes invalidate any cached read state. Reads use a single SQL
+-- query with a LEFT JOIN to users for email display so the admin UI
+-- can render "joe@example.com" instead of a UUID.
+
+local db = require("lapis.db")
+local Global = require("helper.global")
+
+local CustomCategoryQueries = {}
+
+-- ---------------------------------------------------------------------------
+-- Reads — admin moderation queue
+-- ---------------------------------------------------------------------------
+
+-- List custom categories with optional filters. Joins users + tax_categories
+-- + tax_hmrc_categories so the admin UI gets everything it needs in one
+-- round-trip without an N+1.
+function CustomCategoryQueries.list(params)
+    params = params or {}
+    local where = { "tucc.is_active = true" }
+
+    if params.status and params.status ~= "all" then
+        table.insert(where, "tucc.status = " .. db.escape_literal(params.status))
+    end
+    if params.user_uuid and #params.user_uuid > 0 then
+        table.insert(where, "tucc.user_uuid = " .. db.escape_literal(params.user_uuid))
+    end
+    if params.namespace_id then
+        table.insert(where, "tucc.namespace_id = " ..
+                            db.escape_literal(tonumber(params.namespace_id)))
+    end
+    if params.search and #params.search > 0 then
+        local s = db.escape_literal("%" .. params.search .. "%")
+        table.insert(where, "(tucc.name ILIKE " .. s ..
+                            " OR tucc.key_normalized ILIKE " .. s .. ")")
+    end
+
+    local where_sql = table.concat(where, " AND ")
+    local page = tonumber(params.page) or 1
+    local per_page = math.min(tonumber(params.per_page) or 25, 100)
+    local offset = (page - 1) * per_page
+
+    local rows = db.query([[
+        SELECT
+            tucc.id, tucc.uuid, tucc.user_uuid, tucc.namespace_id,
+            tucc.name, tucc.key_normalized, tucc.status,
+            tucc.mapped_to_category_id, tucc.mapped_to_hmrc_category_id,
+            tucc.admin_notes, tucc.reviewed_by_user_uuid, tucc.reviewed_at,
+            tucc.promoted_to_category_id, tucc.promoted_at,
+            tucc.usage_count, tucc.created_at, tucc.updated_at,
+            u.email          AS user_email,
+            NULLIF(TRIM(CONCAT_WS(' ', u.first_name, u.last_name)), '') AS user_name,
+            mapped_cat.key   AS mapped_to_category_key,
+            mapped_cat.label AS mapped_to_category_label,
+            mapped_hmrc.key  AS mapped_to_hmrc_category_key,
+            mapped_hmrc.label AS mapped_to_hmrc_category_label
+        FROM tax_user_custom_categories tucc
+        LEFT JOIN users               u           ON u.uuid = tucc.user_uuid
+        LEFT JOIN tax_categories      mapped_cat  ON mapped_cat.id = tucc.mapped_to_category_id
+        LEFT JOIN tax_hmrc_categories mapped_hmrc ON mapped_hmrc.id = tucc.mapped_to_hmrc_category_id
+        WHERE ]] .. where_sql .. [[
+        ORDER BY
+            CASE tucc.status
+                WHEN 'pending' THEN 0
+                WHEN 'approved' THEN 1
+                WHEN 'promoted' THEN 2
+                WHEN 'rejected' THEN 3
+                ELSE 4
+            END,
+            tucc.created_at DESC
+        LIMIT ? OFFSET ?
+    ]], per_page, offset)
+
+    local count_row = db.query([[
+        SELECT COUNT(*) AS total
+        FROM tax_user_custom_categories tucc
+        WHERE ]] .. where_sql)
+    local total = count_row and count_row[1] and count_row[1].total or 0
+
+    return rows, total, page, per_page
+end
+
+function CustomCategoryQueries.get_by_uuid(uuid)
+    local rows = db.query([[
+        SELECT
+            tucc.*,
+            u.email          AS user_email,
+            NULLIF(TRIM(CONCAT_WS(' ', u.first_name, u.last_name)), '') AS user_name,
+            mapped_cat.key   AS mapped_to_category_key,
+            mapped_cat.label AS mapped_to_category_label,
+            mapped_hmrc.key  AS mapped_to_hmrc_category_key,
+            mapped_hmrc.label AS mapped_to_hmrc_category_label
+        FROM tax_user_custom_categories tucc
+        LEFT JOIN users               u           ON u.uuid = tucc.user_uuid
+        LEFT JOIN tax_categories      mapped_cat  ON mapped_cat.id = tucc.mapped_to_category_id
+        LEFT JOIN tax_hmrc_categories mapped_hmrc ON mapped_hmrc.id = tucc.mapped_to_hmrc_category_id
+        WHERE tucc.uuid = ?
+        LIMIT 1
+    ]], uuid)
+    return rows and rows[1] or nil
+end
+
+-- Sample transactions tagged with this custom so admin can see real-world
+-- usage before deciding the mapping. Capped at 10 newest by default.
+function CustomCategoryQueries.sample_transactions(custom_uuid, limit)
+    limit = math.min(tonumber(limit) or 10, 50)
+    return db.query([[
+        SELECT id, uuid, description, amount, transaction_date, category
+        FROM tax_transactions
+        WHERE custom_category_uuid = ?
+        ORDER BY transaction_date DESC, id DESC
+        LIMIT ?
+    ]], custom_uuid, limit) or {}
+end
+
+-- Find duplicate names across users — promotion candidates. The admin
+-- wants to know "5 different beekeepers all created 'Bee Supplies'" so
+-- they can promote it to a system-wide category in one go.
+function CustomCategoryQueries.find_duplicates(min_users)
+    min_users = tonumber(min_users) or 3
+    return db.query([[
+        SELECT
+            key_normalized,
+            MIN(name) AS sample_name,
+            COUNT(DISTINCT user_uuid) AS user_count,
+            SUM(usage_count) AS total_usage,
+            COUNT(*) FILTER (WHERE status = 'pending')  AS pending_count,
+            COUNT(*) FILTER (WHERE status = 'approved') AS approved_count
+        FROM tax_user_custom_categories
+        WHERE is_active = true
+          AND status IN ('pending', 'approved')
+        GROUP BY key_normalized
+        HAVING COUNT(DISTINCT user_uuid) >= ?
+        ORDER BY user_count DESC, total_usage DESC
+        LIMIT 50
+    ]], min_users) or {}
+end
+
+function CustomCategoryQueries.stats()
+    local rows = db.query([[
+        SELECT status, COUNT(*) AS n
+        FROM tax_user_custom_categories
+        WHERE is_active = true
+        GROUP BY status
+    ]]) or {}
+    local result = {
+        pending = 0, approved = 0, rejected = 0, promoted = 0, total = 0
+    }
+    for _, r in ipairs(rows) do
+        result[r.status] = tonumber(r.n) or 0
+        result.total = result.total + (tonumber(r.n) or 0)
+    end
+    return result
+end
+
+-- ---------------------------------------------------------------------------
+-- Admin moderation actions
+-- ---------------------------------------------------------------------------
+
+-- Approve a custom and link it to a system tax_categories row.
+-- Accepts UUID strings (matches the existing tax_categories admin
+-- API). The integer FKs are resolved here before the UPDATE.
+-- mapped_to_hmrc_category_uuid is optional — if absent we inherit it
+-- from the system category's existing HMRC link.
+function CustomCategoryQueries.approve(uuid, opts)
+    opts = opts or {}
+    if not opts.mapped_to_category_uuid then
+        return nil, "mapped_to_category_uuid is required to approve"
+    end
+
+    -- Resolve system category UUID -> integer id (and grab its HMRC link)
+    local cat = db.select([[
+        id, hmrc_category_id FROM tax_categories
+        WHERE uuid = ? AND is_active = true LIMIT 1
+    ]], opts.mapped_to_category_uuid)
+    if not cat or #cat == 0 then
+        return nil, "Mapped tax_categories row not found or inactive"
+    end
+
+    -- Resolve optional HMRC override UUID -> integer id
+    local hmrc_id = cat[1].hmrc_category_id
+    if opts.mapped_to_hmrc_category_uuid
+       and #tostring(opts.mapped_to_hmrc_category_uuid) > 0 then
+        local hmrc = db.select([[
+            id FROM tax_hmrc_categories
+            WHERE uuid = ? AND is_active = true LIMIT 1
+        ]], opts.mapped_to_hmrc_category_uuid)
+        if not hmrc or #hmrc == 0 then
+            return nil, "Mapped tax_hmrc_categories row not found or inactive"
+        end
+        hmrc_id = hmrc[1].id
+    end
+
+    db.update("tax_user_custom_categories", {
+        status = "approved",
+        mapped_to_category_id = cat[1].id,
+        mapped_to_hmrc_category_id = hmrc_id,
+        admin_notes = opts.admin_notes,
+        reviewed_by_user_uuid = opts.reviewer_uuid,
+        reviewed_at = db.raw("NOW()"),
+        updated_at = db.raw("NOW()"),
+    }, { uuid = uuid })
+
+    return CustomCategoryQueries.get_by_uuid(uuid), nil
+end
+
+function CustomCategoryQueries.reject(uuid, opts)
+    opts = opts or {}
+    if not opts.admin_notes or #opts.admin_notes == 0 then
+        return nil, "admin_notes is required to reject (so users know why)"
+    end
+
+    db.update("tax_user_custom_categories", {
+        status = "rejected",
+        admin_notes = opts.admin_notes,
+        reviewed_by_user_uuid = opts.reviewer_uuid,
+        reviewed_at = db.raw("NOW()"),
+        updated_at = db.raw("NOW()"),
+    }, { uuid = uuid })
+
+    return CustomCategoryQueries.get_by_uuid(uuid), nil
+end
+
+-- Promote a custom into a brand-new system-wide tax_categories row, then
+-- migrate every transaction across users that referenced this custom (or
+-- optionally any custom with the same key_normalized) to point at the new
+-- system row. Marks promoted customs with status='promoted' so the audit
+-- trail shows "this came from user X's submission".
+--
+-- Wraps everything in a single DB transaction. If any step fails the
+-- whole operation rolls back — partially-promoted state is impossible.
+--
+-- opts:
+--   system_key         (required) — slug for the new tax_categories.key
+--   system_label       (required) — display label
+--   hmrc_category_uuid (required) — UUID of a tax_hmrc_categories row
+--   type               (required) — "income" | "expense"
+--   is_tax_deductible
+--   deduction_rate
+--   description, examples
+--   include_other_users (boolean, default false) — when true, every
+--       custom row with the same key_normalized gets promoted in one
+--       go. When false, only the targeted custom is promoted.
+--   promoter_uuid      (required) — admin user_uuid for audit trail
+function CustomCategoryQueries.promote(uuid, opts)
+    opts = opts or {}
+    local required = {
+        "system_key", "system_label", "hmrc_category_uuid", "type", "promoter_uuid"
+    }
+    for _, field in ipairs(required) do
+        if not opts[field] or (type(opts[field]) == "string" and #opts[field] == 0) then
+            return nil, "Missing required field: " .. field
+        end
+    end
+
+    local result
+    db.query("BEGIN")
+    local ok, err = pcall(function()
+        -- Fetch the seed custom so we know its key_normalized + namespace
+        local seed_rows = db.select(
+            "* FROM tax_user_custom_categories WHERE uuid = ? LIMIT 1", uuid
+        )
+        if not seed_rows or #seed_rows == 0 then
+            error("Custom category " .. uuid .. " not found")
+        end
+        local seed = seed_rows[1]
+
+        -- Guard against duplicate system keys
+        local existing_sys = db.select(
+            "id FROM tax_categories WHERE key = ? LIMIT 1", opts.system_key
+        )
+        if existing_sys and #existing_sys > 0 then
+            error("System category key '" .. opts.system_key ..
+                  "' already exists. Pick a unique key.")
+        end
+
+        -- Resolve HMRC category UUID -> integer id
+        local hmrc = db.select([[
+            id FROM tax_hmrc_categories
+            WHERE uuid = ? AND is_active = true LIMIT 1
+        ]], opts.hmrc_category_uuid)
+        if not hmrc or #hmrc == 0 then
+            error("HMRC category not found or inactive: " ..
+                  tostring(opts.hmrc_category_uuid))
+        end
+
+        -- 1. Create the new system tax_categories row
+        local new_cat = db.insert("tax_categories", {
+            uuid = Global.generateStaticUUID(),
+            key = opts.system_key,
+            label = opts.system_label,
+            hmrc_category_id = hmrc[1].id,
+            type = string.lower(opts.type),
+            is_tax_deductible = opts.is_tax_deductible ~= false,
+            deduction_rate = tonumber(opts.deduction_rate) or 1.0,
+            description = opts.description or "",
+            examples = opts.examples or db.NULL,
+            is_active = true,
+            created_at = db.raw("NOW()"),
+            updated_at = db.raw("NOW()"),
+        })
+
+        -- 2. Identify which custom rows to promote
+        local affected_customs
+        if opts.include_other_users then
+            affected_customs = db.select([[
+                * FROM tax_user_custom_categories
+                WHERE key_normalized = ?
+                  AND status IN ('pending', 'approved')
+                  AND is_active = true
+            ]], seed.key_normalized) or {}
+        else
+            affected_customs = { seed }
+        end
+
+        -- 3. Migrate transactions across all affected users to point at the
+        --    new system category. We use a single bulk UPDATE for efficiency
+        --    (handles 50k+ rows in one statement on Postgres without trouble).
+        local custom_uuids = {}
+        for _, c in ipairs(affected_customs) do
+            table.insert(custom_uuids, db.escape_literal(c.uuid))
+        end
+        if #custom_uuids > 0 then
+            db.query([[
+                UPDATE tax_transactions
+                SET category = ]] .. db.escape_literal(opts.system_key) .. [[,
+                    custom_category_uuid = NULL,
+                    modified_by_user_uuid = ]] .. db.escape_literal(opts.promoter_uuid) .. [[,
+                    modified_by_role = 'admin',
+                    modified_at = NOW()
+                WHERE custom_category_uuid IN (]] .. table.concat(custom_uuids, ",") .. [[)
+            ]])
+        end
+
+        -- 4. Mark the customs as promoted
+        for _, c in ipairs(affected_customs) do
+            db.update("tax_user_custom_categories", {
+                status = "promoted",
+                promoted_to_category_id = new_cat.id,
+                promoted_at = db.raw("NOW()"),
+                promoted_by_user_uuid = opts.promoter_uuid,
+                admin_notes = opts.admin_notes,
+                updated_at = db.raw("NOW()"),
+            }, { id = c.id })
+        end
+
+        result = {
+            new_category = new_cat,
+            affected_customs_count = #affected_customs,
+            include_other_users = opts.include_other_users == true,
+        }
+    end)
+
+    if not ok then
+        db.query("ROLLBACK")
+        return nil, tostring(err)
+    end
+    db.query("COMMIT")
+
+    return result, nil
+end
+
+return CustomCategoryQueries

--- a/lapis/routes/tax-admin-custom-categories.lua
+++ b/lapis/routes/tax-admin-custom-categories.lua
@@ -1,0 +1,287 @@
+--[[
+    Tax Admin Custom Categories Routes — issue #308
+
+    Admin moderation surface for user-created custom categories. The
+    user-side CRUD (POST, GET-mine, DELETE-mine) is the other developer's
+    responsibility — this file only exposes admin endpoints.
+
+    Endpoint summary:
+      GET    /api/v2/admin/custom-categories              — paginated list, filterable
+      GET    /api/v2/admin/custom-categories/stats         — counts by status
+      GET    /api/v2/admin/custom-categories/duplicates    — promotion candidates
+      GET    /api/v2/admin/custom-categories/:uuid         — detail + sample transactions
+      PUT    /api/v2/admin/custom-categories/:uuid/approve — approve + map
+      PUT    /api/v2/admin/custom-categories/:uuid/reject  — reject with notes
+      POST   /api/v2/admin/custom-categories/:uuid/promote — create system category + migrate
+
+    Permission gate uses the existing AdminCheck pattern (matches
+    tax-admin-categories.lua / permissions.lua).
+]]
+
+local CustomCategoryQueries = require("queries.CustomCategoryQueries")
+local RequestParser = require("helper.request_parser")
+local AuthMiddleware = require("middleware.auth")
+local AdminCheck = require("helper.admin-check")
+local cjson = require("cjson")
+
+cjson.encode_empty_table_as_object(false)
+
+local function is_admin(user)
+    return AdminCheck.isPlatformAdmin(user)
+end
+
+local function error_response(status, message, details)
+    ngx.log(ngx.ERR, "[Custom Categories Admin] ", message,
+            details and (" | " .. tostring(details)) or "")
+    return {
+        status = status,
+        json = {
+            error = message,
+            details = type(details) == "string" and details or nil,
+        },
+    }
+end
+
+return function(app)
+
+    -- LIST custom categories with filters
+    --   ?status=pending|approved|rejected|promoted|all (default: pending)
+    --   ?user_uuid=<uuid>
+    --   ?namespace_id=<int>
+    --   ?search=<string>          (matches name or key_normalized)
+    --   ?page=1&per_page=25
+    app:get("/api/v2/admin/custom-categories", AuthMiddleware.requireAuth(function(self)
+        if not is_admin(self.current_user) then
+            return error_response(403, "Admin access required")
+        end
+
+        local ok, rows, total, page, per_page = pcall(CustomCategoryQueries.list, {
+            status = self.params.status or "pending",
+            user_uuid = self.params.user_uuid,
+            namespace_id = self.params.namespace_id,
+            search = self.params.search,
+            page = self.params.page,
+            per_page = self.params.per_page,
+        })
+        if not ok then
+            return error_response(500, "Failed to list custom categories", tostring(rows))
+        end
+
+        return {
+            status = 200,
+            json = {
+                data = rows or {},
+                total = total or 0,
+                page = page or 1,
+                per_page = per_page or 25,
+            },
+        }
+    end))
+
+    -- AGGREGATE stats — counts by status. Cheap query the dashboard polls.
+    app:get("/api/v2/admin/custom-categories/stats", AuthMiddleware.requireAuth(function(self)
+        if not is_admin(self.current_user) then
+            return error_response(403, "Admin access required")
+        end
+
+        local ok, stats = pcall(CustomCategoryQueries.stats)
+        if not ok then
+            return error_response(500, "Failed to compute stats", tostring(stats))
+        end
+        return { status = 200, json = { data = stats } }
+    end))
+
+    -- DUPLICATES — names that ≥N users have created. Promotion candidates.
+    --   ?min_users=3 (default)
+    app:get("/api/v2/admin/custom-categories/duplicates", AuthMiddleware.requireAuth(function(self)
+        if not is_admin(self.current_user) then
+            return error_response(403, "Admin access required")
+        end
+
+        local ok, rows = pcall(
+            CustomCategoryQueries.find_duplicates, self.params.min_users
+        )
+        if not ok then
+            return error_response(500, "Failed to find duplicates", tostring(rows))
+        end
+        return { status = 200, json = { data = rows or {} } }
+    end))
+
+    -- DETAIL view — full row + sample transactions
+    app:get("/api/v2/admin/custom-categories/:uuid", AuthMiddleware.requireAuth(function(self)
+        if not is_admin(self.current_user) then
+            return error_response(403, "Admin access required")
+        end
+
+        local row = CustomCategoryQueries.get_by_uuid(self.params.uuid)
+        if not row then
+            return error_response(404, "Custom category not found")
+        end
+
+        local samples = CustomCategoryQueries.sample_transactions(self.params.uuid, 10)
+
+        return {
+            status = 200,
+            json = {
+                data = row,
+                sample_transactions = samples,
+            },
+        }
+    end))
+
+    -- APPROVE: link the custom to an existing system tax_categories row.
+    -- Body: {
+    --   "mapped_to_category_uuid": <string UUID, required>,
+    --   "mapped_to_hmrc_category_uuid": <string UUID, optional — inferred if absent>,
+    --   "admin_notes": <string, optional>
+    -- }
+    app:put("/api/v2/admin/custom-categories/:uuid/approve", AuthMiddleware.requireAuth(function(self)
+        if not is_admin(self.current_user) then
+            return error_response(403, "Admin access required")
+        end
+
+        local params = RequestParser.parse_request(self)
+        local valid, missing = RequestParser.require_params(params, { "mapped_to_category_uuid" })
+        if not valid then
+            return error_response(400, "Missing required fields",
+                                  table.concat(missing, ", "))
+        end
+
+        local reviewer_uuid = self.current_user
+            and (self.current_user.uuid or self.current_user.id)
+            or nil
+
+        local ok, row, err = pcall(CustomCategoryQueries.approve, self.params.uuid, {
+            mapped_to_category_uuid = params.mapped_to_category_uuid,
+            mapped_to_hmrc_category_uuid = params.mapped_to_hmrc_category_uuid,
+            admin_notes = params.admin_notes,
+            reviewer_uuid = reviewer_uuid,
+        })
+        if not ok then
+            return error_response(500, "Approve failed", tostring(row))
+        end
+        if not row and err then
+            return error_response(422, err)
+        end
+
+        return {
+            status = 200,
+            json = { data = row, message = "Custom category approved" },
+        }
+    end))
+
+    -- REJECT with mandatory admin_notes (so the user knows why if we ever
+    -- expose rejection reasons in the user UI).
+    -- Body: { "admin_notes": <string, required> }
+    app:put("/api/v2/admin/custom-categories/:uuid/reject", AuthMiddleware.requireAuth(function(self)
+        if not is_admin(self.current_user) then
+            return error_response(403, "Admin access required")
+        end
+
+        local params = RequestParser.parse_request(self)
+        local valid, missing = RequestParser.require_params(params, { "admin_notes" })
+        if not valid then
+            return error_response(400, "Missing required fields",
+                                  table.concat(missing, ", "))
+        end
+
+        local reviewer_uuid = self.current_user
+            and (self.current_user.uuid or self.current_user.id)
+            or nil
+
+        local ok, row, err = pcall(CustomCategoryQueries.reject, self.params.uuid, {
+            admin_notes = params.admin_notes,
+            reviewer_uuid = reviewer_uuid,
+        })
+        if not ok then
+            return error_response(500, "Reject failed", tostring(row))
+        end
+        if not row and err then
+            return error_response(422, err)
+        end
+
+        return {
+            status = 200,
+            json = { data = row, message = "Custom category rejected" },
+        }
+    end))
+
+    -- PROMOTE: create a brand-new system tax_categories row and migrate
+    -- every transaction across users to point at it. Optionally promotes
+    -- every custom with the same key_normalized in one go.
+    --
+    -- Body: {
+    --   "system_key":          <slug, required>,
+    --   "system_label":        <string, required>,
+    --   "hmrc_category_uuid":  <UUID string, required>,
+    --   "type":                "income"|"expense" (required),
+    --   "is_tax_deductible":   <bool, optional, default true>,
+    --   "deduction_rate":      <number, optional, default 1.0>,
+    --   "description":         <string, optional>,
+    --   "examples":            <string, optional>,
+    --   "include_other_users": <bool, optional, default false>,
+    --   "admin_notes":         <string, optional>
+    -- }
+    app:post("/api/v2/admin/custom-categories/:uuid/promote", AuthMiddleware.requireAuth(function(self)
+        if not is_admin(self.current_user) then
+            return error_response(403, "Admin access required")
+        end
+
+        local params = RequestParser.parse_request(self)
+        local required = { "system_key", "system_label", "hmrc_category_uuid", "type" }
+        local valid, missing = RequestParser.require_params(params, required)
+        if not valid then
+            return error_response(400, "Missing required fields",
+                                  table.concat(missing, ", "))
+        end
+
+        local promoter_uuid = self.current_user
+            and (self.current_user.uuid or self.current_user.id)
+            or nil
+
+        if not promoter_uuid then
+            return error_response(401, "Promoter user UUID could not be determined")
+        end
+
+        -- Coerce booleans defensively — promote() is destructive, so we
+        -- want to be explicit about every flag we forward.
+        local include_others = params.include_other_users
+        if type(include_others) == "string" then
+            include_others = (include_others == "true")
+        end
+        local is_deductible = params.is_tax_deductible
+        if type(is_deductible) == "string" then
+            is_deductible = (is_deductible == "true")
+        end
+
+        local ok, result, err = pcall(CustomCategoryQueries.promote, self.params.uuid, {
+            system_key = params.system_key,
+            system_label = params.system_label,
+            hmrc_category_uuid = params.hmrc_category_uuid,
+            type = params.type,
+            is_tax_deductible = is_deductible ~= false,
+            deduction_rate = tonumber(params.deduction_rate),
+            description = params.description,
+            examples = params.examples,
+            include_other_users = include_others,
+            admin_notes = params.admin_notes,
+            promoter_uuid = promoter_uuid,
+        })
+        if not ok then
+            return error_response(500, "Promote failed", tostring(result))
+        end
+        if not result and err then
+            return error_response(422, err)
+        end
+
+        return {
+            status = 200,
+            json = {
+                data = result,
+                message = "Custom category promoted to system category",
+            },
+        }
+    end))
+
+    ngx.log(ngx.NOTICE, "[Custom Categories Admin] routes initialized")
+end

--- a/lapis/routes/tax-app-settings.lua
+++ b/lapis/routes/tax-app-settings.lua
@@ -1,0 +1,138 @@
+--[[
+    Tax App Settings Routes — issue #308
+
+    Admin CRUD on tax_app_settings (the global key/value store) plus a
+    tiny non-admin endpoint that exposes only the settings flagged as
+    public (is_admin_only = false). The classify page calls the public
+    endpoint to learn whether allow_user_category_editing /
+    allow_user_custom_categories are on.
+
+    Auth model:
+      - GET  /api/v2/admin/settings        — admin only (full list)
+      - GET  /api/v2/admin/settings/:key   — admin only
+      - PUT  /api/v2/admin/settings/:key   — admin only (writes)
+      - GET  /api/v2/settings/public        — any authenticated user
+                                              (returns is_admin_only=false rows)
+
+    Admin check uses the centralized AdminCheck module (platform-level
+    role gate), matching the pattern in permissions.lua. Validation
+    (cross-setting invariants, type checking) happens in
+    AppSettingsQueries — the route layer just translates HTTP↔Lua.
+]]
+
+local AppSettingsQueries = require("queries.AppSettingsQueries")
+local RequestParser = require("helper.request_parser")
+local AuthMiddleware = require("middleware.auth")
+local AdminCheck = require("helper.admin-check")
+local cjson = require("cjson")
+
+cjson.encode_empty_table_as_object(false)
+
+local function is_admin(user)
+    return AdminCheck.isPlatformAdmin(user)
+end
+
+local function error_response(status, message, details)
+    ngx.log(ngx.ERR, "[App Settings] ", message,
+            details and (" | " .. tostring(details)) or "")
+    return {
+        status = status,
+        json = {
+            error = message,
+            details = type(details) == "string" and details or nil,
+        },
+    }
+end
+
+return function(app)
+
+    -- LIST all settings (admin only)
+    -- Optional query param: ?category=classification
+    app:get("/api/v2/admin/settings", AuthMiddleware.requireAuth(function(self)
+        if not is_admin(self.current_user) then
+            return error_response(403, "Admin access required")
+        end
+
+        local ok, result = pcall(AppSettingsQueries.list, {
+            category = self.params.category,
+        })
+        if not ok then
+            return error_response(500, "Failed to list settings", tostring(result))
+        end
+
+        return { status = 200, json = { data = result, total = #result } }
+    end))
+
+    -- GET single setting by key (admin only)
+    app:get("/api/v2/admin/settings/:key", AuthMiddleware.requireAuth(function(self)
+        if not is_admin(self.current_user) then
+            return error_response(403, "Admin access required")
+        end
+
+        local ok, row = pcall(AppSettingsQueries.get, self.params.key)
+        if not ok then
+            return error_response(500, "Failed to fetch setting", tostring(row))
+        end
+        if not row then
+            return error_response(404, "Setting not found")
+        end
+        return { status = 200, json = { data = row } }
+    end))
+
+    -- UPDATE a setting (admin only).
+    -- Body: { "value": <typed value> }
+    -- Cross-setting invariants (e.g. enabling custom categories requires
+    -- editing) are enforced inside AppSettingsQueries.set, not here.
+    app:put("/api/v2/admin/settings/:key", AuthMiddleware.requireAuth(function(self)
+        if not is_admin(self.current_user) then
+            return error_response(403, "Admin access required")
+        end
+
+        local params = RequestParser.parse_request(self)
+        if params.value == nil then
+            return error_response(400, "Field 'value' is required in request body")
+        end
+
+        -- Most clients will send JSON; some legacy callers might send the
+        -- value as a string. Try to JSON-decode strings that look like
+        -- typed primitives so the type check downstream is accurate.
+        local value = params.value
+        if type(value) == "string" then
+            local ok, decoded = pcall(cjson.decode, value)
+            if ok then value = decoded end
+        end
+
+        local user_uuid = self.current_user and (
+            self.current_user.uuid or self.current_user.id
+        ) or nil
+
+        local ok, row, err = pcall(
+            AppSettingsQueries.set, self.params.key, value, user_uuid
+        )
+        if not ok then
+            return error_response(500, "Failed to update setting", tostring(row))
+        end
+        if not row and err then
+            return error_response(422, err)
+        end
+
+        return {
+            status = 200,
+            json = { data = row, message = "Setting updated" }
+        }
+    end))
+
+    -- PUBLIC settings — returns only rows with is_admin_only = false.
+    -- Authenticated but no admin gate — used by the classify page on every
+    -- statement load to know whether the edit affordance should render.
+    app:get("/api/v2/settings/public", AuthMiddleware.requireAuth(function(self)
+        local ok, result = pcall(AppSettingsQueries.list_public)
+        if not ok then
+            return error_response(500, "Failed to list public settings",
+                                  tostring(result))
+        end
+        return { status = 200, json = { data = result, total = #result } }
+    end))
+
+    ngx.log(ngx.NOTICE, "[App Settings] routes initialized")
+end


### PR DESCRIPTION
…(#308)

Schema, RBAC, and admin endpoints for issue #308. The user-facing endpoints (POST /api/v2/tax/custom-categories etc.) are intentionally out of scope and tracked as a separate concern for the user-side dev.

Schema (registered as keys 481–485 in migrations.lua):

  481 — tax_app_settings (key/value JSONB store) seeded with two
        global flags both defaulting to false:
          - allow_user_category_editing
          - allow_user_custom_categories Cross-setting rule enforced server-side: enabling customs requires editing already enabled; disabling editing cascades to disable customs in the same DB transaction.

  482 — tax_user_custom_categories — user-scoped customs with status
        enum (pending/approved/rejected/promoted), mapping FKs to
        tax_categories + tax_hmrc_categories, promotion metadata,
        usage_count counter. UNIQUE(user_uuid, key_normalized).

  483 — tax_transaction_audit — append-only history. Indexed on
        transaction_uuid, user_uuid, created_at. Pruned by FastAPI
        scheduler (default 365 day retention).

  484 — modified_by_user_uuid / modified_by_role / modified_at and
        custom_category_uuid columns on tax_transactions for cheap
        classify-page badge rendering without a JOIN.

  485 — Registers tax_app_settings + tax_custom_categories permission
        modules. Owner/admin/tax_admin: full grants. Accountant: read
        + update on customs only (can moderate but not change global
        flags).

Queries:

  - AppSettingsQueries.lua — TTL-cached read, typed getters, cross-setting validation, cascade-on-write. invalidate() called after every successful write.

  - CustomCategoryQueries.lua — list with JOIN to users for display name (NULLIF(TRIM(CONCAT_WS(' ', first_name, last_name))) since users.name doesn't exist), find_duplicates for promotion candidates, transactional promote() that bulk-migrates every affected user's transactions in one DB statement.

Routes:

  /api/v2/admin/settings              — admin CRUD on settings
  /api/v2/settings/public             — non-admin read of is_admin_only=false rows
  /api/v2/admin/custom-categories/    — list / detail / stats / duplicates
  .../{uuid}/approve                  — link to a system tax_categories row
  .../{uuid}/reject                   — reject with mandatory admin_notes
  .../{uuid}/promote                  — destructive: create new system row +
                                        re-tag every affected user's transactions

All admin endpoints take/return UUID strings on the wire (matching the existing tax_categories admin pattern); integer FKs are resolved internally before DB writes.

Wired into app.lua. Verified all Lua files parse with luac -p.