### PR TITLE
feat(billing): webhooks + reconciliation, subscription management, entitlements

### DIFF
--- a/lapis/app.lua
+++ b/lapis/app.lua
@@ -467,6 +467,9 @@ load_if("tax_copilot", "routes.tax-app-settings")
 load_if("tax_copilot", "routes.tax-admin-custom-categories")
 load_if("tax_copilot", "routes.tax-custom-categories")
 load_if("tax_copilot", "routes.tax-support")
+-- Billing (single-merchant Stripe: admin plans + subscription/one-time checkout)
+load_if("tax_copilot", "routes.billing-plans")
+load_if("tax_copilot", "routes.billing-checkout")
 
 -- ============================================
 -- CRM (Accounts, Contacts, Deals, Pipelines, Leads)

--- a/lapis/app.lua
+++ b/lapis/app.lua
@@ -470,6 +470,8 @@ load_if("tax_copilot", "routes.tax-support")
 -- Billing (single-merchant Stripe: admin plans + subscription/one-time checkout)
 load_if("tax_copilot", "routes.billing-plans")
 load_if("tax_copilot", "routes.billing-checkout")
+load_if("tax_copilot", "routes.billing-webhook")
+load_if("tax_copilot", "routes.billing-account")
 
 -- ============================================
 -- CRM (Accounts, Contacts, Deals, Pipelines, Leads)

--- a/lapis/helper/entitlement-service.lua
+++ b/lapis/helper/entitlement-service.lua
@@ -1,0 +1,84 @@
+--[[
+    Entitlement Service
+    ===================
+
+    Computes what a user can do RIGHT NOW, from their active subscription and
+    the plan's `features` JSON. Fresh on every call (no caching) — Stripe,
+    mirrored via webhooks, is the source of truth. No active subscription =>
+    free-tier defaults.
+
+    Snapshot shape:
+      {
+        has_subscription   = boolean,
+        status             = 'active'|'trialing'|'past_due'|'none',
+        plan               = { uuid, name, plan_type } | nil,
+        current_period_end = timestamp | nil,
+        cancel_at_period_end = boolean,
+        features           = { ... }      -- the plan's entitlement map
+      }
+]]
+
+local BillingSubscriptionQueries = require("queries.BillingSubscriptionQueries")
+local BillingPlanQueries = require("queries.BillingPlanQueries")
+local cjson = require("cjson")
+
+local EntitlementService = {}
+
+-- Baseline when the user has no active subscription. Kept empty (no paid
+-- features) so callers treat "missing" as free-tier; seed a 'free' plan later
+-- if you want explicit free limits.
+local FREE_FEATURES = {}
+
+local function decode_features(plan)
+    if not plan then return {} end
+    local f = plan.features
+    if type(f) == "string" then
+        local ok, decoded = pcall(cjson.decode, f)
+        return (ok and type(decoded) == "table") and decoded or {}
+    end
+    if type(f) == "table" then return f end
+    return {}
+end
+
+local function truthy(v)
+    return v == true or v == "t" or v == "true" or v == 1
+end
+
+-- Full entitlement snapshot for a user within a namespace.
+function EntitlementService.forUser(namespace_id, user_uuid)
+    local sub = BillingSubscriptionQueries.getActiveForUser(namespace_id, user_uuid)
+    if not sub then
+        return {
+            has_subscription = false,
+            status = "none",
+            plan = nil,
+            current_period_end = nil,
+            cancel_at_period_end = false,
+            features = FREE_FEATURES,
+        }
+    end
+
+    local plan = sub.plan_id and BillingPlanQueries.getById(sub.plan_id) or nil
+    return {
+        has_subscription = true,
+        status = sub.status,
+        plan = plan and { uuid = plan.uuid, name = plan.name, plan_type = plan.plan_type } or nil,
+        current_period_end = sub.current_period_end,
+        cancel_at_period_end = truthy(sub.cancel_at_period_end),
+        features = decode_features(plan),
+    }
+end
+
+-- Convenience: does the user's plan grant a boolean feature (e.g. file_to_hmrc)?
+function EntitlementService.can(namespace_id, user_uuid, feature_key)
+    local snap = EntitlementService.forUser(namespace_id, user_uuid)
+    return truthy(snap.features[feature_key])
+end
+
+-- Convenience: numeric limit for a feature (nil = unlimited / not set).
+function EntitlementService.limit(namespace_id, user_uuid, feature_key)
+    local snap = EntitlementService.forUser(namespace_id, user_uuid)
+    return tonumber(snap.features[feature_key])
+end
+
+return EntitlementService

--- a/lapis/lib/billing-urls.lua
+++ b/lapis/lib/billing-urls.lua
@@ -1,0 +1,68 @@
+--[[
+    Billing URL helpers — server-controlled redirects
+    ==================================================
+
+    Shared by the Connect and Checkout flows. Centralises the two pieces of the
+    secure-redirect model so neither flow trusts client-supplied URLs:
+
+      opsapi_base()   our own public base, used to build the Stripe callback
+                      URLs (return/refresh/success/cancel). Prefer the
+                      configured OPSAPI_PUBLIC_URL; derive from the request only
+                      as a dev fallback.
+
+      dashboard_url() a SAFE final redirect for a namespace — the ORIGIN comes
+                      from the namespace's allow-list (or FRONTEND_URL), never
+                      from raw input; the path is server-controlled.
+]]
+
+local Global = require("helper.global")
+local NamespaceQueries = require("queries.NamespaceQueries")
+
+local M = {}
+
+function M.opsapi_base()
+    local base = Global.getEnvVar("OPSAPI_PUBLIC_URL")
+    if base and base ~= "" then return (base:gsub("/+$", "")) end
+    local scheme = ngx.var.http_x_forwarded_proto or ngx.var.scheme or "https"
+    local host = ngx.var.http_x_forwarded_host or ngx.var.http_host or ngx.var.host
+    if not host or host == "" then return nil end
+    local prefix = ngx.var.http_x_forwarded_prefix
+    if prefix and prefix ~= "" then
+        prefix = "/" .. prefix:gsub("^/+", ""):gsub("/+$", "")
+    else
+        prefix = ""
+    end
+    return scheme .. "://" .. host .. prefix
+end
+
+-- Resolve a safe dashboard URL for `namespace_id`.
+--   path_env_key  env var that can override the path (e.g. BILLING_DASHBOARD_PATH)
+--   default_path  fallback path (e.g. "/settings/billing")
+--   query         optional table of query params to append
+-- Returns the URL, or nil if no origin is known for the namespace.
+function M.dashboard_url(namespace_id, path_env_key, default_path, query)
+    local origin
+    local origins = NamespaceQueries.getAllowedRedirectOrigins(namespace_id)
+    if origins and #origins > 0 then origin = origins[1] end
+    if not origin or origin == "" then
+        local fe = Global.getEnvVar("FRONTEND_URL")
+        if fe and fe ~= "" then origin = fe end
+    end
+    if not origin or origin == "" then return nil end
+    origin = origin:gsub("/+$", "")
+
+    local path = (path_env_key and Global.getEnvVar(path_env_key)) or default_path
+    if path:sub(1, 1) ~= "/" then path = "/" .. path end
+
+    local qs = ""
+    if query then
+        local parts = {}
+        for k, v in pairs(query) do
+            parts[#parts + 1] = ngx.escape_uri(k) .. "=" .. ngx.escape_uri(tostring(v))
+        end
+        if #parts > 0 then qs = "?" .. table.concat(parts, "&") end
+    end
+    return origin .. path .. qs
+end
+
+return M

--- a/lapis/lib/payment-provider.lua
+++ b/lapis/lib/payment-provider.lua
@@ -1,0 +1,99 @@
+--[[
+    Payment Provider abstraction + dynamic configuration
+    =====================================================
+
+    Single place that resolves *how* payment-provider credentials are obtained,
+    so no other module reads STRIPE_* env vars directly. Configuration is
+    environment-driven and mode-aware (test | live): switching sandbox <-> live
+    is a config change, never a code change.
+
+    Per-tenant model (Stripe Connect): there is ONE platform secret key. Each
+    tenant is a connected account (acct_...) addressed via destination charges
+    or the Stripe-Account header. This module returns a Stripe client configured
+    for the platform, or for a given connected account.
+
+    Provider-agnostic by design: Wise (bank transfer) slots in behind the same
+    `get(provider)` surface in a later phase with no caller changes.
+
+    All functions fail soft — they return (value, nil) or (nil, error_message)
+    rather than throwing — so route handlers can respond with a clean error.
+]]
+
+local Global = require("helper.global")
+local Stripe = require("lib.stripe")
+
+local PaymentProvider = {}
+
+-- =========================================================================
+-- Stripe configuration (dynamic, mode-aware)
+-- =========================================================================
+
+-- Active Stripe mode: 'test' | 'live'. Inferred from the STRIPE_SECRET_KEY
+-- prefix (sk_live_ / rk_live_ → live), so there is no separate STRIPE_MODE
+-- variable to manage — the single key determines the mode. Swap the key to
+-- switch between test and live.
+function PaymentProvider.stripe_mode()
+    local key = Global.getEnvVar("STRIPE_SECRET_KEY") or ""
+    if key:find("_live_", 1, true) then return "live" end
+    return "test"
+end
+
+-- Resolve the platform Stripe config. One set of variables only:
+--   STRIPE_SECRET_KEY · STRIPE_PUBLISHABLE_KEY · STRIPE_WEBHOOK_SECRET
+-- (STRIPE_CONNECT_WEBHOOK_SECRET and STRIPE_PLATFORM_FEE_PERCENT are optional
+-- and fall back gracefully). No test/live key variants.
+function PaymentProvider.stripe_config()
+    return {
+        mode = PaymentProvider.stripe_mode(),
+        secret_key = Global.getEnvVar("STRIPE_SECRET_KEY"),
+        publishable_key = Global.getEnvVar("STRIPE_PUBLISHABLE_KEY"),
+        webhook_secret = Global.getEnvVar("STRIPE_WEBHOOK_SECRET"),
+    }
+end
+
+-- Whether Stripe is usable (a secret key is present for the active mode).
+-- Routes call this to return a clean 503 instead of risking a throw.
+function PaymentProvider.stripe_configured()
+    local cfg = PaymentProvider.stripe_config()
+    return cfg.secret_key ~= nil and cfg.secret_key ~= ""
+end
+
+-- Return a Stripe client for the platform account (the single merchant defined
+-- by STRIPE_SECRET_KEY). Returns (client, nil) or (nil, error).
+function PaymentProvider.get_stripe()
+    local cfg = PaymentProvider.stripe_config()
+    if not cfg.secret_key or cfg.secret_key == "" then
+        return nil, "Stripe is not configured (missing STRIPE_SECRET_KEY)"
+    end
+
+    local ok, client = pcall(Stripe.new, { api_key = cfg.secret_key })
+    if not ok then
+        return nil, "Failed to initialise Stripe client: " .. tostring(client)
+    end
+    return client, nil
+end
+
+-- =========================================================================
+-- Provider abstraction (Wise-ready)
+-- =========================================================================
+
+local PROVIDERS = {
+    stripe = {
+        name = "stripe",
+        configured = function() return PaymentProvider.stripe_configured() end,
+        get_client = function() return PaymentProvider.get_stripe() end,
+    },
+    -- wise = { ... }  -- slots in during the Wise phase, same surface.
+}
+
+-- Look up a provider adapter by name (defaults to stripe).
+function PaymentProvider.get(provider_name)
+    provider_name = provider_name or "stripe"
+    local p = PROVIDERS[provider_name]
+    if not p then
+        return nil, "Unknown or unsupported payment provider: " .. tostring(provider_name)
+    end
+    return p, nil
+end
+
+return PaymentProvider

--- a/lapis/lib/stripe.lua
+++ b/lapis/lib/stripe.lua
@@ -5,15 +5,18 @@ local Global = require("helper.global")
 local Stripe = {}
 Stripe.__index = Stripe
 
-function Stripe.new()
+-- Construct a Stripe API client for the single platform merchant.
+--   opts.api_key  override the secret key (defaults to STRIPE_SECRET_KEY env)
+function Stripe.new(opts)
+    opts = opts or {}
     local self = setmetatable({}, Stripe)
-    self.api_key = Global.getEnvVar("STRIPE_SECRET_KEY")
+    self.api_key = opts.api_key or Global.getEnvVar("STRIPE_SECRET_KEY")
     self.base_url = "https://api.stripe.com/v1"
-    
+
     if not self.api_key then
-        error("STRIPE_SECRET_KEY environment variable is required")
+        error("Stripe secret key is required (pass opts.api_key or set STRIPE_SECRET_KEY)")
     end
-    
+
     return self
 end
 
@@ -64,7 +67,7 @@ function Stripe:_request(method, endpoint, data, idempotency_key)
         ["Stripe-Version"] = "2023-10-16"
     }
 
-    -- Add idempotency key if provided
+    -- Idempotency key — pass one on retryable writes to avoid double charges.
     if idempotency_key then
         headers["Idempotency-Key"] = idempotency_key
     end
@@ -74,38 +77,52 @@ function Stripe:_request(method, endpoint, data, idempotency_key)
         local params = self:_encode_table(data)
         body = table.concat(params, "&")
     end
-    
-    -- Log request for debugging
-    ngx.log(ngx.INFO, "Stripe API Request: " .. method .. " " .. url)
-    ngx.log(ngx.INFO, "Stripe API Body: " .. body)
-    
+
+    -- TLS peer verification for outbound Stripe calls. Disabled by default to
+    -- match the current deployment, which has no CA trust store configured (no
+    -- lua_ssl_trusted_certificate in nginx.conf, no ca-certificates in the
+    -- image). Turning it on without that store would fail every Stripe call.
+    -- To enable — strongly recommended for production — configure the CA bundle
+    -- in the image + nginx, then set STRIPE_SSL_VERIFY=true. Kept as a config
+    -- switch so enabling it is a deploy-time change, not a code change.
+    local ssl_verify = Global.getEnvVar("STRIPE_SSL_VERIFY") == "true"
+
+    -- Minimal logging by default; full request/response bodies (which can carry
+    -- PII) are logged only when STRIPE_DEBUG=true.
+    local debug_log = Global.getEnvVar("STRIPE_DEBUG") == "true"
+    ngx.log(ngx.INFO, "Stripe API Request: " .. method .. " " .. endpoint)
+    if debug_log then
+        ngx.log(ngx.INFO, "Stripe API Body: " .. body)
+    end
+
     local res, err = httpc:request_uri(url, {
         method = method,
         body = body,
         headers = headers,
-        ssl_verify = false -- Disable SSL verification for debugging
+        ssl_verify = ssl_verify
     })
