### PR TITLE
feat(profile): capture business type on registration

### DIFF
--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -1282,6 +1282,7 @@ local _migrations = {
     ['493_tax_rescope_hmrc_calc_id_index']           = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 72),
     ['494_tax_hmrc_calculations_request_payload']    = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 73),
     ['495_tax_rescope_hmrc_filings_unique']          = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 74),
+    ['496_tax_user_profile_default_profile_key']     = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 75),
 
     -- =========================================================================
     -- CORE AUTH: Password reset tokens

--- a/lapis/migrations/tax-copilot-system.lua
+++ b/lapis/migrations/tax-copilot-system.lua
@@ -2570,4 +2570,51 @@ return {
         ]])
         print("[Tax Copilot] Re-scoped uq_hmrc_filings_calc_committed to (user_uuid, calculation_id, filing_type)")
     end,
+
+    -- 75. Add default_profile_key to tax_user_profiles.
+    --
+    -- This is the user's chosen "what kind of business am I" answer
+    -- captured at registration (and editable via Settings). It's a
+    -- strict reference to ``classification_profiles.profile_key`` —
+    -- distinct from the freeform ``profession`` / ``industry`` /
+    -- ``business_description`` columns on the same table, which
+    -- carry user-typed context for the AI classifier prompt.
+    --
+    --   profession           = "I sell vintage car parts on eBay" (freeform)
+    --   default_profile_key  = "ecommerce_seller"                 (catalog enum)
+    --
+    -- Capturing it once at registration removes the per-classify
+    -- dropdown friction (currently the user picks the same value
+    -- on every statement they classify) and lets the classify API
+    -- resolve a sensible default when the request omits profile_type.
+    --
+    -- We intentionally do NOT add a foreign-key constraint to
+    -- classification_profiles.profile_key. Reasons:
+    --   * The catalog table is namespace-scoped (multi-tenant) — a
+    --     hard FK would make catalog GC awkward.
+    --   * Existing tests/dev fixtures sometimes wipe the catalog
+    --     and reseed; a hard FK turns that into a cascade.
+    --   * We validate at write time in app code (register.lua and
+    --     the FastAPI tax-profile PUT handler), which is the
+    --     appropriate layer for "is this enum value still active".
+    --
+    -- Nullable: existing users have no default until they pick one,
+    -- and the classify endpoint falls back to its existing per-call
+    -- ``profile_type`` field — full backward compatibility.
+    [75] = function()
+        db.query([[
+            ALTER TABLE tax_user_profiles
+            ADD COLUMN IF NOT EXISTS default_profile_key VARCHAR(100)
+        ]])
+        -- Partial index: only the rows that actually carry a value
+        -- need to be looked up by it (e.g. analytics: "how many
+        -- users picked amazon_seller?"). Keeps index size bounded
+        -- as the table grows.
+        db.query([[
+            CREATE INDEX IF NOT EXISTS idx_tax_user_profiles_default_profile_key
+            ON tax_user_profiles (default_profile_key)
+            WHERE default_profile_key IS NOT NULL
+        ]])
+        print("[Tax Copilot] Added default_profile_key column to tax_user_profiles")
+    end,
 }

--- a/lapis/routes/register.lua
+++ b/lapis/routes/register.lua
@@ -6,6 +6,82 @@ local Global = require("helper.global")
 local db = require("lapis.db")
 local Errors = require("lib.errors")
 
