### PR TITLE
feat(mail): non-prod debug banner + cross-env suppression

### DIFF
--- a/devops/helm-charts/diytaxreturn-lapis/templates/deployment.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/templates/deployment.yaml
@@ -56,6 +56,20 @@ spec:
           env:
             - name: LAPIS_ENVIRONMENT
               value: "production"
+            # Deployment-environment label used by helper/mail.lua to
+            # decide whether to inject the non-prod debug banner +
+            # [ENV] subject prefix. We can't reuse LAPIS_ENVIRONMENT
+            # here because it's hardcoded "production" above so the
+            # secret-templated config.lua's single `config("production")`
+            # block is selected — without this split, the banner would
+            # never fire on dev/test/int/acc.
+            #
+            # Values: dev / test / int / acc / prod — matches the suffix
+            # of values-*.yaml. helper/mail.lua treats both "prod" and
+            # "production" as prod (is_production_env), so prod
+            # deployments get no banner.
+            - name: OPSAPI_DEPLOY_ENV
+              value: {{ .Values.env | quote }}
             - name: PROJECT_CODE
               value: {{ .Values.projectCode | default "all" | quote }}
             {{- if and .Values.setup .Values.setup.adminEmail }}

--- a/lapis/.env.example
+++ b/lapis/.env.example
@@ -154,3 +154,49 @@ CORS_CREDENTIALS=true
 #
 # Default for int/test deployments:
 # OTP_SUPPRESS_FOR_EMAIL_REGEX=^diytaxreturnmail\+e2e-.*@gmail\.com$
+
+# ===========================================
+# Non-prod email debug tagging
+# ===========================================
+# helper/mail.lua extends the suppression above to ALL outbound emails
+# (not just OTP) on non-production deployments, and adds two debug
+# affordances so the shared test mailbox stays readable:
+#
+#   1. Subject is prefixed with [ENV] — e.g. "[INT] Your OTP code".
+#      Set up an inbox filter once and routing is automatic.
+#
+#   2. A yellow "NON-PROD EMAIL" banner is injected into the rendered
+#      HTML / text body listing:
+#        - Environment (LAPIS_ENVIRONMENT)
+#        - Host (HOSTNAME)
+#        - Recipient
+#        - Triggered-by user (from opts.triggered_by passed by the
+#          caller, e.g. routes/auth.lua's forgot-password handler)
+#        - Source IP / X-Forwarded-For / Origin / Endpoint
+#        - X-Request-Id / X-Correlation-Id
+#        - Timestamp (UTC)
+#
+# Both behaviours are gated on LAPIS_ENVIRONMENT != "production" — the
+# production path is byte-identical to today.
+#
+# Env detection (the source of truth for "should we tag this email?"):
+#
+#   OPSAPI_DEPLOY_ENV    Canonical deployment label. Set by helm from
+#                        .Values.env on every cluster pod (values:
+#                        dev / test / int / acc / prod). Read first.
+#
+#   LAPIS_ENVIRONMENT    Fallback only — used when OPSAPI_DEPLOY_ENV is
+#                        unset (local dev via docker-compose / start.sh).
+#                        On the cluster this is hard-coded "production"
+#                        so the secret-templated config.lua selects its
+#                        single config("production", ...) block, which
+#                        is WHY we can't reuse it as the deploy label.
+#
+# Both "production" and "prod" count as prod (matches helm's `env: prod`
+# AND Lapis's "production" config-block name). All other values activate
+# the [ENV] subject prefix + debug banner.
+#
+# Both vars must be in nginx.conf's `env` directive list to be visible
+# to the OpenResty worker's Lua scope (already added).
+# OPSAPI_DEPLOY_ENV=local
+# LAPIS_ENVIRONMENT=development

--- a/lapis/config.lua
+++ b/lapis/config.lua
@@ -45,3 +45,50 @@ config("production", {
     port = tonumber(os.getenv("POSTGRES_PORT") or "5432")
   }
 })
