### PR TITLE
fix(lapis): extend OTP suppress regex for @admin.com + self-heal existing values

### DIFF
--- a/devops/helm-charts/diytaxreturn-lapis/templates/deployment.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/templates/deployment.yaml
@@ -74,11 +74,14 @@ spec:
             # whose SMTP delivery must be silently skipped. Used by
             # helper/mail.lua + helper/otp.lua; gated internally on
             # is_production_env, so this is a no-op in prod even when
-            # set — safe to default for every env. Stops Mail Delivery
-            # Subsystem bounces from `@e2e.invalid` E2E sink recipients
-            # landing in SMTP_FROM_EMAIL's inbox.
+            # set — safe to default for every env. Covers three known
+            # non-deliverable sinks that otherwise generate Mail
+            # Delivery Subsystem bounces back to SMTP_FROM_EMAIL:
+            #   - legacy `diytaxreturnmail+e2e-…@gmail.com` E2E pattern
+            #   - `*@e2e.invalid` E2E sink (RFC 6761 reserved TLD)
+            #   - `*@admin.com` test-admin user (MX times out to 127.0.0.1)
             - name: OTP_SUPPRESS_FOR_EMAIL_REGEX
-              value: {{ .Values.otpSuppressForEmailRegex | default "^diytaxreturnmail\\+e2e-.*@gmail\\.com$|@e2e\\.invalid$" | quote }}
+              value: {{ .Values.otpSuppressForEmailRegex | default "^diytaxreturnmail\\+e2e-.*@gmail\\.com$|@e2e\\.invalid$|@admin\\.com$" | quote }}
             - name: PROJECT_CODE
               value: {{ .Values.projectCode | default "all" | quote }}
             {{- if and .Values.setup .Values.setup.adminEmail }}

--- a/start.sh
+++ b/start.sh
@@ -703,17 +703,43 @@ check_and_update_env() {
         echo -e "${GREEN}[+] All environment URLs are correctly configured!${NC}"
     fi
 
-    # ── Ensure OTP_SUPPRESS_FOR_EMAIL_REGEX is set for non-prod ───────
-    # Without this, Lapis attempts real SMTP delivery to E2E sink
-    # recipients like `*@e2e.invalid` — the MX bounces back to
-    # SMTP_FROM_EMAIL and floods that mailbox. helper/mail.lua gates
-    # the suppression on is_production_env, so injecting a non-empty
-    # default in prod would be a no-op; we still skip it on prod to
-    # avoid surprising SREs who may want suppression off entirely.
+    # ── Ensure OTP_SUPPRESS_FOR_EMAIL_REGEX covers required sinks ─────
+    # Lapis attempts real SMTP delivery for any recipient that doesn't
+    # match this regex. Three known non-deliverable destinations on
+    # non-prod envs generate Mail Delivery Subsystem bounces back to
+    # SMTP_FROM_EMAIL and flood that inbox:
+    #   - legacy `diytaxreturnmail+e2e-…@gmail.com` E2E pattern
+    #   - `*@e2e.invalid` E2E sink (RFC 6761 reserved TLD)
+    #   - `*@admin.com` test-admin user (MX times out to 127.0.0.1)
+    # helper/mail.lua gates the suppression on is_production_env, so
+    # injecting a default in prod would be a no-op; we still skip it
+    # on prod to avoid surprising SREs who may want suppression off.
+    #
+    # If the line exists but is missing one of the required patterns
+    # (e.g. an older deploy left `@e2e\.invalid$`-only), extend it
+    # in place rather than overwrite — preserves any custom additions.
     if [[ "$target_env" != "prod" ]]; then
-        if ! grep -q "^OTP_SUPPRESS_FOR_EMAIL_REGEX=" "$ENV_FILE"; then
+        local default_regex='^diytaxreturnmail\+e2e-.*@gmail\.com$|@e2e\.invalid$|@admin\.com$'
+        local required_patterns=('@e2e\.invalid$' '@admin\.com$')
+        local current_line current_value new_value pat
+        current_line=$(grep "^OTP_SUPPRESS_FOR_EMAIL_REGEX=" "$ENV_FILE" | head -1)
+        if [[ -z "$current_line" ]]; then
             echo -e "${YELLOW}[!] OTP_SUPPRESS_FOR_EMAIL_REGEX missing — appending default sink regex${NC}"
-            echo 'OTP_SUPPRESS_FOR_EMAIL_REGEX=^diytaxreturnmail\+e2e-.*@gmail\.com$|@e2e\.invalid$' >> "$ENV_FILE"
+            echo "OTP_SUPPRESS_FOR_EMAIL_REGEX=$default_regex" >> "$ENV_FILE"
+        else
+            current_value="${current_line#OTP_SUPPRESS_FOR_EMAIL_REGEX=}"
+            new_value="$current_value"
+            for pat in "${required_patterns[@]}"; do
+                if [[ "$new_value" != *"$pat"* ]]; then
+                    new_value="$new_value|$pat"
+                fi
+            done
+            if [[ "$new_value" != "$current_value" ]]; then
+                echo -e "${YELLOW}[!] OTP_SUPPRESS_FOR_EMAIL_REGEX missing required patterns — extending${NC}"
+                grep -v "^OTP_SUPPRESS_FOR_EMAIL_REGEX=" "$ENV_FILE" > "${ENV_FILE}.tmp"
+                mv "${ENV_FILE}.tmp" "$ENV_FILE"
+                echo "OTP_SUPPRESS_FOR_EMAIL_REGEX=$new_value" >> "$ENV_FILE"
+            fi
         fi
     fi
 


### PR DESCRIPTION
## Summary
Stops the second wave of Mail Delivery Subsystem bounces caused by the test-env admin user (\`administrative@admin.com\`). Two coordinated changes:

1. **Helm chart default extended** (\`templates/deployment.yaml\`) — now includes \`|@admin\\.com\$\`. No-op in prod (Lua gates on \`is_production_env\`).
2. **\`start.sh\` self-heals existing values** — if \`OTP_SUPPRESS_FOR_EMAIL_REGEX\` is present but missing any of the required patterns (\`@e2e\\.invalid\$\`, \`@admin\\.com\$\`), the missing patterns are appended in place. Existing custom patterns are preserved.

## Why
After #401 + #402, a new bounce flood hit \`tenthmatrix.mailer@gmail.com\`:

> \`administrative@admin.com\` — \`[localhost.admin.com. 127.0.0.1: timed out]\`

Source: \`/home/bwalia/.secrets/opsapi/diytaxreturnuk/<env>/login-creds.json\` configures the test admin as \`administrative@admin.com\`. Every E2E login triggers a 2FA OTP email; \`admin.com\`'s MX returns \`localhost.admin.com.\` (127.0.0.1) → timeout → bounce.

#402's start.sh only **appended when missing**, so the bounces showed even after merge: debian001's source \`.env\` already had a partial regex line (no \`@admin.com\`), and the new \`grep -q\` guard preserved it untouched.

This PR teaches \`start.sh\` to extend an existing line that's missing required patterns. Verified locally with three test cases (missing → append; partial → extend; complete → no-op; all pass).

## Test plan
- [x] \`bash -n start.sh\` syntax-clean.
- [x] Unit-tested all three branches (missing / partial / complete) — see commit message.
- [x] \`helm template\` renders the extended default for dev/int/acc.
- [ ] Merge → docker-compose auto-deploy runs → test-env start.sh extends debian001's existing line in place → bounces stop on \`tenthmatrix.mailer@gmail.com\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)