### PR TITLE
fix(errors): widen error_occurrences.tenant_namespace varchar(255) -> text

### DIFF
--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -1283,6 +1283,7 @@ local _migrations = {
     ['494_tax_hmrc_calculations_request_payload']    = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 73),
     ['495_tax_rescope_hmrc_filings_unique']          = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 74),
     ['496_tax_user_profile_default_profile_key']     = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 75),
+    ['497_tax_widen_error_occurrence_tenant_ns']     = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 76),
 
     -- =========================================================================
     -- CORE AUTH: Password reset tokens

--- a/lapis/migrations/tax-copilot-system.lua
+++ b/lapis/migrations/tax-copilot-system.lua
@@ -2617,4 +2617,29 @@ return {
         ]])
         print("[Tax Copilot] Added default_profile_key column to tax_user_profiles")
     end,
+
+    -- 76. Widen error_occurrences.tenant_namespace from VARCHAR(255) to TEXT.
+    --
+    -- Why: the JWT issued by Lapis carries ``userinfo.namespace`` as a
+    -- multi-field dict (slug, id, uuid, role, permissions, name, …). The
+    -- Python middleware used to ``str(dict)`` it, which produced a Python
+    -- dict repr that easily exceeded 255 chars on tenants with many
+    -- permissions. Every such error then triggered StringDataRightTruncation
+    -- on INSERT and was silently dropped from the audit trail — visible to
+    -- the end user as ``VALIDATION_400 · <ref>``, invisible to admins
+    -- because /admin/errors/occurrences/<uuid> would 404.
+    --
+    -- The middleware fix (PR companion) extracts a short slug for the
+    -- column, but we widen the schema anyway so even a future regression
+    -- can never lose an audit row again. TEXT carries no overhead in
+    -- Postgres vs varchar(N), and the existing btree index works fine on
+    -- text — the actual values we store are still short slugs (~16 chars
+    -- on average).
+    [76] = function()
+        db.query([[
+            ALTER TABLE error_occurrences
+            ALTER COLUMN tenant_namespace TYPE TEXT
+        ]])
+        print("[Tax Copilot] Widened error_occurrences.tenant_namespace VARCHAR(255) -> TEXT")
+    end,
 }


### PR DESCRIPTION
## Summary

Adds Lapis migration #497 (tax-copilot index 76) that widens ``error_occurrences.tenant_namespace`` from ``VARCHAR(255)`` to ``TEXT``.

## Root cause being fixed

The JWT issued by Lapis carries ``userinfo.namespace`` as a multi-field dict (slug, id, uuid, role, permissions, name, …). The Python error middleware was previously doing ``str(value)`` on that dict before persisting it. On any tenant with a non-trivial permission set the Python dict repr exceeded 255 chars and every error INSERT failed with:

```
psycopg2.errors.StringDataRightTruncation:
    value too long for type character varying(255)
```

Visible symptom: the user sees a normal error toast like ``VALIDATION_400 · b8e8154c`` but the matching audit row is missing from ``/admin/errors/occurrences/<uuid>`` — the row never landed.

Verified live on the int server (192.168.1.193): three failing INSERTs in the same minute for a real user encountering ``RULE_START_DATE_NOT_ALIGNED_TO_COMMENCEMENT_DATE``. Schema is identical on the second test server (187.77.179.206) — same latent bug, not yet triggered.

## Why TEXT (and not just a longer varchar)

The companion diy-tax-return-uk PR extracts a short slug (16-char average) before persisting, so values stored here are always small — but widening the column to ``TEXT`` is **belt-and-braces**: even if a future regression in the Python writer hands us a longer value, the INSERT will still succeed and the audit row won't be lost. ``TEXT`` carries no overhead vs ``VARCHAR(N)`` in PostgreSQL, and the existing btree index works unchanged on the new type.

## Migration

Single ALTER COLUMN, idempotent, instant on a healthy DB (Postgres rewrites no data when going varchar→text):

```sql
ALTER TABLE error_occurrences ALTER COLUMN tenant_namespace TYPE TEXT;
```

Already applied + verified on the local dev DB. Acc and int will pick it up on next deploy via the standard migration runner.

## Companion PR

[bwalia/diy-tax-return-uk](https://github.com/bwalia/diy-tax-return-uk) — fix(errors): extract namespace slug + production-ready HMRC env switch.

Land this PR first so the column is widened before the new writer rolls out, though the writer also enforces a 128-char cap defensively — either-first order is safe.

## Test plan
- [ ] Apply migration on int/acc — confirm ``\\d error_occurrences`` shows ``tenant_namespace | text``
- [ ] Existing btree index ``idx_error_occurrences_tenant`` survives the ALTER (verify with ``\\d error_occurrences``)
- [ ] Reproduce a multi-tenant error after companion PR deploys → confirm ``error_occurrences`` row lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)