+
+-- Non-prod deployment environments. Each is a real deployment target
+-- (test on 192.168.1.193 docker, int in k3s, acc in k3s) — but from
+-- the Lapis process's perspective they all need the same nginx setup
+-- as development: listen on 80, use the same postgres connection
+-- parameters, same session/cookie scheme. Without these blocks
+-- `lapis server` would fall back to its built-in default (port 8080)
+-- whenever LAPIS_ENVIRONMENT is "int" / "test" / "acc", which silently
+-- broke the docker healthcheck (which curls port 80) — that's what
+-- got us here.
+--
+-- Each block is identical to "development" right now; this is the
+-- right shape to hang env-specific overrides off later (e.g. custom
+-- postgres host on acc) without losing the port=80 baseline.
+local non_prod_envs = { "test", "int", "acc", "local" }
+for _, env_name in ipairs(non_prod_envs) do
+  config(env_name, {
+    port = 80,
+    server = "nginx",
+    code_cache = "on",
+    num_workers = "1",
+    session_name = "opsapi_session",
+    secret = os.getenv("JWT_SECRET_KEY") or "your-secret-key-here-change-in-production",
+    session_options = {
+      lifetime = 3600 * 24 * 7,
+      regen = 900,
+      storage = "cookie",
+      cookie = {
+        persistent = true,
+        renew = 600,
+        lifetime = 3600 * 24 * 7,
+        path = "/",
+        domain = nil,
+        secure = false,
+        httponly = true,
+        samesite = "Lax"
+      }
+    },
+    postgres = {
+      host = os.getenv("POSTGRES_HOST") or "172.72.0.10",
+      user = os.getenv("POSTGRES_USER") or "pguser",
+      password = os.getenv("POSTGRES_PASSWORD") or "pgpassword",
+      database = os.getenv("POSTGRES_DB") or "opsapi-diytaxreturn",
+      port = tonumber(os.getenv("POSTGRES_PORT") or "5432")
+    }
+  })
+end

--- a/lapis/helper/mail.lua
+++ b/lapis/helper/mail.lua
@@ -263,6 +263,207 @@ function Mail.getTemplates()
 end
 
 -- ============================================================================
