### PR TITLE
fix(helm/lapis): default OTP_SUPPRESS_FOR_EMAIL_REGEX in chart to stop E2E bounces

### DIFF
--- a/devops/helm-charts/diytaxreturn-lapis/templates/deployment.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/templates/deployment.yaml
@@ -70,6 +70,15 @@ spec:
             # deployments get no banner.
             - name: OPSAPI_DEPLOY_ENV
               value: {{ .Values.env | quote }}
+            # PCRE pattern (matched via ngx.re.match) of recipients
+            # whose SMTP delivery must be silently skipped. Used by
+            # helper/mail.lua + helper/otp.lua; gated internally on
+            # is_production_env, so this is a no-op in prod even when
+            # set — safe to default for every env. Stops Mail Delivery
+            # Subsystem bounces from `@e2e.invalid` E2E sink recipients
+            # landing in SMTP_FROM_EMAIL's inbox.
+            - name: OTP_SUPPRESS_FOR_EMAIL_REGEX
+              value: {{ .Values.otpSuppressForEmailRegex | default "^diytaxreturnmail\\+e2e-.*@gmail\\.com$|@e2e\\.invalid$" | quote }}
             - name: PROJECT_CODE
               value: {{ .Values.projectCode | default "all" | quote }}
             {{- if and .Values.setup .Values.setup.adminEmail }}


### PR DESCRIPTION
## Summary
- Adds \`OTP_SUPPRESS_FOR_EMAIL_REGEX\` to the \`diytaxreturn-lapis\` deployment template with a safe default that covers both legacy \`diytaxreturnmail+e2e-…@gmail.com\` accounts and the new \`@e2e.invalid\` sink.
- \`helper/mail.lua\` + \`helper/otp.lua\` already gate the suppression on \`is_production_env\`, so this is a **no-op in prod** even when set. Safe to default for every env.

## Why
The OTP_SUPPRESS regex feature has existed since #400, but the env var was never wired into the helm chart — so every non-prod Lapis (dev / int / acc / test) attempts real SMTP delivery to \`@e2e.invalid\` recipients. The MX 5xx triggers Mail Delivery Subsystem bounces back to \`SMTP_FROM_EMAIL\` (\`tenthmatrix.mailer@gmail.com\`), flooding that inbox.

Only docker-compose installs where someone hand-edited \`.env\` had the suppression active. This bakes it into every non-prod helm deploy by default.

## Override (rarely needed)
Set \`otpSuppressForEmailRegex\` in any \`values-*.yaml\` to change the pattern for that env.

## Test plan
- [x] \`helm template\` renders the new env var for dev/int/acc/prod.
- [ ] Merge → trigger Lapis redeploy for test env (and any other non-prod env on k8s) → confirm Mail Delivery Subsystem bounces stop for \`@e2e.invalid\` recipients.
- [ ] For docker-compose-based deployments (e.g. int on 192.168.1.193 currently, test runner host), separately ensure \`.env\` carries the same regex and force-recreate the Lapis container — the helm change doesn't reach those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)