### PR TITLE
feat(migrations): share payments table across ecommerce + tax_copilot (multi-project-code gating)

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -24,9 +24,9 @@ on:
         type: boolean
         default: false
       PROJECT_CODE:
-        description: "Project code(s) for migrations. Single (tax_copilot) or comma-separated (ecommerce,collaboration)"
-        required: true
-        default: "all"
+        description: "Override migration project code(s) — single (tax_copilot) or comma-separated (ecommerce,collaboration). Leave BLANK to use the env's values file (e.g. values-acc.yaml → tax_copilot)."
+        required: false
+        default: ""
         type: string
       ADMIN_EMAIL:
         description: "Super admin email for namespace setup"
@@ -232,6 +232,15 @@ jobs:
       - name: Deploy OpsAPI
         run: |
           export KUBECONFIG=$(pwd)/kubeconfig
+          # Only override projectCode when an explicit value is passed on
+          # workflow_dispatch. When blank (a push to main, or a dispatch that
+          # leaves it empty) the env's values file decides — values-acc.yaml
+          # sets projectCode: tax_copilot. Previously this forced 'all', which
+          # re-enabled every feature's migrations regardless of the values file.
+          PROJECT_CODE_ARG=""
+          if [ -n "${{ github.event.inputs.PROJECT_CODE }}" ]; then
+            PROJECT_CODE_ARG="--set projectCode=${{ github.event.inputs.PROJECT_CODE }}"
+          fi
           helm upgrade --install diytaxreturn-lapis ${{ env.HELM_CHART_PATH }} \
             -f ${{ steps.env.outputs.VALUES_FILE }} \
             --namespace ${{ steps.env.outputs.TARGET_ENV }} \
@@ -239,10 +248,10 @@ jobs:
             --set image.repository=${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }} \
             --set image.tag=latest \
             --set env=${{ steps.env.outputs.TARGET_ENV }} \
-            --set projectCode=${{ github.event.inputs.PROJECT_CODE || 'all' }} \
             --set setup.adminEmail=${{ github.event.inputs.ADMIN_EMAIL || '' }} \
             --set setup.adminPassword=${{ github.event.inputs.ADMIN_PASSWORD || '' }} \
-            --set setup.namespaceSlug=${{ github.event.inputs.NAMESPACE_SLUG || '' }}
+            --set setup.namespaceSlug=${{ github.event.inputs.NAMESPACE_SLUG || '' }} \
+            $PROJECT_CODE_ARG
 
       - name: Force Refresh Pods
         run: |

--- a/.github/workflows/weekly-acc-release.yml
+++ b/.github/workflows/weekly-acc-release.yml
@@ -49,9 +49,9 @@ on:
         type: boolean
         default: true
       project_code:
-        description: "Project code(s) for DB migrations (single or comma-separated, or 'all')"
+        description: "Override project code(s) for DB migrations (single or comma-separated). Leave BLANK to use values-acc.yaml (tax_copilot)."
         type: string
-        default: "all"
+        default: ""
 
 # Only one acceptance release at a time. An in-flight deploy is allowed to
 # finish so we never leave a half-applied Helm release behind.
@@ -250,13 +250,21 @@ jobs:
       # `--wait` blocks until resources are Ready.
       - name: Helm deploy — OpsAPI
         run: |
+          # Only override projectCode when one is explicitly provided. On the
+          # scheduled run (no inputs) this is blank, so values-acc.yaml decides
+          # (tax_copilot). Previously the `|| 'all'` fallback forced every
+          # feature's migrations on each weekly release.
+          PROJECT_CODE_ARG=""
+          if [ -n "${{ inputs.project_code }}" ]; then
+            PROJECT_CODE_ARG="--set projectCode=${{ inputs.project_code }}"
+          fi
           helm upgrade --install ${{ env.RELEASE_NAME }} ${{ env.HELM_CHART_PATH }} \
             -f ${{ env.HELM_CHART_PATH }}/values-acc.yaml \
             --namespace ${{ env.NAMESPACE }} --create-namespace \
             --set image.repository=${{ env.IMAGE }} \
             --set image.tag=latest \
             --set env=${{ env.TARGET_ENV }} \