+-- Non-prod enrichment + recipient suppression
+-- ============================================================================
+--
+-- Goal: on dev/test/int/acc deployments the shared inbox gets emails
+-- from every environment, and the user can't tell which env or which
+-- user triggered which message. We:
+--   1. Prefix the subject with [ENV] so inbox filtering works.
+--   2. Inject a "DEBUG CONTEXT" banner into the body listing env,
+--      hostname, recipient, triggered_by user, source IP, endpoint,
+--      request_id and timestamp.
+--   3. Suppress sending to recipients matching OTP_SUPPRESS_FOR_EMAIL_REGEX
+--      (e.g. the e2e mailbox `+e2e-...@`) so CI doesn't flood real
+--      mailboxes.
+-- LAPIS_ENVIRONMENT="production" disables all three — prod email path
+-- is byte-identical to before this change.
+
+-- The deployment-environment label ("dev" / "test" / "int" / "acc" /
+-- "prod"). We read OPSAPI_DEPLOY_ENV first because the helm chart
+-- sets it from `.Values.env`; LAPIS_ENVIRONMENT is hard-coded to
+-- "production" by the same chart so the secret-templated config.lua
+-- selects its only `config("production", ...)` block. Reading
+-- LAPIS_ENVIRONMENT alone would therefore always say "production" on
+-- the cluster and the banner would never fire on dev/int/acc.
+-- Local dev keeps working: docker-compose still only sets
+-- LAPIS_ENVIRONMENT, and the fallback chain picks it up.
+--
+-- Final fallback is "production" — fail closed. If neither var is set
+-- (e.g. a misconfigured deploy, or a CLI script run from outside the
+-- normal entrypoints) the system behaves like prod: no banner, no
+-- suppression. You opt INTO the debug banner by explicitly setting
+-- one of the env vars, never out of it by forgetting one.
+local function current_env()
+    return os.getenv("OPSAPI_DEPLOY_ENV")
+        or os.getenv("LAPIS_ENVIRONMENT")
+        or "production"
+end
+
+-- True for both helm's `env: prod` value AND Lapis's "production"
+-- config-block name, so callers don't need to know which one's in
+-- play. Add new aliases here if a new deployment naming convention
+-- appears.
+local function is_production_env(env)
+    return env == "production" or env == "prod"
+end
+
+local function current_hostname()
+    -- HOSTNAME is set by Docker / Kubernetes; falls back to a
+    -- placeholder so the banner always has something to show.
+    return os.getenv("HOSTNAME") or "unknown-host"
+end
+
+--- Should this recipient be silently skipped? Same env var as the
+--- OTP-specific check so SREs configure it once in the .env. Skipping
+--- is double-gated: env != production AND recipient matches regex.
+local function should_suppress_recipient(to)
+    if is_production_env(current_env()) then return false end
+    local pattern = os.getenv("OTP_SUPPRESS_FOR_EMAIL_REGEX")
+    if not pattern or pattern == "" then return false end
+    if type(to) ~= "string" then return false end
+    local matched, _ = ngx.re.match(to, pattern, "jo")
+    return matched ~= nil
+end
+
+--- Capture per-request context from ngx (request handler scope only —
+--- safe to call from a handler, returns empty when called from a
+--- background timer where ngx.var isn't usable). Pure read; never
+--- raises. Caller pairs this with an optional opts.triggered_by table
+--- for the user identity (which lives on `self.current_user`, not ngx).
+local function capture_request_context()
+    local ctx = {}
+    local ok = pcall(function()
+        ctx.source_ip = ngx.var.remote_addr
+        ctx.forwarded_for = ngx.var.http_x_forwarded_for
+        ctx.endpoint = ngx.var.request_method .. " " .. (ngx.var.request_uri or "")
+        ctx.request_id = ngx.var.http_x_request_id
+            or ngx.var.http_x_correlation_id
+        ctx.origin = ngx.var.http_origin or ngx.var.http_referer
+        ctx.user_agent = ngx.var.http_user_agent
+    end)
+    if not ok then return {} end
+    return ctx
+end
+
+--- Minimal HTML escape for values we paste into the debug banner. The
+--- banner is the only place we render free-form ngx vars into HTML.
+local function html_escape(s)
+    if s == nil then return "" end
+    return (tostring(s)
+        :gsub("&", "&amp;")
+        :gsub("<", "&lt;")
+        :gsub(">", "&gt;")
+        :gsub('"', "&quot;")
+        :gsub("'", "&#39;"))
+end
+
+--- Build the debug banner shown to the user inside non-prod emails.
+local function build_debug_banner_html(env, recipient, triggered_by, context)
+    local rows = {}
+    local function row(label, value)
+        if value == nil or value == "" then return end
+        rows[#rows + 1] = string.format(
+            '<tr><td style="padding:2px 12px 2px 0;color:#92400e;font-weight:600;white-space:nowrap;">%s</td><td style="padding:2px 0;color:#451a03;word-break:break-all;">%s</td></tr>',
+            html_escape(label), html_escape(value))
+    end
+
+    row("Environment", env)
+    row("Host",        current_hostname())
+    row("Recipient",   type(recipient) == "table" and table.concat(recipient, ", ") or recipient)
+    if triggered_by then
+        local who = triggered_by.user_email
+            or triggered_by.user_uuid
+            or triggered_by.username
+        if who then
+            local detail = {}
+            if triggered_by.user_email then detail[#detail + 1] = triggered_by.user_email end
+            if triggered_by.user_uuid  then detail[#detail + 1] = "uuid=" .. triggered_by.user_uuid end
+            if triggered_by.role       then detail[#detail + 1] = "role=" .. triggered_by.role end
+            row("Triggered by", table.concat(detail, " · "))
+        end
+        if triggered_by.source then row("Source", triggered_by.source) end
+    end
+    if context.source_ip      then row("Source IP",    context.source_ip) end
+    if context.forwarded_for  then row("Forwarded-For", context.forwarded_for) end
+    if context.endpoint       then row("Endpoint",     context.endpoint) end
+    if context.origin         then row("Origin",       context.origin) end
+    if context.request_id     then row("Request ID",   context.request_id) end
+    if context.user_agent     then row("User-Agent",   context.user_agent) end
+    row("Timestamp", os.date("!%Y-%m-%dT%H:%M:%SZ"))
+
+    return table.concat({
+        '<div style="background:#fffbeb;border:2px solid #f59e0b;border-radius:6px;padding:14px;margin:0 0 18px;font:13px/1.5 \'SFMono-Regular\',Menlo,Consolas,monospace;color:#451a03;">',
+        '<div style="font-size:12px;font-weight:700;letter-spacing:.08em;color:#b45309;margin-bottom:8px;">NON-PROD EMAIL · ',
+        html_escape(string.upper(env)),
+        '</div>',
+        '<div style="font-size:11px;color:#92400e;margin-bottom:10px;">This banner is added on non-production environments to help you trace what triggered this message. It is not present on prod.</div>',
+        '<table style="border-collapse:collapse;font-size:12px;">',
+        table.concat(rows),
+        '</table>',
+        '</div>',
+    })
+end
+
+--- Build the plain-text equivalent of the banner for text-only emails.
+local function build_debug_banner_text(env, recipient, triggered_by, context)
+    local lines = {
+        "============================================================",
+        "NON-PROD DEBUG (env=" .. env .. ")",
+        "------------------------------------------------------------",
+        "Host:         " .. current_hostname(),
+        "Recipient:    " .. (type(recipient) == "table" and table.concat(recipient, ", ") or tostring(recipient)),
+    }
+    if triggered_by then
+        if triggered_by.user_email then lines[#lines + 1] = "Triggered by: " .. triggered_by.user_email end
+        if triggered_by.user_uuid  then lines[#lines + 1] = "User UUID:    " .. triggered_by.user_uuid end
+        if triggered_by.role       then lines[#lines + 1] = "Role:         " .. triggered_by.role end
+        if triggered_by.source     then lines[#lines + 1] = "Source:       " .. triggered_by.source end
+    end
+    if context.source_ip     then lines[#lines + 1] = "Source IP:    " .. context.source_ip end
+    if context.forwarded_for then lines[#lines + 1] = "Forwarded:    " .. context.forwarded_for end
+    if context.endpoint      then lines[#lines + 1] = "Endpoint:     " .. context.endpoint end
+    if context.origin        then lines[#lines + 1] = "Origin:       " .. context.origin end
+    if context.request_id    then lines[#lines + 1] = "Request ID:   " .. context.request_id end
+    lines[#lines + 1] = "Timestamp:    " .. os.date("!%Y-%m-%dT%H:%M:%SZ")
+    lines[#lines + 1] = "============================================================"
+    lines[#lines + 1] = ""
+    return table.concat(lines, "\n")
+end
+
+--- Mutates opts to add env prefix + debug banner. No-op when env is
+--- production. Always safe to call.
+local function enrich_for_non_prod(opts)
+    local env = current_env()
+    if is_production_env(env) then return end
+
+    local context = capture_request_context()
+    local triggered_by = opts.triggered_by
+    opts.triggered_by = nil  -- don't ship it into the JSON payload
+
+    local tag = "[" .. string.upper(env) .. "] "
+    if not opts.subject:find(tag, 1, true) then
+        opts.subject = tag .. opts.subject
+    end
+
+    if opts.html then
+        local banner = build_debug_banner_html(env, opts.to, triggered_by, context)
+        -- Inject right after <body> if present; else prepend.
+        local lower = opts.html:lower()
+        local _, body_open_e = lower:find("<body[^>]*>", 1)
+        if body_open_e then
+            opts.html = opts.html:sub(1, body_open_e) .. banner .. opts.html:sub(body_open_e + 1)
+        else
+            opts.html = banner .. opts.html
+        end
+    end
+
+    if opts.text then
+        opts.text = build_debug_banner_text(env, opts.to, triggered_by, context) .. opts.text
+    end
+end
+
+-- ============================================================================
 -- SMTP Sending (non-blocking via lua-resty-mail)
 -- ============================================================================
 
@@ -394,6 +595,21 @@ function Mail.send(opts)
         ngx.log(ngx.WARN, "[Mail] SMTP not configured — email to ", tostring(opts.to), " not sent")
         return false, "SMTP not configured. Set SMTP_USER and SMTP_PASSWORD environment variables."
     end
+
+    -- Suppress traffic to known E2E recipients on non-prod (stops the
+    -- shared CI mailbox getting flooded). Logged so SREs can audit
+    -- what got skipped. Production is unaffected (the check returns
+    -- false early when LAPIS_ENVIRONMENT=production).
+    if should_suppress_recipient(opts.to) then
+        ngx.log(ngx.NOTICE, "[Mail] SUPPRESSED non-prod email to ", tostring(opts.to),
+            " (matches OTP_SUPPRESS_FOR_EMAIL_REGEX)")
+        return true
+    end
+
+    -- Tag subject + inject debug banner on non-prod envs. Captures
+    -- ngx request context synchronously (still in handler scope)
+    -- before any timer.at hop loses it.
+    enrich_for_non_prod(opts)
 
     -- Synchronous mode (for use in ngx.timer callbacks or lapis exec scripts)
     if opts.sync then

--- a/lapis/helper/otp.lua
+++ b/lapis/helper/otp.lua
@@ -307,6 +307,13 @@ function OTP.sendToEmail(user, brand)
             brand_logo_url = safe_logo,
             support_email = brand.support_email,
         },
+        -- Non-prod debug context. Stripped by Mail.send before the
+        -- SMTP payload is built; only used to populate the banner.
+        triggered_by = {
+            user_uuid = user.uuid,
+            user_email = user.email,
+            source = "otp.sendToEmail",
+        },
     })
 
     if not ok then

--- a/lapis/nginx.conf
+++ b/lapis/nginx.conf
@@ -92,8 +92,21 @@ env TEST_OTP_CODE;
 # When set on int/test/dev, OTP.sendToEmail skips the SMTP send (but
 # still writes the OTP row) for recipients matching this regex. Stops
 # the E2E suite from flooding the shared test mailbox. Ignored when
-# LAPIS_ENVIRONMENT=production.
+# LAPIS_ENVIRONMENT=production. helper/mail.lua extends this to ALL
+# outbound emails (not just OTP) on non-prod environments so the
+# shared inbox stays usable.
 env OTP_SUPPRESS_FOR_EMAIL_REGEX;
+# OpenResty workers don't see process-env vars unless declared here.
+# helper/mail.lua reads OPSAPI_DEPLOY_ENV (set by helm's
+# deployment.yaml from .Values.env, value dev/test/int/acc/prod) to
+# decide whether to inject the [ENV] subject prefix + debug banner
+# into outbound emails. It falls back to LAPIS_ENVIRONMENT for local
+# dev (start.sh / docker-compose only set the latter). Both env names
+# are declared here so neither is invisible to the worker's Lua scope.
+# Prod path is byte-identical to today (is_production_env matches both
+# "prod" and "production").
+env OPSAPI_DEPLOY_ENV;
+env LAPIS_ENVIRONMENT;
 
 # helper/auth-cookies.lua reads these to compose the Set-Cookie header
 # for the opaque refresh token. See helper/auth-cookies.lua and the

--- a/lapis/routes/auth.lua
+++ b/lapis/routes/auth.lua
@@ -552,6 +552,12 @@ return function(app)
                 reset_url = reset_url,
                 expires_in = "30 minutes",
             },
+            -- Non-prod debug context (stripped on prod by Mail.send).
+            triggered_by = {
+                user_uuid = user.uuid,
+                user_email = user.email,
+                source = "auth.forgot-password",
+            },
         })
         if not send_ok then
             ngx.log(ngx.ERR, "[forgot-password] Mail.send failed for user=",

--- a/lapis/routes/email.lua
+++ b/lapis/routes/email.lua
@@ -210,6 +210,18 @@ return function(app)
                 send_opts.from_name = params.from_name
             end
 
+            -- Non-prod debug context. Mail.send strips this before
+            -- the SMTP payload is built; only used to populate the
+            -- yellow banner injected on dev/test/int/acc.
+            if self.current_user then
+                send_opts.triggered_by = {
+                    user_uuid = self.current_user.uuid,
+                    user_email = self.current_user.email,
+                    role = self.current_user.role,
+                    source = "email.send",
+                }
+            end
+
             -- Send (async)
             local success, err = Mail.send(send_opts)
             if not success then


### PR DESCRIPTION
## Why

Every non-prod environment (dev/test/int/acc + local docker) ends up funnelling email to the same Gmail inbox. There's currently no way to tell which deployment fired a given OTP / password-reset / notification email, and the Playwright E2E suite alone dumps ~92 emails per week. PR #397 partially solved the volume problem by suppressing **OTP** emails in CI, but every other email type was unaffected and there was no debug context anywhere.

This change does two things together so the test inbox stays usable:

1. **Subject prefix** — every non-prod email becomes `[ENV] Original subject` (e.g. `[ACC] Reset your DIY Tax Return password`). Set up a Gmail filter once and routing is automatic.
2. **Body banner** — yellow "NON-PROD EMAIL" table injected into the rendered HTML / text listing: env, host, recipient, *triggered_by* user, source IP, X-Forwarded-For, origin, endpoint, request_id, user-agent, timestamp UTC.

The OTP-only `OTP_SUPPRESS_FOR_EMAIL_REGEX` from #397 is also generalised to all email types via the same regex.

**Production is byte-for-byte identical to today.**

## How it composes with helm

The helm chart hard-codes `LAPIS_ENVIRONMENT=production` on every cluster pod because the ExternalSecret-templated `config.lua` only contains a `config("production", ...)` block — flipping it would make Lapis fall back to its built-in port 8080 default and break the healthcheck. So reading `LAPIS_ENVIRONMENT` alone would always say `"production"` on the cluster and the banner would never fire.

This PR introduces a separate **`OPSAPI_DEPLOY_ENV`** env var sourced from `.Values.env` in helm (`dev`/`test`/`int`/`acc`/`prod`). `helper/mail.lua` reads it first, falls back to `LAPIS_ENVIRONMENT`, then defaults to `"production"` (**fail closed** — a misconfigured deploy never accidentally enables the banner).

Both `"prod"` and `"production"` count as prod via `is_production_env()`, so the helm value (`env: prod`) and the Lapis config name (`"production"`) both resolve correctly.

## Behaviour matrix

| Where | `OPSAPI_DEPLOY_ENV` | `LAPIS_ENVIRONMENT` | Subject prefix | Banner | Suppression |
|---|---|---|---|---|---|
| Prod cluster | `prod` (helm) | `production` | none | none | n/a |
| Acc cluster | `acc` (helm) | `production` | `[ACC]` | yes | no-op (regex unset in vault) |
| Int cluster | `int` (helm) | `production` | `[INT]` | yes | no-op (regex unset in vault) |
| Local with `.env LAPIS_ENVIRONMENT=int` | unset | `int` | `[INT]` | yes | fires if regex set |
| Local with no env vars | unset | unset | none | none | none — treated as prod (fail-closed) |

## Files

- `lapis/helper/mail.lua` — new `current_env()` / `is_production_env()` / `should_suppress_recipient()` / `enrich_for_non_prod()` helpers; wired into `Mail.send`.
- `lapis/helper/otp.lua` — passes `triggered_by = { user_uuid, user_email, source }`
- `lapis/routes/auth.lua` — same for forgot-password
- `lapis/routes/email.lua` — same, reads from `self.current_user` (incl. role)
- `lapis/nginx.conf` — adds `env OPSAPI_DEPLOY_ENV;` + `env LAPIS_ENVIRONMENT;`
- `lapis/config.lua` — adds `config(\"test\"/\"int\"/\"acc\"/\"local\")` blocks so local docker-compose with `LAPIS_ENVIRONMENT=int` actually selects port 80 instead of Lapis's built-in 8080 default
- `devops/helm-charts/diytaxreturn-lapis/templates/deployment.yaml` — new `OPSAPI_DEPLOY_ENV` env var sourced from `.Values.env`
- `lapis/.env.example` — documents the dual env-var setup, why we need both, and which values count as prod

\`opts.triggered_by\` is consumed by the banner builder and stripped before the SMTP payload is encoded — never goes over the wire.

## Verification

- `luac -p` clean on all 5 touched Lua files
- `helm template` renders `OPSAPI_DEPLOY_ENV` correctly for `dev`/`int`/`acc`/`prod` values files
- Live `kubectl exec` on int + acc confirms `OTP_SUPPRESS_FOR_EMAIL_REGEX` is unset in vault → suppression is no-op on every cluster until ops sets it
- Container starts and stays healthy locally with `LAPIS_ENVIRONMENT=int` (was previously broken — port 8080 default vs healthcheck on port 80)

## Test plan
- [ ] `helm upgrade diytaxreturn-lapis ... -f values-int.yaml -n int` then `kubectl exec deploy/diytaxreturn-lapis -- printenv OPSAPI_DEPLOY_ENV` → should print `int`
- [ ] Trigger forgot-password on int → email arrives with `[INT]` subject + yellow banner showing env, host, triggered_by user, source IP
- [ ] Repeat on acc → `[ACC]`
- [ ] Repeat on prod → no `[PROD]` tag, no banner, byte-identical to today
- [ ] Set `OTP_SUPPRESS_FOR_EMAIL_REGEX` in int vault to `^diytaxreturnmail\+e2e-.*@gmail\.com$` → CI run no longer floods the inbox for any email type (not just OTP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)