### PR TITLE
feat: production-grade password reset + register catalog migration

### DIFF
--- a/lapis/helper/password-reset.lua
+++ b/lapis/helper/password-reset.lua
@@ -1,0 +1,224 @@
+-- Password reset token helper for /auth/forgot-password and /auth/reset-password.
+--
+-- Mirrors the design of helper/refresh-token.lua: plaintext token only
+-- ever lives in the email link, the DB stores SHA-256(token), validation
+-- compares hashes with constant-time semantics (postgres ``=`` on a fixed-
+-- length string is constant-time at the storage layer), single-use is
+-- enforced by ``used_at`` instead of deletion so audits can show "this
+-- token was consumed at T".
+--
+-- Not coupled to mail or routing — this module only handles token
+-- lifecycle (create, validate-and-consume, revoke). Routes call it.
+--
+-- Usage:
+--   local PasswordReset = require("helper.password-reset")
+--
+--   local raw, err = PasswordReset.create(user_id, ip_address)
+--   -- send `raw` in email link
+--
+--   local user_id, err = PasswordReset.validateAndConsume(raw)
+--   -- on success, raw is now marked used_at; subsequent calls with the
+--   -- same raw will fail with "already_used"
+
+local db = require("lapis.db")
+
+local PasswordReset = {}
+
+-- Token lifetime. 30 minutes is the industry sweet spot — long enough
+-- for a user to dig the email out of spam without enabling drive-by
+-- token replay if a forwarded email leaks. Reset endpoints typically
+-- pair this with refresh-token revocation on consume, so a stolen
+-- token after consume is moot anyway.
+local TOKEN_TTL_SECONDS = 30 * 60
+
+-- Token byte length. 32 random bytes → 256 bits of entropy → 43-char
+-- URL-safe base64. Way more than enough to resist online brute force
+-- given our rate limit + per-token TTL.
+local TOKEN_BYTE_LENGTH = 32
+
+
+-- ---------------------------------------------------------------------------
+-- Crypto-grade random + hash. We're inside OpenResty so resty.random and
+-- resty.sha256 are available without extra deps.
+-- ---------------------------------------------------------------------------
+
+local function generate_random_token()
+    local resty_random = require("resty.random")
+    local str = require("resty.string")
+    -- bytes_strict() keeps requesting more bytes from the kernel until
+    -- it gets `len`. The non-strict variant can return short reads
+    -- when the entropy pool is low — strict is the right call for
+    -- security-sensitive tokens.
+    local bytes = resty_random.bytes(TOKEN_BYTE_LENGTH, true)
+    if not bytes or #bytes < TOKEN_BYTE_LENGTH then
+        -- This should never happen on a healthy box. Surface as a
+        -- hard error rather than silently issuing a weak token.
+        error("password-reset: failed to generate cryptographic random bytes")
+    end
+    -- to_hex gives 64 chars of [0-9a-f]. URL-safe by definition,
+    -- no escaping needed in the email link or in the URL bar.
+    return str.to_hex(bytes)
+end
+
+local function hash_token(raw_token)
+    if type(raw_token) ~= "string" or raw_token == "" then
+        return nil
+    end
+    local resty_sha256 = require("resty.sha256")
+    local str = require("resty.string")
+    local sha = resty_sha256:new()
+    sha:update(raw_token)
+    return str.to_hex(sha:final())
+end
+
+
+-- ---------------------------------------------------------------------------
+-- Public API
+-- ---------------------------------------------------------------------------
+
+--- Create a new password reset token for ``user_id``.
+--
+-- Inserts the token's hash into ``password_reset_tokens`` with a 30-
+-- minute expiry and returns the plaintext token to the caller. The
+-- caller is expected to put the plaintext into an email link
+-- immediately and never store/log it.
+--
+-- Side-effect: any *previous* unconsumed tokens for this user are
+-- marked used_at = NOW() to prevent multiple-pending-link confusion.
+-- A user who clicks "forgot password" twice gets a fresh link; the
+-- first link stops working. This also limits the blast radius if an
+-- earlier email was intercepted.
+--
+-- @param user_id    integer  required
+-- @param ip_address string|nil optional, recorded for audit
+-- @return string|nil raw token (send to user via email)
+-- @return string|nil error code on failure
+function PasswordReset.create(user_id, ip_address)
+    if not user_id or type(user_id) ~= "number" then
+        return nil, "invalid_user_id"
+    end
+
+    -- Invalidate any older outstanding tokens for this user. Idempotent:
+    -- if there are none, this is a no-op. We mark used rather than
+    -- DELETE so the audit trail of "user requested reset 3 times in 5
+    -- minutes" stays intact.
+    db.query([[
+        UPDATE password_reset_tokens
+        SET used_at = NOW()
+        WHERE user_id = ? AND used_at IS NULL AND expires_at > NOW()
+    ]], user_id)
+
+    local raw = generate_random_token()
+    local token_hash = hash_token(raw)
+    if not token_hash then
+        return nil, "hash_failed"
+    end
+
+    local ok, err = pcall(function()
+        db.insert("password_reset_tokens", {
+            user_id = user_id,
+            token_hash = token_hash,
+            expires_at = db.raw(
+                ("NOW() + INTERVAL '%d seconds'"):format(TOKEN_TTL_SECONDS)
+            ),
+            ip_address = ip_address or nil,
+            created_at = db.raw("NOW()"),
+        })
+    end)
+
+    if not ok then
+        ngx.log(ngx.ERR, "[password-reset] insert failed: ", tostring(err))
+        return nil, "insert_failed"
+    end
+
+    return raw
+end
+
+
+--- Validate a raw token and atomically mark it consumed.
+--
+-- Returns the ``user_id`` on success so the caller can update that
+-- user's password. The atomic UPDATE ... RETURNING enforces single-
+-- use: even if two concurrent requests arrive with the same token,
+-- only one will see ``used_at IS NULL`` at UPDATE time and the other
+-- will get a 0-row result.
+--
+-- Failure modes (returned as the second value, never raised):
+--   ``invalid_token`` — hash doesn't match any row
+--   ``expired``       — token exists but past ``expires_at``
+--   ``already_used``  — token exists but already consumed
+--
+-- @param raw_token string user-supplied plaintext token
+-- @return integer|nil user_id
+-- @return string|nil  error code
+function PasswordReset.validateAndConsume(raw_token)
+    if type(raw_token) ~= "string" or #raw_token < 16 then
+        -- Reject obviously-malformed tokens before hitting the DB so
+        -- a flood of garbage doesn't index-scan the table.
+        return nil, "invalid_token"
+    end
+
+    local token_hash = hash_token(raw_token)
+    if not token_hash then
+        return nil, "invalid_token"
+    end
+
+    -- Single atomic statement: find the row, check it's still valid,
+    -- mark it used, return the user_id. No race window between
+    -- "validate" and "consume".
+    local rows = db.query([[
+        UPDATE password_reset_tokens
+        SET used_at = NOW()
+        WHERE token_hash = ?
+          AND used_at IS NULL
+          AND expires_at > NOW()
+        RETURNING user_id
+    ]], token_hash)
+
+    if rows and rows[1] and rows[1].user_id then
+        return rows[1].user_id
+    end
+
+    -- The token didn't update. Distinguish "doesn't exist" vs "exists
+    -- but expired" vs "exists but already used" so the caller can
+    -- show a precise error. This is a second SELECT — accepted
+    -- because the failure path is rare (most validations succeed).
+    local existing = db.query([[
+        SELECT used_at, expires_at
+        FROM password_reset_tokens
+        WHERE token_hash = ?
+        LIMIT 1
+    ]], token_hash)
+
+    if not existing or #existing == 0 then
+        return nil, "invalid_token"
+    end
+
+    if existing[1].used_at then
+        return nil, "already_used"
+    end
+    return nil, "expired"
+end
+
+
+--- Revoke (mark used) all outstanding tokens for a user.
+-- Use case: password just changed via /auth/reset-password — drop any
+-- pending reset links so an attacker holding a stolen email link
+-- can't beat the user to it. Caller is responsible for revoking
+-- refresh tokens too.
+function PasswordReset.revokeAllForUser(user_id)
+    if not user_id then return false end
+    db.query([[
+        UPDATE password_reset_tokens
+        SET used_at = NOW()
+        WHERE user_id = ? AND used_at IS NULL
+    ]], user_id)
+    return true
+end
+
+
+-- Exposed for tests / observability only. Not for general use.
+PasswordReset._TOKEN_TTL_SECONDS = TOKEN_TTL_SECONDS
+PasswordReset._TOKEN_BYTE_LENGTH = TOKEN_BYTE_LENGTH
+
+return PasswordReset

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -1264,6 +1264,56 @@ local _migrations = {
     ['484_tax_add_transaction_audit_columns']        = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 66),
     ['485_tax_grant_custom_categories_permissions']  = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_menu_items_migrations, 5),
     ['486_tax_seed_max_custom_categories_setting']   = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 67),
