### PR TITLE
fix(bank-accounts): canonicalise sort code on save, accept paste formats

### DIFF
--- a/lapis/routes/tax-bank-accounts.lua
+++ b/lapis/routes/tax-bank-accounts.lua
@@ -51,13 +51,21 @@ local function validate_bank_account_params(params, is_create)
         params.account_number = trimmed
     end
 
-    -- sort_code: optional, must be XX-XX-XX format
+    -- sort_code: optional. UK sort codes are exactly 6 digits, commonly
+    -- written XX-XX-XX on statements. Accept what users naturally paste —
+    -- "123456", "12-34-56", "12 34 56" — and canonicalise to XX-XX-XX.
+    -- Mirrors `normalize_sort_code` in backend/app/models/bank_account.py
+    -- so the Python and Lua write paths can't drift.
     if params.sort_code and params.sort_code ~= "" then
         local trimmed = params.sort_code:match("^%s*(.-)%s*$")
-        if not trimmed:match("^%d%d%-%d%d%-%d%d$") then
-            return false, "sort_code must be in XX-XX-XX format (e.g. 20-00-00)"
+        if trimmed:match("[^%d%s%-]") then
+            return false, "sort_code can only contain digits, spaces or hyphens"
         end
-        params.sort_code = trimmed
+        local digits = (trimmed:gsub("[%s%-]", ""))
+        if #digits ~= 6 then
+            return false, "sort_code must be 6 digits (e.g. 20-00-00 or 200000)"
+        end
+        params.sort_code = digits:sub(1, 2) .. "-" .. digits:sub(3, 4) .. "-" .. digits:sub(5, 6)
     end
 
     -- account_type: must be a valid type


### PR DESCRIPTION
## Summary

UK sort codes are exactly 6 digits, commonly written `XX-XX-XX` on statements. The previous validator only accepted that strict form, so:
- pasting `123456` or `12 34 56` got a 400
- pasting fewer than 6 digits (e.g. `122211`) wrote raw to the DB with no canonicalisation — the bug that triggered the user's report on int (sort code saved as `122211`, not `12-22-11`)

## What changes
`validate_bank_account_params` in `lapis/routes/tax-bank-accounts.lua`:
- Trims, rejects any char that isn't digit / space / hyphen.
- Strips to digit-only form, must be exactly 6 digits.
- Canonicalises to `XX-XX-XX` before writing.

## Why this PR exists alongside the FastAPI one
Both Python (FastAPI) and Lua (Lapis) write to `tax_bank_accounts`. The companion PR [bwalia/diy-tax-return-uk#390](https://github.com/bwalia/diy-tax-return-uk/pull/390) updates the Python validator, the TypeScript frontend helper, and the Dart iOS helper to the **same fixture set** — all four implementations validate identically so the write paths can't drift.

## Test plan
- [ ] Deploy to int
- [ ] In the frontend / Flutter app, save a bank account with sort code `123456` → opsapi accepts it, DB row has `sort_code = "12-34-56"`
- [ ] Save with `12 34 56` → same result
- [ ] Save with `123` → 400 with the new error message
- [ ] Save with `12-34-5a` → 400 "can only contain digits, spaces or hyphens"
- [ ] Re-upload the user's Lloyds statement → sort code auto-detected as `122211` is now persisted as `12-22-11`

🤖 Generated with [Claude Code](https://claude.com/claude-code)