### PR TITLE
fix(auth): deliver refresh tokens via HttpOnly cookie + multi-tenant Domain

### DIFF
--- a/lapis/.env.example
+++ b/lapis/.env.example
@@ -84,3 +84,53 @@ CORS_CREDENTIALS=true
 
 # Firebase (deprecated, using APNs)
 # FCM_SERVICE_ACCOUNT_JSON=/app/firebase-credentials.json
+
+# ===========================================
+# Auth refresh-token cookie (helper/auth-cookies.lua)
+# ===========================================
+# The opaque refresh token is delivered to web clients via an HttpOnly
+# Secure cookie set on /auth/login + /auth/google/callback (mobile
+# clients still get it in the JSON response). These vars control the
+# cookie's Domain and Secure attributes.
+#
+# Multi-tenant SaaS: opsapi is one deployment serving many tenants on
+# different apex domains, so the cookie's Domain attribute is resolved
+# PER REQUEST from the calling tenant's Origin. AUTH_COOKIE_TRUSTED_DOMAINS
+# is the single source of truth for "which apex domains may receive
+# the refresh-token cookie". The helper picks the longest-matching
+# entry against the incoming Origin and emits ``Domain=.<match>``.
+#
+# AUTH_COOKIE_TRUSTED_DOMAINS — comma-separated apex domains the
+#   operator trusts to receive cookies. Adding a new tenant is one
+#   comma-append; no per-tenant deployment needed. Leave unset for
+#   single-host proxy deployments where frontend + api share the
+#   same origin (browser scopes the cookie to the host automatically).
+#
+#   Multi-subdomain (recommended for production):
+#       AUTH_COOKIE_TRUSTED_DOMAINS=diytaxreturn.co.uk,tenant-a.com,acme.io
+#   Single-host proxy (frontend + api on one origin):
+#       (leave unset)
+#   Local dev:
+#       (leave unset)
+#
+# AUTH_COOKIE_DOMAIN — explicit override that bypasses
+#   AUTH_COOKIE_TRUSTED_DOMAINS entirely and emits ``Domain=<value>``
+#   verbatim. Useful only for single-tenant deployments that want
+#   one fixed value regardless of incoming Origin. Multi-tenant
+#   deployments should leave this UNSET and use TRUSTED_DOMAINS.
+#
+#   Single-tenant override:    AUTH_COOKIE_DOMAIN=.diytaxreturn.co.uk
+#   Multi-tenant / dev:        (leave unset)
+#
+# AUTH_COOKIE_INSECURE — when "true", drops the Secure flag so
+#   plain-HTTP localhost dev works. NEVER set this in any environment
+#   that runs over HTTPS — the cookie carries a 30-day refresh token
+#   and dropping Secure means any network observer on the path can
+#   lift it.
+#
+#   Local dev (HTTP):          AUTH_COOKIE_INSECURE=true
+#   Any HTTPS env:             (leave unset)
+
+# AUTH_COOKIE_TRUSTED_DOMAINS=
+# AUTH_COOKIE_DOMAIN=
+# AUTH_COOKIE_INSECURE=

