### PR TITLE
fix(billing): plan upgrade/downgrade proration + webhook invoice recording

### DIFF
--- a/lapis/lib/stripe.lua
+++ b/lapis/lib/stripe.lua
@@ -272,6 +272,13 @@ function Stripe:cancel_subscription(subscription_id, at_period_end)
     return self:_request("POST", "/subscriptions/" .. subscription_id, { cancel_at_period_end = true })
 end
 
+-- Update a Subscription (e.g. swap the plan/price for an upgrade/downgrade).
+-- `data` is passed through, so callers can set items = {{ id = <item_id>,
+-- price = <new_price_id> }} and proration_behavior = 'create_prorations'.
+function Stripe:update_subscription(subscription_id, data)
+    return self:_request("POST", "/subscriptions/" .. subscription_id, data or {})
+end
+
 -- Create a Customer
 function Stripe:create_customer(email, name, options)
     options = options or {}

--- a/lapis/routes/billing-account.lua
+++ b/lapis/routes/billing-account.lua
@@ -12,6 +12,7 @@
       GET  /api/v2/billing/payments              the user's payment history
 ]]
 
+local cjson = require("cjson")
 local AuthMiddleware = require("middleware.auth")
 local NamespaceMiddleware = require("middleware.namespace")
 local PaymentProvider = require("lib.payment-provider")
@@ -30,6 +31,14 @@ return function(app)
 
     local function truthy(v)
         return v == true or v == "t" or v == "true" or v == 1
+    end
+
+    local function parse_json_body()
+        ngx.req.read_body()
+        local body = ngx.req.get_body_data()
+        if not body or body == "" then return {} end
+        local ok, data = pcall(cjson.decode, body)
+        return ok and data or {}
     end
 
     local function plan_brief(plan)
@@ -104,6 +113,103 @@ return function(app)
                 cancel_at_period_end = true,
                 current_period_end = sub.current_period_end,
                 message = "Your subscription will end at the close of the current period.",
+            })
+        end)
+    ))
+
+    -- POST /api/v2/billing/subscription/change-plan — upgrade/downgrade.
+    -- Swaps the live Stripe subscription's price (prorated); the
+    -- customer.subscription.updated webhook reconciles plan_id from the new
+    -- price. Target must be an active SUBSCRIPTION plan in this namespace.
+    app:post("/api/v2/billing/subscription/change-plan", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requireNamespace(function(self)
+            local body = parse_json_body()
+            if not body.plan_uuid or body.plan_uuid == "" then
+                return api_response(400, nil, "plan_uuid is required")
+            end
+
+            local sub = BillingSubscriptionQueries.getActiveForUser(self.namespace.id, self.current_user.uuid)
+            if not sub then
+                return api_response(404, nil, "No active subscription to change")
+            end
+            if not sub.stripe_subscription_id or sub.stripe_subscription_id == "" then
+                return api_response(409, nil, "Subscription is not linked to Stripe")
+            end
+
+            local target = BillingPlanQueries.getByUuid(body.plan_uuid)
+            if not target then return api_response(404, nil, "Plan not found") end
+            if tonumber(target.namespace_id) ~= tonumber(self.namespace.id) then
+                return api_response(403, nil, "Access denied")
+            end
+            if not truthy(target.active) then
+                return api_response(409, nil, "Plan is not active")
+            end
+            if target.plan_type ~= "subscription" then
+                return api_response(400, nil, "Can only switch to another subscription plan")
+            end
+            if tonumber(target.id) == tonumber(sub.plan_id) then
+                return api_response(409, nil, "Already on this plan")
+            end
+
+            local stripe, perr = PaymentProvider.get_stripe()
+            if not stripe then return api_response(503, nil, perr or "Billing is not configured") end
+
+            -- Ensure the target plan has a Stripe price.
+            local synced, serr = BillingPlanQueries.ensureStripeSync(target, stripe)
+            if serr or not synced or not synced.stripe_price_id or synced.stripe_price_id == "" then
+                return api_response(502, nil, "Failed to sync plan to Stripe: " .. tostring(serr or "no price"))
+            end
+
+            -- Need the existing subscription item id to swap its price.
+            local current = stripe:retrieve_subscription(sub.stripe_subscription_id)
+            local item = current and current.items and current.items.data and current.items.data[1]
+            if not item or not item.id then
+                return api_response(502, nil, "Could not read current subscription item")
+            end
+
+            -- Upgrade vs downgrade decides how the prorated difference is settled:
+            --   UPGRADE   (paying more) -> "always_invoice": invoice + charge the
+            --             prorated difference NOW so the new plan is paid for as
+            --             soon as its features unlock.
+            --   DOWNGRADE (paying less) -> "create_prorations": bank the unused
+            --             credit and apply it to the NEXT invoice (no refund now).
+            local current_plan = sub.plan_id and BillingPlanQueries.getById(sub.plan_id) or nil
+            local current_amount = current_plan and tonumber(current_plan.amount) or 0
+            local target_amount = tonumber(synced.amount) or 0
+            local is_upgrade = target_amount > current_amount
+            local proration = is_upgrade and "always_invoice" or "create_prorations"
+
+            local updated, uerr = stripe:update_subscription(sub.stripe_subscription_id, {
+                items = { { id = item.id, price = synced.stripe_price_id } },
+                proration_behavior = proration,
+                cancel_at_period_end = false, -- a plan change re-activates a pending cancel
+                -- Keep Stripe's own metadata in step with the new plan so it never
+                -- drifts behind the live price (the webhook resolves plan from the
+                -- price first, but this keeps the audit trail honest).
+                metadata = {
+                    plan_uuid = target.uuid,
+                    namespace_id = tostring(self.namespace.id),
+                    user_uuid = self.current_user.uuid,
+                },
+            })
+            if not updated or not updated.id then
+                ngx.log(ngx.ERR, "Change plan failed: " .. tostring(uerr))
+                return api_response(502, nil, "Failed to change plan: " .. (uerr or "unknown error"))
+            end
+
+            -- Optimistic local update; the webhook also reconciles (idempotent).
+            BillingSubscriptionQueries.upsert({
+                stripe_subscription_id = sub.stripe_subscription_id,
+                plan_id = synced.id,
+                cancel_at_period_end = false,
+            })
+
+            return api_response(200, {
+                plan = plan_brief(synced),
+                change_type = is_upgrade and "upgrade" or "downgrade",
+                message = is_upgrade
+                    and "Your plan has been upgraded. The prorated difference has been charged now."
+                    or "Your plan has been changed. Unused credit will be applied to your next invoice.",
             })
         end)
     ))