-    
+
     if not res then
         ngx.log(ngx.ERR, "Stripe HTTP request failed: " .. (err or "unknown error"))
         return nil, "HTTP request failed: " .. (err or "unknown error")
     end
-    
-    -- Log response for debugging
+
     ngx.log(ngx.INFO, "Stripe API Response Status: " .. res.status)
-    ngx.log(ngx.INFO, "Stripe API Response Body: " .. (res.body or "empty"))
-    
+    if debug_log then
+        ngx.log(ngx.INFO, "Stripe API Response Body: " .. (res.body or "empty"))
+    end
+
     local response_data
     local ok, decode_err = pcall(function()
         response_data = cjson.decode(res.body)
     end)
-    
+
     if not ok then
         ngx.log(ngx.ERR, "Failed to decode Stripe JSON response: " .. (decode_err or "unknown error"))
         ngx.log(ngx.ERR, "Raw response body: " .. (res.body or "empty"))
         return nil, "Failed to decode JSON response: " .. (decode_err or "unknown error")
     end
-    
+
     if res.status >= 400 then
         local error_msg = "Stripe API error"
         if response_data and response_data.error then
@@ -114,7 +131,7 @@ function Stripe:_request(method, endpoint, data, idempotency_key)
         ngx.log(ngx.ERR, "Stripe API error: " .. error_msg)
         return nil, error_msg, response_data
     end
-    
+
     return response_data, nil
 end
 
@@ -162,7 +179,17 @@ function Stripe:create_checkout_session(options)
         data.automatic_tax = options.automatic_tax
     end
 
-    return self:_request("POST", "/checkout/sessions", data)
+    -- Connect + subscription/one-time pass-throughs:
+    --   subscription_data   { application_fee_percent, transfer_data = { destination }, metadata }
+    --   payment_intent_data { application_fee_amount, transfer_data = { destination }, metadata }
+    --   customer / client_reference_id / allow_promotion_codes
+    if options.customer then data.customer = options.customer end
+    if options.client_reference_id then data.client_reference_id = options.client_reference_id end
+    if options.subscription_data then data.subscription_data = options.subscription_data end
+    if options.payment_intent_data then data.payment_intent_data = options.payment_intent_data end
+    if options.allow_promotion_codes ~= nil then data.allow_promotion_codes = options.allow_promotion_codes end
+
+    return self:_request("POST", "/checkout/sessions", data, options.idempotency_key)
 end
 
 -- Create a Payment Intent (keeping for compatibility)
@@ -201,6 +228,24 @@ function Stripe:create_payment_intent(amount, currency, options)
     return self:_request("POST", "/payment_intents", data)
 end
 
+-- Create a PaymentIntent on the platform account. Amount is in MINOR units
+-- (e.g. 599 = £5.99) — NOT multiplied. Used by the native mobile Payment Sheet
+-- for one-time purchases. options: amount, currency, customer, metadata,
+-- receipt_email, description, idempotency_key.
+function Stripe:create_payment_intent_minor(options)
+    options = options or {}
+    local data = {
+        amount = math.floor(tonumber(options.amount) or 0),
+        currency = options.currency or "gbp",
+        automatic_payment_methods = { enabled = true },
+    }
+    if options.customer then data.customer = options.customer end
+    if options.metadata then data.metadata = options.metadata end
+    if options.receipt_email then data.receipt_email = options.receipt_email end
+    if options.description then data.description = options.description end
+    return self:_request("POST", "/payment_intents", data, options.idempotency_key)
+end
+
 -- Retrieve a Payment Intent
 function Stripe:retrieve_payment_intent(payment_intent_id)
     return self:_request("GET", "/payment_intents/" .. payment_intent_id, nil)
@@ -216,28 +261,141 @@ end
 -- Create a Customer
 function Stripe:create_customer(email, name, options)
     options = options or {}
-    
+
     local data = {
         email = email
     }
-    
+
     if name then
         data.name = name
     end
-    
+
     if options.phone then
         data.phone = options.phone
     end
-    
+
     if options.address then
         data.address = options.address
     end
-    
+
     if options.metadata then
         data.metadata = options.metadata
     end
-    
+
     return self:_request("POST", "/customers", data)
+end
+
+-- =========================================================================
+-- Products & Prices (the plan catalogue). Created on the platform account.
+-- =========================================================================
+
+-- Create a Product. options: name (required), description, active, metadata.
+function Stripe:create_product(options)
+    options = options or {}
+    local data = { name = options.name }
+    if options.description and options.description ~= "" then data.description = options.description end
+    if options.active ~= nil then data.active = options.active end
+    if options.metadata then data.metadata = options.metadata end
+    return self:_request("POST", "/products", data, options.idempotency_key)
+end
+
+-- Create a Price. options: product (required), unit_amount (MINOR units),
+-- currency, recurring = { interval, interval_count } for subscriptions,
+-- nickname, metadata. Prices are immutable in Stripe — to change an amount,
+-- create a new Price and repoint the plan.
+function Stripe:create_price(options)
+    options = options or {}
+    local data = {
+        product = options.product,
+        unit_amount = options.unit_amount,
+        currency = options.currency or "gbp",
+    }
+    if options.recurring then data.recurring = options.recurring end
+    if options.nickname then data.nickname = options.nickname end
+    if options.metadata then data.metadata = options.metadata end
+    return self:_request("POST", "/prices", data, options.idempotency_key)
+end
+
+-- Update mutable fields on a Product (e.g. name, description, active=false to archive).
+function Stripe:update_product(product_id, fields)
+    return self:_request("POST", "/products/" .. product_id, fields or {})
+end
+
+-- Update mutable fields on a Price (only `active`, `nickname`, `metadata` are mutable).
+function Stripe:update_price(price_id, fields)
+    return self:_request("POST", "/prices/" .. price_id, fields or {})
+end
+
+-- =========================================================================
+-- Webhook signature verification (module-level — runs before we know the
+-- connected account, so it does not need a client instance)
+-- =========================================================================
+
+-- Constant-time comparison to avoid leaking signature info via timing.
+function Stripe._secure_compare(a, b)
+    if type(a) ~= "string" or type(b) ~= "string" then return false end
+    if #a ~= #b then return false end
+    local diff = 0
+    for i = 1, #a do
+        diff = bit.bor(diff, bit.bxor(a:byte(i), b:byte(i)))
+    end
+    return diff == 0
+end
+
+-- Verify a Stripe webhook and return the decoded event.
+--   payload         the RAW request body (must be the exact bytes Stripe sent)
+--   sig_header      the Stripe-Signature header ("t=...,v1=...")
+--   webhook_secret  the endpoint's signing secret (whsec_...)
+--   tolerance       max age in seconds (default 300) — replay protection
+-- Returns (event_table, nil) on success or (nil, error_message) on failure.
+function Stripe.construct_event(payload, sig_header, webhook_secret, tolerance)
+    if not payload or payload == "" then return nil, "empty payload" end
+    if not sig_header or sig_header == "" then return nil, "missing Stripe-Signature header" end
+    if not webhook_secret or webhook_secret == "" then return nil, "webhook secret not configured" end
+    tolerance = tolerance or 300
+
+    -- Parse "t=<ts>,v1=<sig>,v1=<sig>"
+    local timestamp
+    local v1_sigs = {}
+    for part in sig_header:gmatch("[^,]+") do
+        local k, v = part:match("^%s*(%w+)%s*=%s*(.+)%s*$")
+        if k == "t" then
+            timestamp = tonumber(v)
+        elseif k == "v1" then
+            table.insert(v1_sigs, v)
+        end
+    end
+    if not timestamp then return nil, "no timestamp in signature header" end
+    if #v1_sigs == 0 then return nil, "no v1 signature in header" end
+
+    -- Replay protection.
+    if math.abs(ngx.time() - timestamp) > tolerance then
+        return nil, "timestamp outside tolerance"
+    end
+
+    -- Expected signature = HMAC-SHA256(secret, "<timestamp>.<payload>"), hex.
+    local ok_hmac, hmac = pcall(require, "resty.openssl.hmac")
+    if not ok_hmac then return nil, "hmac library unavailable" end
+    local h, herr = hmac.new(webhook_secret, "sha256")
+    if not h then return nil, "hmac init failed: " .. tostring(herr) end
+    if not h:update(tostring(timestamp) .. "." .. payload) then
+        return nil, "hmac update failed"
+    end
+    local mac = h:final()
+    local expected = mac:gsub(".", function(c) return string.format("%02x", string.byte(c)) end)
+
+    local matched = false
+    for _, sig in ipairs(v1_sigs) do
+        if Stripe._secure_compare(expected, sig) then
+            matched = true
+            break
+        end
+    end
+    if not matched then return nil, "signature verification failed" end
+
+    local ok_decode, event = pcall(cjson.decode, payload)
+    if not ok_decode then return nil, "failed to decode event payload" end
+    return event, nil
 end
 
 return Stripe

--- a/lapis/lib/stripe.lua
+++ b/lapis/lib/stripe.lua
@@ -258,6 +258,20 @@ function Stripe:retrieve_checkout_session(session_id)
     return self:_request("GET", url, nil)
 end
 
+-- Retrieve a Subscription.
+function Stripe:retrieve_subscription(subscription_id)
+    return self:_request("GET", "/subscriptions/" .. subscription_id, nil)
+end
+
+-- Cancel a Subscription. Default is graceful (at period end — the user keeps
+-- access until the paid period runs out); pass at_period_end=false to end now.
+function Stripe:cancel_subscription(subscription_id, at_period_end)
+    if at_period_end == false then
+        return self:_request("DELETE", "/subscriptions/" .. subscription_id, nil)
+    end
+    return self:_request("POST", "/subscriptions/" .. subscription_id, { cancel_at_period_end = true })
+end
+
 -- Create a Customer
 function Stripe:create_customer(email, name, options)
     options = options or {}

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -132,6 +132,11 @@ local tax_copilot_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILO
 -- Dynamic Profile Builder (tax_copilot feature)
 local profile_builder_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.dynamic-profile-builder") or {}
 
+-- Billing / payments (Stripe Connect: subscriptions + one-time). Gated on
+-- tax_copilot for now; broaden to a feature list (e.g. {ECOMMERCE, TAX_COPILOT})
+-- once multiple project codes need it. See migrations/billing-system.lua.
+local billing_system_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.billing-system") or {}
+
 -- CRM
 local crm_system_migrations = load_if_enabled(ProjectConfig.FEATURES.CRM, "migrations.crm-system") or {}
 local crm_leads_migrations = load_if_enabled(ProjectConfig.FEATURES.CRM, "migrations.crm-leads") or {}
@@ -1667,6 +1672,22 @@ local _migrations = {
     end,
 
     -- =========================================================================
+    -- =========================================================================
+    -- BILLING SYSTEM (single-merchant Stripe: subscriptions + one-time) — gated
+    -- on tax_copilot. Tables: plans, subscriptions, payments, refunds, webhook
+    -- events, usage meters. Key 700 is a retired no-op (the old per-tenant
+    -- Connect payment-accounts table, removed when billing went single-merchant).
+    -- Keys are numeric so they run before the zz* finalizers. See
+    -- migrations/billing-system.lua.
+    -- =========================================================================
+    ['700_billing_payment_accounts'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, billing_system_migrations, 1),
+    ['701_billing_plans'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, billing_system_migrations, 2),
+    ['702_billing_subscriptions'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, billing_system_migrations, 3),
+    ['703_billing_payments'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, billing_system_migrations, 4),
+    ['704_billing_refunds'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, billing_system_migrations, 5),
+    ['705_billing_webhook_events'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, billing_system_migrations, 6),
+    ['706_billing_usage_meters'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, billing_system_migrations, 7),
+
     -- Theme system foundation (Phase 0): drop obsolete scaffold.
     -- Replaced by new tables in Phase 1 migration 621_create_theme_system.
     -- =========================================================================

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -1719,6 +1719,8 @@ local _migrations = {
     ['704_billing_refunds'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, billing_system_migrations, 5),
     ['705_billing_webhook_events'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, billing_system_migrations, 6),
     ['706_billing_usage_meters'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, billing_system_migrations, 7),
+    ['707_billing_audit_columns'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, billing_system_migrations, 8),
+    ['708_billing_drop_payment_accounts'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, billing_system_migrations, 9),
 
     -- Theme system foundation (Phase 0): drop obsolete scaffold.
     -- Replaced by new tables in Phase 1 migration 621_create_theme_system.

--- a/lapis/migrations/billing-system.lua
+++ b/lapis/migrations/billing-system.lua
@@ -294,4 +294,34 @@ return {
         ]])
         db.query([[ CREATE INDEX idx_usage_meters_lookup ON usage_meters (namespace_id, user_uuid, meter_key) ]])
     end,
+
+    -- ========================================================================
+    -- [8] Audit / tracking columns (additive, idempotent). Added after the
+    -- initial tables shipped, so ADD COLUMN IF NOT EXISTS keeps it safe to
+    -- re-run on databases that already have the base schema.
+    -- ========================================================================
+    [8] = function()
+        -- Subscriptions: which webhook last touched the row, trial start, and
+        -- when access actually ended (vs canceled_at = when cancellation was set).
+        db.query("ALTER TABLE billing_subscriptions ADD COLUMN IF NOT EXISTS last_event_id TEXT")
+        db.query("ALTER TABLE billing_subscriptions ADD COLUMN IF NOT EXISTS last_event_at TIMESTAMP")
+        db.query("ALTER TABLE billing_subscriptions ADD COLUMN IF NOT EXISTS trial_start TIMESTAMP")
+        db.query("ALTER TABLE billing_subscriptions ADD COLUMN IF NOT EXISTS ended_at TIMESTAMP")
+
+        -- Payments: when the charge actually settled (for revenue reporting).
+        db.query("ALTER TABLE billing_payments ADD COLUMN IF NOT EXISTS paid_at TIMESTAMP")
+
+        -- Webhook events: test vs live, so test traffic is never mistaken for real.
+        db.query("ALTER TABLE stripe_webhook_events ADD COLUMN IF NOT EXISTS livemode BOOLEAN")
+    end,
+
+    -- ========================================================================
+    -- [9] Drop the dead Stripe Connect table. Billing is single-merchant now;
+    -- step [1] no longer creates namespace_payment_accounts, but databases
+    -- migrated before that pivot still have it (unused, no FKs into it).
+    -- Idempotent — a no-op where it was never created.
+    -- ========================================================================
+    [9] = function()
+        db.query("DROP TABLE IF EXISTS namespace_payment_accounts CASCADE")
+    end,
 }