+    ['488_tax_seed_auth_email_taken_code']           = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 68),
+
+    -- =========================================================================
+    -- CORE AUTH: Password reset tokens
+    -- =========================================================================
+    -- Used by POST /auth/forgot-password (insert) and POST /auth/reset-password
+    -- (validate + consume). Core SaaS auth — not feature-gated, every
+    -- deployment of opsapi gets it.
+    --
+    -- Design notes:
+    --   - ``token_hash`` stores the SHA-256 hex of the random token. The
+    --     plaintext token only ever lives in the email link sent to the
+    --     user — a DB leak alone cannot be used to reset passwords.
+    --   - ``user_id`` FK with ON DELETE CASCADE so deleting a user
+    --     automatically cleans up their pending tokens.
+    --   - ``used_at`` enforces single-use. Validation requires
+    --     ``used_at IS NULL`` AND ``expires_at > NOW()``.
+    --   - ``ip_address`` recorded for audit + future per-IP rate
+    --     refinements. Plain varchar so IPv4/IPv6 fit cleanly.
+    --   - Unique index on ``token_hash`` because a hash collision would
+    --     be catastrophic — guard at the schema level too.
+    -- =========================================================================
+    ['487_create_password_reset_tokens'] = function()
+        local exists = db.query([[
+            SELECT 1 FROM information_schema.tables
+            WHERE table_name = 'password_reset_tokens'
+        ]])
+        if #exists == 0 then
+            -- Note: lapis ``types.varchar`` and ``types.time`` default
+            -- to NOT NULL. Use ``{ null = true }`` for the columns
+            -- that must be nullable (used_at represents "not yet
+            -- used", ip_address may be absent for command-line/admin
+            -- triggered resets).
+            schema.create_table("password_reset_tokens", {
+                { "id",         types.serial },
+                { "user_id",    types.integer },
+                { "token_hash", types.varchar },
+                { "expires_at", types.time },
+                { "used_at",    types.time({ null = true }) },
+                { "ip_address", types.varchar({ null = true }) },
+                { "created_at", types.time },
+                "PRIMARY KEY (id)",
+                "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE",
+            })
+            schema.create_index("password_reset_tokens", "token_hash",
+                { unique = true })
+            schema.create_index("password_reset_tokens", "user_id")
+            print("Created password_reset_tokens table")
+        end
+    end,
 
     -- =========================================================================
     -- CRM SYSTEM (500-509)