-            --set projectCode=${{ inputs.project_code || 'all' }} \
+            $PROJECT_CODE_ARG \
             --atomic --wait --timeout 5m
 
       # ----- Health gate — the E2E pre-condition ----------------------------

--- a/lapis/helper/project-config.lua
+++ b/lapis/helper/project-config.lua
@@ -213,6 +213,24 @@ function ProjectConfig.isFeatureEnabled(feature)
     return false
 end
 
+-- Check if ANY of the given features is enabled.
+-- Accepts a single feature string OR a list of feature strings.
+-- Lets a single migration be gated on multiple project codes — e.g.
+-- conditional({FEATURES.ECOMMERCE, FEATURES.TAX_COPILOT}, fn) creates the
+-- table when the active PROJECT_CODE is *either* ecommerce or tax_copilot,
+-- so a shared table lands in both projects without enabling a whole suite.
+function ProjectConfig.isAnyFeatureEnabled(features)
+    if type(features) ~= "table" then
+        return ProjectConfig.isFeatureEnabled(features)
+    end
+    for _, f in ipairs(features) do
+        if ProjectConfig.isFeatureEnabled(f) then
+            return true
+        end
+    end
+    return false
+end
+
 -- Shorthand checks for common features
 function ProjectConfig.isCoreEnabled()
     return true -- Core is always enabled

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -42,8 +42,10 @@ local function skip_migration(name, feature)
 end
 
 -- Helper function to conditionally load migration modules
+-- `feature` may be a single feature string or a list of feature strings;
+-- the module loads if the active PROJECT_CODE enables ANY of them.
 local function load_if_enabled(feature, module_name)
-    if ProjectConfig.isFeatureEnabled(feature) then
+    if ProjectConfig.isAnyFeatureEnabled(feature) then
         local ok, module = pcall(require, module_name)
         if ok then
             return module