--- a/lapis/migrations/billing-system.lua
+++ b/lapis/migrations/billing-system.lua
@@ -1,0 +1,297 @@
+--[[
+    Billing System Migrations (Stripe Connect, multi-tenant SaaS)
+    =============================================================
+
+    Production billing for the platform: per-tenant Stripe Connect (Express)
+    accounts collect from their own clients, with the platform taking a
+    configurable application fee. Supports BOTH recurring subscriptions and
+    one-time purchases, behind a provider abstraction so Wise (bank transfer)
+    can be added later without schema changes.
+
+    Design notes:
+    - Every table is namespace-scoped (the tenant), mirroring the invoicing
+      and CRM modules. The "paying client" is referenced by `user_uuid`
+      (consistent with tax_user_subscriptions and the invoicing module).
+    - Monetary amounts are stored in MINOR units (e.g. pence) as BIGINT to
+      avoid floating-point rounding — same convention Stripe uses.
+    - This is intentionally separate from the ecommerce `payments`/`orders`
+      tables: billing here is subscription/Connect-centric, not order-centric.
+    - Idempotency for webhooks is enforced by the UNIQUE event_id on
+      stripe_webhook_events; replayed events are no-ops.
+
+    Tables:
+    =======
+    1. namespace_payment_accounts - per-tenant Connect account + onboarding state
+    2. billing_plans              - dynamic plans (subscription | one_time)
+    3. billing_subscriptions      - recurring subscriptions per user
+    4. billing_payments           - payment ledger (one-time + subscription invoices)
+    5. billing_refunds            - refunds against billing_payments
+    6. stripe_webhook_events      - webhook idempotency + audit
+    7. usage_meters               - metered entitlement caps (e.g. AI classify)
+]]
+
+local db = require("lapis.db")
+
+-- Helper: does a table already exist? Keeps every step idempotent so a
+-- re-run (or running on a DB that predates this module) is a safe no-op.
+local function table_exists(name)
+    local result = db.query(
+        "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = ?) as exists", name)
+    return result and result[1] and result[1].exists
+end
+
+return {
+    -- ========================================================================
+    -- [1] (removed) Previously created namespace_payment_accounts for Stripe
+    -- Connect connected accounts. Billing is now single-merchant — the platform's
+    -- own Stripe account (STRIPE_SECRET_KEY) is the merchant — so no per-tenant
+    -- connected accounts exist. Kept as a no-op to preserve migration ordering;
+    -- fresh installs simply never create the table.
+    -- ========================================================================
+    [1] = function() end,
+
+    -- ========================================================================
+    -- [2] billing_plans — dynamic, namespace-scoped plan catalogue
+    -- ========================================================================
+    [2] = function()
+        if table_exists("billing_plans") then return end
+
+        db.query([[
+            CREATE TABLE billing_plans (
+                id BIGSERIAL PRIMARY KEY,
+                uuid TEXT UNIQUE NOT NULL,
+                namespace_id BIGINT NOT NULL REFERENCES namespaces(id) ON DELETE CASCADE,
+                name TEXT NOT NULL,
+                description TEXT,
+                plan_type TEXT NOT NULL DEFAULT 'subscription' CHECK (plan_type IN ('subscription','one_time')),
+                -- Minor units (e.g. 599 = £5.99).
+                amount BIGINT NOT NULL CHECK (amount >= 0),
+                currency TEXT NOT NULL DEFAULT 'gbp',
+                -- Recurrence (subscriptions only).
+                billing_interval TEXT CHECK (billing_interval IN ('day','week','month','year')),
+                interval_count INTEGER NOT NULL DEFAULT 1 CHECK (interval_count >= 1),
+                trial_days INTEGER NOT NULL DEFAULT 0 CHECK (trial_days >= 0),
+                -- Stripe product/price ids, created on the platform account on first checkout/sync.
+                stripe_product_id TEXT,
+                stripe_price_id TEXT,
+                -- Entitlements granted, e.g. {"file_to_hmrc":true,"max_bank_accounts":5,"ai_classify_cap":null}.
+                features JSONB DEFAULT '{}',
+                active BOOLEAN NOT NULL DEFAULT TRUE,
+                sort_order INTEGER NOT NULL DEFAULT 0,
+                metadata JSONB DEFAULT '{}',
+                created_at TIMESTAMP DEFAULT NOW(),
+                updated_at TIMESTAMP DEFAULT NOW(),
+                deleted_at TIMESTAMP,
+                -- Subscriptions must declare an interval; one-time must not.
+                CONSTRAINT billing_plans_interval_chk CHECK (
+                    (plan_type = 'subscription' AND billing_interval IS NOT NULL) OR
+                    (plan_type = 'one_time'     AND billing_interval IS NULL)
+                )
+            )
+        ]])
+
+        db.query([[ CREATE INDEX idx_billing_plans_namespace ON billing_plans (namespace_id) ]])
+        db.query([[ CREATE INDEX idx_billing_plans_namespace_active ON billing_plans (namespace_id, active) ]])
+        db.query([[
+            CREATE INDEX idx_billing_plans_stripe_price ON billing_plans (stripe_price_id)
+            WHERE stripe_price_id IS NOT NULL
+        ]])
+    end,
+
+    -- ========================================================================
+    -- [3] billing_subscriptions — recurring subscriptions per user
+    -- ========================================================================
+    [3] = function()
+        if table_exists("billing_subscriptions") then return end
+
+        db.query([[
+            CREATE TABLE billing_subscriptions (
+                id BIGSERIAL PRIMARY KEY,
+                uuid TEXT UNIQUE NOT NULL,
+                namespace_id BIGINT NOT NULL REFERENCES namespaces(id) ON DELETE CASCADE,
+                user_uuid TEXT NOT NULL,
+                plan_id BIGINT REFERENCES billing_plans(id) ON DELETE SET NULL,
+                provider TEXT NOT NULL DEFAULT 'stripe' CHECK (provider IN ('stripe','wise')),
+                stripe_subscription_id TEXT,
+                stripe_customer_id TEXT,
+                -- Mirrors Stripe subscription statuses.
+                status TEXT NOT NULL DEFAULT 'incomplete'
+                    CHECK (status IN ('incomplete','incomplete_expired','trialing','active','past_due','canceled','unpaid','paused')),
+                current_period_start TIMESTAMP,
+                current_period_end TIMESTAMP,
+                cancel_at_period_end BOOLEAN NOT NULL DEFAULT FALSE,
+                canceled_at TIMESTAMP,
+                trial_end TIMESTAMP,
+                metadata JSONB DEFAULT '{}',
+                created_at TIMESTAMP DEFAULT NOW(),
+                updated_at TIMESTAMP DEFAULT NOW()
+            )
+        ]])
+
+        db.query([[
+            CREATE UNIQUE INDEX idx_billing_subs_stripe_id ON billing_subscriptions (stripe_subscription_id)
+            WHERE stripe_subscription_id IS NOT NULL
+        ]])
+        db.query([[ CREATE INDEX idx_billing_subs_namespace ON billing_subscriptions (namespace_id) ]])
+        db.query([[ CREATE INDEX idx_billing_subs_user ON billing_subscriptions (user_uuid) ]])
+        db.query([[ CREATE INDEX idx_billing_subs_namespace_user ON billing_subscriptions (namespace_id, user_uuid) ]])
+        db.query([[ CREATE INDEX idx_billing_subs_status ON billing_subscriptions (status) ]])
+        -- Reconciler sweeps expiring subscriptions by period end.
+        db.query([[ CREATE INDEX idx_billing_subs_period_end ON billing_subscriptions (current_period_end) ]])
+    end,
+
+    -- ========================================================================
+    -- [4] billing_payments — payment ledger (one-time + subscription invoices)
+    -- ========================================================================
+    [4] = function()
+        if table_exists("billing_payments") then return end
+
+        db.query([[
+            CREATE TABLE billing_payments (
+                id BIGSERIAL PRIMARY KEY,
+                uuid TEXT UNIQUE NOT NULL,
+                namespace_id BIGINT NOT NULL REFERENCES namespaces(id) ON DELETE CASCADE,
+                user_uuid TEXT,
+                plan_id BIGINT REFERENCES billing_plans(id) ON DELETE SET NULL,
+                subscription_id BIGINT REFERENCES billing_subscriptions(id) ON DELETE SET NULL,
+                provider TEXT NOT NULL DEFAULT 'stripe' CHECK (provider IN ('stripe','wise')),
+                payment_type TEXT NOT NULL DEFAULT 'one_time' CHECK (payment_type IN ('one_time','subscription')),
+                -- Stripe object references.
+                stripe_payment_intent_id TEXT,
+                stripe_checkout_session_id TEXT,
+                stripe_charge_id TEXT,
+                stripe_invoice_id TEXT,
+                stripe_customer_id TEXT,
+                -- Connected account that received the funds (Connect).
+                connected_account_id TEXT,
+                amount BIGINT NOT NULL CHECK (amount >= 0),
+                currency TEXT NOT NULL DEFAULT 'gbp',
+                application_fee_amount BIGINT NOT NULL DEFAULT 0 CHECK (application_fee_amount >= 0),
+                status TEXT NOT NULL DEFAULT 'pending'
+                    CHECK (status IN ('pending','processing','succeeded','failed','canceled','refunded','partially_refunded')),
+                payment_method_type TEXT,
+                card_brand TEXT,
+                card_last4 TEXT,
+                receipt_email TEXT,
+                receipt_url TEXT,
+                failure_code TEXT,
+                failure_message TEXT,
+                metadata JSONB DEFAULT '{}',
+                created_at TIMESTAMP DEFAULT NOW(),
+                updated_at TIMESTAMP DEFAULT NOW()
+            )
+        ]])
+
+        db.query([[
+            CREATE UNIQUE INDEX idx_billing_payments_pi ON billing_payments (stripe_payment_intent_id)
+            WHERE stripe_payment_intent_id IS NOT NULL
+        ]])
+        db.query([[
+            CREATE INDEX idx_billing_payments_checkout ON billing_payments (stripe_checkout_session_id)
+            WHERE stripe_checkout_session_id IS NOT NULL
+        ]])
+        db.query([[ CREATE INDEX idx_billing_payments_namespace ON billing_payments (namespace_id) ]])
+        db.query([[ CREATE INDEX idx_billing_payments_user ON billing_payments (user_uuid) ]])
+        db.query([[ CREATE INDEX idx_billing_payments_subscription ON billing_payments (subscription_id) ]])
+        db.query([[ CREATE INDEX idx_billing_payments_status ON billing_payments (status) ]])
+        db.query([[ CREATE INDEX idx_billing_payments_created ON billing_payments USING BRIN (created_at) ]])
+    end,
+
+    -- ========================================================================
+    -- [5] billing_refunds — refunds against billing_payments
+    -- ========================================================================
+    [5] = function()
+        if table_exists("billing_refunds") then return end
+
+        db.query([[
+            CREATE TABLE billing_refunds (
+                id BIGSERIAL PRIMARY KEY,
+                uuid TEXT UNIQUE NOT NULL,
+                namespace_id BIGINT NOT NULL REFERENCES namespaces(id) ON DELETE CASCADE,
+                payment_id BIGINT NOT NULL REFERENCES billing_payments(id) ON DELETE CASCADE,
+                provider TEXT NOT NULL DEFAULT 'stripe' CHECK (provider IN ('stripe','wise')),
+                stripe_refund_id TEXT,
+                amount BIGINT NOT NULL CHECK (amount >= 0),
+                currency TEXT NOT NULL DEFAULT 'gbp',
+                reason TEXT,
+                status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','succeeded','failed','canceled')),
+                refund_type TEXT NOT NULL DEFAULT 'full' CHECK (refund_type IN ('full','partial')),
+                processed_by_user_uuid TEXT,
+                metadata JSONB DEFAULT '{}',
+                created_at TIMESTAMP DEFAULT NOW(),
+                updated_at TIMESTAMP DEFAULT NOW()
+            )
+        ]])
+
+        db.query([[
+            CREATE UNIQUE INDEX idx_billing_refunds_stripe_id ON billing_refunds (stripe_refund_id)
+            WHERE stripe_refund_id IS NOT NULL
+        ]])
+        db.query([[ CREATE INDEX idx_billing_refunds_namespace ON billing_refunds (namespace_id) ]])
+        db.query([[ CREATE INDEX idx_billing_refunds_payment ON billing_refunds (payment_id) ]])
+    end,
+
+    -- ========================================================================
+    -- [6] stripe_webhook_events — idempotency + audit for inbound webhooks
+    -- ========================================================================
+    [6] = function()
+        if table_exists("stripe_webhook_events") then return end
+
+        db.query([[
+            CREATE TABLE stripe_webhook_events (
+                id BIGSERIAL PRIMARY KEY,
+                uuid TEXT UNIQUE NOT NULL,
+                -- Stripe event id (evt_...). UNIQUE = idempotency guard: a replayed
+                -- webhook collides here and is treated as already-processed.
+                event_id TEXT UNIQUE NOT NULL,
+                event_type TEXT NOT NULL,
+                -- Connected account the event belongs to (Connect). NULL = platform event.
+                stripe_account_id TEXT,
+                api_version TEXT,
+                payload JSONB NOT NULL,
+                status TEXT NOT NULL DEFAULT 'received' CHECK (status IN ('received','processed','failed','ignored')),
+                error_message TEXT,
+                attempts INTEGER NOT NULL DEFAULT 0,
+                processed_at TIMESTAMP,
+                created_at TIMESTAMP DEFAULT NOW()
+            )
+        ]])
+
+        db.query([[ CREATE INDEX idx_swe_event_type ON stripe_webhook_events (event_type) ]])
+        db.query([[ CREATE INDEX idx_swe_account ON stripe_webhook_events (stripe_account_id) ]])
+        db.query([[ CREATE INDEX idx_swe_status ON stripe_webhook_events (status) ]])
+        db.query([[ CREATE INDEX idx_swe_created ON stripe_webhook_events USING BRIN (created_at) ]])
+    end,
+
+    -- ========================================================================
+    -- [7] usage_meters — metered entitlement caps (e.g. AI classify per period)
+    -- ========================================================================
+    [7] = function()
+        if table_exists("usage_meters") then return end
+
+        db.query([[
+            CREATE TABLE usage_meters (
+                id BIGSERIAL PRIMARY KEY,
+                uuid TEXT UNIQUE NOT NULL,
+                namespace_id BIGINT NOT NULL REFERENCES namespaces(id) ON DELETE CASCADE,
+                user_uuid TEXT NOT NULL,
+                meter_key TEXT NOT NULL,
+                period_start DATE NOT NULL,
+                period_end DATE NOT NULL,
+                used_count BIGINT NOT NULL DEFAULT 0 CHECK (used_count >= 0),
+                -- NULL = unlimited.
+                limit_count BIGINT,
+                metadata JSONB DEFAULT '{}',
+                created_at TIMESTAMP DEFAULT NOW(),
+                updated_at TIMESTAMP DEFAULT NOW()
+            )
+        ]])
+
+        -- One counter row per (tenant, user, meter, period).
+        db.query([[
+            CREATE UNIQUE INDEX idx_usage_meters_unique
+            ON usage_meters (namespace_id, user_uuid, meter_key, period_start)
+        ]])
+        db.query([[ CREATE INDEX idx_usage_meters_lookup ON usage_meters (namespace_id, user_uuid, meter_key) ]])
+    end,
+}

