### PR TITLE
fix(lapis): rename legacy test-admin email to @e2e.invalid (root-cause fix for bounce flood)

### DIFF
--- a/.github/workflows/deploy-docker-self-hosted.yml
+++ b/.github/workflows/deploy-docker-self-hosted.yml
@@ -171,6 +171,23 @@ jobs:
           fi
         shell: bash
 
+      - name: Migrate legacy admin email in login-creds.json (INT)
+        run: |
+          # Companion to Lapis migration 78. The historical placeholder
+          # `administrative@admin.com` is non-deliverable (its MX times out)
+          # and floods SMTP_FROM_EMAIL with Mail Delivery Subsystem bounces
+          # on every E2E login. Rewriting to `@e2e.invalid` lets the chart-
+          # default OTP_SUPPRESS_FOR_EMAIL_REGEX short-circuit the SMTP send.
+          # Idempotent: only acts when the legacy literal is present.
+          CREDS="/home/bwalia/.secrets/opsapi/diytaxreturnuk/int/login-creds.json"
+          if [ -f "$CREDS" ] && grep -q '"administrative@admin\.com"' "$CREDS"; then
+            echo "[migrate] rewriting $CREDS → administrative@e2e.invalid"
+            sed -i 's/administrative@admin\.com/administrative@e2e.invalid/g' "$CREDS"
+          else
+            echo "[migrate] $CREDS already migrated or absent — no action"
+          fi
+        shell: bash
+
       - name: Make start.sh executable
         run: chmod +x ./start.sh
         shell: bash
@@ -356,6 +373,23 @@ jobs:
           else
             echo "Error: .env file not found at $SERVER_ENV"
             exit 1
+          fi
+        shell: bash
+
+      - name: Migrate legacy admin email in login-creds.json (Test)
+        run: |
+          # Companion to Lapis migration 78. The historical placeholder
+          # `administrative@admin.com` is non-deliverable (its MX times out)
+          # and floods SMTP_FROM_EMAIL with Mail Delivery Subsystem bounces
+          # on every E2E login. Rewriting to `@e2e.invalid` lets the chart-
+          # default OTP_SUPPRESS_FOR_EMAIL_REGEX short-circuit the SMTP send.
+          # Idempotent: only acts when the legacy literal is present.
+          CREDS="/home/bwalia/.secrets/opsapi/diytaxreturnuk/test/login-creds.json"
+          if [ -f "$CREDS" ] && grep -q '"administrative@admin\.com"' "$CREDS"; then
+            echo "[migrate] rewriting $CREDS → administrative@e2e.invalid"
+            sed -i 's/administrative@admin\.com/administrative@e2e.invalid/g' "$CREDS"
+          else
+            echo "[migrate] $CREDS already migrated or absent — no action"
           fi
         shell: bash
 

--- a/lapis/migrations/tax-copilot-system.lua
+++ b/lapis/migrations/tax-copilot-system.lua
@@ -2769,4 +2769,41 @@ return {
               "to snake_case keys (was camelCase MTD field names on " ..
               "some rows due to classifier hardcode — see companion PR).")
     end,
+
+    -- 78. Rename legacy test-admin email `administrative@admin.com` to
+    -- `administrative@e2e.invalid`. The original placeholder address
+    -- resolves to a non-routable MX (admin.com → localhost.admin.com.
+    -- 127.0.0.1, times out) — every E2E login as the test admin
+    -- triggers an OTP send that bounces back to SMTP_FROM_EMAIL,
+    -- flooding `tenthmatrix.mailer@gmail.com` with Mail Delivery
+    -- Subsystem warnings.
+    --
+    -- The RFC 6761 `.invalid` TLD is guaranteed undeliverable, and the
+    -- OTP_SUPPRESS_FOR_EMAIL_REGEX baked into the chart by #401/#403
+    -- matches `@e2e\.invalid$` — so Lapis short-circuits the SMTP send
+    -- entirely instead of handing a doomed message to Gmail. Companion
+    -- workflow change in `deploy-docker-self-hosted.yml` rewrites the
+    -- `login-creds.json` file on each runner so E2E flows log in with
+    -- the new email.
+    --
+    -- Idempotent: only renames when the legacy email exists (so safe
+    -- to re-run on every deploy).
+    [78] = function()
+        db.query([[
+            UPDATE users
+            SET email = 'administrative@e2e.invalid',
+                username = 'administrative@e2e.invalid',
+                updated_at = NOW()
+            WHERE email = 'administrative@admin.com'
+        ]])
+        local res = db.select(
+            "COUNT(*) as cnt FROM users WHERE email = 'administrative@e2e.invalid'"
+        )
+        local count = (res and res[1] and res[1].cnt) or 0
+        print(string.format(
+            "[Tax Copilot] Renamed legacy test-admin to administrative@e2e.invalid " ..
+            "(rows currently bearing the new email: %d).",
+            count
+        ))
+    end,
 }


### PR DESCRIPTION
## Summary
Root-cause fix for the Mail Delivery Subsystem flood that #401/#402/#403 only partially silenced. Renames the legacy test admin from \`administrative@admin.com\` (non-deliverable, MX times out) to \`administrative@e2e.invalid\` (RFC 6761 reserved TLD, matched by the existing chart-baked OTP_SUPPRESS regex).

## Why
Every E2E login as the test admin sends a 2FA OTP to \`administrative@admin.com\`. Gmail accepts the message, fails to deliver to \`admin.com\`'s MX (\`localhost.admin.com.\` → 127.0.0.1, timed out), and bounces back to SMTP_FROM_EMAIL (\`tenthmatrix.mailer@gmail.com\`). Even after extending OTP_SUPPRESS to cover \`@admin\.com\$\`, observed bounces continued post-deploy from the test runner — likely because the test container's regex didn't pick up the in-place \`.env\` edit cleanly (start.sh's compose recreate did fire but suppression still didn't engage in practice).

Instead of extending the suppression regex further, fix the address at the source. \`@e2e.invalid\` is RFC 6761 reserved and matched by the chart default we shipped in #401 — a path we've already proven works.

## Changes
1. **\`lapis/migrations/tax-copilot-system.lua\`** — adds migration 78: \`UPDATE users SET email='administrative@e2e.invalid' WHERE email='administrative@admin.com'\`. Idempotent (no-op once migrated).
2. **\`.github/workflows/deploy-docker-self-hosted.yml\`** — adds a step to both INT and TEST deploy jobs that rewrites the runner's local \`login-creds.json\` to use the new email. Idempotent (\`grep -q\` guard). Runs before \`start.sh\` so creds match the DB after migration 78 lands.

## Test plan
- [x] YAML syntax check passes (\`python3 -c "import yaml; yaml.safe_load(...)"\`).
- [x] Migration is idempotent — re-runs are no-ops once email is migrated.
- [ ] Merge → auto-deploy runs → migration 78 renames DB users on int + test → workflow step rewrites \`login-creds.json\` on both runners → next E2E daily run logs in as \`administrative@e2e.invalid\` → matched by chart-baked regex → no SMTP send → Mail Delivery Subsystem bounces stop.

## Forward-compatible
Future envs (dev/acc/prod via k8s helm) using the chart's bootstrap path can still set \`administrative@admin.com\` as their admin email — migration 78 will rename it on first deploy. New admin emails set after migration 78 are untouched (idempotent guard is the exact-match email).

🤖 Generated with [Claude Code](https://claude.com/claude-code)