### PR TITLE
feat(tax_copilot): add Apple IAP subscription tables (plans, user subs, ASSN dedup)

### DIFF
--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -1286,6 +1286,22 @@ local _migrations = {
     ['497_tax_widen_error_occurrence_tenant_ns']     = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 76),
     ['498_tax_backfill_orphan_category_hmrc_links']  = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 77),
 
+    -- 499–503: Apple in-app subscription tables (iOS StoreKit, ASSN V2).
+    --   499  → tax_subscription_plans (product catalogue, multi-platform-ready)
+    --   500  → seed the single launch plan: DIYTaxReturnStandard £5.99/mo
+    --   501  → tax_user_subscriptions (per-user entitlement, FastAPI writes)
+    --   502  → indexes for user_uuid / expires_at / app_account_token
+    --   503  → tax_processed_apple_notifications (webhook dedup + orphan store)
+    -- Numeric prefixes 500–503 coexist with the CRM block's 500_/501_ keys
+    -- below — Lapis tracks applied migrations by the full string key, not
+    -- the numeric portion, and dup numerics already appear across feature
+    -- blocks elsewhere in this table.
+    ['499_tax_create_subscription_plans']            = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 78),
+    ['500_tax_seed_subscription_plan_standard']      = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 79),
+    ['501_tax_create_user_subscriptions']            = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 80),
+    ['502_tax_add_user_subscriptions_indexes']       = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 81),
+    ['503_tax_create_processed_apple_notifications'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 82),
+
     -- =========================================================================
     -- CORE AUTH: Password reset tokens
     -- =========================================================================

--- a/lapis/migrations/tax-copilot-system.lua
+++ b/lapis/migrations/tax-copilot-system.lua
@@ -2769,4 +2769,119 @@ return {
               "to snake_case keys (was camelCase MTD field names on " ..
               "some rows due to classifier hardcode — see companion PR).")
     end,