--- a/lapis/models/BillingPaymentModel.lua
+++ b/lapis/models/BillingPaymentModel.lua
@@ -1,0 +1,5 @@
+-- Payment ledger row (one-time + subscription invoices), namespace-scoped.
+-- Thin Lapis model; business logic lives in queries/BillingPaymentQueries.lua.
+local Model = require("lapis.db.model").Model
+local BillingPayments = Model:extend("billing_payments", { timestamp = true })
+return BillingPayments

--- a/lapis/models/BillingPlanModel.lua
+++ b/lapis/models/BillingPlanModel.lua
@@ -1,0 +1,5 @@
+-- Namespace-scoped billing plan (subscription | one_time).
+-- Thin Lapis model; business logic lives in queries/BillingPlanQueries.lua.
+local Model = require("lapis.db.model").Model
+local BillingPlans = Model:extend("billing_plans", { timestamp = true })
+return BillingPlans

--- a/lapis/models/BillingSubscriptionModel.lua
+++ b/lapis/models/BillingSubscriptionModel.lua
@@ -1,0 +1,5 @@
+-- Recurring subscription row, namespace-scoped.
+-- Thin Lapis model; logic lives in queries/BillingSubscriptionQueries.lua.
+local Model = require("lapis.db.model").Model
+local BillingSubscriptions = Model:extend("billing_subscriptions", { timestamp = true })
+return BillingSubscriptions

--- a/lapis/models/StripeWebhookEventModel.lua
+++ b/lapis/models/StripeWebhookEventModel.lua
@@ -1,0 +1,5 @@
+-- Inbound Stripe webhook event (idempotency + audit).
+-- Thin Lapis model; logic lives in queries/StripeWebhookQueries.lua.
+local Model = require("lapis.db.model").Model
+local StripeWebhookEvents = Model:extend("stripe_webhook_events", { timestamp = false })
+return StripeWebhookEvents

--- a/lapis/queries/BillingPaymentQueries.lua
+++ b/lapis/queries/BillingPaymentQueries.lua
@@ -1,0 +1,80 @@
+--[[
+    Billing Payment Queries
+    =======================
+
+    The payment ledger (`billing_payments`) — one row per checkout/payment
+    attempt. A 'pending' row is created when checkout starts; the webhook
+    (Phase 5) upserts it to its terminal state. The UNIQUE indexes on
+    stripe_payment_intent_id / stripe_checkout_session_id make that idempotent.
+
+    Amounts are MINOR units (pence).
+]]
+
+local BillingPaymentModel = require("models.BillingPaymentModel")
+local Global = require("helper.global")
+local db = require("lapis.db")
+local cjson = require("cjson")
+
+local BillingPaymentQueries = {}
+
+local function as_json(v)
+    if v == nil then return nil end
+    if type(v) == "table" then return cjson.encode(v) end
+    return v
+end
+
+-- Create a pending payment row at checkout start.
+function BillingPaymentQueries.createPending(params)
+    params.uuid = params.uuid or Global.generateUUID()
+    params.status = params.status or "pending"
+    params.provider = params.provider or "stripe"
+    params.payment_type = params.payment_type or "one_time"
+    params.currency = (params.currency or "gbp"):lower()
+    params.amount = math.floor(tonumber(params.amount) or 0)
+    params.application_fee_amount = math.floor(tonumber(params.application_fee_amount) or 0)
+    params.metadata = as_json(params.metadata)
+    params.created_at = db.raw("NOW()")
+    params.updated_at = db.raw("NOW()")
+    return BillingPaymentModel:create(params, { returning = "*" })
+end
+
+function BillingPaymentQueries.getByUuid(uuid)
+    local rows = db.query("SELECT * FROM billing_payments WHERE uuid = ? LIMIT 1", uuid)
+    return rows and rows[1] or nil
+end
+
+function BillingPaymentQueries.getBySessionId(session_id)
+    if not session_id or session_id == "" then return nil end
+    local rows = db.query(
+        "SELECT * FROM billing_payments WHERE stripe_checkout_session_id = ? LIMIT 1", session_id)
+    return rows and rows[1] or nil
+end
+
+function BillingPaymentQueries.getByPaymentIntentId(pi_id)
+    if not pi_id or pi_id == "" then return nil end
+    local rows = db.query(
+        "SELECT * FROM billing_payments WHERE stripe_payment_intent_id = ? LIMIT 1", pi_id)
+    return rows and rows[1] or nil
+end
+
+-- Update a payment by uuid.
+function BillingPaymentQueries.update(uuid, fields)
+    local row = BillingPaymentModel:find({ uuid = uuid })
+    if not row then return nil end
+    fields.updated_at = db.raw("NOW()")
+    if fields.metadata ~= nil then fields.metadata = as_json(fields.metadata) end
+    row:update(fields)
+    return row
+end
+
+-- List a user's payments in a namespace (most recent first).
+function BillingPaymentQueries.listForUser(namespace_id, user_uuid, opts)
+    opts = opts or {}
+    local limit = tonumber(opts.limit) or 50
+    local rows = db.query(
+        "SELECT * FROM billing_payments WHERE namespace_id = ? AND user_uuid = ? " ..
+        "ORDER BY created_at DESC LIMIT ?", namespace_id, user_uuid, limit)
+    return rows or {}
+end
+
+return BillingPaymentQueries

--- a/lapis/queries/BillingPaymentQueries.lua
+++ b/lapis/queries/BillingPaymentQueries.lua
@@ -33,6 +33,8 @@ function BillingPaymentQueries.createPending(params)
     params.amount = math.floor(tonumber(params.amount) or 0)
     params.application_fee_amount = math.floor(tonumber(params.application_fee_amount) or 0)
     params.metadata = as_json(params.metadata)
+    -- Stamp when the money actually settled.
+    if params.status == "succeeded" and params.paid_at == nil then params.paid_at = db.raw("NOW()") end
     params.created_at = db.raw("NOW()")
     params.updated_at = db.raw("NOW()")
     return BillingPaymentModel:create(params, { returning = "*" })
@@ -57,12 +59,20 @@ function BillingPaymentQueries.getByPaymentIntentId(pi_id)
     return rows and rows[1] or nil
 end
 
+function BillingPaymentQueries.getByInvoiceId(invoice_id)
+    if not invoice_id or invoice_id == "" then return nil end
+    local rows = db.query(
+        "SELECT * FROM billing_payments WHERE stripe_invoice_id = ? ORDER BY created_at DESC LIMIT 1", invoice_id)
+    return rows and rows[1] or nil
+end
+
 -- Update a payment by uuid.
 function BillingPaymentQueries.update(uuid, fields)
     local row = BillingPaymentModel:find({ uuid = uuid })
     if not row then return nil end
     fields.updated_at = db.raw("NOW()")
     if fields.metadata ~= nil then fields.metadata = as_json(fields.metadata) end
+    if fields.status == "succeeded" and fields.paid_at == nil then fields.paid_at = db.raw("NOW()") end
     row:update(fields)
     return row
 end

--- a/lapis/queries/BillingPlanQueries.lua
+++ b/lapis/queries/BillingPlanQueries.lua
@@ -1,0 +1,190 @@
+--[[
+    Billing Plan Queries
+    ====================
+
+    CRUD for `billing_plans` (dynamic, namespace-scoped) plus lazy Stripe sync.
+
+    Plans live in our DB as the source of truth; their Stripe Product/Price are
+    created on demand (ensureStripeSync). Prices are immutable in Stripe, so a
+    price-affecting change creates a NEW Price and repoints the plan.
+
+    Amounts are MINOR units (pence) throughout — same as Stripe `unit_amount`.
+]]
+
+local BillingPlanModel = require("models.BillingPlanModel")
+local Global = require("helper.global")
+local db = require("lapis.db")
+local cjson = require("cjson")
+
+local BillingPlanQueries = {}
+
+local VALID_TYPES = { subscription = true, one_time = true }
+local VALID_INTERVALS = { day = true, week = true, month = true, year = true }
+
+-- Validate plan input. Returns (true) or (false, error_message).
+function BillingPlanQueries.validate(params)
+    if not params.name or params.name == "" then
+        return false, "name is required"
+    end
+    local plan_type = params.plan_type or "subscription"
+    if not VALID_TYPES[plan_type] then
+        return false, "plan_type must be 'subscription' or 'one_time'"
+    end
+    local amount = tonumber(params.amount)
+    if not amount or amount < 0 or math.floor(amount) ~= amount then
+        return false, "amount must be a non-negative integer (minor units, e.g. pence)"
+    end
+    if plan_type == "subscription" then
+        if not params.billing_interval or not VALID_INTERVALS[params.billing_interval] then
+            return false, "billing_interval must be one of day|week|month|year for subscriptions"
+        end
+    elseif params.billing_interval ~= nil then
+        return false, "one_time plans must not set billing_interval"
+    end
+    return true
+end
+
+local function encode_features(v)
+    if v == nil then return nil end
+    if type(v) == "table" then return cjson.encode(v) end
+    return v
+end
+
+-- Decode JSONB-ish columns on a row for API responses.
+local function decode_row(row)
+    if not row then return row end
+    if type(row.features) == "string" then
+        local ok, decoded = pcall(cjson.decode, row.features)
+        if ok then row.features = decoded end
+    end
+    if type(row.metadata) == "string" then
+        local ok, decoded = pcall(cjson.decode, row.metadata)
+        if ok then row.metadata = decoded end
+    end
+    return row
+end
+BillingPlanQueries.decode_row = decode_row
+
+-- Create a plan. Caller must have validated and set namespace_id.
+function BillingPlanQueries.create(params)
+    params.uuid = params.uuid or Global.generateUUID()
+    params.plan_type = params.plan_type or "subscription"
+    params.currency = (params.currency or "gbp"):lower()
+    params.interval_count = tonumber(params.interval_count) or 1
+    params.trial_days = tonumber(params.trial_days) or 0
+    params.amount = math.floor(tonumber(params.amount) or 0)
+    params.features = encode_features(params.features)
+    params.metadata = encode_features(params.metadata)
+    params.created_at = db.raw("NOW()")
+    params.updated_at = db.raw("NOW()")
+    return BillingPlanModel:create(params, { returning = "*" })
+end
+
+-- Fetch a plan by uuid (any namespace); caller verifies ownership.
+function BillingPlanQueries.getByUuid(uuid)
+    local rows = db.query(
+        "SELECT * FROM billing_plans WHERE uuid = ? AND deleted_at IS NULL LIMIT 1", uuid)
+    return rows and rows[1] or nil
+end
+
+-- List a namespace's plans. opts.include_inactive, opts.plan_type filter.
+function BillingPlanQueries.listByNamespace(namespace_id, opts)
+    opts = opts or {}
+    local where = { "namespace_id = ?", "deleted_at IS NULL" }
+    local vals = { namespace_id }
+    if not opts.include_inactive then
+        table.insert(where, "active = TRUE")
+    end
+    if opts.plan_type and VALID_TYPES[opts.plan_type] then
+        table.insert(where, "plan_type = ?")
+        table.insert(vals, opts.plan_type)
+    end
+    local sql = "SELECT * FROM billing_plans WHERE " .. table.concat(where, " AND ") ..
+        " ORDER BY sort_order ASC, created_at ASC"
+    local rows = db.query(sql, unpack(vals))
+    for i = 1, #rows do decode_row(rows[i]) end
+    return rows
+end
+
+-- Update a plan by uuid. Returns the updated model or nil.
+function BillingPlanQueries.update(uuid, fields)
+    local plan = BillingPlanModel:find({ uuid = uuid })
+    if not plan then return nil end
+    fields.updated_at = db.raw("NOW()")
+    if fields.features ~= nil then fields.features = encode_features(fields.features) end
+    if fields.metadata ~= nil then fields.metadata = encode_features(fields.metadata) end
+    if fields.amount ~= nil then fields.amount = math.floor(tonumber(fields.amount) or 0) end
+    if fields.currency ~= nil then fields.currency = tostring(fields.currency):lower() end
+    plan:update(fields)
+    return plan
+end
+
+-- Soft delete (and deactivate) a plan.
+function BillingPlanQueries.softDelete(uuid)
+    local plan = BillingPlanModel:find({ uuid = uuid })
+    if not plan then return nil end
+    plan:update({ active = false, deleted_at = db.raw("NOW()"), updated_at = db.raw("NOW()") })
+    return plan
+end
+
+-- Null out the Stripe price id so the next ensureStripeSync mints a fresh
+-- Price (used when a price-affecting field changes — Stripe Prices are
+-- immutable, so the old one is archived and replaced).
+function BillingPlanQueries.clearStripePrice(uuid)
+    local plan = BillingPlanModel:find({ uuid = uuid })
+    if not plan then return nil end
+    plan:update({ stripe_price_id = db.NULL, updated_at = db.raw("NOW()") })
+    return plan
+end
+
+-- Ensure a plan has a Stripe Product + Price (creating them on demand).
+-- Returns (plan, nil) when synced/already-synced, or (plan, error) on failure.
+-- `stripe` is a platform client (no connected account) — destination charges
+-- keep products/prices on the platform account.
+function BillingPlanQueries.ensureStripeSync(plan, stripe)
+    if not plan then return plan, "plan not found" end
+    if plan.stripe_price_id and plan.stripe_price_id ~= "" then
+        return plan, nil
+    end
+
+    local product_id = plan.stripe_product_id
+    if not product_id or product_id == "" then
+        local product, perr = stripe:create_product({
+            name = plan.name,
+            description = plan.description,
+            metadata = { plan_uuid = plan.uuid, namespace_id = tostring(plan.namespace_id) },
+        })
+        if not product or not product.id then
+            return plan, "Failed to create Stripe product: " .. tostring(perr)
+        end
+        product_id = product.id
+    end
+
+    local price_opts = {
+        product = product_id,
+        unit_amount = math.floor(tonumber(plan.amount) or 0),
+        currency = (plan.currency or "gbp"):lower(),
+        metadata = { plan_uuid = plan.uuid },
+    }
+    if plan.plan_type == "subscription" then
+        price_opts.recurring = {
+            interval = plan.billing_interval,
+            interval_count = tonumber(plan.interval_count) or 1,
+        }
+    end
+
+    local price, prerr = stripe:create_price(price_opts)
+    if not price or not price.id then
+        -- Persist the product id so a retry doesn't create a duplicate product.
+        BillingPlanQueries.update(plan.uuid, { stripe_product_id = product_id })
+        return plan, "Failed to create Stripe price: " .. tostring(prerr)
+    end
+
+    local updated = BillingPlanQueries.update(plan.uuid, {
+        stripe_product_id = product_id,
+        stripe_price_id = price.id,
+    })
+    return (updated or plan), nil
+end
+
+return BillingPlanQueries