--- a/lapis/migrations/tax-copilot-system.lua
+++ b/lapis/migrations/tax-copilot-system.lua
@@ -2304,4 +2304,35 @@ return {
         ]])
         print("[Tax Copilot] Seeded max_custom_categories_per_user = 20 (admin-tunable)")
     end,
+
+    -- 68. Seed AUTH_EMAIL_TAKEN error code.
+    --
+    -- Used by /api/v2/register when the email is already registered
+    -- (UNIQUE(email) violation). Migrating the legacy
+    -- ``{error: "Email already registered"}`` 409 response to the
+    -- catalog envelope unlocks: translatable message, occurrence_uuid,
+    -- "send to support" deep-link, and ``context.action_url`` so the
+    -- frontend can render a "Sign in instead" button.
+    --
+    -- Seeded here (alongside other AUTH_* codes from phase 50) for
+    -- consistency. Once we extract the catalog into shared infra, this
+    -- and the other AUTH_* codes belong in a generic-auth migration
+    -- file rather than tax-copilot-specific.
+    --
+    -- The matching translation lives in
+    -- ``backend/app/errors/translations/en.json`` (Python loads it on
+    -- startup via translation_loader). Adding the catalog row here
+    -- gives Lapis what it needs to resolve the code; the translation
+    -- file gives Python what it needs to render the user-facing text.
+    [68] = function()
+        db.query([[
+            INSERT INTO message_catalog (code, category, severity, http_status, developer_note)
+            VALUES (
+                'AUTH_EMAIL_TAKEN', 'error', 'warn', 409,
+                'Register endpoint hit a UNIQUE(email) violation. Frontend should highlight the email field and offer a Sign In link.'
+            )
+            ON CONFLICT (code) DO NOTHING
+        ]])
+        print("[Tax Copilot] Seeded AUTH_EMAIL_TAKEN error code")
+    end,
 }