+
+    -- 78. tax_subscription_plans — product catalogue for the iOS in-app
+    --     subscription (Apple StoreKit). google_product_id and
+    --     stripe_price_id are reserved for future Android/web payment
+    --     surfaces; v1 only populates apple_product_id.
+    [78] = function()
+        schema.create_table("tax_subscription_plans", {
+            { "id",                types.serial },
+            { "uuid",              types.varchar({ unique = true }) },
+            { "apple_product_id",  types.varchar({ unique = true }) },
+            { "google_product_id", types.varchar({ null = true }) },
+            { "stripe_price_id",   types.varchar({ null = true }) },
+            { "display_name",      types.varchar },
+            { "description",       types.text({ null = true }) },
+            { "price_cents",       types.integer },
+            { "currency",          types.varchar({ default = "'GBP'" }) },
+            { "period",            types.varchar },
+            { "is_active",         types.boolean({ default = true }) },
+            { "created_at",        types.time({ default = db.raw("NOW()") }) },
+            { "updated_at",        types.time({ default = db.raw("NOW()") }) },
+            "PRIMARY KEY (id)"
+        })
+        schema.create_index("tax_subscription_plans", "apple_product_id")
+    end,
+
+    -- 79. Seed the single launch plan: DIYTaxReturnStandard, £5.99/month.
+    --     Idempotent — re-running the migration must not duplicate the
+    --     row (see SELECT-then-INSERT pattern used in migration [4]).
+    [79] = function()
+        local existing = db.select(
+            "uuid FROM tax_subscription_plans WHERE apple_product_id = ?",
+            "DIYTaxReturnStandard"
+        )
+        if not existing or #existing == 0 then
+            db.query([[
+                INSERT INTO tax_subscription_plans
+                    (uuid, apple_product_id, display_name, description,
+                     price_cents, currency, period, is_active,
+                     created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+            ]],
+                MigrationUtils.generateUUID(),
+                "DIYTaxReturnStandard",
+                "Standard",
+                "Full access to DIY Tax Return UK.",
+                599,
+                "GBP",
+                "month",
+                true
+            )
+        end
+    end,
+
+    -- 80. tax_user_subscriptions — per-user entitlement row, written by
+    --     FastAPI from /api/iap/validate (auth'd) and from the Apple
+    --     ASSN V2 webhook. original_transaction_id is globally unique
+    --     so a second user submitting the same receipt is rejected at
+    --     the DB layer (Apple's model: one entitlement per Apple ID).
+    --     `environment` is analytics-only, never used for gating.
+    --     `app_account_token` is reserved for the future StoreKit 2
+    --     migration; the in_app_purchase 3.x plugin uses StoreKit 1
+    --     which doesn't populate it, so v1 leaves this column NULL.
+    [80] = function()
+        schema.create_table("tax_user_subscriptions", {
+            { "id",                       types.serial },
+            { "uuid",                     types.varchar({ unique = true }) },
+            { "user_uuid",                types.varchar },
+            { "plan_uuid",                types.varchar({ null = true }) },
+            { "apple_product_id",         types.varchar },
+            { "original_transaction_id",  types.varchar({ unique = true }) },
+            { "latest_transaction_id",    types.varchar({ null = true }) },
+            { "status",                   types.varchar },
+            { "environment",              types.varchar },
+            { "purchased_at",             types.time({ null = true }) },
+            { "expires_at",               types.time({ null = true }) },
+            { "auto_renew",               types.boolean({ default = true }) },
+            { "cancel_reason",            types.varchar({ null = true }) },
+            { "latest_receipt",           types.text({ null = true }) },
+            { "app_account_token",        types.varchar({ null = true }) },
+            { "created_at",               types.time({ default = db.raw("NOW()") }) },
+            { "updated_at",               types.time({ default = db.raw("NOW()") }) },
+            "PRIMARY KEY (id)"
+        })
+    end,
+
+    -- 81. Lookup indexes for tax_user_subscriptions. expires_at is
+    --     scanned by the reconciler sweep; app_account_token is
+    --     pre-indexed for the future StoreKit 2 cutover.
+    [81] = function()
+        schema.create_index("tax_user_subscriptions", "user_uuid")
+        schema.create_index("tax_user_subscriptions", "expires_at")
+        schema.create_index("tax_user_subscriptions", "app_account_token")
+    end,
+
+    -- 82. tax_processed_apple_notifications — dedup store for Apple
+    --     ASSN V2 webhooks. Phase 1 of the FastAPI webhook handler
+    --     verifies + INSERTs here + ACKs Apple within the 30s window;
+    --     Phase 2 (BackgroundTask / reconciler) re-decodes signed_payload
+    --     and applies state. Rows with processed_at IS NULL are either
+    --     orphans (webhook arrived before /validate) or transient
+    --     failures awaiting the 5-min reconciler sweep.
+    [82] = function()
+        schema.create_table("tax_processed_apple_notifications", {
+            { "id",                       types.serial },
+            { "notification_uuid",        types.varchar({ unique = true }) },
+            { "notification_type",        types.varchar },
+            { "original_transaction_id",  types.varchar({ null = true }) },
+            { "signed_payload",           types.text },
+            { "received_at",              types.time({ default = db.raw("NOW()") }) },
+            { "processed_at",             types.time({ null = true }) },
+            "PRIMARY KEY (id)"
+        })
+        schema.create_index("tax_processed_apple_notifications", "processed_at")
+        schema.create_index("tax_processed_apple_notifications", "original_transaction_id")
+    end,
 }


### PR DESCRIPTION
## What this is

PR 1 of 4 for the **iOS in-app subscription** rollout in `diy-tax-return-uk` ("DIY Tax Return Standard", £5.99/month, Apple product ID `DIYTaxReturnStandard`). This PR ships **opsapi schema only** — three new tables under the existing `TAX_COPILOT` feature flag. FastAPI will own all reads/writes against them; opsapi owns DDL.

## Why opsapi-first

opsapi runs the Lapis migrations on the shared Postgres. The FastAPI follow-up PR maps these tables via SQLModel and will fail to start if the tables don't exist yet, so this must land + deploy to int **before** the FastAPI PR is merged.

## Changes

| File | Change |
|------|--------|
| `lapis/migrations/tax-copilot-system.lua` | Append functions `[78]`–`[82]` |
| `lapis/migrations.lua` | Append dispatch entries `['499_…']`–`['503_…']` |

### New tables

**`tax_subscription_plans`** (mig 499) — product catalogue, seeded (mig 500) with the single launch plan. `google_product_id` / `stripe_price_id` are reserved nullable columns for future Android / web payment surfaces.

**`tax_user_subscriptions`** (mig 501, indexes mig 502) — per-user entitlement row. `original_transaction_id` is `UNIQUE` so a second user re-submitting the same Apple receipt is rejected at the DB layer (Apple's "one entitlement per Apple ID per product" model — receipts belong to the Apple ID, not our user). `environment` is captured **for analytics only**, never used to reject. `app_account_token` is reserved nullable for the future StoreKit 2 cutover; the `in_app_purchase` 3.x Flutter plugin used in v1 is StoreKit-1-only and does not populate `appAccountToken`, so v1 leaves this column NULL.

**`tax_processed_apple_notifications`** (mig 503) — dedup + replay store for the Apple ASSN V2 webhook. Phase 1 of the FastAPI handler verifies + INSERTs + ACKs within Apple's ~30s window; Phase 2 (BackgroundTask + 5-min reconciler) re-decodes `signed_payload` and applies state. `notification_uuid` is `UNIQUE` so Apple's retries no-op. Rows with `processed_at IS NULL` are either orphans (webhook arrived before the user's `/iap/validate` call) or transient failures awaiting the reconciler.

## Conventions matched

All against the existing `tax_copilot` block in this file:

- `default = "'GBP'"` — **inner single quotes** required; `"GBP"` would emit `DEFAULT GBP` (column reference → SQL syntax error)
- `MigrationUtils.generateUUID()` — not `generate_uuid()` (different helper)
- `db.raw("NOW()")` for timestamp defaults
- `"PRIMARY KEY (id)"` trailing entry on every `create_table` (matches every existing table in this file)
- Seed uses **`SELECT`-then-`INSERT`** idempotency pattern from migration `[4]` so re-running the dispatcher does not duplicate the row
- Seed `INSERT` uses `db.query([[...]], ...)` rather than `db.insert(...)` to match the local style (no `db.insert` calls exist in this file)

## On the 500–503 numeric prefix collision

`['500_crm_create_pipelines']` already exists at line ~1435. The collision is **string-key-safe**: Lapis tracks applied migrations by the full string key, and duplicate numeric prefixes already appear across feature blocks in this dispatcher (e.g. `26`–`37` each appear twice). No action needed; the inline comment in `migrations.lua` calls this out for future readers.

## Verification (int)

1. Merge → CI promotes opsapi to int.
2. `adminer` (or `psql`) on the int Postgres:
   - `tax_subscription_plans`, `tax_user_subscriptions`, `tax_processed_apple_notifications` exist.
   - `SELECT * FROM tax_subscription_plans;` returns exactly **one** row with `apple_product_id = 'DIYTaxReturnStandard'`, `price_cents = 599`, `currency = 'GBP'`, `period = 'month'`, `is_active = true`.
   - Indexes on `tax_user_subscriptions(user_uuid, expires_at, app_account_token)` and on `tax_processed_apple_notifications(processed_at, original_transaction_id)` are present.
3. Re-running the dispatcher (which happens on every opsapi boot) does **not** duplicate the seed row.

## Follow-ups (out of scope here)

- **PR 2** (FastAPI): SQLModel mappings, `_resolve_iap_environment()`, `apple-store-server-library` dep, `AppleRootCA-G3.cer` (DER), `/api/iap/me/status` endpoint, APScheduler reconciler stub.
- **PR 3** (Flutter): `SubscriptionApiService` + provider, status-only `SubscriptionView`, Settings row.
- **PR 4** (StoreKit + webhooks): `IapService`, `/api/iap/validate` with `verifyReceipt` (prod-first / sandbox-fallback on `21007`, `password` field required), `/api/iap/webhook/apple/{path_secret}` two-phase handler, `/api/iap/admin/grant`, reconciler activation, full state-transition table including `REFUND`/`REVOKE` using `signedTransactionInfo.revocationDate` (not `NOW()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)