### PR TITLE
fix(otp): suppress SMTP send for E2E test recipients on non-prod envs

### DIFF
--- a/lapis/.env.example
+++ b/lapis/.env.example
@@ -134,3 +134,23 @@ CORS_CREDENTIALS=true
 # AUTH_COOKIE_TRUSTED_DOMAINS=
 # AUTH_COOKIE_DOMAIN=
 # AUTH_COOKIE_INSECURE=
+
+# ===========================================
+# E2E OTP-email suppression (int/test/dev only)
+# ===========================================
+# When set on a non-production deployment, OTP.sendToEmail still creates
+# the OTP row in the DB (so OTP.verify works exactly as before — magic
+# TEST_OTP_CODE or the real code from the row) but SKIPS the SMTP send
+# for recipients matching the regex.
+#
+# Used to stop the Playwright suite from flooding diytaxreturnmail@gmail.com
+# with ~92 OTP emails per week. CI generates emails tagged
+# `diytaxreturnmail+e2e-<timestamp>@gmail.com`; the regex only matches
+# that tag, so manual logins (bare address or any other `+suffix`) still
+# get their OTP delivered normally.
+#
+# Double-gated: the check is skipped entirely when
+# LAPIS_ENVIRONMENT=production, so acc and prod are unaffected.
+#
+# Default for int/test deployments:
+# OTP_SUPPRESS_FOR_EMAIL_REGEX=^diytaxreturnmail\+e2e-.*@gmail\.com$

--- a/lapis/helper/otp.lua
+++ b/lapis/helper/otp.lua
@@ -267,6 +267,27 @@ function OTP.sendToEmail(user, brand)
         return false, err
     end
 
+    -- E2E test traffic suppression. CI runs the Playwright suite many times
+    -- a day and each register/login dumps a real OTP into the shared test
+    -- mailbox (diytaxreturnmail@gmail.com via Gmail plus-addressing). We
+    -- still CREATE the OTP row above so OTP.verify works normally — only
+    -- the SMTP send is skipped. Double-gated:
+    --   1) LAPIS_ENVIRONMENT must not be "production"  (acc + prod = always send)
+    --   2) Recipient must match OTP_SUPPRESS_FOR_EMAIL_REGEX
+    -- If the env var is unset, behaviour is identical to before this change.
+    local suppress_regex = os.getenv("OTP_SUPPRESS_FOR_EMAIL_REGEX")
+    if env ~= "production" and suppress_regex and suppress_regex ~= "" then
+        local matched, regex_err = ngx.re.match(user.email, suppress_regex, "jo")
+        if regex_err then
+            ngx.log(ngx.WARN, "[OTP] Bad OTP_SUPPRESS_FOR_EMAIL_REGEX (", suppress_regex,
+                "): ", regex_err, " — falling back to sending the email")
+        elseif matched then
+            ngx.log(ngx.NOTICE, "[OTP] Suppressed email for E2E test recipient ", user.email,
+                " (env=", env, ", code still in DB for OTP.verify)")
+            return true
+        end
+    end
+
     brand = brand or {}
     local app_name = type(brand.app_name) == "string" and brand.app_name ~= "" and brand.app_name or "DIY Tax Return"
     local safe_color = sanitize_hex_color(brand.brand_color)

--- a/lapis/nginx.conf
+++ b/lapis/nginx.conf
@@ -89,6 +89,11 @@ env LANGFUSE_PUBLIC_KEY;
 env LANGFUSE_SECRET_KEY;
 env LANGFUSE_BASE_URL;
 env TEST_OTP_CODE;
+# When set on int/test/dev, OTP.sendToEmail skips the SMTP send (but
+# still writes the OTP row) for recipients matching this regex. Stops
+# the E2E suite from flooding the shared test mailbox. Ignored when
+# LAPIS_ENVIRONMENT=production.
+env OTP_SUPPRESS_FOR_EMAIL_REGEX;
 
 # helper/auth-cookies.lua reads these to compose the Set-Cookie header
 # for the opaque refresh token. See helper/auth-cookies.lua and the


### PR DESCRIPTION
## Why

The existing `TEST_OTP_CODE` magic-code bypass only short-circuits OTP **verification**, not **sending** — so every CI run dumped real OTP emails into the shared test mailbox. Roughly **92 OTP emails per week** were arriving in `diytaxreturnmail@gmail.com`:

- `daily-e2e-tests.yml` (every day, int + test): ~56/week
- `diy-tax-return-web-frontend-unit-test.yml` (weekly Thursday + workflow_dispatch): ~36/run (3 envs × 12 OTPs)

The biggest single offender is `rbac.spec.ts` — 8 separate `loginAs(...)` calls per env, each generating a fresh OTP.

