### PR TITLE
feat: per-namespace allow-list for password reset redirect URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,6 +617,31 @@ helm upgrade --install opsapi ./devops/helm-charts/opsapi \
   --namespace <namespace> --create-namespace
 ```
 
+##### Per-environment frontend URL (required for password reset emails)
+
+Each `values-<env>.yaml` MUST set `frontendUrl` to the canonical frontend
+origin for that environment. The deployment template injects it as
+`FRONTEND_URL`, which migration 489 uses to bootstrap
+`namespaces.allowed_redirect_origins` on first run AND the runtime
+fallback uses if any namespace's column is empty.
+
+```yaml
+# values-acc.yaml example
+frontendUrl: "https://acc.diytaxreturn.co.uk"
+# optional comma-separated extras for multi-frontend tenants:
+# passwordResetAllowedOrigins: "https://acc-alt.diytaxreturn.co.uk"
+```
+
+Without this, password reset emails will contain `http://localhost`
+links — a WARN log fires in production. See [Password Reset Flow](#password-reset-flow).
+After first deploy, verify the bootstrap landed:
+
+```bash
+kubectl -n <namespace> exec deploy/diytaxreturn-lapis -- \
+  psql $DATABASE_URL -c \
+  "SELECT slug, allowed_redirect_origins FROM namespaces;"
+```
+
 #### OpsAPI Node
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -272,6 +272,11 @@ All environment variables are in `lapis/.env`. The `.sample.env` file has workin
 | `CORS_ALLOWED_ORIGINS` | Comma-separated explicit origin URLs |
 | `NODE_API_URL` | Node.js service URL |
 | `OPSAPI_SSL_VERIFY` | SSL verification for external calls (`true`/`false`) |
+| `SMTP_HOST` / `SMTP_PORT` / `SMTP_USER` / `SMTP_PASSWORD` | SMTP server for outbound email (password reset, invitations, OTP) |
+| `SMTP_FROM_EMAIL` / `SMTP_FROM_NAME` | Default sender for outbound email |
+| `APP_NAME` | Display name used in email subject lines (default `OpsAPI`) |
+| `FRONTEND_URL` | **Bootstrap-only**: seeds `namespaces.allowed_redirect_origins` on first run of migration 489. Auto-set by `start.sh`. After migration, the source of truth is the DB column — see [Password Reset Flow](#password-reset-flow). |
+| `PASSWORD_RESET_ALLOWED_ORIGINS` | **Bootstrap-only**: comma-separated extra origins for the same migration 489 bootstrap. Used when one tenant has multiple frontends (e.g. staging + prod). |
 
 **Note:** `NEXT_PUBLIC_API_URL` is a build-time variable for the Next.js dashboard. If changed after initial build, rebuild with:
 
@@ -366,6 +371,182 @@ docker exec -e "PROJECT_CODE=all" -it opsapi lapis migrate
 | `GET /metrics` | Prometheus metrics |
 | `POST /auth/login` | Login (returns JWT) |
 | `POST /api/v2/register` | User registration |
+| `POST /auth/forgot-password` | Request a password-reset email — see [Password Reset Flow](#password-reset-flow) |
+| `POST /auth/reset-password` | Consume a reset token and set a new password |
+
+---
+
+## Password Reset Flow
+
+OpsAPI ships a production-grade password reset flow that scales to
+multi-tenant SaaS without per-environment code or env-var changes
+once a tenant is configured.
+
+### Two-step flow
+
+```
+┌─────────┐     1. POST /auth/forgot-password         ┌─────────┐
+│ Browser │ ─────{email, redirect_url}──────────────► │ OpsAPI  │
+└─────────┘                                            └─────────┘
+                                                            │
+                                              2. Look up user → namespace
+                                                 → allow-list of origins
+                                                            │
+                                              3. Validate redirect_url
+                                                 against allow-list
+                                                            │
+                                              4. Generate 32-byte CSPRNG
+                                                 token, store SHA-256(token)
+                                                            │
+                                              5. Send email with link:
+                                                 ${origin}/reset-password
+                                                 ?token=${plaintext_token}
+                                                            │
+┌─────────┐    User clicks email link             ◄──────────┘
+│ Browser │ ─────────────► /reset-password?token=xxxxx
+│         │                                              │
+│         │     6. POST /auth/reset-password             │
+│         │ ─────{token, new_password}────────────────► OpsAPI
+└─────────┘                                              │
+                                              7. Atomic UPDATE..RETURNING
+                                                 (single-use, race-free)
+                                                            │
+                                              8. bcrypt-hash new password,
+                                                 store, revoke ALL refresh
+                                                 tokens for the user
+                                                            │
+                                              9. 200 OK
+```
+
+### Where the email link points: namespace allow-list
+
+The frontend sends `redirect_url` (its own origin) in the request body.
+OpsAPI validates it against the user's namespace allow-list before
+interpolating it into the email link. This stops an attacker submitting
+a forgot-password for someone else's email with `redirect_url:
+"https://evil.com"` — the link mailed to the real user would otherwise
+point at the attacker's site.
+
+**Allow-list lookup priority:**
+
+1. **`namespaces.allowed_redirect_origins`** (primary, multi-tenant SaaS source of truth)
+   — `TEXT[]` column populated per tenant. The first entry is the
+   canonical primary used as fallback when the request's `redirect_url`
+   isn't in the list.
+
+2. **`PASSWORD_RESET_ALLOWED_ORIGINS` + `FRONTEND_URL` env vars** (bootstrap fallback)
+   — used only when the user's namespace has an empty/NULL column.
+   Migration 489 uses these env vars to populate the column on first
+   run, so the env vars become inert once any namespace is bootstrapped.
+
+3. **`http://localhost`** — last-resort default, for dev only. A WARN
+   log fires if production hits this path.
+
+### Configure a new tenant
+
+For each new SaaS tenant / new environment / new frontend domain, set
+the namespace's allow-list. Three ways depending on your workflow:
+
+**A — `start.sh` auto-bootstrap (existing pattern):**
+Set `FRONTEND_URL` (and optionally `PASSWORD_RESET_ALLOWED_ORIGINS`) in
+the environment. On first migration run, all namespaces with empty
+allow-lists are populated from these env vars.
+
+```bash
+FRONTEND_URL=https://app.example.com \
+PASSWORD_RESET_ALLOWED_ORIGINS=https://staging.example.com,https://acc.example.com \
+  ./start.sh prod
+```
+
+**B — Direct SQL (any time after migration runs):**
+```sql
+UPDATE namespaces
+SET allowed_redirect_origins = ARRAY[
+  'https://app.example.com',         -- primary (first entry)
+  'https://staging.example.com',
+  'https://acc.example.com'
+]
+WHERE slug = 'tax-copilot';
+```
+
+**C — Admin UI (planned, not yet shipped):**
+A future PR adds an "Allowed redirect URLs" tab in `/admin/settings`
+so tenant owners can manage their own list without DB access. The DB
+column is the same; the UI is just CRUD.
+
+### Security properties
+
+| Property | Implementation |
+|---|---|
+| **Cryptographic randomness** | 32 bytes from `resty.random.bytes(N, true)` — `bytes_strict` so a low-entropy pool fails loud rather than issuing a weak token |
+| **Token storage** | SHA-256(token) hex; the plaintext token only ever lives in the email link, never persisted, never logged |
+| **Single-use** | Atomic `UPDATE ... RETURNING` with `used_at IS NULL AND expires_at > NOW()` — no race window between validate and consume |
+| **Token TTL** | 30 minutes (industry standard for reset links) |
+| **Enumeration safety** | `/forgot-password` always returns 200 with the same response body, regardless of whether the email exists |
+| **Rate limit** | `/forgot-password` 5/hour per IP, `/reset-password` 10/min per IP — token itself is the strong gate, rate limit is anti-abuse |
+| **Refresh-token revocation** | On successful reset, every `refresh_tokens` row for the user is revoked — kicks attackers out of any stolen sessions |
+| **Multi-pending-token cleanup** | Re-requesting forgot-password invalidates earlier unconsumed tokens; consuming a token invalidates siblings |
+| **Phishing-domain protection** | The user-supplied `redirect_url` is validated against the namespace allow-list before being interpolated into the email body |
+
+### Verifying it locally
+
+```bash
+# 1. Confirm the column exists and is populated
+docker exec opsapi-postgres-dev-db psql -U pguser -d opsapi-diytaxreturn \
+  -c "SELECT slug, allowed_redirect_origins FROM namespaces;"
+
+# 2. Trigger forgot-password with an allow-listed origin
+curl -X POST http://localhost/opsapi/auth/forgot-password \
+  -H "Content-Type: application/json" \
+  -d '{"email":"admin@taxreturn.uk","redirect_url":"http://localhost"}'
+
+# 3. Trigger with a NON-allow-listed origin (attacker simulation) —
+#    should return 200 (enumeration-safe) but log a WARN and use the
+#    namespace's primary origin in the email
+curl -X POST http://localhost/opsapi/auth/forgot-password \
+  -H "Content-Type: application/json" \
+  -d '{"email":"admin@taxreturn.uk","redirect_url":"https://attacker.com"}'
+
+# 4. Confirm the WARN was logged
+tail -50 lapis/logs/error.log | grep "forgot-password"
+# Expected: "[forgot-password] redirect_url not in allow-list, using primary;
+#            requested=https://attacker.com primary=http://localhost user_id=..."
+
+# 5. Synthesise a token for QA (skips the actual email send)
+docker exec opsapi-postgres-dev-db psql -U pguser -d opsapi-diytaxreturn -c "
+  DELETE FROM password_reset_tokens WHERE user_id = 4;
+  INSERT INTO password_reset_tokens (user_id, token_hash, expires_at, created_at)
+  VALUES (4, encode(digest('local_qa_token_42chars_for_testing_only', 'sha256'), 'hex'),
+          NOW() + INTERVAL '30 minutes', NOW());
+"
+
+# 6. Consume it
+curl -X POST http://localhost/opsapi/auth/reset-password \
+  -H "Content-Type: application/json" \
+  -d '{"token":"local_qa_token_42chars_for_testing_only","new_password":"NewPass123!"}'
+```
+
+### Rolling out to a new environment
+
+1. Deploy this branch — migration 489 runs automatically on container start.
+2. If `FRONTEND_URL` (and optionally `PASSWORD_RESET_ALLOWED_ORIGINS`)
+   is set, the migration auto-bootstraps every namespace's allow-list
+   from those env vars. **You're done.**
+3. Otherwise, populate manually via the SQL in option B above.
+4. Verify with the curl smoke-tests above.
+5. Subsequent additions (new staging URL, domain rename) use option B
+   — no opsapi restart, no env-var change required.
+
+### Files involved
+
+| File | Role |
+|---|---|
+| [`lapis/migrations/tax-copilot-system.lua`](lapis/migrations/tax-copilot-system.lua) | Phase 487 — `password_reset_tokens` table |
+| [`lapis/migrations.lua`](lapis/migrations.lua) | Phase 489 — `namespaces.allowed_redirect_origins` column + bootstrap |
+| [`lapis/helper/password-reset.lua`](lapis/helper/password-reset.lua) | Token lifecycle (create / validate-and-consume / revoke) |
+| [`lapis/queries/NamespaceQueries.lua`](lapis/queries/NamespaceQueries.lua) | `getAllowedRedirectOrigins()` helper |
+| [`lapis/routes/auth.lua`](lapis/routes/auth.lua) | `/auth/forgot-password` and `/auth/reset-password` route handlers |
+| [`lapis/views/emails/password_reset.etlua`](lapis/views/emails/password_reset.etlua) | Email template |
 
 ---
 

--- a/devops/helm-charts/diytaxreturn-lapis/templates/deployment.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/templates/deployment.yaml
@@ -70,6 +70,27 @@ spec:
             - name: NAMESPACE_SLUG
               value: {{ .Values.setup.namespaceSlug | quote }}
             {{- end }}
+            # ── Password reset email links + allow-list bootstrap ──────────
+            # These two env vars feed migration 489's auto-bootstrap of
+            # ``namespaces.allowed_redirect_origins`` AND the legacy
+            # env-var fallback in /auth/forgot-password (defence in
+            # depth for any namespace whose column is empty at runtime).
+            #
+            # ``frontendUrl``  = canonical primary frontend for this tenant.
+            # ``passwordResetAllowedOrigins`` = optional comma-separated
+            # extras for multi-frontend tenants (staging + prod, or
+            # per-region domains).
+            #
+            # See README.md → Password Reset Flow for the full lookup
+            # priority chain.
+            {{- if .Values.frontendUrl }}
+            - name: FRONTEND_URL
+              value: {{ .Values.frontendUrl | quote }}
+            {{- end }}
+            {{- if .Values.passwordResetAllowedOrigins }}
+            - name: PASSWORD_RESET_ALLOWED_ORIGINS
+              value: {{ .Values.passwordResetAllowedOrigins | quote }}
+            {{- end }}
       volumes:
         - name: {{ .Release.Name }}-cm-{{ .Release.Namespace }}-vol
           configMap:

--- a/devops/helm-charts/diytaxreturn-lapis/values-acc.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/values-acc.yaml
@@ -2,6 +2,16 @@ env: acc
 app: diytaxreturn-lapis
 projectCode: all
 
+# ─── Password reset email link target ─────────────────────────────────
+# Canonical frontend origin for this environment. Migration 489 uses
+# this to bootstrap ``namespaces.allowed_redirect_origins`` on first
+# run; runtime path also falls back to it if any namespace's column
+# is empty. See README.md → Password Reset Flow.
+frontendUrl: "https://acc.diytaxreturn.co.uk"
+# Optional: comma-separated extra origins (e.g. an alternate domain
+# or migration period when both old + new domains should be valid).
+# passwordResetAllowedOrigins: "https://acc-alt.diytaxreturn.co.uk"
+
 image:
   repository: bwalia/opsapi
   tag: latest

--- a/devops/helm-charts/diytaxreturn-lapis/values-dev.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/values-dev.yaml
@@ -2,6 +2,15 @@ env: dev
 app: diytaxreturn-lapis
 projectCode: all
 
+# ─── Password reset email link target ─────────────────────────────────
+# Canonical frontend origin for the dev cluster. Migration 489 uses
+# this to bootstrap ``namespaces.allowed_redirect_origins``. Update
+# to your dev frontend URL if you have one; leaving empty is safe —
+# the auth.lua localhost dev fallback will fire and a WARN gets
+# logged. See README.md → Password Reset Flow.
+frontendUrl: "https://dev.diytaxreturn.co.uk"
+# passwordResetAllowedOrigins: ""
+
 image:
   repository: bwalia/opsapi
   tag: latest

--- a/devops/helm-charts/diytaxreturn-lapis/values-int.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/values-int.yaml
@@ -2,6 +2,18 @@ env: int
 app: diytaxreturn-lapis
 projectCode: all
 
+# ─── Password reset email link target ─────────────────────────────────
+# Canonical frontend origin for this environment. Migration 489 uses
+# this to bootstrap ``namespaces.allowed_redirect_origins`` on first
+# run; runtime path also falls back to it if any namespace's column
+# is empty. See README.md → Password Reset Flow.
+#
+# Note: int currently runs on a docker-compose host (192.168.1.193),
+# not k3s. This value applies if/when int migrates to k3s. For the
+# docker-compose deployment, FRONTEND_URL is set by start.sh.
+frontendUrl: "https://int.diytaxreturn.co.uk"
+# passwordResetAllowedOrigins: ""
+
 image:
   repository: bwalia/opsapi
   tag: latest

--- a/devops/helm-charts/diytaxreturn-lapis/values-prod.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/values-prod.yaml
@@ -2,6 +2,18 @@ env: prod
 app: diytaxreturn-lapis
 projectCode: all
 
+# ─── Password reset email link target ─────────────────────────────────
+# Canonical frontend origin for production. Migration 489 uses this
+# to bootstrap ``namespaces.allowed_redirect_origins`` on first run;
+# runtime path also falls back to it if any namespace's column is
+# empty. See README.md → Password Reset Flow.
+#
+# TODO: confirm the production hostname before first deploy. Likely
+# values: https://app.diytaxreturn.co.uk, https://www.diytaxreturn.co.uk,
+# or https://diytaxreturn.co.uk. Update before going live.
+frontendUrl: "https://app.diytaxreturn.co.uk"
+# passwordResetAllowedOrigins: ""
+
 image:
   repository: bwalia/opsapi
   tag: latest

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -1316,6 +1316,100 @@ local _migrations = {
     end,
 
     -- =========================================================================
+    -- CORE AUTH: Per-namespace allow-list of frontend origins for password
+    -- reset emails (and any future "redirect to a frontend" flow).
+    -- =========================================================================
+    --
+    -- Why this column exists
+    --   opsapi is multi-tenant SaaS — different consumers (tax-copilot,
+    --   future products) run their own frontends at their own domains.
+    --   When a user clicks "forgot password", the email link must point
+    --   at THE FRONTEND THAT ISSUED THE REQUEST, not a hardcoded one.
+    --
+    --   The /auth/forgot-password endpoint receives ``redirect_url`` in
+    --   the body — but that's user-supplied, so we can't trust it
+    --   blindly (an attacker could phish via legitimate-looking emails
+    --   pointing at attacker.com). The defence is a per-namespace
+    --   allow-list: the user's namespace declares which origins are
+    --   legitimate, the request's origin is validated against it.
+    --
+    -- Why per-namespace, not per-app or env var
+    --   Per-namespace is the right granularity for SaaS:
+    --     - Tenant onboarding adds a row to namespaces — adds the
+    --       allowed origins in the same step. No env-var update, no
+    --       opsapi restart per new tenant.
+    --     - One tenant can have multiple frontends (staging/prod),
+    --       both legitimate, both in the list.
+    --     - One tenant compromised? Remove their origins from the
+    --       list and they can't be phished anymore.
+    --   The pattern matches Auth0 "Allowed Callback URLs" per app,
+    --   Okta "Trusted Origins", Supabase "Site URL + redirect URLs".
+    --
+    -- Bootstrap from env vars
+    --   To avoid breaking existing deployments (int, acc) that rely on
+    --   FRONTEND_URL / PASSWORD_RESET_ALLOWED_ORIGINS env vars set by
+    --   start.sh, this migration ALSO populates the allow-list for any
+    --   namespace whose column is currently NULL/empty. Idempotent —
+    --   re-running won't overwrite admin edits.
+    --
+    --   Once every namespace has its column populated, the env-var
+    --   fallback in routes/auth.lua becomes a defence-in-depth path,
+    --   not the primary lookup. Future PR can remove the fallback
+    --   when telemetry confirms zero hits on it.
+    -- =========================================================================
+    ['489_add_namespace_allowed_redirect_origins'] = function()
+        -- 1. Add the column. ``IF NOT EXISTS`` makes the migration
+        --    idempotent — safe to re-run, safe across rolling deploys.
+        db.query([[
+            ALTER TABLE namespaces
+            ADD COLUMN IF NOT EXISTS allowed_redirect_origins TEXT[]
+        ]])
+
+        -- 2. Bootstrap. For namespaces with NULL/empty column, fill
+        --    from env vars so deployments that already had FRONTEND_URL
+        --    + PASSWORD_RESET_ALLOWED_ORIGINS configured continue
+        --    working with no manual SQL after this migration runs.
+        local frontend_url = os.getenv("FRONTEND_URL")
+        local extra_csv = os.getenv("PASSWORD_RESET_ALLOWED_ORIGINS")
+
+        local origins = {}
+        local seen = {}
+        local function add_origin(o)
+            if not o or o == "" then return end
+            local trimmed = o:match("^%s*(.-)%s*$")
+            -- Canonicalise: strip path/query/fragment, keep scheme + host.
+            local canon = trimmed:match("^(https?://[^/]+)") or trimmed
+            if canon == "" or seen[canon] then return end
+            seen[canon] = true
+            table.insert(origins, canon)
+        end
+        add_origin(frontend_url)
+        if extra_csv and extra_csv ~= "" then
+            for o in extra_csv:gmatch("[^,]+") do add_origin(o) end
+        end
+
+        if #origins == 0 then
+            print("[Auth] Namespace allow-list column added; no env vars set, " ..
+                  "skipping bootstrap. Populate via SQL or admin UI.")
+            return
+        end
+
+        -- Update only NULL/empty rows. Already-populated namespaces
+        -- (e.g. someone hand-edited via SQL or a future admin UI)
+        -- aren't disturbed.
+        db.query([[
+            UPDATE namespaces
+            SET allowed_redirect_origins = ?,
+                updated_at = NOW()
+            WHERE allowed_redirect_origins IS NULL
+               OR cardinality(allowed_redirect_origins) = 0
+        ]], db.array(origins))
+
+        print(("[Auth] Namespace allow-list bootstrapped from env vars: %s"):format(
+            table.concat(origins, ", ")))
+    end,
+
+    -- =========================================================================
     -- CRM SYSTEM (500-509)
     -- =========================================================================
     ['500_crm_create_pipelines'] = conditional_array(ProjectConfig.FEATURES.CRM, crm_system_migrations, 1),

--- a/lapis/queries/NamespaceQueries.lua
+++ b/lapis/queries/NamespaceQueries.lua
@@ -522,6 +522,32 @@ function NamespaceQueries.getUserDefaultNamespace(user_id)
     return nil
 end
 
+--- Return the namespace's allow-list of frontend origins for redirect
+-- emails (password reset, future invitation links, etc.).
+--
+-- Schema: ``namespaces.allowed_redirect_origins TEXT[]``. Stored as
+-- canonical origins (``scheme://host[:port]``); migration 489 also
+-- bootstraps it from FRONTEND_URL + PASSWORD_RESET_ALLOWED_ORIGINS env
+-- vars when first added.
+--
+-- Returns an empty Lua array (NOT nil) when the column is unset, so
+-- callers can safely iterate without nil-guards.
+--
+-- @param namespace_id number
+-- @return table  array of origin strings (possibly empty)
+function NamespaceQueries.getAllowedRedirectOrigins(namespace_id)
+    if not namespace_id then return {} end
+    local rows = db.query(
+        "SELECT allowed_redirect_origins FROM namespaces WHERE id = ? LIMIT 1",
+        namespace_id
+    )
+    if not rows or #rows == 0 then return {} end
+    local arr = rows[1].allowed_redirect_origins
+    if type(arr) ~= "table" then return {} end
+    return arr
+end
+
+
 --- Get user's permissions in a namespace
 -- @param user_id number User ID
 -- @param namespace_id number Namespace ID

--- a/lapis/routes/auth.lua
+++ b/lapis/routes/auth.lua
@@ -426,24 +426,6 @@ return function(app)
         end
         email = email:lower():match("^%s*(.-)%s*$")
 
-        -- Resolve the redirect target. Anything not in the allow-list
-        -- is silently replaced with the default — never echo an
-        -- attacker-supplied origin into the email body.
-        local allowed = get_allowed_reset_origins()
-        local origin = default_reset_origin()
-        if redirect_url and type(redirect_url) == "string" then
-            -- Strip any path/query the caller included; we only trust
-            -- the origin part.
-            local origin_only = redirect_url:match("^(https?://[^/]+)") or redirect_url
-            if allowed[origin_only] then
-                origin = origin_only
-            else
-                ngx.log(ngx.WARN,
-                    "[forgot-password] rejected unlisted redirect_url=",
-                    tostring(redirect_url))
-            end
-        end
-
         -- Generic success response — same shape whether the email
         -- exists or not. Prevents an attacker from enumerating
         -- registered emails by submitting a list and watching for
@@ -468,6 +450,91 @@ return function(app)
             -- Email not registered. Return the same 200-OK as the
             -- success path so the response is timing-stable.
             return generic_ok
+        end
+
+        -- ────────────────────────────────────────────────────────────
+        -- Resolve which frontend origin to use in the email link.
+        --
+        -- Priority (the SaaS-correct order):
+        --   1. The user's namespace allow-list (DB) — primary.
+        --      Multi-tenant: each tenant declares its own legitimate
+        --      frontend origins via ``namespaces.allowed_redirect_
+        --      origins``. New tenant onboarding adds a row, no env-
+        --      var update or opsapi restart needed.
+        --   2. The legacy global env-var allow-list. Bootstrap-only
+        --      fallback for existing deployments where the namespace
+        --      column hasn't been populated yet (migration 489 will
+        --      bootstrap it from these env vars on first run).
+        --
+        -- The user-supplied ``redirect_url`` is validated against the
+        -- effective allow-list — we never echo an attacker-supplied
+        -- origin into an email. If validation fails, we fall back to
+        -- the first allow-listed origin (canonical primary for that
+        -- namespace).
+        -- ────────────────────────────────────────────────────────────
+        local function canonicalise(url)
+            if type(url) ~= "string" or url == "" then return nil end
+            return url:match("^(https?://[^/]+)") or url
+        end
+
+        -- Build the effective allow-list: namespace first, env-var fallback.
+        local allowed_set = {}
+        local first_origin = nil
+        local function add_to_allowed(o)
+            local canon = canonicalise(o)
+            if not canon or allowed_set[canon] then return end
+            allowed_set[canon] = true
+            if not first_origin then first_origin = canon end
+        end
+
+        local user_ns = NamespaceQueries.getUserDefaultNamespace(user.id)
+        if user_ns and user_ns.id then
+            local ns_origins = NamespaceQueries.getAllowedRedirectOrigins(user_ns.id)
+            for _, o in ipairs(ns_origins or {}) do add_to_allowed(o) end
+        end
+
+        -- Env-var fallback. Lets pre-existing deployments with
+        -- FRONTEND_URL / PASSWORD_RESET_ALLOWED_ORIGINS continue
+        -- working until namespace columns are populated. Once
+        -- migration 489 runs on a fresh DB, these are auto-bootstrapped
+        -- and this fallback becomes inert.
+        if not first_origin then
+            for legacy_origin, _ in pairs(get_allowed_reset_origins()) do
+                add_to_allowed(legacy_origin)
+            end
+        end
+
+        -- Pick the origin to use in the email link.
+        --   - Caller's redirect_url if it's allow-listed (preserves
+        --     "land on the frontend that issued the request" UX when
+        --     a tenant has multiple allow-listed origins, e.g.
+        --     staging + prod).
+        --   - Otherwise the first allow-listed origin (canonical
+        --     primary for that namespace).
+        --   - Last resort: env-var default. Only reachable when
+        --     namespace allow-list is empty AND no env var set —
+        --     should not happen in any properly-configured env, but
+        --     we'd rather send a localhost-pointing email than crash.
+        local origin
+        local requested = canonicalise(redirect_url)
+        if requested and allowed_set[requested] then
+            origin = requested
+        elseif first_origin then
+            origin = first_origin
+            if requested then
+                ngx.log(ngx.WARN,
+                    "[forgot-password] redirect_url not in allow-list, using primary; ",
+                    "requested=", tostring(redirect_url),
+                    " primary=", origin,
+                    " user_id=", user.id)
+            end
+        else
+            origin = default_reset_origin()
+            ngx.log(ngx.WARN,
+                "[forgot-password] no allow-list configured for namespace; ",
+                "using env default. user_id=", user.id,
+                " namespace_id=", user_ns and user_ns.id or "nil",
+                " origin=", origin)
         end
 
         local ip = ngx.var.remote_addr


### PR DESCRIPTION
Builds on the merged password-reset feature (#380, #381). Replaces the env-var-only allow-list with a multi-tenant-native solution: each namespace owns its allowed frontend origins in a `TEXT[]` column on the `namespaces` table.

## Why this matters for going live

opsapi is multi-tenant SaaS. Different consumers (tax-copilot, future products) run their own frontends at their own domains. Today's env-var allow-list means:
- Adding a tenant = config change + opsapi restart
- One opsapi instance can't cleanly serve N tenants with N domains
- Tenant rotation needs DevOps

Per-namespace allow-list means:
- Tenant onboarding adds a row (no deploy)
- Multiple frontends per tenant work natively (staging + prod)
- Compromised tenant frontend → remove URL from list, no opsapi restart
- Future admin UI = CRUD on this column, tenant owners self-serve

Pattern matches Auth0 "Allowed Callback URLs", Okta "Trusted Origins", Supabase "Redirect URLs".

## What changes

### Schema (migration 489)

```sql
ALTER TABLE namespaces
ADD COLUMN IF NOT EXISTS allowed_redirect_origins TEXT[]
```

Migration also **auto-bootstraps** every namespace's column from `FRONTEND_URL` + `PASSWORD_RESET_ALLOWED_ORIGINS` env vars on first run. Existing deployments with those env vars continue working zero-touch.

### Lookup priority in `/auth/forgot-password`

1. **`namespaces.allowed_redirect_origins`** ← primary, multi-tenant native, admin-manageable
2. `PASSWORD_RESET_ALLOWED_ORIGINS` / `FRONTEND_URL` env vars ← bootstrap-only fallback
3. `http://localhost` ← last-resort dev default; WARN logged in production

### Behaviour

The user-supplied `redirect_url` is validated against the effective allow-list:
- **In allow-list** → used in the email link (preserves "land on the frontend that issued the request" UX when tenant has multiple allow-listed origins)
- **Not in allow-list** → falls back to first allow-listed entry (canonical primary), WARN logged with `requested=` + `primary=` + `user_id=` for ops visibility into phishing attempts
- **Allow-list completely empty** → env-var fallback, then localhost dev default

Response stays 200 + same body in all cases (enumeration-safe).

## Files changed

| File | Change |
|---|---|
| `lapis/migrations.lua` | New migration 489 (column + bootstrap) — 83 lines |
| `lapis/queries/NamespaceQueries.lua` | New `getAllowedRedirectOrigins(namespace_id)` helper — 25 lines |
| `lapis/routes/auth.lua` | Refactor forgot-password origin resolution — ~80 lines, replaces the env-var-only block |
| `README.md` | New "Password Reset Flow" section: two-step diagram, allow-list architecture, three configuration paths (start.sh / SQL / future admin UI), 9-row security-property table, local verification commands, rollout checklist, file index |

## Verified end-to-end on local

```
Allow-listed origin (http://localhost):
  → 200 + email link uses http://localhost ✓

Attacker origin (https://attacker.com):
  → 200 (enumeration-safe)
  → WARN logged: "redirect_url not in allow-list, using primary;
     requested=https://attacker.com primary=http://localhost user_id=4"
  → email link uses http://localhost (the namespace's primary) ✓

Empty allow-list (column NULL):
  → falls through to env-var path
  → defence in depth for not-yet-bootstrapped namespaces ✓

Namespace lookup actually fires:
  → SQL log shows: SELECT allowed_redirect_origins FROM namespaces WHERE id = 2 ✓
```

## Deployment for int / acc / prod

**Existing deployments (int, acc, prod that already have `FRONTEND_URL` set by `start.sh` or k8s config):**

1. Deploy this branch
2. Migration 489 runs on container start
3. Migration auto-bootstraps every namespace's `allowed_redirect_origins` from `FRONTEND_URL` + `PASSWORD_RESET_ALLOWED_ORIGINS`
4. **You're done.** Email links land on the right domain.

**Verify after deploy:**
```bash
docker exec opsapi-postgres-... psql -U pguser -d opsapi-... -c \
  "SELECT slug, allowed_redirect_origins FROM namespaces;"
```

Should show your env's frontend URL(s) in every namespace's column.

**Adding a new staging URL or new tenant later (no opsapi restart):**
```sql
UPDATE namespaces
SET allowed_redirect_origins = ARRAY[
  'https://app.example.com',         -- primary (first entry)
  'https://staging.example.com',
  'https://acc.example.com'
]
WHERE slug = 'tax-copilot';
```

## Test plan

- [ ] Migration 489 applies cleanly on a fresh DB, idempotent on re-run
- [ ] Migration bootstraps existing namespaces from env vars when those env vars are set
- [ ] Migration leaves already-populated namespaces alone (admin edits not overwritten)
- [ ] `/auth/forgot-password` with allow-listed origin → 200, email link uses that origin
- [ ] `/auth/forgot-password` with attacker origin → 200 (enumeration-safe), WARN logged, email link uses namespace primary
- [ ] `/auth/forgot-password` with empty namespace allow-list → falls back to env-var path (set both empty for ultimate fallback test)
- [ ] `/auth/reset-password` flow continues to work end-to-end (no regression in the consume path)
- [ ] `luac -p` clean

## Out of scope on this branch

- `lapis/docker-compose.yml` (gatus/ollama disabled — local env tweak)
- `lapis/nginx.conf` (Docker NAT DNS resolver — separate concern)

## Future follow-ups

- Admin UI in `/admin/settings` to let tenant owners manage their own allow-list without DB access (the column is the same; the UI is just CRUD)
- Deprecate the env-var fallback once telemetry confirms zero hits across all envs

🤖 Generated with [Claude Code](https://claude.com/claude-code)