### PR TITLE
feat: admin UI endpoints for redirect-origins + primary-always-wins reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,20 +386,20 @@ once a tenant is configured.
 
 ```
 ┌─────────┐     1. POST /auth/forgot-password         ┌─────────┐
-│ Browser │ ─────{email, redirect_url}──────────────► │ OpsAPI  │
+│ Browser │ ─────{email}─────────────────────────────► │ OpsAPI  │
 └─────────┘                                            └─────────┘
                                                             │
                                               2. Look up user → namespace
                                                  → allow-list of origins
                                                             │
-                                              3. Validate redirect_url
-                                                 against allow-list
+                                              3. Pick primary
+                                                 (= first entry in list)
                                                             │
                                               4. Generate 32-byte CSPRNG
                                                  token, store SHA-256(token)
                                                             │
                                               5. Send email with link:
-                                                 ${origin}/reset-password
+                                                 ${primary}/reset-password
                                                  ?token=${plaintext_token}
                                                             │
 ┌─────────┐    User clicks email link             ◄──────────┘
@@ -418,21 +418,27 @@ once a tenant is configured.
                                               9. 200 OK
 ```
 
-### Where the email link points: namespace allow-list
+### Where the email link points: primary always wins
 
-The frontend sends `redirect_url` (its own origin) in the request body.
-OpsAPI validates it against the user's namespace allow-list before
-interpolating it into the email link. This stops an attacker submitting
-a forgot-password for someone else's email with `redirect_url:
-"https://evil.com"` — the link mailed to the real user would otherwise
-point at the attacker's site.
+The reset-link destination is the **namespace primary** — the first
+entry in `namespaces.allowed_redirect_origins`. Admins set it through
+the admin UI; OpsAPI does not honour any caller-supplied `redirect_url`
+when picking the destination. This means:
 
-**Allow-list lookup priority:**
+- **Admin-controlled, not caller-controlled.** Changing where reset
+  emails land is a UI action, not a code change. Phishing attempts that
+  POST forgot-password with `redirect_url: "https://evil.com"` cannot
+  redirect the email link to the attacker's site.
+- **Predictable for tenants.** Whatever the admin marks as primary in
+  the UI is exactly where every reset email points — no surprise
+  echo-back to whichever frontend the request originated from.
 
-1. **`namespaces.allowed_redirect_origins`** (primary, multi-tenant SaaS source of truth)
-   — `TEXT[]` column populated per tenant. The first entry is the
-   canonical primary used as fallback when the request's `redirect_url`
-   isn't in the list.
+**Origin lookup priority:**
+
+1. **`namespaces.allowed_redirect_origins[1]`** (primary, multi-tenant SaaS source of truth)
+   — `TEXT[]` column populated per tenant. Position 1 is authoritative;
+   subsequent entries are reserved for future use cases (e.g. OAuth
+   callback aliases) and do not affect password-reset routing.
 
 2. **`PASSWORD_RESET_ALLOWED_ORIGINS` + `FRONTEND_URL` env vars** (bootstrap fallback)
    — used only when the user's namespace has an empty/NULL column.
@@ -469,10 +475,12 @@ SET allowed_redirect_origins = ARRAY[
 WHERE slug = 'tax-copilot';
 ```
 
-**C — Admin UI (planned, not yet shipped):**
-A future PR adds an "Allowed redirect URLs" tab in `/admin/settings`
-so tenant owners can manage their own list without DB access. The DB
-column is the same; the UI is just CRUD.
+**C — Admin UI (`/admin/settings` → "Frontend URLs" tab):**
+Platform admins manage the per-namespace list with no DB access:
+add/remove URLs, drag the primary to position 1, save. The first
+entry is automatically used as the primary destination for reset
+emails. Backed by `GET`/`PUT
+/api/v2/admin/namespaces/:uuid/redirect-origins`.
 
 ### Security properties
 
@@ -486,7 +494,7 @@ column is the same; the UI is just CRUD.
 | **Rate limit** | `/forgot-password` 5/hour per IP, `/reset-password` 10/min per IP — token itself is the strong gate, rate limit is anti-abuse |
 | **Refresh-token revocation** | On successful reset, every `refresh_tokens` row for the user is revoked — kicks attackers out of any stolen sessions |
 | **Multi-pending-token cleanup** | Re-requesting forgot-password invalidates earlier unconsumed tokens; consuming a token invalidates siblings |