The existing code even calls this out at [`lapis/helper/otp.lua:256-258`](https://github.com/bwalia/opsapi/blob/main/lapis/helper/otp.lua#L256-L258):
> *"…we still create a real OTP and send the email so users receive the code. This allows developers to bypass with the test code while real users get emails."*

## What changes

A surgical, **double-gated**, **opt-in** suppression hook in `OTP.sendToEmail`:

```lua
-- After OTP.create() succeeds, before Mail.send():
local suppress_regex = os.getenv("OTP_SUPPRESS_FOR_EMAIL_REGEX")
if env ~= "production" and suppress_regex and suppress_regex ~= "" then
    local matched, _ = ngx.re.match(user.email, suppress_regex, "jo")
    if matched then
        ngx.log(ngx.NOTICE, "[OTP] Suppressed email for E2E test recipient ", user.email, ...)
        return true  -- OTP row is in the DB; verify still works
    end
end
```

Plus:
- `nginx.conf` — `env OTP_SUPPRESS_FOR_EMAIL_REGEX;` so OpenResty exposes the var to Lua (it strips environment otherwise).
- `.env.example` — usage docs with the recommended int/test value.

## Safety properties

| Property | How it's enforced |
|---|---|
| **Production unaffected** | Gate 1: `env != "production"` skips check entirely. acc + prod always send. |
| **Default behaviour unchanged** | Gate 2: if env var unset, the regex-match branch is never entered. |
| **`OTP.verify` still works** | OTP row is still written to DB (only `Mail.send` is skipped). Magic `TEST_OTP_CODE` and real-code lookup both work. |
| **Manual logins on int/test still get OTPs** | The recommended regex `^diytaxreturnmail\+e2e-.*@gmail\.com$` only matches CI-tagged addresses. Bare `diytaxreturnmail@gmail.com` or any other `+suffix` flows through. |
| **Audit trail** | `ngx.log(ngx.NOTICE, "[OTP] Suppressed ...")` so SREs see every suppression. |
| **Reversible** | Unset the env var → behavior reverts. |
| **Fails open** | If the regex itself is malformed, log a WARN and fall back to sending. |

## How to enable on int/test

Add to the `.env` (or compose `environment:` block, or helm value) of each non-production deployment:

```
OTP_SUPPRESS_FOR_EMAIL_REGEX=^diytaxreturnmail\+e2e-.*@gmail\.com$
```

That's it. No restart of any other service needed — only the lapis pod/container needs to pick up the new var on next reload.

## Pairs with

[bwalia/diy-tax-return-uk PR — tag e2e emails with `+e2e-`](https://github.com/bwalia/diy-tax-return-uk/pull/393). That PR changes `register.spec.ts`'s `generateUniqueEmail()` to emit `diytaxreturnmail+e2e-<timestamp>@gmail.com`. Both PRs are independent — this PR is safe to deploy on its own (does nothing without the env var), and the e2e PR is safe on its own (Gmail plus-addressing still routes to the inbox).

## Follow-up (optional, ops side, not in this PR)

The first ~6 OTPs per env per run come from `register.spec.ts`-generated emails — fully suppressed once both PRs ship.

The remaining ~6 per env per run come from fixed CI secrets (`E2E_TEST_EMAIL`, `E2E_ADMIN_EMAIL`, `E2E_ACCOUNTANT_EMAIL`, `E2E_CLIENT_EMAIL`, `E2E_VIEWER_EMAIL`). To suppress those too:
1. Reissue the secrets with values like `diytaxreturnmail+e2e-admin@gmail.com`, OR
2. Extend the regex to cover the existing secret values: `^diytaxreturnmail(\+e2e-.*|\+admin|\+accountant|...)?@gmail\.com$`.

Option 1 is cleaner but requires re-registering those fixture users in int + test DBs. Out of scope for this PR.

## Test plan
- [ ] Deploy to int (lapis only): `OTP_SUPPRESS_FOR_EMAIL_REGEX=^diytaxreturnmail\+e2e-.*@gmail\.com$`
- [ ] Trigger `daily-e2e-tests.yml`: confirm zero OTPs arrive in test mailbox; tests still pass (magic code still works)
- [ ] Manual login on int with `diytaxreturnmail@gmail.com` — OTP arrives normally
- [ ] Manual login on int with `diytaxreturnmail+manual@gmail.com` — OTP arrives normally
- [ ] Confirm acc behavior unchanged (no env var set there; `LAPIS_ENVIRONMENT=production` is the second gate anyway)
- [ ] Check lapis logs for `[OTP] Suppressed email for E2E test recipient` lines as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)