--- a/lapis/routes/billing-webhook.lua
+++ b/lapis/routes/billing-webhook.lua
@@ -60,6 +60,25 @@ local function context_from_metadata(meta)
     }
 end
 
+-- An invoice's subscription link and tenant metadata moved under
+-- invoice.parent.subscription_details in 2025+ Stripe API versions — the
+-- top-level invoice.subscription / invoice.payment_intent fields are now null.
+-- Resolve from every known location so renewals and proration (upgrade)
+-- invoices are recorded, not just first-checkout ones.
+local function invoice_subscription_id(invoice)
+    local sd = invoice.parent and invoice.parent.subscription_details
+    local ln = invoice.lines and invoice.lines.data and invoice.lines.data[1]
+    local lp = ln and ln.parent and ln.parent.subscription_item_details
+    return id_of(invoice.subscription)
+        or (sd and id_of(sd.subscription))
+        or (lp and id_of(lp.subscription))
+end
+
+local function invoice_metadata(invoice)
+    local sd = invoice.parent and invoice.parent.subscription_details
+    return (sd and sd.metadata) or invoice.metadata or {}
+end
+
 -- ── Event handlers ──────────────────────────────────────────────────────────
 -- Each receives the event's data.object and may raise on a hard failure
 -- (caller pcall's them and returns 5xx so Stripe retries).
@@ -125,12 +144,16 @@ local function upsert_subscription_from_object(sub, deleted, event)
     -- period boundaries that used to live on the subscription object itself.
     local item = sub.items and sub.items.data and sub.items.data[1]
 
-    -- Resolve the plan from metadata, else from the item's price.
-    local plan_id = ctx.plan_id
-    if not plan_id and item and item.price then
+    -- Resolve the plan from the CURRENT PRICE first — it is authoritative and
+    -- changes on upgrade/downgrade. metadata.plan_uuid only reflects the plan
+    -- the subscription was CREATED with (it goes stale after a plan switch),
+    -- so it's a fallback for the rare case the price isn't in our catalogue.
+    local plan_id
+    if item and item.price then
         local plan = BillingPlanQueries.getByStripePriceId(id_of(item.price))
         if plan then plan_id = plan.id end
     end
+    if not plan_id then plan_id = ctx.plan_id end
 
     -- Period dates: top-level (older API) OR on the item (newer API).
     local period_start = nz(sub.current_period_start) or (item and nz(item.current_period_start))
@@ -161,7 +184,7 @@ function handlers.customer_subscription_updated(sub, event) upsert_subscription_
 function handlers.customer_subscription_deleted(sub, event) upsert_subscription_from_object(sub, true, event) end
 
 function handlers.invoice_paid(invoice)
-    local sub_id = id_of(invoice.subscription)
+    local sub_id = invoice_subscription_id(invoice)
     local pi_id = id_of(invoice.payment_intent)
     local invoice_id = id_of(invoice.id)
     local sub = sub_id and BillingSubscriptionQueries.getByStripeId(sub_id) or nil
@@ -184,13 +207,19 @@ function handlers.invoice_paid(invoice)
         return
     end
 
-    -- No existing row (e.g. a renewal) — record it. Needs tenant context.
-    if sub then
+    -- No existing row — record it. This is the path for renewals AND for
+    -- upgrade prorations (always_invoice), neither of which has a checkout row.
+    -- Tenant context comes from our subscription row when we have it, else from
+    -- the invoice's own metadata (set on the subscription at checkout/change).
+    local ctx = context_from_metadata(invoice_metadata(invoice))
+    local namespace_id = sub and sub.namespace_id or ctx.namespace_id
+    local user_uuid = sub and sub.user_uuid or ctx.user_uuid
+    if namespace_id and user_uuid then
         BillingPaymentQueries.createPending({
-            namespace_id = sub.namespace_id,
-            user_uuid = sub.user_uuid,
-            plan_id = sub.plan_id,
-            subscription_id = sub.id,
+            namespace_id = namespace_id,
+            user_uuid = user_uuid,
+            plan_id = (sub and sub.plan_id) or ctx.plan_id,
+            subscription_id = sub and sub.id or nil,
             payment_type = "subscription",
             stripe_payment_intent_id = pi_id,
             stripe_invoice_id = invoice_id,
@@ -200,11 +229,13 @@ function handlers.invoice_paid(invoice)
             receipt_url = nz(invoice.hosted_invoice_url),
             status = "succeeded",
         })
+    else
+        ngx.log(ngx.WARN, "invoice.paid: no tenant context for invoice " .. tostring(invoice_id))
     end
 end
 
 function handlers.invoice_payment_failed(invoice)
-    local sub_id = id_of(invoice.subscription)
+    local sub_id = invoice_subscription_id(invoice)
     if sub_id then
         local sub = BillingSubscriptionQueries.getByStripeId(sub_id)
         if sub and sub.status ~= "canceled" then


### PR DESCRIPTION
## What

Builds plan **upgrade/downgrade** on the customer subscription, and fixes two webhook reconciliation bugs uncovered while testing it.

### New
- **`POST /api/v2/billing/subscription/change-plan`** — swaps the live Stripe subscription's price (no new checkout). Validates the target is an active *subscription* plan in the same namespace and not the current plan.
  - **Upgrade** (paying more) → `always_invoice`: the prorated difference is invoiced + charged to the saved card immediately, so the new plan is paid for as its features unlock.
  - **Downgrade** (paying less) → `create_prorations`: unused credit is banked and applied to the next invoice (no instant refund).
  - Refreshes the Stripe subscription's `metadata` (plan_uuid/namespace/user) on every switch so it can't drift behind the price.
- `stripe.lua`: `Stripe:update_subscription(id, data)` helper.

### Fixes
- **Stale plan on upgrade.** The webhook resolved `plan_id` from `metadata.plan_uuid` first, but Stripe only sets subscription metadata at *creation* — so after a plan switch it pointed at the old plan and clobbered `plan_id` back on every `customer.subscription.updated`. Now resolved from the **current price first**, metadata only as fallback.
- **Renewals & upgrade-proration invoices not recorded.** The 2025+ Stripe API (`2026-04-22.dahlia`) moved the subscription link and tenant metadata off the top-level `invoice.subscription` / `invoice.payment_intent` (now `null`) into `invoice.parent.subscription_details`. The `invoice.paid` handler only read the old fields, so any invoice without a checkout session (every renewal **and** every upgrade proration) was silently skipped. Now resolves from the new location with line-item fallback.

## Testing
- Verified against the live sandbox: upgraded Pro → Max, confirmed Stripe charged £2.00 to the saved card (−£7.99 unused Pro + £9.99 remaining Max), then **replayed the real `invoice.paid` event** and confirmed the £2 now lands in `billing_payments`. Idempotent on replay.
- `luajit -e assert(loadfile(...))` passes on all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)