+--- Validate that a business profile key is acceptable.
+-- @param profile_key string|nil The candidate key (e.g. "amazon_seller")
+-- @return boolean ok      — true if valid OR if the value is empty/nil
+--                           (caller decides whether the field is required)
+-- @return string|nil error_reason — set when ok=false, one of:
+--                           "inactive_profile_key" / "invalid_profile_key_format"
+--
+-- The canonical catalog is the union of two sources:
+--   * classification_profiles table (admin-managed, namespace-scoped)
+--   * filesystem profile rules under backend/app/profiles/ (FastAPI side)
+-- Lapis can only read the DB half. So we use a tiered policy:
+--   1. If the key matches a row in classification_profiles → trust it,
+--      reject only when the row is explicitly inactive.
+--   2. If the key isn't in the table → accept on a format check
+--      (lower_snake_case ASCII). The frontend sources its dropdown
+--      from /api/tax-profile/types which returns the FULL union, so
+--      a key arriving here unrecognised in the DB came from the
+--      filesystem half — also valid. The format check guards against
+--      arbitrary user-supplied strings (SQL-safe via parameterised
+--      queries elsewhere; this is just to keep the column tidy).
+--
+-- We deliberately don't enforce a DB-level FK to classification_profiles
+-- (see migration #75 rationale). Validation lives here so the same
+-- rule applies to every caller that accepts a profile key
+-- (registration today; settings update + OAuth onboarding next).
+local function validate_profile_key(profile_key)
+    if not profile_key or profile_key == "" then
+        return true  -- caller decides whether to treat empty as a hard error
+    end
+
+    -- Format check: lower_snake_case ASCII, 1-100 chars. Matches the
+    -- shape every existing key in the codebase uses.
+    if not profile_key:match("^[a-z][a-z0-9_]*$") or #profile_key > 100 then
+        return false, "invalid_profile_key_format"
+    end
+
+    -- Soft DB check: only reject when we're certain (row exists AND
+    -- is_active = false). Missing row falls through to "accept" so
+    -- filesystem-only profiles work without a duplicate registry.
+    local rows = db.query(
+        "SELECT is_active FROM classification_profiles WHERE profile_key = ? LIMIT 1",
+        profile_key
+    )
+    if rows and #rows > 0 then
+        local is_active = rows[1].is_active
+        -- Lapis pgmoon returns booleans as Lua booleans; older drivers
+        -- as 't'/'f' strings. Accept both shapes.
+        if is_active == false or is_active == 'f' or is_active == 0 then
+            return false, "inactive_profile_key"
+        end
+    end
+    return true
+end
+
+--- Persist the user's chosen default_profile_key into tax_user_profiles.
+-- Called after the user row + namespace assignment exist so the
+-- profile row exists too (assignUserToNamespace is responsible for
+-- creating the row downstream of the namespace dispatch).
+-- Idempotent via ON CONFLICT — safe even if the row was created
+-- earlier in the request.
+local function save_default_profile_key(user_id, user_uuid, profile_key)
+    if not profile_key or profile_key == "" then return end
+    local ok, err = pcall(function()
+        db.query([[
+            INSERT INTO tax_user_profiles (user_id, user_uuid, default_profile_key, created_at, updated_at)
+            VALUES (?, ?, ?, NOW(), NOW())
+            ON CONFLICT (user_uuid) DO UPDATE
+            SET default_profile_key = EXCLUDED.default_profile_key,
+                updated_at = NOW()
+        ]], user_id, user_uuid, profile_key)
+    end)
+    if not ok then
+        ngx.log(ngx.ERR, "[Register] Failed to save default_profile_key: ", tostring(err))
+    end
+end
+
 -- Auto-assign new user to the active project namespace
 local function assignUserToNamespace(user_id, user_uuid)
     local ok, err = pcall(function()
@@ -128,11 +204,51 @@ return function(app)
                 })
             end
 
