### PR TITLE
fix(lapis/start.sh): inject OTP_SUPPRESS_FOR_EMAIL_REGEX for non-prod deploys

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -703,6 +703,20 @@ check_and_update_env() {
         echo -e "${GREEN}[+] All environment URLs are correctly configured!${NC}"
     fi
 
+    # ── Ensure OTP_SUPPRESS_FOR_EMAIL_REGEX is set for non-prod ───────
+    # Without this, Lapis attempts real SMTP delivery to E2E sink
+    # recipients like `*@e2e.invalid` — the MX bounces back to
+    # SMTP_FROM_EMAIL and floods that mailbox. helper/mail.lua gates
+    # the suppression on is_production_env, so injecting a non-empty
+    # default in prod would be a no-op; we still skip it on prod to
+    # avoid surprising SREs who may want suppression off entirely.
+    if [[ "$target_env" != "prod" ]]; then
+        if ! grep -q "^OTP_SUPPRESS_FOR_EMAIL_REGEX=" "$ENV_FILE"; then
+            echo -e "${YELLOW}[!] OTP_SUPPRESS_FOR_EMAIL_REGEX missing — appending default sink regex${NC}"
+            echo 'OTP_SUPPRESS_FOR_EMAIL_REGEX=^diytaxreturnmail\+e2e-.*@gmail\.com$|@e2e\.invalid$' >> "$ENV_FILE"
+        fi
+    fi
+
     return 0
 }
 


### PR DESCRIPTION
## Summary
- Self-heals every docker-compose Lapis deploy: after \`check_and_update_env\`'s URL block, if \`OTP_SUPPRESS_FOR_EMAIL_REGEX\` is missing from \`lapis/.env\` AND \`target_env != prod\`, appends the default sink regex.
- Existing values are never overwritten — only missing lines are added.

## Why
Companion to #401. The k8s helm chart now defaults the regex, but the docker-compose path (\`deploy-docker-self-hosted.yml\` → \`start.sh\`) copies a per-runner \`.env\` from \`/home/bwalia/.secrets/opsapi/diytaxreturnuk/<env>/.env\`. The test runner (\`debian001\`) has no \`OTP_SUPPRESS_FOR_EMAIL_REGEX\` line in that source, so test Lapis keeps SMTPing to \`@e2e.invalid\` — the MX bounces fill \`tenthmatrix.mailer@gmail.com\`.

After this, the next test deploy auto-appends the regex on debian001, recreates the container, and the bounces stop. Same applies to int going forward (resilient to source-\`.env\` drift).

## Override
Anyone who wants a different pattern can set \`OTP_SUPPRESS_FOR_EMAIL_REGEX=...\` (any non-empty value) in the env's source \`.env\` — \`start.sh\` only appends when the line is absent.

## Test plan
- [x] \`bash -n start.sh\` passes syntax check.
- [ ] Merge → trigger \`deploy-docker-self-hosted.yml\` (or push to main, which auto-runs it) → confirm test deploy log shows the \"appending default sink regex\" line on first run → bounces stop on \`tenthmatrix.mailer@gmail.com\`.
- [ ] Repeat run shows no append message (idempotent — line is now present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)