--- a/lapis/queries/BillingPlanQueries.lua
+++ b/lapis/queries/BillingPlanQueries.lua
@@ -87,6 +87,21 @@ function BillingPlanQueries.getByUuid(uuid)
     return rows and rows[1] or nil
 end
 
+-- Fetch a plan by primary key id.
+function BillingPlanQueries.getById(id)
+    if not id then return nil end
+    local rows = db.query("SELECT * FROM billing_plans WHERE id = ? LIMIT 1", id)
+    return rows and rows[1] or nil
+end
+
+-- Resolve a plan from its Stripe price id (used by subscription webhooks).
+function BillingPlanQueries.getByStripePriceId(price_id)
+    if not price_id or price_id == "" then return nil end
+    local rows = db.query(
+        "SELECT * FROM billing_plans WHERE stripe_price_id = ? AND deleted_at IS NULL LIMIT 1", price_id)
+    return rows and rows[1] or nil
+end
+
 -- List a namespace's plans. opts.include_inactive, opts.plan_type filter.
 function BillingPlanQueries.listByNamespace(namespace_id, opts)
     opts = opts or {}

--- a/lapis/queries/BillingSubscriptionQueries.lua
+++ b/lapis/queries/BillingSubscriptionQueries.lua
@@ -1,0 +1,109 @@
+--[[
+    Billing Subscription Queries
+    ============================
+
+    Upsert + lookup for `billing_subscriptions`. Driven by Stripe webhooks
+    (customer.subscription.* and checkout.session.completed). Keyed by
+    stripe_subscription_id so repeated/out-of-order events converge.
+
+    Stripe sends timestamps as unix seconds; we convert with to_timestamp().
+]]
+
+local BillingSubscriptionModel = require("models.BillingSubscriptionModel")
+local Global = require("helper.global")
+local db = require("lapis.db")
+local cjson = require("cjson")
+
+local BillingSubscriptionQueries = {}
+
+-- unix seconds -> a db.raw to_timestamp(), or nil when absent.
+local function ts(unix)
+    local n = tonumber(unix)
+    if not n or n <= 0 then return nil end
+    return db.raw(string.format("to_timestamp(%d)", math.floor(n)))
+end
+
+function BillingSubscriptionQueries.getByStripeId(sub_id)
+    if not sub_id or sub_id == "" then return nil end
+    local rows = db.query(
+        "SELECT * FROM billing_subscriptions WHERE stripe_subscription_id = ? LIMIT 1", sub_id)
+    return rows and rows[1] or nil
+end
+
+function BillingSubscriptionQueries.getByUuid(uuid)
+    local rows = db.query("SELECT * FROM billing_subscriptions WHERE uuid = ? LIMIT 1", uuid)
+    return rows and rows[1] or nil
+end
+
+-- Most recent subscription for a user in a namespace (any status).
+function BillingSubscriptionQueries.getLatestForUser(namespace_id, user_uuid)
+    local rows = db.query(
+        "SELECT * FROM billing_subscriptions WHERE namespace_id = ? AND user_uuid = ? " ..
+        "ORDER BY created_at DESC LIMIT 1", namespace_id, user_uuid)
+    return rows and rows[1] or nil
+end
+
+-- The user's current entitling subscription (active / trialing / past_due),
+-- most recent first. past_due is still entitling while dunning runs.
+function BillingSubscriptionQueries.getActiveForUser(namespace_id, user_uuid)
+    local rows = db.query(
+        "SELECT * FROM billing_subscriptions WHERE namespace_id = ? AND user_uuid = ? " ..
+        "AND status IN ('active','trialing','past_due') ORDER BY created_at DESC LIMIT 1",
+        namespace_id, user_uuid)
+    return rows and rows[1] or nil
+end
+
+-- Insert or update a subscription keyed by stripe_subscription_id.
+-- fields:
+--   stripe_subscription_id (required), stripe_customer_id, status,
+--   plan_id, namespace_id, user_uuid (required for first insert),
+--   current_period_start/end, canceled_at, trial_end (unix seconds),
+--   cancel_at_period_end (bool), metadata (table)
+-- Returns (model, nil) or (nil, error).
+function BillingSubscriptionQueries.upsert(fields)
+    if not fields.stripe_subscription_id or fields.stripe_subscription_id == "" then
+        return nil, "stripe_subscription_id is required"
+    end
+
+    local set = {
+        updated_at = db.raw("NOW()"),
+    }
+    if fields.stripe_customer_id ~= nil then set.stripe_customer_id = fields.stripe_customer_id end
+    if fields.status ~= nil then set.status = fields.status end
+    if fields.plan_id ~= nil then set.plan_id = fields.plan_id end
+    if fields.cancel_at_period_end ~= nil then set.cancel_at_period_end = fields.cancel_at_period_end == true end
+    if fields.current_period_start ~= nil then set.current_period_start = ts(fields.current_period_start) end
+    if fields.current_period_end ~= nil then set.current_period_end = ts(fields.current_period_end) end
+    if fields.canceled_at ~= nil then set.canceled_at = ts(fields.canceled_at) end
+    if fields.trial_start ~= nil then set.trial_start = ts(fields.trial_start) end
+    if fields.trial_end ~= nil then set.trial_end = ts(fields.trial_end) end
+    if fields.ended_at ~= nil then set.ended_at = ts(fields.ended_at) end
+    if fields.metadata ~= nil then set.metadata = cjson.encode(fields.metadata) end
+    -- Track which webhook event last mutated this row (audit / debugging).
+    if fields.last_event_id ~= nil then
+        set.last_event_id = fields.last_event_id
+        set.last_event_at = db.raw("NOW()")
+    end
+
+    local existing = BillingSubscriptionQueries.getByStripeId(fields.stripe_subscription_id)
+    if existing then
+        local m = BillingSubscriptionModel:find({ id = existing.id })
+        if not m then return nil, "subscription vanished" end
+        m:update(set)
+        return m
+    end
+
+    -- First insert needs the tenant + user (NOT NULL columns).
+    if not fields.namespace_id or not fields.user_uuid then
+        return nil, "namespace_id and user_uuid are required to create a subscription"
+    end
+    set.uuid = Global.generateUUID()
+    set.stripe_subscription_id = fields.stripe_subscription_id
+    set.namespace_id = fields.namespace_id
+    set.user_uuid = fields.user_uuid
+    set.status = fields.status or "incomplete"
+    set.created_at = db.raw("NOW()")
+    return BillingSubscriptionModel:create(set, { returning = "*" })
+end
+
+return BillingSubscriptionQueries

--- a/lapis/queries/StripeWebhookQueries.lua
+++ b/lapis/queries/StripeWebhookQueries.lua
@@ -1,0 +1,53 @@
+--[[
+    Stripe Webhook Queries
+    ======================
+
+    Idempotency + audit for inbound Stripe webhooks. The UNIQUE event_id is the
+    idempotency guard: `recordOnce` inserts with ON CONFLICT DO NOTHING and
+    reports whether THIS delivery is the first one — so a replayed event is a
+    no-op. Handlers then mark the row processed / failed / ignored.
+]]
+
+local Global = require("helper.global")
+local db = require("lapis.db")
+local cjson = require("cjson")
+
+local StripeWebhookQueries = {}
+
+-- Record the event (or bump its attempt count) and return its CURRENT status:
+--   'processed' -> already handled successfully; caller should skip.
+--   'received' | 'failed' -> first delivery or a retry; caller should process.
+-- This makes Stripe retries work: a handler that returned non-2xx left the row
+-- un-'processed', so the next delivery re-runs it (handlers are idempotent).
+function StripeWebhookQueries.beginProcessing(params)
+    local livemode = params.livemode
+    if livemode == nil then livemode = db.NULL end
+    local rows = db.query([[
+        INSERT INTO stripe_webhook_events
+            (uuid, event_id, event_type, api_version, livemode, payload, status, attempts, created_at)
+        VALUES (?, ?, ?, ?, ?, ?::jsonb, 'received', 1, NOW())
+        ON CONFLICT (event_id)
+            DO UPDATE SET attempts = stripe_webhook_events.attempts + 1
+        RETURNING status
+    ]], Global.generateUUID(), params.event_id, params.event_type,
+        params.api_version or db.NULL, livemode, cjson.encode(params.payload or {}))
+    return (rows and rows[1] and rows[1].status) or "received"
+end
+
+function StripeWebhookQueries.markProcessed(event_id)
+    db.query("UPDATE stripe_webhook_events SET status = 'processed', processed_at = NOW() WHERE event_id = ?",
+        event_id)
+end
+
+function StripeWebhookQueries.markIgnored(event_id)
+    db.query("UPDATE stripe_webhook_events SET status = 'ignored', processed_at = NOW() WHERE event_id = ?",
+        event_id)
+end
+
+function StripeWebhookQueries.markFailed(event_id, message)
+    db.query(
+        "UPDATE stripe_webhook_events SET status = 'failed', error_message = ?, processed_at = NOW() WHERE event_id = ?",
+        message and tostring(message):sub(1, 1000) or "error", event_id)
+end
+
+return StripeWebhookQueries

--- a/lapis/routes/billing-account.lua
+++ b/lapis/routes/billing-account.lua
@@ -1,0 +1,133 @@
+--[[
+    Billing — Customer account (the user's own subscription / entitlements)
+    =======================================================================
+
+    Per-user, namespace-scoped. Not owner-gated — every authenticated member
+    manages their OWN subscription here.
+
+    Endpoints:
+      GET  /api/v2/billing/subscription          current subscription + plan inline
+      GET  /api/v2/billing/entitlements          computed snapshot (what they can do)
+      POST /api/v2/billing/subscription/cancel    cancel at period end (keeps access)
+      GET  /api/v2/billing/payments              the user's payment history
+]]
+
+local AuthMiddleware = require("middleware.auth")
+local NamespaceMiddleware = require("middleware.namespace")
+local PaymentProvider = require("lib.payment-provider")
+local EntitlementService = require("helper.entitlement-service")
+local BillingSubscriptionQueries = require("queries.BillingSubscriptionQueries")
+local BillingPlanQueries = require("queries.BillingPlanQueries")
+local BillingPaymentQueries = require("queries.BillingPaymentQueries")
+
+return function(app)
+    local function api_response(status, data, error_msg)
+        if error_msg then
+            return { status = status, json = { success = false, error = error_msg } }
+        end
+        return { status = status, json = { success = true, data = data } }
+    end
+
+    local function truthy(v)
+        return v == true or v == "t" or v == "true" or v == 1
+    end
+
+    local function plan_brief(plan)
+        if not plan then return nil end
+        return {
+            uuid = plan.uuid,
+            name = plan.name,
+            plan_type = plan.plan_type,
+            amount = tonumber(plan.amount),
+            currency = plan.currency,
+            billing_interval = plan.billing_interval,
+            interval_count = tonumber(plan.interval_count),
+        }
+    end
+
+    -- GET /api/v2/billing/subscription — the user's current subscription.
+    app:get("/api/v2/billing/subscription", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requireNamespace(function(self)
+            local sub = BillingSubscriptionQueries.getActiveForUser(self.namespace.id, self.current_user.uuid)
+            if not sub then
+                return api_response(200, { has_subscription = false })
+            end
+            local plan = sub.plan_id and BillingPlanQueries.getById(sub.plan_id) or nil
+            return api_response(200, {
+                has_subscription = true,
+                uuid = sub.uuid,
+                status = sub.status,
+                current_period_start = sub.current_period_start,
+                current_period_end = sub.current_period_end,
+                cancel_at_period_end = truthy(sub.cancel_at_period_end),
+                trial_end = sub.trial_end,
+                plan = plan_brief(plan),
+            })
+        end)
+    ))
+
+    -- GET /api/v2/billing/entitlements — computed snapshot.
+    app:get("/api/v2/billing/entitlements", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requireNamespace(function(self)
+            return api_response(200, EntitlementService.forUser(self.namespace.id, self.current_user.uuid))
+        end)
+    ))
+
+    -- POST /api/v2/billing/subscription/cancel — cancel at period end.
+    app:post("/api/v2/billing/subscription/cancel", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requireNamespace(function(self)
+            local sub = BillingSubscriptionQueries.getActiveForUser(self.namespace.id, self.current_user.uuid)
+            if not sub then
+                return api_response(404, nil, "No active subscription to cancel")
+            end
+            if not sub.stripe_subscription_id or sub.stripe_subscription_id == "" then
+                return api_response(409, nil, "Subscription is not linked to Stripe")
+            end
+
+            local stripe, perr = PaymentProvider.get_stripe()
+            if not stripe then return api_response(503, nil, perr or "Billing is not configured") end
+
+            local res, serr = stripe:cancel_subscription(sub.stripe_subscription_id, true)
+            if not res or not res.id then
+                ngx.log(ngx.ERR, "Cancel subscription failed: " .. tostring(serr))
+                return api_response(502, nil, "Failed to cancel subscription: " .. (serr or "unknown error"))
+            end
+
+            -- Optimistic local update; the customer.subscription.updated webhook
+            -- will also reconcile (idempotent).
+            BillingSubscriptionQueries.upsert({
+                stripe_subscription_id = sub.stripe_subscription_id,
+                cancel_at_period_end = true,
+            })
+
+            return api_response(200, {
+                cancel_at_period_end = true,
+                current_period_end = sub.current_period_end,
+                message = "Your subscription will end at the close of the current period.",
+            })
+        end)
+    ))
+
+    -- GET /api/v2/billing/payments — the user's payment history.
+    app:get("/api/v2/billing/payments", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requireNamespace(function(self)
+            local rows = BillingPaymentQueries.listForUser(self.namespace.id, self.current_user.uuid,
+                { limit = tonumber(self.params.limit) or 50 })
+            local out = {}
+            for i = 1, #rows do
+                local p = rows[i]
+                out[i] = {
+                    uuid = p.uuid,
+                    status = p.status,
+                    payment_type = p.payment_type,
+                    amount = tonumber(p.amount),
+                    currency = p.currency,
+                    paid_at = p.paid_at,
+                    created_at = p.created_at,
+                    receipt_url = p.receipt_url,
+                }
+            end
+            return api_response(200, out)
+        end)
+    ))
+end