-| **Phishing-domain protection** | The user-supplied `redirect_url` is validated against the namespace allow-list before being interpolated into the email body |
+| **Phishing-domain protection** | Email destination is the admin-configured namespace primary; `redirect_url` from the client is ignored, so an attacker cannot steer the email link to a phishing domain |
 
 ### Verifying it locally
 
@@ -495,22 +503,21 @@ column is the same; the UI is just CRUD.
 docker exec opsapi-postgres-dev-db psql -U pguser -d opsapi-diytaxreturn \
   -c "SELECT slug, allowed_redirect_origins FROM namespaces;"
 
-# 2. Trigger forgot-password with an allow-listed origin
+# 2. Trigger forgot-password — destination is always the namespace primary,
+#    regardless of any redirect_url the caller sends
 curl -X POST http://localhost/opsapi/auth/forgot-password \
   -H "Content-Type: application/json" \
-  -d '{"email":"admin@taxreturn.uk","redirect_url":"http://localhost"}'
+  -d '{"email":"admin@taxreturn.uk"}'
 
-# 3. Trigger with a NON-allow-listed origin (attacker simulation) —
-#    should return 200 (enumeration-safe) but log a WARN and use the
-#    namespace's primary origin in the email
+# 3. Even when an attacker sends a phishing redirect_url, the email link
+#    still points at the configured primary (server ignores redirect_url)
 curl -X POST http://localhost/opsapi/auth/forgot-password \
   -H "Content-Type: application/json" \
   -d '{"email":"admin@taxreturn.uk","redirect_url":"https://attacker.com"}'
 
-# 4. Confirm the WARN was logged
-tail -50 lapis/logs/error.log | grep "forgot-password"
-# Expected: "[forgot-password] redirect_url not in allow-list, using primary;
-#            requested=https://attacker.com primary=http://localhost user_id=..."
+# 4. Confirm by inspecting the latest reset-link in the email log /
+#    queue — it should be ${primary}/reset-password?token=... where
+#    ${primary} matches allowed_redirect_origins[1] from step 1.
 
 # 5. Synthesise a token for QA (skips the actual email send)
 docker exec opsapi-postgres-dev-db psql -U pguser -d opsapi-diytaxreturn -c "

--- a/lapis/queries/NamespaceQueries.lua
+++ b/lapis/queries/NamespaceQueries.lua
@@ -12,6 +12,56 @@ local Model = require("lapis.db.model").Model
 local Namespaces = Model:extend("namespaces")
 local NamespaceQueries = {}
 
+--- Derive a sensible default ``allowed_redirect_origins`` for a freshly
+-- created namespace from environment variables, mirroring the bootstrap
+-- logic in migration 489.
+--
+-- Why this exists
+--   Without this, ``NamespaceQueries.create`` leaves the column NULL,
+--   so the runtime fallback in /auth/forgot-password kicks in for every
+--   new tenant and every tenant ends up sharing the global env-var
+--   FRONTEND_URL. Populating the column at create-time gives admins
+--   a visible default they can later override via SQL or the (planned)
+--   admin UI, and lets us eventually drop the runtime env-var fallback
+--   entirely once every namespace has its column populated.
+--
+-- Multi-tenant caveat (intentional, not a bug)
+--   The default is whatever ``FRONTEND_URL`` /
+--   ``PASSWORD_RESET_ALLOWED_ORIGINS`` happen to be set to on the
+--   opsapi instance — typically the URL of the FIRST tenant. For
+--   subsequent tenants on a multi-tenant instance, callers MUST pass
+--   their own ``allowed_redirect_origins`` in the ``data`` table to
+--   override this default. See the route handlers in
+--   ``routes/namespaces.lua`` for the recommended pattern: derive
+--   from the request's X-Forwarded-Host or accept an explicit
+--   parameter from the admin UI.
+--
+-- @return table  array of canonicalised origin strings (possibly empty)
+local function derive_default_allowed_origins()
+    local frontend_url = os.getenv("FRONTEND_URL")
+    local extra_csv = os.getenv("PASSWORD_RESET_ALLOWED_ORIGINS")
+
+    local origins = {}
+    local seen = {}
+    local function add(o)
+        if not o or o == "" then return end
+        local trimmed = o:match("^%s*(.-)%s*$")
+        -- Canonicalise: strip path/query/fragment, keep scheme + host[:port].
+        -- Same canonicalisation applied at runtime in routes/auth.lua so
+        -- comparisons are apples-to-apples.
+        local canon = trimmed:match("^(https?://[^/]+)") or trimmed
+        if canon == "" or seen[canon] then return end
+        seen[canon] = true
+        table.insert(origins, canon)
+    end
+    add(frontend_url)
+    if extra_csv and extra_csv ~= "" then
+        for o in extra_csv:gmatch("[^,]+") do add(o) end
+    end
+    return origins
+end
+
+
 --- Generate a unique slug from name
 -- @param name string The namespace name
 -- @return string The generated slug