-            local user = UserQueries.create(params)
+            -- Capture the optional business profile key BEFORE creating
+            -- the user — if the value is malformed we fail fast without
+            -- leaving an orphan user record. Empty / nil is allowed
+            -- (legacy clients that don't send the field continue to
+            -- work; the user picks one later in /onboarding or Settings).
+            local default_profile_key = params.default_profile_key
+            if default_profile_key and default_profile_key ~= "" then
+                local ok, reason = validate_profile_key(default_profile_key)
+                if not ok then
+                    return Errors.response(self, "VALIDATION_400", {
+                        context = {
+                            field = "default_profile_key",
+                            reason = reason,
+                            provided = default_profile_key,
+                            user_message = (reason == "inactive_profile_key")
+                                and "That business profile is no longer offered. Please pick another."
+                                or  "Unknown business profile. Please pick from the list.",
+                        },
+                    })
+                end
+            end
+
+            -- Build the users-table payload as a fresh shallow copy
+            -- minus our new field. This avoids depending on caller
+            -- mutations to ``self.params`` (which Lapis may wrap with
+            -- a metatable that treats ``= nil`` as a no-op) and keeps
+            -- the contract with UserQueries.create explicit: it
+            -- receives only fields valid for the users table.
+            local user_create_params = {}
+            for k, v in pairs(params) do
+                if k ~= "default_profile_key" then
+                    user_create_params[k] = v
+                end
+            end
+            local user = UserQueries.create(user_create_params)
             user.password = nil
 
             -- Auto-assign to project namespace (member role + default namespace)
             assignUserToNamespace(user.id, user.uuid)
+
+            -- Persist the validated profile key onto tax_user_profiles.
+            -- Runs after assignUserToNamespace so the profile row's
+            -- creation race is owned by the namespace setup; this
+            -- call is an idempotent UPSERT either way.
+            save_default_profile_key(user.id, user.uuid, default_profile_key)
 
             -- Generate JWT token for immediate authentication
             local JWT_SECRET_KEY = Global.getEnvVar("JWT_SECRET_KEY")
@@ -149,7 +265,14 @@ return function(app)
                     id = user.id,
                     email = user.email,
                     username = user.username,
-                    role = user.role
+                    role = user.role,
+                    -- Surface the freshly-saved business profile key
+                    -- so the frontend can render the right onboarding
+                    -- state and pre-fill classify without a second
+                    -- /api/tax-profile fetch on the very next page.
+                    -- Always set explicitly to a string-or-nil for
+                    -- consumer parsers; cjson omits nils on encode.
+                    default_profile_key = default_profile_key,
                 },
                 exp = ngx.time() + (60 * 60) -- 1 hour expiry (matches DEFAULT_EXPIRATION)
             }


### PR DESCRIPTION
## Summary
- Add `default_profile_key` column to `tax_user_profiles` (with partial index on non-null values for catalog reverse-lookups).
- Accept `default_profile_key` on `POST /auth/register` so basic signup captures the user's business type once and the FastAPI classifier can fall back to it on every subsequent statement.

## Why
The Python classifier needs a per-user business profile (taxi driver, freelance dev, etc.) to apply the right HMRC categorisation rules. Previously users had to re-pick on every classify call. This PR captures the choice at registration so the classifier can resolve it from `tax_user_profiles` automatically.

OAuth signup is handled in the diy-tax-return-uk PR (an onboarding interstitial after the JWT lands, since OAuth skips this form).

## Validation
The `validate_profile_key` helper does a tiered check:
1. Format gate: `^[a-z][a-z0-9_]*$`, ≤100 chars
2. Soft DB check against `classification_profiles` (active-only) — invalid keys 422 with a structured envelope so the React form can render an inline error.

Empty/missing `default_profile_key` is accepted (the field is optional on the form when the catalog fails to load — the classifier falls back to "pick one" UX).

The Lapis `self.params` metatable rejects nil-strip, so the field is filtered via shallow-copy before `UserQueries.create` to prevent it leaking into the `users` table insert.

## Companion PR
- diy-tax-return-uk → ``fix/hmrc-filing-reliability``: register form dropdown, OAuth onboarding interstitial, classify endpoint fallback chain, settings edit field, UI rename to "Business type".

## Test plan
- [ ] Register a new user with a valid `default_profile_key` → row appears in `tax_user_profiles` with the key set
- [ ] Register without `default_profile_key` → user is created, no `tax_user_profiles` row insert is attempted
- [ ] Register with an invalid `default_profile_key` → 422 with `{ field: "default_profile_key", reason: "...", user_message: "..." }`
- [ ] Verify migration is idempotent (run, rollback, re-run)
- [ ] Confirm the partial index `idx_tax_user_profiles_default_profile_key` exists on non-null values only