--- a/lapis/routes/billing-checkout.lua
+++ b/lapis/routes/billing-checkout.lua
@@ -1,0 +1,277 @@
+--[[
+    Billing — Checkout (subscriptions + one-time)
+    ==============================================
+
+    Standard single-merchant Stripe: the platform's OWN Stripe account
+    (STRIPE_SECRET_KEY in .env) is the merchant — funds settle directly to it.
+    No Stripe Connect / connected accounts. Anyone who self-hosts OpsAPI just
+    sets their own Stripe keys in .env and billing works.
+
+    Works for web (hosted Checkout URL) and mobile (native Payment Sheet via a
+    PaymentIntent client_secret, one-time only).
+
+    success/cancel URLs are server-controlled (our own public callback that
+    302s to the namespace's allow-listed dashboard) — never client-supplied.
+
+    Endpoints:
+      POST /api/v2/billing/checkout                 (auth)   hosted Checkout Session -> { checkout_url }
+      POST /api/v2/billing/checkout/payment-intent  (auth)   native one-time PaymentIntent -> { client_secret }
+      GET  /api/v2/billing/checkout/:session_id     (auth)   session status
+      GET  /api/v2/public/billing/checkout/return   (public) 302 to dashboard (success|cancel)
+
+    Local billing_payments rows are created 'pending' here and reconciled to
+    their terminal state by the webhook; the unique Stripe-id indexes keep that
+    idempotent.
+]]
+
+local cjson = require("cjson")
+local AuthMiddleware = require("middleware.auth")
+local NamespaceMiddleware = require("middleware.namespace")
+local PaymentProvider = require("lib.payment-provider")
+local BillingUrls = require("lib.billing-urls")
+local BillingPlanQueries = require("queries.BillingPlanQueries")
+local BillingPaymentQueries = require("queries.BillingPaymentQueries")
+local NamespaceQueries = require("queries.NamespaceQueries")
+local Global = require("helper.global")
+
+return function(app)
+    local function parse_json_body()
+        ngx.req.read_body()
+        local body = ngx.req.get_body_data()
+        if not body or body == "" then return {} end
+        local ok, data = pcall(cjson.decode, body)
+        return ok and data or {}
+    end
+
+    local function api_response(status, data, error_msg)
+        if error_msg then
+            return { status = status, json = { success = false, error = error_msg } }
+        end
+        return { status = status, json = { success = true, data = data } }
+    end
+
+    local function truthy(v)
+        return v == true or v == "t" or v == "true" or v == 1
+    end
+
+    -- Load the caller's own plan and validate it. Returns (plan) or (nil, status, err).
+    local function load_owned_plan(self, plan_uuid)
+        if not plan_uuid or plan_uuid == "" then
+            return nil, 400, "plan_uuid is required"
+        end
+        local plan = BillingPlanQueries.getByUuid(plan_uuid)
+        if not plan then return nil, 404, "Plan not found" end
+        if tonumber(plan.namespace_id) ~= tonumber(self.namespace.id) then
+            return nil, 403, "Access denied"
+        end
+        if not truthy(plan.active) then
+            return nil, 409, "Plan is not active"
+        end
+        return plan
+    end
+
+    -- Resolve the platform Stripe client and ensure the plan has a synced
+    -- stripe_price_id (product/price created on the platform account on demand).
+    -- Returns (ctx, nil) or (nil, status, err).
+    local function prepare_charge(plan)
+        if not PaymentProvider.stripe_configured() then
+            return nil, 503, "Billing is not configured"
+        end
+        local stripe = PaymentProvider.get_stripe()
+        if not stripe then return nil, 503, "Billing is not configured" end
+
+        local synced, serr = BillingPlanQueries.ensureStripeSync(plan, stripe)
+        if serr or not synced or not synced.stripe_price_id or synced.stripe_price_id == "" then
+            return nil, 502, "Failed to sync plan to Stripe: " .. tostring(serr or "no price")
+        end
+
+        return { stripe = stripe, plan = synced }
+    end
+
+    local function shared_metadata(self, plan)
+        return {
+            namespace_id = tostring(self.namespace.id),
+            namespace_uuid = self.namespace.uuid or "",
+            user_uuid = self.current_user.uuid,
+            plan_uuid = plan.uuid,
+            payment_type = plan.plan_type,
+        }
+    end
+
+    -- ----------------------------------------------------------------------
+    -- POST /api/v2/billing/checkout  (hosted Checkout Session; web + mobile)
+    -- ----------------------------------------------------------------------
+    app:post("/api/v2/billing/checkout", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requireNamespace(function(self)
+            local body = parse_json_body()
+            local plan, pstatus, perr = load_owned_plan(self, body.plan_uuid)
+            if not plan then return api_response(pstatus, nil, perr) end
+
+            local ctx, cstatus, cerr = prepare_charge(plan)
+            if not ctx then return api_response(cstatus, nil, cerr) end
+            plan = ctx.plan
+
+            local base = BillingUrls.opsapi_base()
+            if not base then
+                return api_response(500, nil, "Server public URL not configured (set OPSAPI_PUBLIC_URL)")
+            end
+            local ns_ref = ngx.escape_uri(self.namespace.uuid or tostring(self.namespace.id))
+            -- Stripe substitutes {CHECKOUT_SESSION_ID}; keep it un-escaped.
+            local success_url = base .. "/api/v2/public/billing/checkout/return?ns=" .. ns_ref ..
+                "&result=success&session_id={CHECKOUT_SESSION_ID}"
+            local cancel_url = base .. "/api/v2/public/billing/checkout/return?ns=" .. ns_ref .. "&result=cancel"
+
+            local meta = shared_metadata(self, plan)
+            local opts = {
+                mode = (plan.plan_type == "subscription") and "subscription" or "payment",
+                line_items = { { price = plan.stripe_price_id, quantity = 1 } },
+                success_url = success_url,
+                cancel_url = cancel_url,
+                customer_email = self.current_user.email,
+                client_reference_id = self.current_user.uuid,
+                metadata = meta,
+            }
+
+            if plan.plan_type == "subscription" then
+                local sub = { metadata = meta }
+                local trial = tonumber(plan.trial_days)
+                if trial and trial > 0 then sub.trial_period_days = math.floor(trial) end
+                opts.subscription_data = sub
+            else
+                opts.payment_intent_data = { metadata = meta }
+            end
+
+            local session, serr = ctx.stripe:create_checkout_session(opts)
+            if not session or not session.id then
+                ngx.log(ngx.ERR, "Checkout: create_checkout_session failed: " .. tostring(serr))
+                return api_response(502, nil, "Failed to start checkout: " .. (serr or "unknown error"))
+            end
+
+            -- Pending ledger row (idempotent via unique session index).
+            if not BillingPaymentQueries.getBySessionId(session.id) then
+                BillingPaymentQueries.createPending({
+                    namespace_id = self.namespace.id,
+                    user_uuid = self.current_user.uuid,
+                    plan_id = plan.id,
+                    payment_type = plan.plan_type,
+                    stripe_checkout_session_id = session.id,
+                    amount = plan.amount,
+                    currency = plan.currency,
+                    receipt_email = self.current_user.email,
+                    metadata = { plan_uuid = plan.uuid },
+                })
+            end
+
+            return api_response(200, {
+                session_id = session.id,
+                checkout_url = session.url,
+                mode = opts.mode,
+            })
+        end)
+    ))
+
+    -- ----------------------------------------------------------------------
+    -- POST /api/v2/billing/checkout/payment-intent  (native sheet; one-time)
+    -- ----------------------------------------------------------------------
+    app:post("/api/v2/billing/checkout/payment-intent", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requireNamespace(function(self)
+            local body = parse_json_body()
+            local plan, pstatus, perr = load_owned_plan(self, body.plan_uuid)
+            if not plan then return api_response(pstatus, nil, perr) end
+            if plan.plan_type ~= "one_time" then
+                return api_response(400, nil,
+                    "The native payment sheet supports one-time plans only; use /checkout for subscriptions")
+            end
+
+            local ctx, cstatus, cerr = prepare_charge(plan)
+            if not ctx then return api_response(cstatus, nil, cerr) end
+            plan = ctx.plan
+
+            local meta = shared_metadata(self, plan)
+            local pi, serr = ctx.stripe:create_payment_intent_minor({
+                amount = plan.amount,
+                currency = plan.currency,
+                receipt_email = self.current_user.email,
+                description = plan.name,
+                metadata = meta,
+            })
+            if not pi or not pi.id then
+                ngx.log(ngx.ERR, "Checkout PI: create_payment_intent_minor failed: " .. tostring(serr))
+                return api_response(502, nil, "Failed to start payment: " .. (serr or "unknown error"))
+            end
+
+            if not BillingPaymentQueries.getByPaymentIntentId(pi.id) then
+                BillingPaymentQueries.createPending({
+                    namespace_id = self.namespace.id,
+                    user_uuid = self.current_user.uuid,
+                    plan_id = plan.id,
+                    payment_type = "one_time",
+                    stripe_payment_intent_id = pi.id,
+                    amount = plan.amount,
+                    currency = plan.currency,
+                    receipt_email = self.current_user.email,
+                    metadata = { plan_uuid = plan.uuid },
+                })
+            end
+
+            return api_response(200, {
+                payment_intent_id = pi.id,
+                client_secret = pi.client_secret,
+                publishable_key = PaymentProvider.stripe_config().publishable_key,
+                amount = tonumber(plan.amount),
+                currency = plan.currency,
+            })
+        end)
+    ))
+
+    -- ----------------------------------------------------------------------
+    -- GET /api/v2/billing/checkout/:session_id  (status)
+    -- ----------------------------------------------------------------------
+    app:get("/api/v2/billing/checkout/:session_id", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requireNamespace(function(self)
+            local stripe = PaymentProvider.get_stripe()
+            if not stripe then return api_response(503, nil, "Billing is not configured") end
+
+            local session = stripe:retrieve_checkout_session(self.params.session_id)
+            if not session or not session.id then
+                return api_response(404, nil, "Checkout session not found")
+            end
+            -- Tenant isolation: the session metadata must match this namespace.
+            local meta_ns = session.metadata and session.metadata.namespace_id
+            if meta_ns and tostring(meta_ns) ~= tostring(self.namespace.id) then
+                return api_response(403, nil, "Access denied")
+            end
+
+            return api_response(200, {
+                session_id = session.id,
+                status = session.status,
+                payment_status = session.payment_status,
+                subscription = session.subscription,
+                payment_intent = type(session.payment_intent) == "table"
+                    and session.payment_intent.id or session.payment_intent,
+            })
+        end)
+    ))
+
+    -- ----------------------------------------------------------------------
+    -- GET /api/v2/public/billing/checkout/return  (browser redirect target)
+    -- Pure, safe redirect to the namespace's allow-listed dashboard.
+    -- ----------------------------------------------------------------------
+    app:get("/api/v2/public/billing/checkout/return", function(self)
+        local result = self.params.result or "return"
+        local target
+        local ns = self.params.ns
+        if ns and ns ~= "" then
+            local namespace = NamespaceQueries.findByIdentifier(ns)
+            if namespace then
+                target = BillingUrls.dashboard_url(namespace.id, "BILLING_DASHBOARD_PATH", "/settings/billing",
+                    { checkout = result, session_id = self.params.session_id })
+            end
+        end
+        if not target then
+            local fe = Global.getEnvVar("FRONTEND_URL")
+            target = (fe and fe ~= "" and (fe:gsub("/+$", "") .. "/?checkout=" .. result)) or "/"
+        end
+        return { redirect_to = target }
+    end)
+end