@@ -39,7 +89,18 @@ local function generateSlug(name)
 end
 
 --- Create a new namespace
--- @param data table { name, slug?, description?, domain?, logo_url?, plan?, settings?, max_users?, max_stores?, owner_user_id? }
+-- @param data table {
+--   name, slug?, description?, domain?, logo_url?, plan?, settings?,
+--   max_users?, max_stores?, owner_user_id?,
+--   allowed_redirect_origins? — array of canonical origin strings
+--     (``scheme://host[:port]``) that this namespace's password-reset
+--     emails are allowed to link to. If omitted, defaults to the value
+--     derived from FRONTEND_URL + PASSWORD_RESET_ALLOWED_ORIGINS env
+--     vars (same shape as migration 489's bootstrap). For multi-tenant
+--     deployments the caller SHOULD pass this explicitly so each
+--     tenant gets its own URL — see the helper docstring above for
+--     the rationale.
+-- }
 -- @return table The created namespace
 function NamespaceQueries.create(data)
     local timestamp = Global.getCurrentTimestamp()
@@ -48,6 +109,17 @@ function NamespaceQueries.create(data)
     local slug = data.slug
     if not slug or slug == "" then
         slug = generateSlug(data.name)
+    end
+
+    -- Resolve the allow-list. Caller-supplied wins; an explicit empty
+    -- table is respected (treated as "deliberately empty"); only
+    -- ``nil`` (key absent) triggers the env-var fallback. Distinguishes
+    -- "I want no origins" from "I forgot to pass any" — important when
+    -- an admin UI explicitly clears the list to lock the namespace
+    -- out of password-reset emails.
+    local allowed_origins = data.allowed_redirect_origins
+    if allowed_origins == nil then
+        allowed_origins = derive_default_allowed_origins()
     end
 
     local namespace_data = {
@@ -67,6 +139,15 @@ function NamespaceQueries.create(data)
         created_at = timestamp,
         updated_at = timestamp
     }
+
+    -- Only set the array column when we actually have origins. An
+    -- empty Lua table sent to Postgres TEXT[] becomes ``{}`` (empty
+    -- array), which the runtime treats the same as NULL — but the
+    -- DB column allows NULL too, so this is just clarity for any
+    -- admin querying the table later.
+    if #allowed_origins > 0 then
+        namespace_data.allowed_redirect_origins = db.array(allowed_origins)
+    end
 
     return Namespaces:create(namespace_data, { returning = "*" })
 end
@@ -521,6 +602,109 @@ function NamespaceQueries.getUserDefaultNamespace(user_id)
 
     return nil
 end
+
+--- Validate + canonicalise a list of frontend origin strings.
+--
+-- Rules:
+--   - Must be ``http://`` or ``https://`` only — rejects ``javascript:``,
+--     ``data:``, ``file:``, etc. that would be useful for XSS pivots
+--     in an email link.
+--   - Path/query/fragment stripped — only the origin (scheme + host
+--     + optional port) is stored.
+--   - Whitespace trimmed.
+--   - Duplicates removed (preserves first-seen order).
+--   - Empty list is allowed (admin can intentionally disable password
+--     reset for a namespace); caller can enforce non-empty if desired.
+--
+-- Returns ``(canonicalised_array, nil)`` on success or
+-- ``(nil, error_message)`` on validation failure (first bad entry
+-- wins so the message points at the actual offender).
+local function validate_origins(input)
+    if type(input) ~= "table" then
+        return nil, "expected an array of URL strings"
+    end
+    local out = {}
+    local seen = {}
+    for i, raw in ipairs(input) do
+        if type(raw) ~= "string" then
+            return nil, ("entry #%d is not a string"):format(i)
+        end
+        local trimmed = raw:match("^%s*(.-)%s*$")
+        if trimmed == "" then
+            return nil, ("entry #%d is empty"):format(i)
+        end
+        -- Strict scheme check: only http/https. The match anchors the
+        -- whole string so embedded ``http://`` inside ``javascript:..``
+        -- can't sneak through.
+        local canon = trimmed:match("^(https?://[^/%s]+)")
+        if not canon or canon == "" then
+            return nil, ("entry #%d is not a valid http(s) origin: %s")
+                :format(i, trimmed)
+        end
+        -- Reject anything more than the canonical origin — if the
+        -- input still has trailing path/query that we stripped, fine,
+        -- silently keep just the origin. But we already trimmed
+        -- whitespace; the regex eats nothing past the host so any
+        -- residue (path) gets dropped naturally.
+        if not seen[canon] then
+            seen[canon] = true
+            table.insert(out, canon)
+        end
+    end
+    return out, nil
+end
+
+
+--- Replace the namespace's ``allowed_redirect_origins`` with a
+-- validated array. Used by the admin UI's "Frontend URLs" settings
+-- panel.
+--
+-- Validation is centralised here (not at the route layer) so any
+-- caller — admin UI, future bulk-import script, programmatic
+-- onboarding — gets the same guarantees.
+--
+-- @param id string|number ID or UUID of the namespace
+-- @param origins table  array of URL strings (validated + canonicalised)
+-- @return table|nil  the updated namespace row, or nil on failure
+-- @return string|nil error message on failure
+function NamespaceQueries.updateAllowedRedirectOrigins(id, origins)
+    local validated, err = validate_origins(origins or {})
+    if not validated then
+        return nil, err
+    end
+
+    local namespace = NamespaceQueries.show(id)
+    if not namespace then
+        return nil, "namespace not found"
+    end
+
+    -- ``db.array({})`` for empty arrays is also accepted by the
+    -- driver — produces the empty Postgres array literal ``{}``.
+    -- Distinct from NULL (which the runtime treats as "use env-var
+    -- fallback"), an empty array means "explicitly no origins
+    -- allowed" — admin chose to disable password reset for this
+    -- namespace.
+    -- Empty input collapses to NULL in the column. Postgres can't
+    -- handle ``ARRAY[]`` without an explicit cast, and treating
+    -- "empty admin input" the same as "never configured" simplifies
+    -- the runtime fallback contract: NULL = use env-var FRONTEND_URL.
+    -- An admin who wants to fully disable password reset for a
+    -- tenant clears the env var separately.
+    if #validated == 0 then
+        namespace:update({
+            allowed_redirect_origins = db.raw("NULL"),
+            updated_at = Global.getCurrentTimestamp(),
+        })
+    else
+        namespace:update({
+            allowed_redirect_origins = db.array(validated),
+            updated_at = Global.getCurrentTimestamp(),
+        })
+    end
+
+    return namespace
+end
+
 
 --- Return the namespace's allow-list of frontend origins for redirect
 -- emails (password reset, future invitation links, etc.).

--- a/lapis/routes/auth.lua
+++ b/lapis/routes/auth.lua
@@ -407,14 +407,18 @@ return function(app)
     --   - On successful reset, ALL refresh tokens for the user are
     --     revoked. An attacker holding a stolen session is kicked
     --     out the moment the user resets.
-    --   - ``redirect_url`` validated against an allow-list before
-    --     interpolation into the email. SaaS deployments serving
-    --     multiple frontends configure the list via env var.
+    --   - Email link points at the **namespace primary** — the first
+    --     entry in ``namespaces.allowed_redirect_origins``, set via the
+    --     admin UI. ``redirect_url`` from the client is ignored;
+    --     destination is admin-controlled, not caller-controlled.
     -- =====================================================================
     app:post("/auth/forgot-password", RateLimit.wrap(FORGOT_LIMIT, function(self)
         local body = parse_json_body()
         local email = body.email or self.params.email
-        local redirect_url = body.redirect_url or self.params.redirect_url
+        -- ``redirect_url`` was previously honoured via an "echo back"
+        -- policy. We now always use the namespace primary so admins
+        -- control reset destinations from the UI without code changes;
+        -- any redirect_url supplied by the client is silently ignored.
 
         -- Basic shape validation. Beyond this we deliberately give
         -- back the same 200-OK response regardless of what the email
@@ -455,80 +459,48 @@ return function(app)
         -- ────────────────────────────────────────────────────────────
         -- Resolve which frontend origin to use in the email link.
         --
-        -- Priority (the SaaS-correct order):
-        --   1. The user's namespace allow-list (DB) — primary.
-        --      Multi-tenant: each tenant declares its own legitimate
-        --      frontend origins via ``namespaces.allowed_redirect_
-        --      origins``. New tenant onboarding adds a row, no env-
-        --      var update or opsapi restart needed.
-        --   2. The legacy global env-var allow-list. Bootstrap-only
-        --      fallback for existing deployments where the namespace
-        --      column hasn't been populated yet (migration 489 will
-        --      bootstrap it from these env vars on first run).
+        -- Pick the origin to use in the email link.
         --
-        -- The user-supplied ``redirect_url`` is validated against the
-        -- effective allow-list — we never echo an attacker-supplied
-        -- origin into an email. If validation fails, we fall back to
-        -- the first allow-listed origin (canonical primary for that
-        -- namespace).
+        -- Policy: **primary always wins.** The first entry in the
+        -- namespace allow-list (``namespaces.allowed_redirect_origins[1]``)
+        -- is the canonical destination for reset emails. Admins set it
+        -- via the admin UI — no code changes, no env-var updates, no
+        -- restart needed. Caller-supplied ``redirect_url`` is ignored;
+        -- destination is admin-controlled, not caller-controlled.
+        --
+        -- Fallback chain (only reached if the prior level is empty):
+        --   1. Namespace primary — first row of the namespace's
+        --      ``allowed_redirect_origins`` array.
+        --   2. Env-var primary — legacy ``FRONTEND_URL`` /
+        --      ``PASSWORD_RESET_ALLOWED_ORIGINS``. Inert once migration
+        --      489 has bootstrapped the namespace column.
+        --   3. ``default_reset_origin()`` — last-resort dev default
+        --      pointing at localhost. Only reachable when the namespace
+        --      column AND env vars are empty.
         -- ────────────────────────────────────────────────────────────
         local function canonicalise(url)
             if type(url) ~= "string" or url == "" then return nil end
             return url:match("^(https?://[^/]+)") or url
         end
 
-        -- Build the effective allow-list: namespace first, env-var fallback.
-        local allowed_set = {}
-        local first_origin = nil
-        local function add_to_allowed(o)
-            local canon = canonicalise(o)
-            if not canon or allowed_set[canon] then return end
-            allowed_set[canon] = true
-            if not first_origin then first_origin = canon end
-        end
-
+        local origin
         local user_ns = NamespaceQueries.getUserDefaultNamespace(user.id)
         if user_ns and user_ns.id then
             local ns_origins = NamespaceQueries.getAllowedRedirectOrigins(user_ns.id)
-            for _, o in ipairs(ns_origins or {}) do add_to_allowed(o) end
+            for _, o in ipairs(ns_origins or {}) do
+                local canon = canonicalise(o)
+                if canon then origin = canon; break end
+            end
         end
 
-        -- Env-var fallback. Lets pre-existing deployments with
-        -- FRONTEND_URL / PASSWORD_RESET_ALLOWED_ORIGINS continue
-        -- working until namespace columns are populated. Once
-        -- migration 489 runs on a fresh DB, these are auto-bootstrapped
-        -- and this fallback becomes inert.
-        if not first_origin then
+        if not origin then
             for legacy_origin, _ in pairs(get_allowed_reset_origins()) do
-                add_to_allowed(legacy_origin)
+                origin = canonicalise(legacy_origin)
+                if origin then break end
             end
         end
 
-        -- Pick the origin to use in the email link.
-        --   - Caller's redirect_url if it's allow-listed (preserves
-        --     "land on the frontend that issued the request" UX when
-        --     a tenant has multiple allow-listed origins, e.g.
-        --     staging + prod).
-        --   - Otherwise the first allow-listed origin (canonical
-        --     primary for that namespace).
-        --   - Last resort: env-var default. Only reachable when
-        --     namespace allow-list is empty AND no env var set —
-        --     should not happen in any properly-configured env, but
-        --     we'd rather send a localhost-pointing email than crash.
-        local origin
-        local requested = canonicalise(redirect_url)
-        if requested and allowed_set[requested] then
-            origin = requested
-        elseif first_origin then
-            origin = first_origin
-            if requested then
-                ngx.log(ngx.WARN,
-                    "[forgot-password] redirect_url not in allow-list, using primary; ",
-                    "requested=", tostring(redirect_url),
-                    " primary=", origin,
-                    " user_id=", user.id)
-            end
-        else
+        if not origin then
             origin = default_reset_origin()
             ngx.log(ngx.WARN,
                 "[forgot-password] no allow-list configured for namespace; ",

--- a/lapis/routes/namespaces.lua
+++ b/lapis/routes/namespaces.lua
@@ -1627,6 +1627,99 @@ return function(app)
         end)
     }))
 
+    -- =====================================================================
+    -- Frontend URLs (allowed_redirect_origins) — drives password reset
+    -- email links. See README.md → Password Reset Flow.
+    --
+    -- Two endpoints:
+    --   GET  /api/v2/admin/namespaces/:id/redirect-origins
+    --        → returns the current array. Empty array = no origins set
+    --          (runtime falls back to env-var FRONTEND_URL); NULL is
+    --          surfaced as empty array for client-simplicity.
+    --   PUT  /api/v2/admin/namespaces/:id/redirect-origins
+    --        body: { origins: ["https://app.example.com", ...] }
+    --        → replaces the array. Validation in
+    --          NamespaceQueries.updateAllowedRedirectOrigins:
+    --          http(s) only, canonicalised, deduped.
+    --
+    -- Auth: platform admin only. Not exposed to namespace owners
+    -- because the wrong allow-list can lock users out of their own
+    -- accounts; tightening to platform admin keeps it inside the
+    -- support team for now. Easy to widen later.
+    -- =====================================================================
+    app:get("/api/v2/admin/namespaces/:id/redirect-origins",
+        AuthMiddleware.requireAuth(function(self)
+            if not check_platform_admin(self.current_user) then
+                return error_response(403, "Platform admin access required")
+            end
+
+            local namespace = NamespaceQueries.show(self.params.id)
+            if not namespace then
+                return error_response(404, "Namespace not found")
+            end
+
+            local origins = NamespaceQueries.getAllowedRedirectOrigins(namespace.id)
+            return success_response({
+                namespace_id = namespace.id,
+                namespace_uuid = namespace.uuid,
+                namespace_slug = namespace.slug,
+                origins = origins,
+                -- Surface the canonical primary explicitly so the UI
+                -- can label it without re-implementing "first entry"
+                -- logic (and so a future change to "primary is a
+                -- separate column" doesn't ripple to the client).
+                primary_origin = origins[1] or nil,
+            })
+        end))
+
+    app:put("/api/v2/admin/namespaces/:id/redirect-origins",
+        AuthMiddleware.requireAuth(function(self)
+            if not check_platform_admin(self.current_user) then
+                return error_response(403, "Platform admin access required")
+            end
+
+            local namespace = NamespaceQueries.show(self.params.id)
+            if not namespace then
+                return error_response(404, "Namespace not found")
+            end
+
+            local params = RequestParser.parse_request(self)
+            local origins_input = params.origins
+            if origins_input == nil then
+                return error_response(400,
+                    "Missing 'origins' field — provide an array of URL strings")
+            end
+            if type(origins_input) ~= "table" then
+                return error_response(400,
+                    "'origins' must be an array of URL strings")
+            end
+
+            local before_origins = NamespaceQueries.getAllowedRedirectOrigins(namespace.id)
+
+            local updated, err = NamespaceQueries.updateAllowedRedirectOrigins(
+                namespace.id, origins_input
+            )
+            if not updated then
+                return error_response(400, err or "validation failed")
+            end
+
+            -- Audit hook — preserve the before/after for the activity
+            -- log so investigators can reconstruct who changed what.
+            audit(self, "update", "namespace_redirect_origins", namespace.uuid,
+                { origins = before_origins },
+                { origins = NamespaceQueries.getAllowedRedirectOrigins(namespace.id) })
+
+            local fresh = NamespaceQueries.getAllowedRedirectOrigins(namespace.id)
+            return success_response({
+                namespace_id = namespace.id,
+                namespace_uuid = namespace.uuid,
+                namespace_slug = namespace.slug,
+                origins = fresh,
+                primary_origin = fresh[1] or nil,
+                message = "Allowed redirect origins updated.",
+            })
+        end))
+
     -- Get namespace statistics (platform admin)
     app:get("/api/v2/admin/namespaces/:id/stats", AuthMiddleware.requireAuth(function(self)
         if not check_platform_admin(self.current_user) then


### PR DESCRIPTION
## Summary

- **Admin endpoints** \`GET\` / \`PUT /api/v2/admin/namespaces/:uuid/redirect-origins\` — let platform admins manage a namespace's reset-link allow-list without DB access. Validates http(s)-only, strips path/query, dedupes, audit-logged on PUT.
- **Primary always wins** — \`/auth/forgot-password\` now picks \`allowed_redirect_origins[1]\` unconditionally; caller-supplied \`redirect_url\` is read but never consulted for selection. Whatever the admin marks as primary in the UI is exactly where reset emails land.
- README updated to document both — flow diagram, lookup chain, configuration via admin UI tab (option C now describes shipping UI rather than \"planned\"), and phishing-protection rationale.

Layered on top of #382. The frontend admin UI tab that drives the new endpoints ships in a separate diy-tax-return-uk PR.

## Why primary-wins (instead of the prior echo-back)

Before: \`/auth/forgot-password\` preferred caller-supplied \`redirect_url\` whenever it matched any allow-list entry, falling back to position 1 only on miss. This was the multi-frontend \"echo back\" pattern.

Problem: if an admin marks \`https://app.example.com\` as primary but a user clicks forgot-password from a stale localhost entry that's still in the allow-list, the email points at localhost — making the \"primary\" toggle in the UI feel decorative.

New policy: position 1 is authoritative. Subsequent entries remain in the array as accepted aliases (reserved for future use cases like OAuth callbacks) but don't influence password-reset routing.

Trade-off accepted: per-frontend echo-back is gone (tenants on staging+prod no longer route a staging-initiated reset back to staging). Acceptable because the admin owns destination via UI now, with no code changes — which the original brief asked for explicitly before the live freeze.

## Test plan

- [x] GET endpoint returns origins + primary for a namespace with non-empty list
- [x] PUT endpoint accepts a valid array; DB reflects new ordering
- [x] PUT empty array → DB column becomes NULL (not empty array; Postgres ARRAY[] type-cast issue dodged via \`db.raw(\"NULL\")\`)
- [x] PUT rejects \`javascript:\` / \`data:\` / \`file:\` schemes
- [x] PUT non-platform-admin → 403
- [x] /auth/forgot-password with no \`redirect_url\` → email link uses namespace primary
- [x] /auth/forgot-password with allow-listed \`redirect_url\` (e.g. \`http://localhost:3847\`) → email link still uses primary, not the requested origin
- [x] /auth/forgot-password with non-allow-listed \`redirect_url\` (e.g. \`https://attacker.com\`) → email link still uses primary; no echo-back
- [x] Empty namespace allow-list → falls through to env-var primary, then \`http://localhost\` last-resort with WARN log
- [x] Admin UI exercised: list, add, mark primary, save — DB confirms new ordering (verified via \`SELECT allowed_redirect_origins FROM namespaces\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)