### PR TITLE
feat: custom categories admin + user CRUD + audit (#308)

### DIFF
--- a/lapis/app.lua
+++ b/lapis/app.lua
@@ -461,6 +461,7 @@ load_if("tax_copilot", "routes.tax-admin-categories")
 load_if("tax_copilot", "routes.tax-admin-profiles")
 load_if("tax_copilot", "routes.tax-app-settings")
 load_if("tax_copilot", "routes.tax-admin-custom-categories")
+load_if("tax_copilot", "routes.tax-custom-categories")
 load_if("tax_copilot", "routes.tax-support")
 
 -- ============================================

--- a/lapis/lib/error_occurrence.lua
+++ b/lapis/lib/error_occurrence.lua
@@ -129,11 +129,17 @@ end
 --   ip_address       string
 --   self             table   Lapis request (used to auto-fill the above)
 function Occurrence.record(args)
+    -- The UUID is generated up-front and returned to the caller so the
+    -- error envelope can include `occurrence_uuid`, giving admin a deep
+    -- link to /admin/errors/occurrences/<uuid> from the user's toast.
+    -- Mirrors the FastAPI catalog handler's behaviour.
+    local row_uuid = require("helper.global").generateUUID()
+
     local ok, err = pcall(function()
         local self = args.self
 
         local row = {
-            uuid = require("helper.global").generateUUID(),
+            uuid = row_uuid,
             code = args.code or "SYSTEM_500",
             catalog_uuid = args.catalog_uuid,
             correlation_id = args.correlation_id or require("helper.global").generateUUID(),
@@ -174,9 +180,13 @@ function Occurrence.record(args)
 
     if not ok then
         -- Logging a warning is as loud as we ever get. Failing audit must
-        -- not surface to the user.
+        -- not surface to the user. Returns nil so the caller knows the
+        -- envelope shouldn't carry an occurrence_uuid (the row didn't
+        -- actually land in the table).
         ngx.log(ngx.WARN, "error_occurrence: insert failed: ", tostring(err))
+        return nil
     end
+    return row_uuid
 end
 
 

--- a/lapis/lib/errors.lua
+++ b/lapis/lib/errors.lua
@@ -89,7 +89,12 @@ function Errors.response(self, code, opts)
     -- ``self`` has already been torn down — inserts silently dropped. If
     -- the sync path ever becomes a hot-spot we'll move to a lua-resty-
     -- producer queue, not back to naked timers.
-    Occurrence.record({
+    -- Capture the occurrence UUID so the envelope can carry an
+    -- `occurrence_uuid` deep-link for admin (mirrors FastAPI). When the
+    -- audit insert fails (e.g. DB hiccup), Occurrence.record returns nil
+    -- and we just omit the field — clients gracefully degrade to
+    -- correlation_id-only.
+    local occurrence_uuid = Occurrence.record({
         self = self,
         code = resolved.code,
         catalog_uuid = resolved.catalog_uuid ~= "" and resolved.catalog_uuid or nil,
@@ -109,6 +114,9 @@ function Errors.response(self, code, opts)
     }
     if resolved.title and resolved.title ~= "" then
         envelope.title = resolved.title
+    end
+    if occurrence_uuid then
+        envelope.occurrence_uuid = occurrence_uuid
     end
     if opts.context and next(opts.context) then
         envelope.context = opts.context

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -1260,6 +1260,7 @@ local _migrations = {
     ['483_tax_create_transaction_audit']             = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 65),
     ['484_tax_add_transaction_audit_columns']        = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 66),
     ['485_tax_grant_custom_categories_permissions']  = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_menu_items_migrations, 5),
+    ['486_tax_seed_max_custom_categories_setting']   = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 67),
 
     -- =========================================================================
     -- CRM SYSTEM (500-509)

--- a/lapis/migrations/tax-copilot-system.lua
+++ b/lapis/migrations/tax-copilot-system.lua
@@ -2276,4 +2276,32 @@ return {
         db.query("CREATE INDEX IF NOT EXISTS idx_tx_custom_category ON tax_transactions(custom_category_uuid)")
         print("[Tax Copilot] Added modified_by_* + custom_category_uuid columns to tax_transactions")
     end,
+
+    -- 67. Seed max_custom_categories_per_user setting (issue #308 user side).
+    --
+    -- Per-user creation cap that admins can tune at runtime without a code
+    -- change. Default 20 matches the issue's suggested limit. Stored in
+    -- tax_app_settings as an admin-only integer so it doesn't leak through
+    -- /api/settings/public — the user-side POST endpoint reads it directly
+    -- from the cached settings_service to enforce the cap.
+    --
+    -- ON CONFLICT DO NOTHING so re-running the migration on a system that
+    -- already has the row (e.g. an admin tuned the value to 50) doesn't
+    -- silently reset their override.
+    [67] = function()
+        db.query([[
+            INSERT INTO tax_app_settings
+                (setting_key, setting_value, setting_type, description, category, is_admin_only)
+            VALUES (
+                'max_custom_categories_per_user',
+                '20'::jsonb,
+                'integer',
+                'Maximum number of custom categories a single user can have at once. The user-side POST endpoint rejects creation beyond this cap. Promoted/rejected customs do not count toward the limit.',
+                'classification',
+                TRUE
+            )
+            ON CONFLICT (setting_key) DO NOTHING
+        ]])
+        print("[Tax Copilot] Seeded max_custom_categories_per_user = 20 (admin-tunable)")
+    end,
 }

--- a/lapis/queries/CustomCategoryQueries.lua
+++ b/lapis/queries/CustomCategoryQueries.lua
@@ -309,8 +309,13 @@ function CustomCategoryQueries.promote(uuid, opts)
                   tostring(opts.hmrc_category_uuid))
         end
 
-        -- 1. Create the new system tax_categories row
-        local new_cat = db.insert("tax_categories", {
+        -- 1. Create the new system tax_categories row.
+        --
+        -- `db.insert` without a `returning` opt returns only the affected-
+        -- rows count (not the inserted row), so `new_cat.id` would be nil
+        -- and the promoted_to_category_id back-link below would silently
+        -- store NULL. Pass `{returning = "*"}` to get the full row back.
+        local insert_result = db.insert("tax_categories", {
             uuid = Global.generateStaticUUID(),
             key = opts.system_key,
             label = opts.system_label,
@@ -323,7 +328,11 @@ function CustomCategoryQueries.promote(uuid, opts)
             is_active = true,
             created_at = db.raw("NOW()"),
             updated_at = db.raw("NOW()"),
-        })
+        }, { returning = "*" })
+        if not insert_result or not insert_result[1] then
+            error("Failed to create promoted tax_categories row")
+        end
+        local new_cat = insert_result[1]
 
         -- 2. Identify which custom rows to promote
         local affected_customs

--- a/lapis/queries/UserCustomCategoryQueries.lua
+++ b/lapis/queries/UserCustomCategoryQueries.lua
@@ -1,0 +1,321 @@
+-- User Custom Category Queries — issue #308 (user side)
+--
+-- This module owns the read/write surface for a USER managing their
+-- own custom categories. Every function takes `user_uuid` so it scopes
+-- automatically — there's no path here that lets one user see or
+-- modify another user's customs.
+--
+-- The admin-side moderation surface (approve, reject, promote, list-
+-- across-users) lives in CustomCategoryQueries.lua and is intentionally
+-- separated so a user-facing endpoint can never accidentally call an
+-- admin-privileged function.
+--
+-- Validation rules enforced here (mirrors what the route layer also
+-- checks; defence in depth):
+--   - Name length 2-100 chars
+--   - Name not empty after trim
+--   - Slug uniqueness per user (UNIQUE constraint enforces; we 422
+--     before hitting it for a clean error code)
+--   - Per-user count cap read from tax_app_settings.max_custom_categories_per_user
+--     (admin-tunable, default 20)
+--
+-- The cap query reads through AppSettingsQueries which is TTL-cached,
+-- so it doesn't hit the DB on every create.
+
+local db = require("lapis.db")
+local AppSettingsQueries = require("queries.AppSettingsQueries")
+
+local UserCustomCategoryQueries = {}
+
+local DEFAULT_MAX_CUSTOMS_PER_USER = 20
+
+-- ---------------------------------------------------------------------------
+-- Helpers
+-- ---------------------------------------------------------------------------
+
+-- Slugify a user-provided name into a `key_normalized` suitable for the
+-- UNIQUE(user_uuid, key_normalized) constraint. Mirrors the conventions
+-- the existing tax_categories.key uses (lowercase, underscores).
+--
+--   "Bee Supplies"             -> "bee_supplies"
+--   "  Auto-Repair! "          -> "auto_repair"
+--   "Café — équipement"        -> "caf_quipement"   (non-ASCII stripped)
+--
+-- We deliberately keep the slug ASCII-only to avoid weird URL/query
+-- escaping issues downstream. The user's original `name` is preserved
+-- in the `name` column for display.
+local function slugify(input)
+    if not input then return "" end
+    local s = tostring(input):lower()
+    -- collapse anything not [a-z0-9] into a single underscore
+    s = s:gsub("[^a-z0-9]+", "_")
+    -- trim leading/trailing underscores
+    s = s:gsub("^_+", ""):gsub("_+$", "")
+    -- collapse runs (defensive; the substitution above already does this)
+    s = s:gsub("__+", "_")
+    return s
+end
+
+local function trim(input)
+    if not input then return "" end
+    local s = tostring(input)
+    return (s:gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+local function get_max_per_user()
+    local row = AppSettingsQueries.get("max_custom_categories_per_user")
+    if row and type(row.setting_value) == "number" then
+        return row.setting_value
+    end
+    -- Some JSONB drivers surface integers as strings — handle defensively
+    if row and tonumber(row.setting_value) then
+        return tonumber(row.setting_value)
+    end
+    return DEFAULT_MAX_CUSTOMS_PER_USER
+end
+
+local function feature_enabled()
+    return AppSettingsQueries.get_bool("allow_user_custom_categories", false)
+end
+
+-- ---------------------------------------------------------------------------
+-- Reads
+-- ---------------------------------------------------------------------------
+
+-- List the current user's customs. Includes promoted + rejected so the
+-- user can see the full lifecycle of what they've submitted; the UI can
+-- filter to active ones if desired.
+function UserCustomCategoryQueries.list_for_user(user_uuid, params)
+    params = params or {}
+    -- Every column reference must be qualified with the `tucc` alias —
+    -- both `tax_user_custom_categories` and `tax_categories` have an
+    -- `is_active` column, and the LEFT JOIN below would make the
+    -- unqualified reference ambiguous. Postgres rejects with:
+    --   ERROR: column reference "is_active" is ambiguous
+    local where = { "tucc.user_uuid = " .. db.escape_literal(user_uuid),
+                    "tucc.is_active = true" }
+    if params.status and params.status ~= "all" then
+        table.insert(where, "tucc.status = " .. db.escape_literal(params.status))
+    end
+    local where_sql = table.concat(where, " AND ")
+
+    return db.query([[
+        SELECT
+            tucc.id, tucc.uuid, tucc.user_uuid, tucc.namespace_id,
+            tucc.name, tucc.key_normalized, tucc.status,
+            tucc.mapped_to_category_id, tucc.mapped_to_hmrc_category_id,
+            tucc.admin_notes, tucc.reviewed_at,
+            tucc.promoted_to_category_id, tucc.promoted_at,
+            tucc.usage_count, tucc.is_active,
+            tucc.created_at, tucc.updated_at,
+            mapped_cat.key   AS mapped_to_category_key,
+            mapped_cat.label AS mapped_to_category_label
+        FROM tax_user_custom_categories tucc
+        LEFT JOIN tax_categories mapped_cat
+               ON mapped_cat.id = tucc.mapped_to_category_id
+        WHERE ]] .. where_sql .. [[
+        ORDER BY tucc.created_at DESC
+    ]]) or {}
+end
+
+function UserCustomCategoryQueries.get_for_user(user_uuid, custom_uuid)
+    local rows = db.query([[
+        SELECT
+            tucc.*,
+            mapped_cat.key   AS mapped_to_category_key,
+            mapped_cat.label AS mapped_to_category_label
+        FROM tax_user_custom_categories tucc
+        LEFT JOIN tax_categories mapped_cat
+               ON mapped_cat.id = tucc.mapped_to_category_id
+        WHERE tucc.uuid = ? AND tucc.user_uuid = ? AND tucc.is_active = true
+        LIMIT 1
+    ]], custom_uuid, user_uuid)
+    return rows and rows[1] or nil
+end
+
+function UserCustomCategoryQueries.count_active_for_user(user_uuid)
+    -- Count only "active" customs from the user's perspective: pending +
+    -- approved. Rejected/promoted shouldn't count toward the cap because
+    -- the user can no longer use them.
+    local result = db.query([[
+        SELECT COUNT(*) AS n
+        FROM tax_user_custom_categories
+        WHERE user_uuid = ? AND is_active = TRUE
+          AND status IN ('pending', 'approved')
+    ]], user_uuid)
+    return result and result[1] and tonumber(result[1].n) or 0
+end
+
+-- ---------------------------------------------------------------------------
+-- Writes
+-- ---------------------------------------------------------------------------
+
+-- Create a new custom for `user_uuid`. Returns (row, nil) on success or
+-- (nil, error_message, http_status) on failure so the route layer can map
+-- to the right HTTP response.
+function UserCustomCategoryQueries.create_for_user(user_uuid, namespace_id, params)
+    params = params or {}
+
+    if not feature_enabled() then
+        return nil,
+            "Custom categories are currently disabled. Ask your administrator to enable them in App Settings.",
+            403
+    end
+
+    local raw_name = trim(params.name or "")
+    if #raw_name < 2 then
+        return nil, "Name must be at least 2 characters", 400
+    end
+    if #raw_name > 100 then
+        return nil, "Name must be at most 100 characters", 400
+    end
+
+    local key = slugify(raw_name)
+    if #key < 2 then
+        return nil, "Name must contain at least 2 letters or digits", 400
+    end
+    if #key > 120 then
+        -- key_normalized column is varchar(120); slugify shouldn't grow
+        -- past that but be defensive
+        key = key:sub(1, 120)
+    end
+
+    -- Per-user cap (admin-tunable via tax_app_settings).
+    --
+    -- Known race: if a user fires two concurrent POSTs from different
+    -- tabs/devices we may briefly accept (cap+1) rows before either
+    -- transaction commits its count. The check-then-insert window is
+    -- tiny (single round trip) and the worst case is one extra row over
+    -- the cap. Worth-fixing-only-when only if the cap becomes a
+    -- compliance limit (it's a UX guardrail today). Mitigations available
+    -- if needed:
+    --   - SELECT ... FOR UPDATE on a per-user lock row
+    --   - INSERT ... WHERE (SELECT COUNT(*) ...) < max in a CTE
+    -- For now we accept the +/-1 imprecision.
+    local existing = UserCustomCategoryQueries.count_active_for_user(user_uuid)
+    local max_allowed = get_max_per_user()
+    if existing >= max_allowed then
+        return nil,
+            ("You've reached the limit of %d custom categories. Delete or wait for admin moderation on existing ones."):format(max_allowed),
+            422
+    end
+
+    -- Pre-flight uniqueness check for a clean error code (the UNIQUE
+    -- constraint will also enforce, but raising IntegrityError gives a
+    -- worse client experience).
+    local dup = db.query([[
+        SELECT id FROM tax_user_custom_categories
+        WHERE user_uuid = ? AND key_normalized = ? AND is_active = TRUE
+        LIMIT 1
+    ]], user_uuid, key)
+    if dup and #dup > 0 then
+        return nil,
+            ("You already have a custom category named %q."):format(raw_name),
+            422
+    end
+
+    -- Use RETURNING * so the response includes the DB-generated columns
+    -- (uuid via gen_random_uuid() default, the integer id, exact server
+    -- timestamps). Without this `db.insert` returns only the affected-rows
+    -- count and the frontend gets `undefined` for `name` / `uuid` /
+    -- `status` — which would render an empty row in the picker.
+    local result = db.insert("tax_user_custom_categories", {
+        user_uuid = user_uuid,
+        namespace_id = tonumber(namespace_id) or 0,
+        name = raw_name,
+        key_normalized = key,
+        status = "pending",
+        usage_count = 0,
+        is_active = true,
+        created_at = db.raw("NOW()"),
+        updated_at = db.raw("NOW()"),
+    }, { returning = "*" })
+
+    if not result or not result[1] then
+        return nil, "Failed to create custom category", 500
+    end
+    return result[1], nil, 201
+end
+
+-- Rename a pending custom. Approved/rejected/promoted customs cannot be
+-- renamed by the user — once admin has touched it, the name is part of
+-- the moderation record and changing it would invalidate the audit trail.
+function UserCustomCategoryQueries.rename_for_user(user_uuid, custom_uuid, new_name)
+    local row = UserCustomCategoryQueries.get_for_user(user_uuid, custom_uuid)
+    if not row then
+        return nil, "Custom category not found", 404
+    end
+    if row.status ~= "pending" then
+        return nil,
+            "Only pending custom categories can be renamed",
+            422
+    end
+
+    local raw_name = trim(new_name or "")
+    if #raw_name < 2 then
+        return nil, "Name must be at least 2 characters", 400
+    end
+    if #raw_name > 100 then
+        return nil, "Name must be at most 100 characters", 400
+    end
+
+    local key = slugify(raw_name)
+    if #key < 2 then
+        return nil, "Name must contain at least 2 letters or digits", 400
+    end
+
+    if key ~= row.key_normalized then
+        local dup = db.query([[
+            SELECT id FROM tax_user_custom_categories
+            WHERE user_uuid = ? AND key_normalized = ?
+              AND uuid <> ? AND is_active = TRUE
+            LIMIT 1
+        ]], user_uuid, key, custom_uuid)
+        if dup and #dup > 0 then
+            return nil,
+                ("You already have a custom category named %q."):format(raw_name),
+                422
+        end
+    end
+
+    db.update("tax_user_custom_categories", {
+        name = raw_name,
+        key_normalized = key,
+        updated_at = db.raw("NOW()"),
+    }, { uuid = custom_uuid, user_uuid = user_uuid })
+
+    return UserCustomCategoryQueries.get_for_user(user_uuid, custom_uuid), nil, 200
+end
+
+-- Delete (soft, sets is_active = false) a pending custom. Refuses if any
+-- transaction is currently tagged with it — the user must clear the
+-- transaction tag first. Approved/promoted customs cannot be deleted by
+-- the user; only admin can do that via the moderation surface.
+function UserCustomCategoryQueries.delete_for_user(user_uuid, custom_uuid)
+    local row = UserCustomCategoryQueries.get_for_user(user_uuid, custom_uuid)
+    if not row then
+        return nil, "Custom category not found", 404
+    end
+    if row.status ~= "pending" then
+        return nil,
+            "Only pending custom categories can be deleted by the user. " ..
+            "Approved or promoted ones must be removed by an admin.",
+            422
+    end
+    if tonumber(row.usage_count or 0) > 0 then
+        return nil,
+            "Cannot delete: " .. tostring(row.usage_count) ..
+            " transaction(s) are currently tagged with this category. " ..
+            "Re-categorise those transactions first.",
+            422
+    end
+
+    db.update("tax_user_custom_categories", {
+        is_active = false,
+        updated_at = db.raw("NOW()"),
+    }, { uuid = custom_uuid, user_uuid = user_uuid })
+
+    return { uuid = custom_uuid, deleted = true }, nil, 200
+end
+
+return UserCustomCategoryQueries

--- a/lapis/routes/tax-custom-categories.lua
+++ b/lapis/routes/tax-custom-categories.lua
@@ -1,0 +1,186 @@
+--[[
+    Tax User Custom Categories Routes — issue #308 (user side)
+
+    Lets a user manage their OWN custom category names. The admin
+    moderation surface (approve/reject/promote, list across users) is
+    in tax-admin-custom-categories.lua and is not reachable here.
+
+    Endpoint summary:
+      GET    /api/v2/tax/custom-categories          — list my customs
+      GET    /api/v2/tax/custom-categories/:uuid    — detail (mine only)
+      POST   /api/v2/tax/custom-categories          — create
+      PUT    /api/v2/tax/custom-categories/:uuid    — rename (pending only)
+      DELETE /api/v2/tax/custom-categories/:uuid    — soft-delete (pending only)
+
+    The frontend's userCustomCategoryApi.rename uses lapisApi.put to match.
+    PUT semantics fit better than PATCH here because the body is a full
+    replacement of the editable field set (just `name` for now).
+
+    Auth: every route is gated by AuthMiddleware.requireAuth. Admin/
+    accountant gates are NOT applied — these are user-self-service
+    endpoints. The query layer enforces user_uuid scoping so a logged-in
+    user can never see or modify another user's customs through this
+    surface, even via parameter manipulation.
+
+    The feature flag (allow_user_custom_categories) is checked on POST.
+    GET / PATCH / DELETE keep working when the flag flips off so users
+    can clean up after themselves — locking them out of their own data
+    is bad UX.
+]]
+
+local UserCustomCategoryQueries = require("queries.UserCustomCategoryQueries")
+local RequestParser = require("helper.request_parser")
+local AuthMiddleware = require("middleware.auth")
+
+local function error_response(status, message, details)
+    ngx.log(ngx.ERR, "[Custom Categories] ", message,
+            details and (" | " .. tostring(details)) or "")
+    return {
+        status = status,
+        json = {
+            error = message,
+            details = type(details) == "string" and details or nil,
+        },
+    }
+end
+
+local function user_uuid(self)
+    if not self.current_user then return nil end
+    return self.current_user.uuid or self.current_user.id
+end
+
+local function namespace_id(self)
+    if self.current_user and self.current_user.namespace_id then
+        return tonumber(self.current_user.namespace_id) or 0
+    end
+    -- Lapis sometimes nests namespace info under userinfo
+    if self.current_user and self.current_user.userinfo
+       and self.current_user.userinfo.namespace then
+        local ns = self.current_user.userinfo.namespace
+        return tonumber(ns.id or ns.namespace_id) or 0
+    end
+    return 0
+end
+
+return function(app)
+
+    -- LIST my custom categories (optionally filtered by status)
+    --   ?status=pending|approved|rejected|promoted|all  (default: all)
+    app:get("/api/v2/tax/custom-categories",
+        AuthMiddleware.requireAuth(function(self)
+            local uid = user_uuid(self)
+            if not uid or uid == "" then
+                return error_response(401, "Authentication required")
+            end
+
+            local rows = UserCustomCategoryQueries.list_for_user(uid, {
+                status = self.params.status,
+            })
+
+            return {
+                status = 200,
+                json = { data = rows or {}, total = #(rows or {}) }
+            }
+        end)
+    )
+
+    -- DETAIL — same shape as the list rows but a single row
+    app:get("/api/v2/tax/custom-categories/:uuid",
+        AuthMiddleware.requireAuth(function(self)
+            local uid = user_uuid(self)
+            if not uid or uid == "" then
+                return error_response(401, "Authentication required")
+            end
+
+            local row = UserCustomCategoryQueries.get_for_user(uid, self.params.uuid)
+            if not row then
+                return error_response(404, "Custom category not found")
+            end
+            return { status = 200, json = { data = row } }
+        end)
+    )
+
+    -- CREATE a new custom for me
+    -- Body: { "name": "Bee Supplies" }
+    app:post("/api/v2/tax/custom-categories",
+        AuthMiddleware.requireAuth(function(self)
+            local uid = user_uuid(self)
+            if not uid or uid == "" then
+                return error_response(401, "Authentication required")
+            end
+
+            local params = RequestParser.parse_request(self)
+            -- Reject non-string values explicitly so a `{ name: true }` or
+            -- `{ name: 42 }` body doesn't slip through and create a category
+            -- with an unexpected name. RequestParser doesn't enforce types.
+            if type(params.name) ~= "string" or #params.name == 0 then
+                return error_response(400, "Field 'name' is required and must be a string")
+            end
+
+            local row, err, status = UserCustomCategoryQueries.create_for_user(
+                uid, namespace_id(self), { name = params.name }
+            )
+            if not row then
+                return error_response(status or 500, err)
+            end
+
+            return {
+                status = 201,
+                json = {
+                    data = row,
+                    message = "Custom category created. An admin will review it shortly.",
+                },
+            }
+        end)
+    )
+
+    -- RENAME (pending only)
+    -- Body: { "name": "New Name" }
+    app:put("/api/v2/tax/custom-categories/:uuid",
+        AuthMiddleware.requireAuth(function(self)
+            local uid = user_uuid(self)
+            if not uid or uid == "" then
+                return error_response(401, "Authentication required")
+            end
+
+            local params = RequestParser.parse_request(self)
+            if type(params.name) ~= "string" or #params.name == 0 then
+                return error_response(400, "Field 'name' is required and must be a string")
+            end
+
+            local row, err, status = UserCustomCategoryQueries.rename_for_user(
+                uid, self.params.uuid, params.name
+            )
+            if not row then
+                return error_response(status or 500, err)
+            end
+            return {
+                status = 200,
+                json = { data = row, message = "Custom category renamed" },
+            }
+        end)
+    )
+
+    -- DELETE (pending + zero usage only). Soft-delete.
+    app:delete("/api/v2/tax/custom-categories/:uuid",
+        AuthMiddleware.requireAuth(function(self)
+            local uid = user_uuid(self)
+            if not uid or uid == "" then
+                return error_response(401, "Authentication required")
+            end
+
+            local row, err, status = UserCustomCategoryQueries.delete_for_user(
+                uid, self.params.uuid
+            )
+            if not row then
+                return error_response(status or 500, err)
+            end
+            return {
+                status = 200,
+                json = { message = "Custom category deleted" },
+            }
+        end)
+    )
+
+    ngx.log(ngx.NOTICE, "[Custom Categories] user-side routes initialized")
+end


### PR DESCRIPTION
Closes #308 (Lapis side).

Pairs with [bwalia/diy-tax-return-uk#311](https://github.com/bwalia/diy-tax-return-uk/pull/311) — together they deliver the full issue #308 feature set across both backends.

## Schema (already on this branch from earlier commits)

5 phased migrations, all idempotent — re-runnable safely.

| Phase | Migration | What |
|---|---|---|
| 63 | `tax_create_app_settings` | key/value store for runtime feature flags + admin-tunable values |
| 64 | `tax_create_user_custom_categories` | per-user custom categories with status state machine (pending → approved/rejected → promoted) |
| 65 | `tax_create_transaction_audit` | append-only history table for every transaction state change |
| 66 | `tax_add_transaction_audit_columns` | `modified_by_user_uuid`, `modified_by_role`, `modified_at`, `custom_category_uuid` on `tax_transactions` |
| 67 | `tax_seed_max_custom_categories_setting` | seeds `max_custom_categories_per_user = 20` (admin-tunable) |

Plus phase [5] in the menu-items migrations: registers the new RBAC modules (`tax_app_settings`, `tax_custom_categories`) and grants them to default admin roles.

## Admin moderation surface (already shipped earlier)

| Method | Route | RBAC | Purpose |
|---|---|---|---|
| GET/PUT | `/api/v2/admin/settings` | `tax_app_settings:read/update` | App settings CRUD with cross-setting cascade (disabling editing disables customs) |
| GET | `/api/v2/admin/custom-categories` | `tax_custom_categories:read` | Moderation queue with status filter, search, pagination |
| GET | `/api/v2/admin/custom-categories/stats` | `tax_custom_categories:read` | Counts by status |
| GET | `/api/v2/admin/custom-categories/duplicates` | `tax_custom_categories:read` | Finds customs proposed by ≥3 distinct users (promotion candidates) |
| PUT | `/api/v2/admin/custom-categories/{uuid}/approve` | `tax_custom_categories:update` | Approve + map to a system category |
| PUT | `/api/v2/admin/custom-categories/{uuid}/reject` | `tax_custom_categories:update` | Reject with admin notes |
| POST | `/api/v2/admin/custom-categories/{uuid}/promote` | `tax_custom_categories:manage` | Destructive: creates a new system `tax_categories` row, bulk-migrates every affected user's transactions, marks customs as `promoted` — all in one DB transaction |

## What's new in this PR

### 1. User-side custom categories (`/api/v2/tax/custom-categories`)

- **Where:** new `routes/tax-custom-categories.lua` + `queries/UserCustomCategoryQueries.lua`
- All routes scope strictly to the calling `user_uuid` — no path lets one user see or modify another's customs
- Pre-flight validation before the DB constraint trips:
  - Name length 2–100 chars
  - Slug uniqueness per user (the UNIQUE constraint also enforces, but raising IntegrityError gives a worse client experience)
  - Per-user cap read from `tax_app_settings.max_custom_categories_per_user` (admin-tunable, default 20)
  - Cap query reads through TTL-cached `AppSettingsQueries`, so it doesn't hit the DB on every create
- Refuses delete when any transaction still references the custom — admin-side moderation owns the lifecycle for approved/promoted customs
- `db.insert(..., { returning = "*" })` so the response includes the DB-generated `uuid` and timestamps. Without this the frontend would render an empty row in the picker (lesson from a bug fix earlier in the session — same pattern applied to the admin promote path below).

### 2. Error envelope improvements (mirror FastAPI catalog handler)

- `lib/error_occurrence.lua` — `Occurrence.record` now generates the row UUID up-front and returns it on success, `nil` on failure. Lets the caller include the same `occurrence_uuid` in the response envelope.
- `lib/errors.lua` — `Errors.response` captures that UUID and adds it to the envelope. Frontend already renders a "send to support" button when the field is present, so admin gets a deep-link from the user's toast straight to `/admin/errors/occurrences/<uuid>`. Gracefully degrades to `correlation_id`-only when the audit insert fails.

### 3. Bug fix on admin promote

- `queries/CustomCategoryQueries.lua` — `db.insert` without `returning="*"` was silently dropping `new_cat.id`, so `promoted_to_category_id` was being stored as `NULL` on every promotion. Now passes `returning="*"` and errors loudly if the row fails to come back.

## Permission model

Two new RBAC modules registered (granted by phase [5] of the menu-items migration):

- `tax_app_settings` (read, update, manage) — gates the App Settings page
- `tax_custom_categories` (read, update, manage) — gates the Custom Categories moderation queue

Existing modules untouched: `tax_transactions:read` is reused for the per-transaction audit history endpoint and the new global activity log endpoint on the FastAPI side.

## Test plan

- [ ] Run `lapis migrate` on a fresh DB — all migrations apply cleanly; re-running is a no-op
- [ ] Run `lapis migrate` on an already-migrated DB — phase 67 doesn't reset an admin's tuned `max_custom_categories_per_user` value (ON CONFLICT DO NOTHING)
- [ ] User can POST `/api/v2/tax/custom-categories` with `{name: "Bee Supplies"}` and get back the new row with `uuid`, `name`, `key_normalized`, `status: "pending"`
- [ ] Duplicate name (same user) → 422 with clean error code, not 500
- [ ] Name shorter than 2 chars or longer than 100 → 422
- [ ] Hitting the cap → 422 with the configured cap value in the message
- [ ] User cannot list/get/edit another user's customs (force a different `user_uuid` in the JWT — gets empty list / 404)
- [ ] DELETE refuses when a transaction is still tagged with the custom (`usage_count > 0`)
- [ ] Admin promotes a custom → `promoted_to_category_id` is now populated (the bug fix)
- [ ] Any error response carries `occurrence_uuid` in the envelope (check the toast in the frontend for the support button)
- [ ] `luac -p` passes on every changed `.lua` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)