--- a/lapis/routes/billing-plans.lua
+++ b/lapis/routes/billing-plans.lua
@@ -1,0 +1,313 @@
+--[[
+    Billing — Plans catalogue
+    =========================
+
+    Dynamic, namespace-scoped plans (subscription | one_time) with lazy Stripe
+    Product/Price sync. Plans are our source of truth; Stripe objects are
+    created on demand and re-pointed when a price-affecting field changes
+    (Stripe Prices are immutable).
+
+    Endpoints:
+      POST   /api/v2/billing/plans              (auth, owner)  create
+      GET    /api/v2/billing/plans              (auth)         list (namespace)
+      GET    /api/v2/billing/plans/:uuid        (auth)         get one
+      PUT    /api/v2/billing/plans/:uuid        (auth, owner)  update
+      DELETE /api/v2/billing/plans/:uuid        (auth, owner)  soft delete
+      POST   /api/v2/billing/plans/:uuid/sync   (auth, owner)  retry Stripe sync
+      GET    /api/v2/public/billing/plans?ns=…  (public)       active plans (pricing page)
+
+    Amounts are MINOR units (pence).
+]]
+
+local cjson = require("cjson")
+local AuthMiddleware = require("middleware.auth")
+local NamespaceMiddleware = require("middleware.namespace")
+local PaymentProvider = require("lib.payment-provider")
+local BillingPlanQueries = require("queries.BillingPlanQueries")
+local NamespaceQueries = require("queries.NamespaceQueries")
+
+-- Fields whose change requires a new Stripe Price (Prices are immutable).
+local PRICE_FIELDS = { "amount", "currency", "billing_interval", "interval_count", "plan_type" }
+
+return function(app)
+    local function parse_json_body()
+        ngx.req.read_body()
+        local body = ngx.req.get_body_data()
+        if not body or body == "" then return {} end
+        local ok, data = pcall(cjson.decode, body)
+        return ok and data or {}
+    end
+
+    local function api_response(status, data, error_msg)
+        if error_msg then
+            return { status = status, json = { success = false, error = error_msg } }
+        end
+        return { status = status, json = { success = true, data = data } }
+    end
+
+    -- Billing management is a namespace-admin action: the owner, a platform
+    -- admin, or anyone holding the namespace.manage permission. (hasPermission
+    -- already returns true for owners and platform admins.)
+    local function is_manager(self)
+        return NamespaceMiddleware.hasPermission(self, "namespace", "manage")
+    end
+
+    -- Public projection — never leak Stripe ids or internal columns.
+    local function public_plan(p)
+        return {
+            uuid = p.uuid,
+            name = p.name,
+            description = p.description,
+            plan_type = p.plan_type,
+            amount = tonumber(p.amount),
+            currency = p.currency,
+            billing_interval = p.billing_interval,
+            interval_count = tonumber(p.interval_count),
+            trial_days = tonumber(p.trial_days),
+            features = p.features,
+        }
+    end
+
+    -- Best-effort Stripe sync for a freshly created/updated plan. Never throws;
+    -- returns a sync_error string (or nil) to surface in the response.
+    local function try_sync(plan)
+        if not PaymentProvider.stripe_configured() then
+            return nil, "Stripe not configured; plan saved without a Stripe price"
+        end
+        local stripe = PaymentProvider.get_stripe()
+        if not stripe then return nil, "Stripe not configured" end
+        local _, serr = BillingPlanQueries.ensureStripeSync(plan, stripe)
+        return BillingPlanQueries.getByUuid(plan.uuid), serr
+    end
+
+    -- ----------------------------------------------------------------------
+    -- POST /api/v2/billing/plans
+    -- ----------------------------------------------------------------------
+    app:post("/api/v2/billing/plans", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requireNamespace(function(self)
+            if not is_manager(self) then
+                return api_response(403, nil, "Only a namespace owner can manage plans")
+            end
+            local body = parse_json_body()
+
+            local ok, verr = BillingPlanQueries.validate(body)
+            if not ok then
+                return api_response(400, nil, verr)
+            end
+
+            local plan = BillingPlanQueries.create({
+                namespace_id = self.namespace.id,
+                name = body.name,
+                description = body.description,
+                plan_type = body.plan_type or "subscription",
+                amount = body.amount,
+                currency = body.currency or "gbp",
+                billing_interval = body.billing_interval,
+                interval_count = body.interval_count,
+                trial_days = body.trial_days,
+                features = body.features,
+                active = (body.active ~= false),
+                sort_order = tonumber(body.sort_order) or 0,
+                metadata = body.metadata,
+            })
+            if not plan then
+                return api_response(500, nil, "Failed to create plan")
+            end
+
+            local synced, sync_error = try_sync(plan)
+            local row = BillingPlanQueries.decode_row(synced or BillingPlanQueries.getByUuid(plan.uuid))
+            return {
+                status = 201,
+                json = { success = true, data = row, sync_error = sync_error },
+            }
+        end)
+    ))
+
+    -- ----------------------------------------------------------------------
+    -- GET /api/v2/billing/plans
+    -- ----------------------------------------------------------------------
+    app:get("/api/v2/billing/plans", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requireNamespace(function(self)
+            local plans = BillingPlanQueries.listByNamespace(self.namespace.id, {
+                include_inactive = self.params.include_inactive == "true",
+                plan_type = self.params.plan_type,
+            })
+            return api_response(200, plans)
+        end)
+    ))
+
+    -- ----------------------------------------------------------------------
+    -- GET /api/v2/billing/plans/:uuid
+    -- ----------------------------------------------------------------------
+    app:get("/api/v2/billing/plans/:uuid", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requireNamespace(function(self)
+            local plan = BillingPlanQueries.getByUuid(self.params.uuid)
+            if not plan then
+                return api_response(404, nil, "Plan not found")
+            end
+            if tonumber(plan.namespace_id) ~= tonumber(self.namespace.id) then
+                return api_response(403, nil, "Access denied")
+            end
+            return api_response(200, BillingPlanQueries.decode_row(plan))
+        end)
+    ))
+
+    -- ----------------------------------------------------------------------
+    -- PUT /api/v2/billing/plans/:uuid
+    -- ----------------------------------------------------------------------
+    app:put("/api/v2/billing/plans/:uuid", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requireNamespace(function(self)
+            if not is_manager(self) then
+                return api_response(403, nil, "Only a namespace owner can manage plans")
+            end
+            local plan = BillingPlanQueries.getByUuid(self.params.uuid)
+            if not plan then
+                return api_response(404, nil, "Plan not found")
+            end
+            if tonumber(plan.namespace_id) ~= tonumber(self.namespace.id) then
+                return api_response(403, nil, "Access denied")
+            end
+
+            local body = parse_json_body()
+
+            -- Validate the merged result so partial updates stay consistent.
+            local merged = {
+                name = body.name ~= nil and body.name or plan.name,
+                plan_type = body.plan_type ~= nil and body.plan_type or plan.plan_type,
+                amount = body.amount ~= nil and body.amount or plan.amount,
+                billing_interval = body.billing_interval ~= nil and body.billing_interval or plan.billing_interval,
+            }
+            local ok, verr = BillingPlanQueries.validate(merged)
+            if not ok then
+                return api_response(400, nil, verr)
+            end
+
+            -- Did a price-affecting field change?
+            local price_changed = false
+            for _, f in ipairs(PRICE_FIELDS) do
+                if body[f] ~= nil and tostring(body[f]) ~= tostring(plan[f]) then
+                    price_changed = true
+                    break
+                end
+            end
+
+            local fields = {}
+            for _, f in ipairs({ "name", "description", "plan_type", "amount", "currency",
+                "billing_interval", "interval_count", "trial_days", "features", "sort_order", "metadata" }) do
+                if body[f] ~= nil then fields[f] = body[f] end
+            end
+            if body.active ~= nil then fields.active = (body.active == true) end
+
+            local sync_error
+            local updated = BillingPlanQueries.update(self.params.uuid, fields)
+            if not updated then
+                return api_response(500, nil, "Failed to update plan")
+            end
+
+            -- Reconcile Stripe (best-effort): update the product, and when a
+            -- price-affecting field changed, archive the old (immutable) price
+            -- and let ensureStripeSync create a fresh one.
+            if PaymentProvider.stripe_configured() then
+                local stripe = PaymentProvider.get_stripe()
+                if stripe then
+                    if plan.stripe_product_id and plan.stripe_product_id ~= ""
+                        and (body.name ~= nil or body.description ~= nil) then
+                        stripe:update_product(plan.stripe_product_id,
+                            { name = updated.name, description = updated.description })
+                    end
+                    if price_changed and plan.stripe_price_id and plan.stripe_price_id ~= "" then
+                        stripe:update_price(plan.stripe_price_id, { active = false })
+                        BillingPlanQueries.clearStripePrice(self.params.uuid)
+                    end
+                    local _, serr = BillingPlanQueries.ensureStripeSync(
+                        BillingPlanQueries.getByUuid(self.params.uuid), stripe)
+                    sync_error = serr
+                end
+            end
+
+            local row = BillingPlanQueries.decode_row(BillingPlanQueries.getByUuid(self.params.uuid))
+            return { status = 200, json = { success = true, data = row, sync_error = sync_error } }
+        end)
+    ))
+
+    -- ----------------------------------------------------------------------
+    -- DELETE /api/v2/billing/plans/:uuid
+    -- ----------------------------------------------------------------------
+    app:delete("/api/v2/billing/plans/:uuid", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requireNamespace(function(self)
+            if not is_manager(self) then
+                return api_response(403, nil, "Only a namespace owner can manage plans")
+            end
+            local plan = BillingPlanQueries.getByUuid(self.params.uuid)
+            if not plan then
+                return api_response(404, nil, "Plan not found")
+            end
+            if tonumber(plan.namespace_id) ~= tonumber(self.namespace.id) then
+                return api_response(403, nil, "Access denied")
+            end
+
+            -- Best-effort archive the Stripe product/price so it can't be bought.
+            if PaymentProvider.stripe_configured() then
+                local stripe = PaymentProvider.get_stripe()
+                if stripe then
+                    if plan.stripe_price_id and plan.stripe_price_id ~= "" then
+                        stripe:update_price(plan.stripe_price_id, { active = false })
+                    end
+                    if plan.stripe_product_id and plan.stripe_product_id ~= "" then
+                        stripe:update_product(plan.stripe_product_id, { active = false })
+                    end
+                end
+            end
+
+            BillingPlanQueries.softDelete(self.params.uuid)
+            return api_response(200, { message = "Plan deleted" })
+        end)
+    ))
+
+    -- ----------------------------------------------------------------------
+    -- POST /api/v2/billing/plans/:uuid/sync — retry Stripe sync
+    -- ----------------------------------------------------------------------
+    app:post("/api/v2/billing/plans/:uuid/sync", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requireNamespace(function(self)
+            if not is_manager(self) then
+                return api_response(403, nil, "Only a namespace owner can manage plans")
+            end
+            local plan = BillingPlanQueries.getByUuid(self.params.uuid)
+            if not plan then
+                return api_response(404, nil, "Plan not found")
+            end
+            if tonumber(plan.namespace_id) ~= tonumber(self.namespace.id) then
+                return api_response(403, nil, "Access denied")
+            end
+            if not PaymentProvider.stripe_configured() then
+                return api_response(503, nil, "Billing is not configured")
+            end
+            local stripe = PaymentProvider.get_stripe()
+            local _, serr = BillingPlanQueries.ensureStripeSync(plan, stripe)
+            if serr then
+                return api_response(502, nil, serr)
+            end
+            return api_response(200, BillingPlanQueries.decode_row(BillingPlanQueries.getByUuid(self.params.uuid)))
+        end)
+    ))
+
+    -- ----------------------------------------------------------------------
+    -- GET /api/v2/public/billing/plans?ns=<namespace_uuid|slug> — pricing page
+    -- ----------------------------------------------------------------------
+    app:get("/api/v2/public/billing/plans", function(self)
+        local ns = self.params.ns
+        if not ns or ns == "" then
+            return api_response(400, nil, "ns (namespace) is required")
+        end
+        local namespace = NamespaceQueries.findByIdentifier(ns)
+        if not namespace then
+            return api_response(404, nil, "Namespace not found")
+        end
+        local plans = BillingPlanQueries.listByNamespace(namespace.id, { include_inactive = false })
+        local out = {}
+        for i = 1, #plans do
+            out[i] = public_plan(plans[i])
+        end
+        return api_response(200, out)
+    end)
+end