--- a/lapis/helper/auth-cookies.lua
+++ b/lapis/helper/auth-cookies.lua
@@ -1,0 +1,252 @@
+--[[
+    Auth Cookies Helper (helper/auth-cookies.lua)
+
+    Reads, writes, and clears the HttpOnly Secure cookie that carries
+    the opaque refresh token. Set alongside the JSON ``refresh_token``
+    field on /auth/login (so mobile clients keep working) and as the
+    *only* refresh-token transport on /auth/google/callback (where
+    the response is a redirect — no JSON body to inhabit).
+
+    Why a cookie instead of a URL query param or localStorage:
+
+    * URL query strings leak through server access logs, browser
+      history, HTTP Referer headers, browser extensions, browser
+      cache, and shoulder-surfing. With a 30-day token lifetime,
+      one leak hands an attacker 720× the window of a leaked
+      1-hour JWT.
+    * localStorage is XSS-readable. Any successful injection on the
+      origin extracts every refresh token in the browser. HttpOnly
+      cookies are JS-invisible and survive XSS that doesn't have
+      service-worker-grade access.
+    * ``SameSite=Strict`` cookies are CSRF-safe and still work
+      across same-site cross-origin subdomains (``app`` ↔ ``api``).
+    * The browser auto-includes the cookie on every request to the
+      cookie's Domain — refresh "just works" without the frontend
+      ever ferrying the value.
+
+    Cookie attributes:
+
+    * ``HttpOnly``         — JS can't read it (XSS-safe)
+    * ``Secure``           — HTTPS-only (omitted only when
+                             AUTH_COOKIE_INSECURE=true for plain-HTTP
+                             local dev)
+    * ``SameSite=Strict``  — CSRF-safe; still works cross-origin
+                             within same site
+    * ``Path=/``           — sent on every request to the domain
+    * ``Domain``           — derived per-request from the calling
+                             tenant's Origin (see "Multi-tenant
+                             cookie-domain resolution" below). May
+                             be omitted entirely (host-scoped) for
+                             single-host proxy deployments.
+    * ``Max-Age=2592000``  — 30 days, matches RefreshToken expiry
+
+    Multi-tenant cookie-domain resolution
+    --------------------------------------
+
+    opsapi is a SaaS product — one deployment serves many tenants on
+    different apex domains (``tenant-a.com``, ``acme.io``, ...). A
+    static ``AUTH_COOKIE_DOMAIN`` doesn't scale because each tenant
+    needs a Domain attribute matching their own eTLD+1.
+
+    The Domain attribute is resolved per-request using this priority:
+
+      1. If ``AUTH_COOKIE_DOMAIN`` is explicitly set, use it verbatim.
+         Useful for single-tenant deployments where the operator
+         wants one fixed value regardless of incoming Origin.
+
+      2. Else, look up the request's ``Origin`` host against
+         ``AUTH_COOKIE_TRUSTED_DOMAINS`` — a comma-separated list of
+         apex domains the operator has approved for cookie scoping.
+         The longest matching suffix wins, and the cookie is set
+         with ``Domain=.<match>``.
+
+      3. Else, omit the Domain attribute entirely. The browser
+         scopes the cookie to the request host. This is correct for
+         single-host reverse-proxy deployments where the frontend
+         and api share an origin (e.g., nginx routing ``/api`` and
+         ``/`` to different upstreams under one hostname).
+
+    Tenants typically configure step 2 with one entry per tenant:
+
+        AUTH_COOKIE_TRUSTED_DOMAINS=diytaxreturn.co.uk,tenant-a.com,acme.io
+
+    Adding a new tenant is a single comma-append, no per-tenant
+    opsapi instance required.
+
+    CORS prerequisites (handled in nginx, not here):
+
+    1. ``Access-Control-Allow-Credentials: true`` on api responses.
+    2. ``Access-Control-Allow-Origin`` echoes the specific request
+       origin (never ``*``).
+
+    Frontend must set ``withCredentials: true`` on the API client.
+]]
+
+local AuthCookies = {}
+
+-- The cookie name. Stable and human-readable so server logs / cookie
+-- inspectors are clear about what's there.
+local COOKIE_NAME = "refresh_token"
+
+-- 30 days, mirrors RefreshToken.EXPIRY_SECONDS in helper/refresh-token.lua.
+-- Keeping these aligned avoids the cookie outliving the DB row (or
+-- vice versa) and producing zombie auth state.
+local MAX_AGE_SECONDS = 30 * 24 * 60 * 60
+
+--- Parse the AUTH_COOKIE_TRUSTED_DOMAINS env into a Lua array.
+-- Splits on commas, trims whitespace, drops empty entries. Cached on
+-- the worker process — env vars don't change without an nginx reload.
+local _trusted_domains_cache
+local function trusted_domains()
+    if _trusted_domains_cache ~= nil then return _trusted_domains_cache end
+    local raw = os.getenv("AUTH_COOKIE_TRUSTED_DOMAINS") or ""
+    local list = {}
+    for entry in raw:gmatch("[^,]+") do
+        local clean = entry:gsub("^%s+", ""):gsub("%s+$", "")
+        -- Strip an optional leading dot so the operator can paste
+        -- either ".tenant.com" or "tenant.com" — we always store
+        -- without the dot and add it back when emitting.
+        clean = clean:gsub("^%.", "")
+        if clean ~= "" then
+            list[#list + 1] = clean:lower()
+        end
+    end
+    _trusted_domains_cache = list
+    return list
+end
+
+--- Extract the hostname from an Origin header value.
+-- @param origin string|nil e.g. "https://app.tenant.com:8443"
+-- @return string|nil hostname (lowercased) or nil if unparseable
+local function origin_to_host(origin)
+    if not origin or origin == "" then return nil end
+    local host = origin:match("^https?://([^:/]+)")
+    if not host then return nil end
+    return host:lower()
+end
+
+--- Resolve the cookie's Domain attribute for the current request.
+-- Returns the value to put after ``Domain=`` (with leading dot), or
+-- nil to omit the Domain attribute entirely.
+-- @param self table Lapis request context (for header reading)
+-- @return string|nil
+local function resolve_cookie_domain(self)
+    -- 1. Explicit override wins. Operators wanting one fixed value
+    --    regardless of Origin can still configure that.
+    local override = os.getenv("AUTH_COOKIE_DOMAIN")
+    if override and override ~= "" then
+        return override  -- emitted verbatim — operator owns the format
+    end
+
+    -- 2. Multi-tenant: longest-suffix match against allowlist.
+    local list = trusted_domains()
+    if #list > 0 and self and self.req and self.req.headers then
+        local origin = self.req.headers["Origin"] or self.req.headers["origin"]
+        local host = origin_to_host(origin)
+        if host then
+            local best
+            for _, allowed in ipairs(list) do
+                -- Match if host ends with ".<allowed>" or equals it.
+                -- Equality covers the apex itself ("tenant.com").
+                -- Suffix match covers subdomains ("app.tenant.com").
+                local matches = host == allowed
+                    or host:sub(-(#allowed + 1)) == "." .. allowed
+                if matches and (not best or #allowed > #best) then
+                    best = allowed
+                end
+            end
+            if best then
+                return "." .. best
+            end
+        end
+    end
+
+    -- 3. No allowlist match → omit Domain. Browser scopes to the
+    --    request host. Correct for single-host proxy deployments
+    --    and for local dev. Wrong (cookie won't be sent on the
+    --    other subdomain's requests) for cross-subdomain setups
+    --    where the operator forgot to configure the allowlist —
+    --    that's a deliberate fail-closed: better a broken refresh
+    --    than a cookie that leaks across an unintended domain.
+    return nil
+end
+
+--- Build the Set-Cookie header value.
+-- @param self table|nil Lapis request context (for Origin lookup)
+-- @param value string|nil Cookie value (empty for clearing)
+-- @param max_age number Cookie max age in seconds (0 to clear)
+-- @return string The Set-Cookie header value
+local function format_cookie(self, value, max_age)
+    local parts = {
+        COOKIE_NAME .. "=" .. (value or ""),
+        "Path=/",
+        "HttpOnly",
+        "SameSite=Strict",
+        "Max-Age=" .. tostring(max_age or 0),
+    }
+
+    local domain = resolve_cookie_domain(self)
+    if domain then
+        table.insert(parts, "Domain=" .. domain)
+    end
+
+    -- Secure default-on. The only way to disable is the explicit
+    -- AUTH_COOKIE_INSECURE=true env var, intended for localhost dev
+    -- over plain HTTP. NEVER set this in any HTTPS environment.
+    if os.getenv("AUTH_COOKIE_INSECURE") ~= "true" then
+        table.insert(parts, "Secure")
+    end
+
+    return table.concat(parts, "; ")
+end
+
+--- Set the refresh-token cookie on the current response.
+-- Safe to call from any handler before the response is finalised.
+-- No-op when token is empty (so callers don't need to nil-check).
+-- @param self table Lapis request context (for Origin-aware Domain)
+-- @param token string The opaque refresh token to persist client-side
+function AuthCookies.set(self, token)
+    if not token or token == "" then return end
+    ngx.header["Set-Cookie"] = format_cookie(self, token, MAX_AGE_SECONDS)
+end
+
+--- Clear the refresh-token cookie. Used on logout and when the
+-- backend has detected the cookie's value is no longer valid (e.g.
+-- token revoked, family rotated out).
+-- @param self table Lapis request context (for Origin-aware Domain
+--             — must match the original Set-Cookie's Domain or the
+--             browser keeps the original around).
+function AuthCookies.clear(self)
+    ngx.header["Set-Cookie"] = format_cookie(self, "", 0)
+end
+
+--- Read the refresh-token cookie from the incoming request.
+-- @param self table Lapis request context (for ``self.req.headers``)
+-- @return string|nil The cookie value, or nil if absent
+function AuthCookies.read(self)
+    -- Lapis populates self.cookies from the Cookie header. Try that
+    -- first since it's the documented API.
+    if self and self.cookies and self.cookies[COOKIE_NAME] then
+        return self.cookies[COOKIE_NAME]
+    end
+
+    -- Fallback: parse the Cookie header by hand. Handles cases where
+    -- self.cookies isn't populated yet (some lapis middleware orders)
+    -- and keeps this helper usable from contexts that have only the
+    -- raw request.
+    local cookie_hdr = nil
+    if self and self.req and self.req.headers then
+        cookie_hdr = self.req.headers["cookie"] or self.req.headers["Cookie"]
+    end
+    if not cookie_hdr then return nil end
+
+    for kv in cookie_hdr:gmatch("([^;]+)") do
+        local k, v = kv:match("^%s*([^=]+)%s*=%s*(.*)%s*$")
+        if k == COOKIE_NAME then
+            return v
+        end
+    end
+    return nil
+end
+
+return AuthCookies

--- a/lapis/nginx.conf
+++ b/lapis/nginx.conf
@@ -90,6 +90,13 @@ env LANGFUSE_SECRET_KEY;
 env LANGFUSE_BASE_URL;
 env TEST_OTP_CODE;
 
+# helper/auth-cookies.lua reads these to compose the Set-Cookie header
+# for the opaque refresh token. See helper/auth-cookies.lua and the
+# .env.example block for the full multi-tenant / dev / prod matrix.
+env AUTH_COOKIE_TRUSTED_DOMAINS;
+env AUTH_COOKIE_DOMAIN;
+env AUTH_COOKIE_INSECURE;
+
 worker_processes ${{NUM_WORKERS}};
 error_log stderr notice;
 daemon off;

--- a/lapis/routes/auth.lua
+++ b/lapis/routes/auth.lua
@@ -11,6 +11,7 @@ local RateLimit = require("middleware.rate-limit")
 local Errors = require("lib.errors")
 local OTP = require("helper.otp")
 local RefreshToken = require("helper.refresh-token")
+local AuthCookies = require("helper.auth-cookies")
 local PasswordReset = require("helper.password-reset")
 local Mail = require("helper.mail")
 
@@ -86,11 +87,14 @@ end
 
 --- Build the full login response (user + token + namespaces + refresh_token).
 -- Shared by both login and 2FA verify to avoid duplication.
+-- @param self table Lapis request context (used by AuthCookies to
+--             resolve the cookie's Domain attribute from the
+--             calling tenant's Origin — see helper/auth-cookies.lua)
 -- @param userWithRoles table User record from UserQueries.show()
 -- @param user_id number Internal user ID
 -- @param device_info string|nil Optional device description for refresh token
 -- @return table JSON-ready response body
-local function build_login_response(userWithRoles, user_id, device_info)
+local function build_login_response(self, userWithRoles, user_id, device_info)
     local rolesArray = {}
     if userWithRoles.roles then
         for _, role in ipairs(userWithRoles.roles) do
@@ -171,11 +175,23 @@ local function build_login_response(userWithRoles, user_id, device_info)
     -- Issue an opaque refresh token (stored hashed in DB, revocable).
     -- Wrapped in pcall: if the refresh_tokens table doesn't exist yet (migration
     -- pending), login must still succeed — just without a refresh token.
+    --
+    -- The token is delivered to the client through TWO transports:
+    --   1. JSON body (``refresh_token`` field below) — for mobile/CLI
+    --      clients that don't speak cookies.
+    --   2. HttpOnly Secure cookie via AuthCookies.set — the canonical
+    --      web transport. JS-invisible so XSS can't read it; auto-sent
+    --      by the browser on every refresh request, no localStorage
+    --      handoff required. See helper/auth-cookies.lua for the full
+    --      security rationale.
+    -- Web clients should prefer the cookie and may treat the JSON
+    -- ``refresh_token`` as optional.
     local refresh_token_raw
     if user_id then
         local ok, rt_or_err, rt_err = pcall(RefreshToken.create, user_id, device_info)
         if ok and rt_or_err then
             refresh_token_raw = rt_or_err
+            pcall(AuthCookies.set, self, rt_or_err)
         else
             ngx.log(ngx.WARN, "[AUTH] Refresh token creation skipped: ",
                 tostring(ok and rt_err or rt_or_err))
@@ -331,7 +347,7 @@ return function(app)
 
         return {
             status = 200,
-            json = build_login_response(userWithRoles, user_id, device_info)
+            json = build_login_response(self, userWithRoles, user_id, device_info)
         }
     end))
 
@@ -863,6 +879,35 @@ return function(app)
             })
         end
 
+        -- Issue an opaque refresh token alongside the JWT, mirroring
+        -- /auth/login. Delivered ONLY via HttpOnly Secure cookie — never
+        -- in the redirect URL, because URL params leak through server
+        -- access logs, browser history, Referer headers, and browser
+        -- extensions. See helper/auth-cookies.lua for the full
+        -- rationale.
+        --
+        -- Without this, OAuth-signed-up users had no refresh_token at
+        -- all and the frontend fell through to the legacy JWT-only
+        -- refresh path, which 401s under certain proxy/JWT
+        -- configurations and forced an unnecessary re-login.
+        --
+        -- pcall mirrors /auth/login: if the refresh_tokens migration
+        -- hasn't run yet, OAuth login still succeeds — the user just
+        -- won't get refresh-on-401 until the migration lands.
+        local device_info = ngx.req.get_headers()["user-agent"]
+        if device_info and #device_info > 255 then
+            device_info = device_info:sub(1, 255)
+        end
+        if user.id then
+            local ok_rt, rt_or_err, rt_err = pcall(RefreshToken.create, user.id, device_info)
+            if ok_rt and rt_or_err then
+                pcall(AuthCookies.set, self, rt_or_err)
+            else
+                ngx.log(ngx.WARN, "[AUTH] OAuth refresh token creation skipped: ",
+                    tostring(ok_rt and rt_err or rt_or_err))
+            end
+        end
+
         -- Determine redirect URL based on client type
         -- If redirect_from contains 'desktop' or 'electron', use custom protocol
         -- Otherwise, use web frontend URL
@@ -871,7 +916,10 @@ return function(app)
         local final_url
 
         if is_desktop then
-            -- Desktop app: use custom protocol
+            -- Desktop app: use custom protocol. Desktop doesn't share
+            -- the browser's cookie jar so this leaves desktop OAuth
+            -- without a refresh token — the desktop client will need
+            -- a separate exchange step (out of scope for this fix).
             final_url = string.format("wsl-chat://auth/callback?token=%s", ngx.escape_uri(token))
         else
             -- Web app: use frontend_url from state (passed by frontend), fall back to env var
@@ -893,6 +941,13 @@ return function(app)
                 self.session[k] = nil
             end
         end
+
+        -- Clear the refresh-token cookie. Browser keeps the cookie
+        -- around indefinitely otherwise — even after the user logs
+        -- out — and would auto-include it on subsequent /auth/refresh
+        -- attempts, which would then succeed if the underlying DB
+        -- token wasn't also revoked. Belt-and-braces: zero out both.
+        pcall(AuthCookies.clear, self)
 
         -- Clear user's cart and deactivate device tokens
         local user_uuid = ngx.var.http_x_user_id
@@ -1148,14 +1203,32 @@ return function(app)
 
     -- Token refresh endpoint with opaque refresh token + backward compat
     --
-    -- New flow:  POST /auth/refresh  { "refresh_token": "<opaque>" }
-    --            → validates opaque token, rotates it, issues new JWT + new refresh token
+    -- Token sources, in priority order:
+    --   1. JSON body / form ``refresh_token`` field (mobile, CLI, and
+    --      existing localStorage-based web sessions)
+    --   2. ``refresh_token`` HttpOnly cookie (modern web — set by
+    --      /auth/login + /auth/google/callback via AuthCookies)
+    --   3. ``Authorization: Bearer <jwt>`` legacy fallback
     --
-    -- Legacy:    POST /auth/refresh  (Authorization: Bearer <jwt>)
-    --            → re-signs the JWT (old behavior, for clients that haven't upgraded)
+    -- The cookie path is the canonical web transport because it's
+    -- XSS-safe (HttpOnly), CSRF-safe (SameSite=Strict), and never
+    -- traverses URL/log/history/Referer channels. See
+    -- helper/auth-cookies.lua for the full rationale.
     app:post("/auth/refresh", RateLimit.wrap(REFRESH_LIMIT, function(self)
         local params = parse_json_body()
         local refresh_token_raw = params.refresh_token or self.params.refresh_token
+
+        -- Cookie fallback when the body / form didn't carry one. We
+        -- check this BEFORE the legacy Authorization-header path so
+        -- modern web sessions (no localStorage refresh_token) hit the
+        -- well-tested opaque-rotation path instead of the brittle
+        -- JWT-resign fallback.
+        if (not refresh_token_raw or refresh_token_raw == "") then
+            local cookie_token = AuthCookies.read(self)
+            if cookie_token and cookie_token ~= "" then
+                refresh_token_raw = cookie_token
+            end
+        end
 
         -- ── New flow: opaque refresh token ──
         if refresh_token_raw and refresh_token_raw ~= "" then
@@ -1238,6 +1311,15 @@ return function(app)
                 local ok_rotate, new_refresh = pcall(RefreshToken.rotate,
                     rt_data.id, rt_data.user_id, rt_data.family_id, device_info)
 
+                -- Persist the rotated token on the same two transports
+                -- as login: HttpOnly cookie for web, JSON body for
+                -- mobile/CLI. Browser auto-replaces the old cookie
+                -- (same name/path/domain) so the next refresh round
+                -- carries the new value with no client work required.
+                if ok_rotate and new_refresh then
+                    pcall(AuthCookies.set, self, new_refresh)
+                end
+
                 return {
                     status = 200,
                     json = {
@@ -1290,9 +1372,20 @@ return function(app)
         local params = parse_json_body()
         local refresh_token_raw = params.refresh_token or self.params.refresh_token
 
+        -- Cookie-based clients send the refresh token via HttpOnly
+        -- cookie, not body. Read both so revocation works for every
+        -- transport. Always clear the cookie regardless — browsers
+        -- otherwise hold on to it forever and would silently
+        -- "re-login" the user on the next refresh.
+        if (not refresh_token_raw or refresh_token_raw == "") then
+            refresh_token_raw = AuthCookies.read(self)
+        end
+
         if refresh_token_raw and refresh_token_raw ~= "" then
             pcall(RefreshToken.revoke, refresh_token_raw)
         end
+
+        pcall(AuthCookies.clear, self)
 
         return {
             status = 200,


### PR DESCRIPTION
## Summary

Route refresh tokens through an `HttpOnly` `Secure` cookie set by Lapis on `/auth/login`, `/auth/2fa/verify`, and `/auth/google/callback`. The cookie is the canonical web transport (JS-invisible, `SameSite=Strict`, browser-managed). Mobile / CLI clients still receive `refresh_token` in the JSON response body — no breaking change for native apps.

## The bug this fixes

`/auth/google/callback` used to redirect with only a JWT in the URL and no refresh token. Frontends fell back to storing the JWT itself as a fake refresh value, which silently failed the opaque-token rotation path on every refresh — surfacing as 401s and forced re-logins for **Google-OAuth-signed-up users**, while basic-registration users continued to work.

## Why a cookie (not URL params or localStorage)

| Transport | Verdict |
|-----------|---------|
| URL query string | ❌ Leaks via server access logs, browser history, `Referer` headers, browser extensions, cache, shoulder-surfing. With a 30-day token lifetime that's ~720× the exposure of a leaked 1-hour JWT. |
| localStorage | ⚠️ XSS-readable. OK as a backup transport for clients that asked for the JSON copy; not the primary. |
| **HttpOnly cookie** | ✅ JS-invisible (XSS-safe), `SameSite=Strict` (CSRF-safe), browser auto-sends it. |

## Multi-tenant SaaS support

`opsapi` is one deployment serving many tenants on different apex domains. A static `AUTH_COOKIE_DOMAIN` doesn't scale.

The cookie's `Domain` attribute is resolved **per request** in this priority:

1. `AUTH_COOKIE_DOMAIN` (explicit override) → emit verbatim
2. `AUTH_COOKIE_TRUSTED_DOMAINS` allowlist + request `Origin` → longest-suffix match → `Domain=.<match>`
3. Neither / no match → omit `Domain` (host-scoped) — fail-closed for unknown origins; correct for single-host proxy deployments

Adding a SaaS tenant is one comma-append:

```env
AUTH_COOKIE_TRUSTED_DOMAINS=diytaxreturn.co.uk,tenant-a.com,acme.io
```

## Endpoints touched

| Endpoint | Change |
|----------|--------|
| `build_login_response` (basic + 2FA login) | Sets cookie alongside JSON `refresh_token` |
| `/auth/google/callback` | Creates opaque token + sets cookie; redirect URL no longer carries `refresh_token` |
| `/auth/refresh` | Accepts token from body → cookie → legacy Authorization header (in that priority); rotates cookie on every successful refresh |
| `/auth/logout` (both routes) | Revokes from cookie if body absent; clears cookie unconditionally |

## Operator config matrix

| Env | Local dev (HTTP) | int / acc / prod (HTTPS) |
|-----|------------------|--------------------------|
| `AUTH_COOKIE_TRUSTED_DOMAINS` | unset | `diytaxreturn.co.uk` (or `tenant-a.com,acme.io,…` for multi-tenant) |
| `AUTH_COOKIE_DOMAIN` | unset | unset (use TRUSTED_DOMAINS) |
| `AUTH_COOKIE_INSECURE` | `true` | unset |

OpenResty requires `env` directives in `nginx.conf` to expose values to Lua workers — added.

## Live test results (against local stack)

| Scenario | Origin | TRUSTED_DOMAINS | Result |
|----------|--------|-----------------|--------|
| Local dev | (none) | unset | `Path=/; HttpOnly; SameSite=Strict; Max-Age=2592000` (no Domain) ✅ |
| Tenant A | `https://app.tenant-a.com` | `diytaxreturn.co.uk,tenant-a.com` | `…; Domain=.tenant-a.com` ✅ |
| Tenant B sub-sub | `https://int.diytaxreturn.co.uk` | `diytaxreturn.co.uk,tenant-a.com` | `…; Domain=.diytaxreturn.co.uk` (longest match) ✅ |
| Untrusted Origin | `https://evil.com` | `diytaxreturn.co.uk` | no Domain (cookie won't reach evil.com) ✅ |
| Explicit override | `https://app.tenant-a.com` | (ignored) `AUTH_COOKIE_DOMAIN=.fixed.example` | `…; Domain=.fixed.example` ✅ |
| Body-path refresh | — | — | 200 OK + new rotated cookie ✅ |
| Cookie-only refresh (empty body) | — | — | 200 OK + new rotated cookie ✅ |
| Reuse rotated token | — | — | 401 + family revoked (theft detection) ✅ |
| Logout | — | — | `Set-Cookie: refresh_token=; Max-Age=0` ✅ |

## Backwards compatibility

- Existing localStorage sessions with real opaque tokens: keep working (body path)
- Existing OAuth sessions with JWT-as-fake-refresh: hit empty-body path → cookie absent → legacy fallback → forced logout → next login self-heals to cookie path
- Mobile / CLI clients: unaffected — `refresh_token` still in `/auth/login` JSON response

## Paired frontend PR

[bwalia/diy-tax-return-uk#347](https://github.com/bwalia/diy-tax-return-uk/pull/347) — adds `withCredentials: true` to `lapisApi`, stops seeding `REFRESH_TOKEN_KEY` with the JWT itself, updates docs. Land **this** PR first (frontend depends on it).

## Test plan

- [x] Lua syntax check both files
- [x] Live-tested all four Domain-resolution paths
- [x] Live-tested rotation security (revoked token rejection)
- [x] Live-tested cookie-only refresh path
- [x] Live-tested logout cookie clear
- [ ] On int after merge: deploy with `AUTH_COOKIE_TRUSTED_DOMAINS=diytaxreturn.co.uk` and verify Google OAuth users no longer 401 on `/auth/refresh`
- [ ] On int after merge: verify basic-registration users continue to refresh cleanly
- [ ] On int after merge: verify mobile clients (which read `refresh_token` from JSON body) continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)