@@ -64,8 +66,13 @@ local ecommerce_migrations = load_if_enabled(ProjectConfig.FEATURES.ECOMMERCE, "
 local production_schema_upgrade = load_if_enabled(ProjectConfig.FEATURES.ECOMMERCE, "production-schema-upgrade") or {}
 local order_management_migrations = load_if_enabled(ProjectConfig.FEATURES.ECOMMERCE,
     "migrations.order-management-enhancement") or {}
-local payment_tracking_migrations = load_if_enabled(ProjectConfig.FEATURES.ECOMMERCE, "migrations.payment-tracking") or
-    {}
+-- payment-tracking holds the standalone `payments` table (steps 1-2) AND
+-- order-coupled steps (3-10 alter the ecommerce `orders` table). Load the
+-- module under ecommerce OR tax_copilot so tax_copilot can get the shared
+-- `payments` table; the order-coupled keys below stay gated on ECOMMERCE only.
+local payment_tracking_migrations = load_if_enabled(
+    { ProjectConfig.FEATURES.ECOMMERCE, ProjectConfig.FEATURES.TAX_COPILOT },
+    "migrations.payment-tracking") or {}
 local stripe_integration_migrations = load_if_enabled(ProjectConfig.FEATURES.ECOMMERCE, "migrations.stripe-integration") or
     {}
 local multi_currency_migrations = load_if_enabled(ProjectConfig.FEATURES.ECOMMERCE, "migrations.multi-currency-support") or
@@ -159,27 +166,43 @@ local kafka_audit_migrations = require("migrations.kafka-audit-system")
 -- HELPER FUNCTIONS FOR CONDITIONAL MIGRATIONS
 -- =============================================================================
 
--- Returns the migration function or a skip function (with tracking)
+-- Human-readable label for a feature spec (string or list of strings),
+-- used for migration tracking / skip logs. {"ecommerce","tax_copilot"} → "ecommerce+tax_copilot"
+local function feature_label(feature)
+    if type(feature) == "table" then
+        return table.concat(feature, "+")
+    end
+    return feature
+end
+
+-- Returns the migration function or a skip function (with tracking).
+-- `feature` is a single feature string OR a list of feature strings; the
+-- migration runs if the active PROJECT_CODE enables ANY of them. This lets a
+-- single table be shared across project codes, e.g.
+--   conditional({ProjectConfig.FEATURES.ECOMMERCE, ProjectConfig.FEATURES.TAX_COPILOT}, fn)
 local function conditional(feature, migration_func)
-    if ProjectConfig.isFeatureEnabled(feature) and migration_func then
+    local label = feature_label(feature)
+    if ProjectConfig.isAnyFeatureEnabled(feature) and migration_func then
         return function(...)
-            MigrationTracker.recordRan(feature, feature)
+            MigrationTracker.recordRan(label, label)
             return migration_func(...)
         end
     end
-    return skip_migration(feature, feature)
+    return skip_migration(label, label)
 end
 
--- Returns the migration from an array or a skip function (with tracking)
+-- Returns the migration from an array or a skip function (with tracking).
+-- `feature` may be a single feature string or a list (OR semantics) — see conditional().
 local function conditional_array(feature, migrations_array, index)
-    local name = feature .. "[" .. tostring(index) .. "]"
-    if ProjectConfig.isFeatureEnabled(feature) and migrations_array and migrations_array[index] then
+    local label = feature_label(feature)
+    local name = label .. "[" .. tostring(index) .. "]"
+    if ProjectConfig.isAnyFeatureEnabled(feature) and migrations_array and migrations_array[index] then
         return function(...)
-            MigrationTracker.recordRan(name, feature)
+            MigrationTracker.recordRan(name, label)
             return migrations_array[index](...)
         end
     end
-    return skip_migration(name, feature)
+    return skip_migration(name, label)
 end
 
 -- Dry-run: preview what would run/skip without touching the DB.
@@ -643,9 +666,18 @@ local _migrations = {
         6),
     ['53_create_patient_documents_table'] = conditional_array(ProjectConfig.FEATURES.HOSPITAL, hospital_crm_migrations, 7),
 
-    -- Payment Tracking (conditional on ecommerce)
-    ['54_create_payments_table'] = conditional_array(ProjectConfig.FEATURES.ECOMMERCE, payment_tracking_migrations, 1),
-    ['55_add_payment_indexes'] = conditional_array(ProjectConfig.FEATURES.ECOMMERCE, payment_tracking_migrations, 2),
+    -- Payment Tracking.
+    -- The `payments` table + its indexes are SHARED across ecommerce and
+    -- tax_copilot: the table is standalone (order_id/user_id are plain nullable
+    -- integers with no FK constraint), so it creates cleanly under tax_copilot
+    -- where the ecommerce `orders` table does not exist. A tax-service payment
+    -- is simply a row with user_id set and order_id NULL.
+    ['54_create_payments_table'] = conditional_array({ ProjectConfig.FEATURES.ECOMMERCE, ProjectConfig.FEATURES.TAX_COPILOT }, payment_tracking_migrations, 1),
+    ['55_add_payment_indexes'] = conditional_array({ ProjectConfig.FEATURES.ECOMMERCE, ProjectConfig.FEATURES.TAX_COPILOT }, payment_tracking_migrations, 2),
+    -- Steps 56-63 stay ECOMMERCE-only: they alter/extend the `orders` table
+    -- (add payment_id, status constraints, tracking) and create order-centric
+    -- tables (order_status_history, refunds). Under pure tax_copilot `orders`
+    -- doesn't exist, so widening these would fail at key 56.
     ['56_add_payment_id_to_orders'] = conditional_array(ProjectConfig.FEATURES.ECOMMERCE, payment_tracking_migrations, 3),
     ['57_update_order_status_enum'] = conditional_array(ProjectConfig.FEATURES.ECOMMERCE, payment_tracking_migrations, 4),
     ['58_create_order_status_history'] = conditional_array(ProjectConfig.FEATURES.ECOMMERCE, payment_tracking_migrations,


### PR DESCRIPTION
## Why

When we integrate the payment gateway into the tax product, we want to **reuse the existing `payments` table** rather than author a new one — but the tax app runs `PROJECT_CODE=tax_copilot`, under which the ecommerce migrations (including `payments`) don't run. This adds the ability to gate a single migration on **multiple** project codes (OR semantics), so one table can be installed under more than one `PROJECT_CODE` without dragging in a whole feature suite — and fixes the deploy workflows so the chosen project code actually takes effect.

## What changed

**Mechanism**
- `ProjectConfig.isAnyFeatureEnabled(features)` — accepts a single feature string **or** a list; returns true if the active `PROJECT_CODE` enables *any* of them.
- `migrations.lua`: `load_if_enabled` / `conditional` / `conditional_array` now accept a string-or-list (backward compatible). `feature_label()` renders a list as `ecommerce+tax_copilot` for migration-tracker logs.

**Applied to the payments table**
- Keys `54_create_payments_table` + `55_add_payment_indexes` and the `payment-tracking` module loader are now gated on `{ECOMMERCE, TAX_COPILOT}`.
- The `payments` table is **standalone** — `order_id` and `user_id` are plain nullable integers with no FK constraint — so it creates cleanly under `tax_copilot` where the ecommerce `orders` table doesn't exist. A tax-service payment = a row with `user_id` set and `order_id` NULL (it also has `stripe_payment_intent_id`, `stripe_customer_id`, `amount`, `currency`, `status`, card fields, `receipt_url`, `metadata`, `stripe_raw_response`).

**Deliberately NOT shared**
- Keys `56`–`63` stay `ECOMMERCE`-only — they alter/extend `orders` (payment_id, status constraint, tracking columns) and create order-centric tables (`order_status_history`, `refunds`). Under pure `tax_copilot` `orders` doesn't exist, so widening these would fail at key 56.

**Deploy workflows — stop forcing `projectCode=all`**
- `deploy-k3s.yml` and `weekly-acc-release.yml` passed `--set projectCode=${input || 'all'}`, which **always overrode** the per-env values files (that's why live acc ran `all` despite `values-acc.yaml` declaring `tax_copilot`).
- Now `--set projectCode` is only added when an explicit value is given. When blank — a **push to main**, or the **weekly scheduled** run — the override is omitted and the values file decides (`values-acc.yaml` → `tax_copilot`). The `workflow_dispatch` inputs default to `""` instead of `"all"`, so a manual run can still override on demand.

## Safety

- Migrations are keyed by **stable string names**, so widening a gate never renumbers or re-runs an already-applied migration.
- **Existing envs** (acc/prod deployed with `PROJECT_CODE=all`): `54` already ran for real, `payments` exists → no-op. **Fresh tax_copilot env**: `54` runs for real → gets `payments`.
- **⚠️ Behavior change on merge:** the next push-to-main / weekly deploy switches acc (and prod, same values) from `all` → `tax_copilot`. Existing ecommerce tables **persist** (migrations never drop) and `payments` keeps working (shared gate). New ecommerce-only migrations would simply be skipped on those envs going forward.
- **Rollout order:** no environment has actually deployed under `tax_copilot` yet (acc still runs `all`), so merging this *before* the first tax_copilot deploy keeps every path clean.

## Verification
- `luajit` `loadfile` syntax check on both Lua files; both workflow YAMLs parse with `yaml.safe_load`.
- OR-semantics assertions pass under `PROJECT_CODE=tax_copilot` (`{ecommerce,tax_copilot}` → true, `ecommerce` → false) and `=ecommerce` (`{ecommerce,tax_copilot}` → true, `tax_copilot` → false).

🤖 Generated with [Claude Code](https://claude.com/claude-code)