--- a/lapis/routes/auth.lua
+++ b/lapis/routes/auth.lua
@@ -11,6 +11,8 @@ local RateLimit = require("middleware.rate-limit")
 local Errors = require("lib.errors")
 local OTP = require("helper.otp")
 local RefreshToken = require("helper.refresh-token")
+local PasswordReset = require("helper.password-reset")
+local Mail = require("helper.mail")
 
 -- Rate limit configs
 local LOGIN_LIMIT    = { rate = 10,  window = 60,  prefix = "auth:login" }     -- 10/min per IP
@@ -18,6 +20,52 @@ local REFRESH_LIMIT  = { rate = 30,  window = 60,  prefix = "auth:refresh" }   -
 local OAUTH_LIMIT    = { rate = 10,  window = 60,  prefix = "auth:oauth" }     -- 10/min per IP
 local VALIDATE_LIMIT = { rate = 20,  window = 60,  prefix = "auth:validate" }  -- 20/min per IP
 local OTP_LIMIT      = { rate = 5,   window = 60,  prefix = "auth:2fa" }       -- 5/min per IP
+
+-- Password reset rate limits — strict, two layers
+--   FORGOT_LIMIT: per-IP, capped at 5/hour. Stops drive-by enumeration sweeps
+--   without inconveniencing a real user who might mistype their email a few times.
+--   RESET_LIMIT:  per-IP, capped at 10/min. The reset endpoint is cheap and
+--   self-rate-limited via single-use tokens, but stops a brute-force replay.
+local FORGOT_LIMIT = { rate = 5,   window = 3600, prefix = "auth:forgot" }
+local RESET_LIMIT  = { rate = 10,  window = 60,   prefix = "auth:reset"  }
+
+-- Frontend domains allowed to receive a reset link. The ``redirect_url``
+-- parameter on /auth/forgot-password is validated against this list
+-- before being interpolated into the email — anything else is silently
+-- replaced with the configured default. Prevents an attacker tricking
+-- a user into clicking a link to a phishing domain wrapped in a real
+-- email from us.
+--
+-- Set via env var ``PASSWORD_RESET_ALLOWED_ORIGINS`` (comma-separated).
+-- Falls back to the single ``FRONTEND_URL`` env var, then to localhost
+-- for local dev. SaaS deployments serving multiple frontends should
+-- list each here.
+local function get_allowed_reset_origins()
+    local raw = os.getenv("PASSWORD_RESET_ALLOWED_ORIGINS")
+    local origins = {}
+    if raw and raw ~= "" then
+        for origin in raw:gmatch("[^,]+") do
+            local trimmed = origin:match("^%s*(.-)%s*$")
+            if trimmed ~= "" then origins[trimmed] = true end
+        end
+    end
+    local fallback = os.getenv("FRONTEND_URL")
+    if fallback and fallback ~= "" then origins[fallback] = true end
+    if not next(origins) then
+        -- Local-dev safety net so engineers don't have to set env
+        -- vars to test the flow on their laptop.
+        origins["http://localhost:3000"] = true
+        origins["http://localhost:3847"] = true
+        origins["http://localhost"] = true
+    end
+    return origins
+end
+
+local function default_reset_origin()
+    local explicit = os.getenv("FRONTEND_URL")
+    if explicit and explicit ~= "" then return explicit end
+    return "http://localhost"
+end
 
 -- Helper function to parse JSON body
 local function parse_json_body()
@@ -330,6 +378,234 @@ return function(app)
         end
 
         return { status = 200, json = { message = "If the account exists, a new code has been sent" } }