--- a/lapis/routes/billing-webhook.lua
+++ b/lapis/routes/billing-webhook.lua
@@ -1,0 +1,328 @@
+--[[
+    Billing — Stripe webhook (single-merchant)
+    ==========================================
+
+    The authoritative, server-to-server source of truth. Stripe POSTs events
+    here; we verify the signature, dedupe, and reconcile billing_payments /
+    billing_subscriptions to their terminal state.
+
+    POST /api/v2/public/billing/webhook   (public, auth-exempt via /public/)
+
+    Security & reliability:
+      - Signature verified against STRIPE_WEBHOOK_SECRET over the RAW body.
+      - Idempotent: stripe_webhook_events.event_id is unique; an event already
+        marked 'processed' is skipped, but 'received'/'failed' re-runs on retry.
+      - Handlers are idempotent (keyed by Stripe ids), so reprocessing is safe.
+      - We return 2xx once handled; 5xx on a handler error so Stripe retries.
+
+    Handled events:
+      checkout.session.completed
+      customer.subscription.created | .updated | .deleted
+      invoice.paid | invoice.payment_failed
+      payment_intent.succeeded | payment_intent.payment_failed
+      charge.refunded
+]]
+
+local cjson = require("cjson")
+local Stripe = require("lib.stripe")
+local PaymentProvider = require("lib.payment-provider")
+local StripeWebhookQueries = require("queries.StripeWebhookQueries")
+local BillingPaymentQueries = require("queries.BillingPaymentQueries")
+local BillingSubscriptionQueries = require("queries.BillingSubscriptionQueries")
+local BillingPlanQueries = require("queries.BillingPlanQueries")
+
+-- Treat JSON null / empty string as nil.
+local function nz(v)
+    if v == nil or v == cjson.null or v == "" then return nil end
+    return v
+end
+
+-- A Stripe field that may be a bare id string or an expanded object.
+local function id_of(v)
+    v = nz(v)
+    if type(v) == "table" then return nz(v.id) end
+    return v
+end
+
+-- Resolve { namespace_id, user_uuid, plan_id } from a Stripe object's metadata.
+local function context_from_metadata(meta)
+    meta = meta or {}
+    local plan_id
+    local plan_uuid = nz(meta.plan_uuid)
+    if plan_uuid then
+        local plan = BillingPlanQueries.getByUuid(plan_uuid)
+        if plan then plan_id = plan.id end
+    end
+    return {
+        namespace_id = tonumber(nz(meta.namespace_id)),
+        user_uuid = nz(meta.user_uuid),
+        plan_id = plan_id,
+    }
+end
+
+-- ── Event handlers ──────────────────────────────────────────────────────────
+-- Each receives the event's data.object and may raise on a hard failure
+-- (caller pcall's them and returns 5xx so Stripe retries).
+
+local handlers = {}
+
+function handlers.checkout_session_completed(session)
+    local meta = session.metadata or {}
+    local ctx = context_from_metadata(meta)
+    local paid = nz(session.payment_status) == "paid"
+
+    -- For a subscription checkout, ensure the subscription row exists and link it.
+    local subscription_row_id
+    if nz(session.mode) == "subscription" and id_of(session.subscription) then
+        local sub, serr = BillingSubscriptionQueries.upsert({
+            stripe_subscription_id = id_of(session.subscription),
+            stripe_customer_id = id_of(session.customer),
+            status = "active",
+            plan_id = ctx.plan_id,
+            namespace_id = ctx.namespace_id,
+            user_uuid = ctx.user_uuid,
+            metadata = meta,
+        })
+        if sub then subscription_row_id = sub.id end
+        if serr then ngx.log(ngx.WARN, "webhook checkout: subscription upsert: " .. tostring(serr)) end
+    end
+
+    local fields = {
+        status = paid and "succeeded" or "processing",
+        stripe_payment_intent_id = id_of(session.payment_intent),
+        stripe_customer_id = id_of(session.customer),
+        stripe_invoice_id = id_of(session.invoice),
+        subscription_id = subscription_row_id,
+    }
+
+    local existing = BillingPaymentQueries.getBySessionId(session.id)
+    if existing then
+        BillingPaymentQueries.update(existing.uuid, fields)
+    elseif ctx.namespace_id then
+        -- No pending row (e.g. created out-of-band) — record it now.
+        BillingPaymentQueries.createPending({
+            namespace_id = ctx.namespace_id,
+            user_uuid = ctx.user_uuid,
+            plan_id = ctx.plan_id,
+            payment_type = nz(meta.payment_type) or (nz(session.mode) == "subscription" and "subscription" or "one_time"),
+            stripe_checkout_session_id = session.id,
+            stripe_payment_intent_id = fields.stripe_payment_intent_id,
+            stripe_customer_id = fields.stripe_customer_id,
+            stripe_invoice_id = fields.stripe_invoice_id,
+            subscription_id = subscription_row_id,
+            amount = tonumber(session.amount_total) or 0,
+            currency = nz(session.currency) or "gbp",
+            status = fields.status,
+        })
+    end
+end
+
+local function upsert_subscription_from_object(sub, deleted, event)
+    local meta = sub.metadata or {}
+    local ctx = context_from_metadata(meta)
+
+    -- The first item carries the price and (in 2025+ Stripe API versions) the
+    -- period boundaries that used to live on the subscription object itself.
+    local item = sub.items and sub.items.data and sub.items.data[1]
+
+    -- Resolve the plan from metadata, else from the item's price.
+    local plan_id = ctx.plan_id
+    if not plan_id and item and item.price then
+        local plan = BillingPlanQueries.getByStripePriceId(id_of(item.price))
+        if plan then plan_id = plan.id end
+    end
+
+    -- Period dates: top-level (older API) OR on the item (newer API).
+    local period_start = nz(sub.current_period_start) or (item and nz(item.current_period_start))
+    local period_end = nz(sub.current_period_end) or (item and nz(item.current_period_end))
+
+    local _, err = BillingSubscriptionQueries.upsert({
+        stripe_subscription_id = sub.id,
+        stripe_customer_id = id_of(sub.customer),
+        status = deleted and "canceled" or nz(sub.status),
+        plan_id = plan_id,
+        namespace_id = ctx.namespace_id,
+        user_uuid = ctx.user_uuid,
+        current_period_start = period_start,
+        current_period_end = period_end,
+        cancel_at_period_end = sub.cancel_at_period_end,
+        canceled_at = nz(sub.canceled_at),
+        trial_start = nz(sub.trial_start),
+        trial_end = nz(sub.trial_end),
+        ended_at = deleted and (nz(sub.ended_at) or os.time()) or nz(sub.ended_at),
+        metadata = meta,
+        last_event_id = event and event.id,
+    })
+    if err then ngx.log(ngx.WARN, "webhook subscription upsert: " .. tostring(err)) end
+end
+
+function handlers.customer_subscription_created(sub, event) upsert_subscription_from_object(sub, false, event) end
+function handlers.customer_subscription_updated(sub, event) upsert_subscription_from_object(sub, false, event) end
+function handlers.customer_subscription_deleted(sub, event) upsert_subscription_from_object(sub, true, event) end
+
+function handlers.invoice_paid(invoice)
+    local sub_id = id_of(invoice.subscription)
+    local pi_id = id_of(invoice.payment_intent)
+    local invoice_id = id_of(invoice.id)
+    local sub = sub_id and BillingSubscriptionQueries.getByStripeId(sub_id) or nil
+
+    local enrich = {
+        status = "succeeded",
+        stripe_payment_intent_id = pi_id,
+        stripe_invoice_id = invoice_id,
+        stripe_customer_id = id_of(invoice.customer),
+        receipt_url = nz(invoice.hosted_invoice_url),
+        subscription_id = sub and sub.id or nil,
+    }
+
+    -- Prefer enriching the existing row (the checkout row carries the invoice id,
+    -- or a prior attempt carries the PI) so we don't create a duplicate charge.
+    local existing = (invoice_id and BillingPaymentQueries.getByInvoiceId(invoice_id))
+        or (pi_id and BillingPaymentQueries.getByPaymentIntentId(pi_id))
+    if existing then
+        BillingPaymentQueries.update(existing.uuid, enrich)
+        return
+    end
+
+    -- No existing row (e.g. a renewal) — record it. Needs tenant context.
+    if sub then
+        BillingPaymentQueries.createPending({
+            namespace_id = sub.namespace_id,
+            user_uuid = sub.user_uuid,
+            plan_id = sub.plan_id,
+            subscription_id = sub.id,
+            payment_type = "subscription",
+            stripe_payment_intent_id = pi_id,
+            stripe_invoice_id = invoice_id,
+            stripe_customer_id = id_of(invoice.customer),
+            amount = tonumber(invoice.amount_paid) or 0,
+            currency = nz(invoice.currency) or "gbp",
+            receipt_url = nz(invoice.hosted_invoice_url),
+            status = "succeeded",
+        })
+    end
+end
+
+function handlers.invoice_payment_failed(invoice)
+    local sub_id = id_of(invoice.subscription)
+    if sub_id then
+        local sub = BillingSubscriptionQueries.getByStripeId(sub_id)
+        if sub and sub.status ~= "canceled" then
+            BillingSubscriptionQueries.upsert({ stripe_subscription_id = sub_id, status = "past_due" })
+        end
+    end
+end
+
+local function finalize_payment_intent(pi, status)
+    -- Match by PI id (native one-time flow) OR by the invoice this PI paid
+    -- (subscription flow — the checkout/invoice row has no PI id yet), so we
+    -- backfill the PI id + card details onto subscription payments too.
+    local row = BillingPaymentQueries.getByPaymentIntentId(pi.id)
+        or (id_of(pi.invoice) and BillingPaymentQueries.getByInvoiceId(id_of(pi.invoice))) or nil
+    local fields = { status = status, stripe_payment_intent_id = pi.id, stripe_customer_id = id_of(pi.customer) }
+
+    -- `charges` is deprecated in newer API versions in favour of latest_charge
+    -- (an id, not expanded) — so card details may be absent from the payload.
+    local charge = pi.charges and pi.charges.data and pi.charges.data[1]
+    if charge then
+        fields.stripe_charge_id = id_of(charge.id)
+        fields.receipt_url = nz(charge.receipt_url)
+        local card = charge.payment_method_details and charge.payment_method_details.card
+        if card then
+            fields.payment_method_type = "card"
+            fields.card_brand = nz(card.brand)
+            fields.card_last4 = nz(card.last4)
+        end
+    end
+    if status == "failed" and pi.last_payment_error then
+        fields.failure_code = nz(pi.last_payment_error.code)
+        fields.failure_message = nz(pi.last_payment_error.message)
+    end
+
+    if row then
+        BillingPaymentQueries.update(row.uuid, fields)
+    end
+end
+
+function handlers.payment_intent_succeeded(pi) finalize_payment_intent(pi, "succeeded") end
+function handlers.payment_intent_payment_failed(pi) finalize_payment_intent(pi, "failed") end
+
+function handlers.charge_refunded(charge)
+    local pi_id = id_of(charge.payment_intent)
+    if not pi_id then return end
+    local row = BillingPaymentQueries.getByPaymentIntentId(pi_id)
+    if not row then return end
+    local refunded = tonumber(charge.amount_refunded) or 0
+    local total = tonumber(charge.amount) or 0
+    BillingPaymentQueries.update(row.uuid, {
+        status = (total > 0 and refunded >= total) and "refunded" or "partially_refunded",
+    })
+end
+
+-- Map Stripe event types to handler keys.
+local DISPATCH = {
+    ["checkout.session.completed"] = handlers.checkout_session_completed,
+    ["customer.subscription.created"] = handlers.customer_subscription_created,
+    ["customer.subscription.updated"] = handlers.customer_subscription_updated,
+    ["customer.subscription.deleted"] = handlers.customer_subscription_deleted,
+    ["invoice.paid"] = handlers.invoice_paid,
+    ["invoice.payment_succeeded"] = handlers.invoice_paid,
+    ["invoice.payment_failed"] = handlers.invoice_payment_failed,
+    ["payment_intent.succeeded"] = handlers.payment_intent_succeeded,
+    ["payment_intent.payment_failed"] = handlers.payment_intent_payment_failed,
+    ["charge.refunded"] = handlers.charge_refunded,
+}
+
+return function(app)
+    app:post("/api/v2/public/billing/webhook", function(self)
+        local cfg = PaymentProvider.stripe_config()
+        if not cfg.webhook_secret or cfg.webhook_secret == "" then
+            ngx.log(ngx.ERR, "Stripe webhook: STRIPE_WEBHOOK_SECRET not configured")
+            return { status = 503, json = { error = "Webhook not configured" } }
+        end
+
+        -- Verify the signature over the RAW body.
+        ngx.req.read_body()
+        local body = ngx.req.get_body_data()
+        if not body then
+            return { status = 400, json = { error = "Empty body" } }
+        end
+        local sig = ngx.req.get_headers()["stripe-signature"]
+
+        local event, verr = Stripe.construct_event(body, sig, cfg.webhook_secret)
+        if not event then
+            ngx.log(ngx.WARN, "Stripe webhook: signature verification failed: " .. tostring(verr))
+            return { status = 400, json = { error = "Invalid signature" } }
+        end
+
+        -- Idempotency / retry-safety.
+        local prior = StripeWebhookQueries.beginProcessing({
+            event_id = event.id,
+            event_type = event.type,
+            api_version = event.api_version,
+            livemode = event.livemode,
+            payload = event,
+        })
+        if prior == "processed" then
+            return { status = 200, json = { received = true, duplicate = true } }
+        end
+
+        local handler = DISPATCH[event.type]
+        if not handler then
+            StripeWebhookQueries.markIgnored(event.id)
+            return { status = 200, json = { received = true, ignored = event.type } }
+        end
+
+        local object = event.data and event.data.object or {}
+        local ok, herr = pcall(handler, object, event)
+        if not ok then
+            ngx.log(ngx.ERR, "Stripe webhook handler error for ", event.type, ": ", tostring(herr))
+            StripeWebhookQueries.markFailed(event.id, herr)
+            -- 5xx so Stripe retries; beginProcessing left it un-'processed'.
+            return { status = 500, json = { error = "Handler failed" } }
+        end
+
+        StripeWebhookQueries.markProcessed(event.id)
+        return { status = 200, json = { received = true } }
+    end)
+end

--- a/start.sh
+++ b/start.sh
@@ -1177,9 +1177,23 @@ else
     })"
 fi
 
-if ! run_lapis_exec "$SETUP_LUA_CMD"; then
+# The setup script is idempotent. `lapis exec` occasionally hits an
+# intermittent OpenResty worker crash (SIGSEGV) on a cold/just-reloaded worker;
+# nginx respawns the worker, so a retry reliably succeeds. Retry a few times
+# before giving up rather than failing the whole start on a transient blip.
+SETUP_OK=false
+for attempt in 1 2 3; do
+    if run_lapis_exec "$SETUP_LUA_CMD"; then
+        SETUP_OK=true
+        break
+    fi
+    echo -e "${YELLOW}[!] Namespace setup attempt ${attempt}/3 failed (transient worker crash); retrying...${NC}"
+    sleep 2
+done
+
+if ! $SETUP_OK; then
     echo ""
-    echo -e "${RED}[!] Namespace setup failed. Inspect container logs:${NC}"
+    echo -e "${RED}[!] Namespace setup failed after 3 attempts. Inspect container logs:${NC}"
     echo -e "${YELLOW}    docker logs ${CONTAINER_NAME}${NC}"
     exit 1
 fi


### PR DESCRIPTION
Builds on the merged single-merchant billing foundation (plans + checkout). Adds the server-to-server reconciliation layer, customer subscription management, and entitlements. Stripe (mirrored via webhooks) is the source of truth.

## Webhooks — `POST /api/v2/public/billing/webhook` (public)
- Signature-verified over the **raw body** (`STRIPE_WEBHOOK_SECRET`) → 400 on mismatch.
- **Idempotent + retry-safe**: `stripe_webhook_events.event_id` unique; `beginProcessing` returns prior status (already-`processed` → skip), 5xx on handler error so Stripe retries (handlers are idempotent upserts).
- Reconciles `checkout.session.completed`, `customer.subscription.created/updated/deleted`, `invoice.paid`/`payment_failed`, `payment_intent.succeeded`/`failed`, `charge.refunded` into `billing_payments` + `billing_subscriptions`.

## Customer account — `routes/billing-account.lua`
- `GET /billing/subscription`, `GET /billing/entitlements`, `POST /billing/subscription/cancel` (at period end), `GET /billing/payments`.
- `helper/entitlement-service.lua` computes a fresh entitlement snapshot from the active subscription's plan `features` (`can()` / `limit()` helpers).

## Data-completeness (migration `707`, `ADD COLUMN IF NOT EXISTS`)
- subscriptions: `last_event_id`/`last_event_at`, `trial_start`, `ended_at`; payments: `paid_at`; webhook events: `livemode`.
- **Fixes NULL `current_period_*`** — subscription period dates now read from `items.data[]` (newer Stripe API moved them off the subscription top-level).
- `invoice.paid` enriches the existing payment row (PI + receipt) instead of duplicating; `paid_at` auto-stamped on success.

## Cleanup
- Migration `708` drops the dead `namespace_payment_accounts` table (Stripe Connect dropped in favour of single-merchant).

## CI
- `start.sh` retries the namespace-setup `lapis exec` 3× — it intermittently hits an OpenResty worker SIGSEGV on a cold worker; the setup is idempotent and succeeds on retry.

## Verification
luajit `loadfile` on all files; integration tests for the webhook dispatch/idempotency/retry-safety + each handler; confirmed against the live dev DB (subscription + payment reconcile correctly, period dates populate). No secrets committed (`lapis/.env` is gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)