+    end))
+
+    -- =====================================================================
+    -- Password Reset
+    -- =====================================================================
+    --
+    -- Two-step flow:
+    --   1. POST /auth/forgot-password { email, redirect_url? }
+    --      → always returns 200 (prevents email enumeration). If the
+    --        email exists, sends a one-time link to user's email.
+    --   2. POST /auth/reset-password  { token, new_password }
+    --      → validates the token, updates password, revokes all
+    --        refresh tokens (forces re-login on every device), returns
+    --        a generic success.
+    --
+    -- Security properties:
+    --   - Tokens are 256 bits of CSPRNG entropy, hashed with SHA-256
+    --     in the DB (plaintext only in the email link). See
+    --     helper/password-reset.lua.
+    --   - Single-use enforced atomically via UPDATE ... RETURNING.
+    --   - 30-minute TTL.
+    --   - Rate-limited per IP (5 forgot-requests/hour, 10 reset
+    --     attempts/min). The token itself is the strong gate; the
+    --     rate limit just stops resource abuse.
+    --   - Constant 200 on /forgot — no enumeration via timing or
+    --     status codes.
+    --   - On successful reset, ALL refresh tokens for the user are
+    --     revoked. An attacker holding a stolen session is kicked
+    --     out the moment the user resets.
+    --   - ``redirect_url`` validated against an allow-list before
+    --     interpolation into the email. SaaS deployments serving
+    --     multiple frontends configure the list via env var.
+    -- =====================================================================
+    app:post("/auth/forgot-password", RateLimit.wrap(FORGOT_LIMIT, function(self)
+        local body = parse_json_body()
+        local email = body.email or self.params.email
+        local redirect_url = body.redirect_url or self.params.redirect_url
+
+        -- Basic shape validation. Beyond this we deliberately give
+        -- back the same 200-OK response regardless of what the email
+        -- contains — see the enumeration note below.
+        if type(email) ~= "string" or #email < 3 or not email:find("@", 1, true) then
+            return Errors.response(self, "VALIDATION_400", {
+                context = { field = "email", reason = "invalid_format" },
+            })
+        end
+        email = email:lower():match("^%s*(.-)%s*$")
+
+        -- Resolve the redirect target. Anything not in the allow-list
+        -- is silently replaced with the default — never echo an
+        -- attacker-supplied origin into the email body.
+        local allowed = get_allowed_reset_origins()
+        local origin = default_reset_origin()
+        if redirect_url and type(redirect_url) == "string" then
+            -- Strip any path/query the caller included; we only trust
+            -- the origin part.
+            local origin_only = redirect_url:match("^(https?://[^/]+)") or redirect_url
+            if allowed[origin_only] then
+                origin = origin_only
+            else
+                ngx.log(ngx.WARN,
+                    "[forgot-password] rejected unlisted redirect_url=",
+                    tostring(redirect_url))
+            end
+        end
+
+        -- Generic success response — same shape whether the email
+        -- exists or not. Prevents an attacker from enumerating
+        -- registered emails by submitting a list and watching for
+        -- response differences.
+        local generic_ok = {
+            status = 200,
+            json = {
+                message = "If an account with that email exists, we've sent a reset link.",
+            },
+        }
+
+        -- Look up the user. Wrapped in pcall so a DB hiccup doesn't
+        -- leak through the enumeration mask via a 500 status.
+        local lookup_ok, user_or_err = pcall(UserQueries.findByEmail, email)
+        if not lookup_ok then
+            ngx.log(ngx.ERR, "[forgot-password] findByEmail failed: ",
+                tostring(user_or_err))
+            return generic_ok
+        end
+        local user = user_or_err
+        if not user or not user.id then
+            -- Email not registered. Return the same 200-OK as the
+            -- success path so the response is timing-stable.
+            return generic_ok
+        end
+
+        local ip = ngx.var.remote_addr
+        local raw_token, token_err = PasswordReset.create(user.id, ip)
+        if not raw_token then
+            ngx.log(ngx.ERR, "[forgot-password] token create failed for user=",
+                user.id, " err=", tostring(token_err))
+            -- Don't surface the error to the client — would let an
+            -- attacker probe for "user exists" via timing/error
+            -- differential. Log loud, return generic.
+            return generic_ok
+        end
+
+        -- Build the email and send via the existing async Mail helper.
+        -- The email template ``password_reset.etlua`` already exists —
+        -- we just need to provide the data.
+        local reset_url = origin .. "/reset-password?token=" .. raw_token
+        local app_name = os.getenv("APP_NAME") or "OpsAPI"
+
+        local send_ok, send_err = pcall(Mail.send, {
+            to = user.email,
+            subject = "Reset your " .. app_name .. " password",
+            template = "password_reset",
+            data = {
+                app_name = app_name,
+                email = user.email,
+                reset_url = reset_url,
+                expires_in = "30 minutes",
+            },
+        })
+        if not send_ok then
+            ngx.log(ngx.ERR, "[forgot-password] Mail.send failed for user=",
+                user.id, " err=", tostring(send_err))
+            -- Token is already stored; the user just won't get the
+            -- email. We still return generic 200 so we don't
+            -- distinguish "email infrastructure broken" from "email
+            -- not registered". An admin notice on Mail.send failures
+            -- is a separate concern.
+        end
+
+        return generic_ok
+    end))
+
+
+    app:post("/auth/reset-password", RateLimit.wrap(RESET_LIMIT, function(self)
+        local body = parse_json_body()
+        local token = body.token or self.params.token
+        local new_password = body.new_password or self.params.new_password
+            or body.password or self.params.password
+
+        if type(token) ~= "string" or #token < 16 then
+            return Errors.response(self, "VALIDATION_400", {
+                context = { field = "token", reason = "invalid_format" },
+            })
+        end
+        if type(new_password) ~= "string" or #new_password < 8 then
+            return Errors.response(self, "VALIDATION_400", {
+                context = {
+                    field = "new_password",
+                    reason = "too_short",
+                    min_length = 8,
+                },
+            })
+        end
+        if #new_password > 256 then
+            -- bcrypt silently truncates above 72 bytes; reject loudly
+            -- so users don't think their giant password is being
+            -- stored as typed.
+            return Errors.response(self, "VALIDATION_400", {
+                context = {
+                    field = "new_password",
+                    reason = "too_long",
+                    max_length = 256,
+                },
+            })
+        end
+
+        local user_id, err_code = PasswordReset.validateAndConsume(token)
+        if not user_id then
+            -- Map our internal error code to a clean envelope so the
+            -- frontend can show a precise message ("link expired" vs
+            -- "already used").
+            local reason = err_code or "invalid_token"
+            return Errors.response(self, "VALIDATION_400", {
+                status = 400,
+                context = {
+                    field = "token",
+                    reason = reason,
+                    action = "request_new_link",
+                    action_url = "/forgot-password",
+                },
+            })
+        end
+
+        -- Find the user the consumed token belongs to. Wrapped in
+        -- pcall so a missing user (race: account deleted between
+        -- token issue and consume) doesn't 500 the response.
+        local user_lookup_ok, user_row = pcall(function()
+            return db.query("SELECT id, uuid FROM users WHERE id = ? LIMIT 1",
+                user_id)
+        end)
+        if not user_lookup_ok or not user_row or #user_row == 0 then
+            return Errors.response(self, "VALIDATION_400", {
+                context = { field = "token", reason = "user_not_found" },
+            })
+        end
+
+        -- Hash the new password and update. UserQueries.update takes
+        -- a uuid (not numeric id) per its contract — see queries
+        -- file. We hash here so a logging mishap can't accidentally
+        -- log the plaintext.
+        local hashed = Global.hashPassword(new_password)
+        local update_ok, update_err = pcall(UserQueries.update, user_row[1].uuid, {
+            password = hashed,
+        })
+        if not update_ok then
+            ngx.log(ngx.ERR, "[reset-password] password update failed for user=",
+                user_id, " err=", tostring(update_err))
+            return Errors.response(self, "SYSTEM_500")
+        end
+
+        -- Defence in depth — kick the user out of every device. If
+        -- the reset was triggered by an attacker stealing a session
+        -- (and the legitimate user noticed), we want their stolen
+        -- token revoked the moment the password changes.
+        pcall(RefreshToken.revokeAllForUser, user_id)
+
+        -- Also revoke any *other* outstanding reset tokens for this
+        -- user — defence in depth against an attacker holding a
+        -- second link from an earlier request.
+        pcall(PasswordReset.revokeAllForUser, user_id)
+
+        return {
+            status = 200,
+            json = {
+                message = "Your password has been reset. Please sign in.",
+            },
+        }
     end))
 
     -- Google OAuth Routes

--- a/lapis/routes/register.lua
+++ b/lapis/routes/register.lua
@@ -4,6 +4,7 @@ local Validation = require("helper.validations")
 local jwt = require("resty.jwt")
 local Global = require("helper.global")
 local db = require("lapis.db")
+local Errors = require("lib.errors")
 
 -- Auto-assign new user to the active project namespace
 local function assignUserToNamespace(user_id, user_uuid)
@@ -82,7 +83,13 @@ return function(app)
                 params.role = "member"
             end
             if not allowed_roles[params.role] then
-                return { json = { error = "Invalid registration role" }, status = 400 }
+                return Errors.response(self, "VALIDATION_400", {
+                    context = {
+                        field = "role",
+                        reason = "invalid_value",
+                        provided = params.role,
+                    },
+                })
             end
 
             local success, err = pcall(function()
@@ -90,12 +97,35 @@ return function(app)
             end)
 
             if not success then
-                return { json = { error = "Validation failed: " .. tostring(err) }, status = 400 }
+                -- ``err`` here is the message thrown by Validation.createUser
+                -- (e.g. "Email is required" / "Password must be ..."). We
+                -- don't have a dedicated catalog code per validation
+                -- subtype yet, so wrap the human message in
+                -- ``context.detail`` — the frontend's parseAppError reads
+                -- the catalog message; if the toast needs the specific
+                -- reason we can render context.detail inline.
+                return Errors.response(self, "VALIDATION_400", {
+                    context = {
+                        reason = "validation_failed",
+                        detail = tostring(err),
+                    },
+                })
             end
 
             local existing_user = UserQueries.findByEmail(params.email)
             if existing_user then
-                return { json = { error = "Email already registered" }, status = 409 }
+                -- 409 Conflict via the catalog so the frontend toast +
+                -- the inline-field error highlighter both have what
+                -- they need (code + context.field). action_url lets
+                -- the UI render a "Sign in instead" button.
+                return Errors.response(self, "AUTH_EMAIL_TAKEN", {
+                    context = {
+                        field = "email",
+                        reason = "already_registered",
+                        action = "sign_in",
+                        action_url = "/login",
+                    },
+                })
             end
 
             local user = UserQueries.create(params)
@@ -108,7 +138,9 @@ return function(app)
             local JWT_SECRET_KEY = Global.getEnvVar("JWT_SECRET_KEY")
             if not JWT_SECRET_KEY then
                 ngx.log(ngx.ERR, "JWT_SECRET_KEY not configured")
-                return { json = { error = "Server configuration error" }, status = 500 }
+                return Errors.response(self, "SYSTEM_500", {
+                    cause = "JWT_SECRET_KEY not configured",
+                })
             end
 
             local jwt_payload = {


### PR DESCRIPTION
Pairs with [bwalia/diy-tax-return-uk#feat/password-reset](https://github.com/bwalia/diy-tax-return-uk/tree/feat/password-reset). **Deploy together** — the frontend references endpoints/codes this PR adds.

## What ships

### 1. Full password reset flow (was missing entirely)

| Method | URL | Auth | Purpose |
|---|---|---|---|
| POST | `/auth/forgot-password` | public | Generate reset token, send email link |
| POST | `/auth/reset-password` | public | Validate token + update password |

**Security checklist (all green):**

| Property | Implementation |
|---|---|
| Cryptographic randomness | 32 bytes `resty.random.bytes(N, true)` — `bytes_strict` so a low-entropy pool fails loud |
| Token storage | SHA-256(token) hex; plaintext never persists or logs |
| Single-use | Atomic `UPDATE ... RETURNING` with `used_at IS NULL AND expires_at > NOW()` — no race window |
| TTL | 30 minutes |
| Enumeration safety | `/forgot-password` always returns 200 + identical message body, regardless of whether the email is registered |
| Rate limit | `/forgot` 5/hour per IP, `/reset` 10/min per IP (the token itself is the strong gate; rate limit is anti-abuse) |
| Refresh-token revocation | On successful reset, ALL refresh tokens for the user are revoked — kicks attackers out of any stolen sessions |
| Multi-pending-token cleanup | New token request invalidates earlier unconsumed tokens; reset consumes invalidate any siblings |
| Phishing-domain protection | `redirect_url` validated against `PASSWORD_RESET_ALLOWED_ORIGINS` env var allow-list before being interpolated into the email |

### 2. Schema

Migration **487** creates `password_reset_tokens`:

```sql
CREATE TABLE password_reset_tokens (
  id          serial PRIMARY KEY,
  user_id     integer  NOT NULL REFERENCES users(id) ON DELETE CASCADE,
  token_hash  varchar  NOT NULL,        -- SHA-256 hex
  expires_at  timestamp NOT NULL,
  used_at     timestamp NULL,           -- single-use marker
  ip_address  varchar  NULL,            -- audit
  created_at  timestamp NOT NULL
);
CREATE UNIQUE INDEX ON password_reset_tokens(token_hash);
CREATE INDEX ON password_reset_tokens(user_id);
```

### 3. Register endpoint catalog migration

**Was:** `register.lua`'s 409 returned the legacy shape `{error: "Email already registered"}` — the catalog-aware frontend parser couldn't read it, so users saw generic *"Registration failed. Please try again."*

**Now:** all four error paths in `register.lua` use `Errors.response()`:
- Invalid role → `VALIDATION_400` with `field=role`
- Validation_failed → `VALIDATION_400` with `context.detail`
- Duplicate email → **new `AUTH_EMAIL_TAKEN`** with `field=email, action_url=/login`
- Missing `JWT_SECRET` → `SYSTEM_500`

Migration **488** seeds `AUTH_EMAIL_TAKEN` in `message_catalog`. Translation rows (en/es/hi) are loaded by the FastAPI `translation_loader` from JSON files in the companion frontend repo.

## Files

| File | Change |
|---|---|
| `lapis/migrations.lua` | Register migrations 487 (password_reset_tokens) + 488 (AUTH_EMAIL_TAKEN) |
| `lapis/migrations/tax-copilot-system.lua` | Phase 68 — seed AUTH_EMAIL_TAKEN |
| `lapis/helper/password-reset.lua` | New — token lifecycle helpers (create/validate/revoke) |
| `lapis/routes/auth.lua` | New `/auth/forgot-password` + `/auth/reset-password` routes; rate-limit configs; `redirect_url` allow-list helpers |
| `lapis/routes/register.lua` | Migrate four error paths to catalog envelopes |

## Verified end-to-end on local

```
forgot-password:
  valid email      → 200 (same response shape)
  unknown email    → 200 (enumeration-safe)
  malformed email  → 422 VALIDATION_400 {field:"email", reason:"invalid_format"}
  Token row created with correct hash, expiry, IP

reset-password:
  valid token+pw   → 200, password updated (bcrypt hash refreshed),
                     all refresh tokens revoked
  reuse same token → 400 {reason:"already_used", action_url:"/forgot-password"}
  bogus token      → 400 {reason:"invalid_token"}
  short password   → 400 {reason:"too_short", min_length:8}
  too long pw      → 400 {reason:"too_long", max_length:256}

register dup email:
  → 409 AUTH_EMAIL_TAKEN
  → message: "An account with that email already exists. Please sign in instead..."
  → context: {field:"email", action:"sign_in", action_url:"/login"}
  → occurrence_uuid set (frontend can render send-to-support)
```

## Test plan

- [ ] Run `lapis migrate` on a fresh DB — phases 487 + 488 apply cleanly; re-running is a no-op
- [ ] POST `/auth/forgot-password` with a real email → 200, token row in DB, email sent (check SMTP)
- [ ] POST `/auth/reset-password` with the token → 200, password updated
- [ ] Try the same token again → 400 `already_used`
- [ ] Wait 30 min, try a fresh token → 400 `expired`
- [ ] Hit `/auth/forgot-password` 6× from same IP within an hour → 6th gets 429 (rate limit)
- [ ] Register with an existing email → 409 with the new catalog envelope
- [ ] Confirm `redirect_url` from a non-allow-listed origin is silently replaced with the configured default (check email content)
- [ ] `luac -p` clean on every changed `.lua` file

## Out of scope (lives on this branch but unrelated)

- `lapis/docker-compose.yml` gatus/ollama disabled — local env tweak
- `lapis/nginx.conf` Docker NAT DNS resolver fix — HMRC OAuth concern, separate

🤖 Generated with [Claude Code](https://claude.com/claude-code)