### PR TITLE
fix(auth): allow /auth/e2e/peek-otp through the global auth filter

### DIFF
--- a/lapis/app.lua
+++ b/lapis/app.lua
@@ -235,6 +235,7 @@ app:before_filter(function(self)
         ["/auth/refresh"] = true,         -- Handles its own token validation
         ["/auth/2fa/verify"] = true,      -- 2FA OTP verification (pre-auth)
         ["/auth/2fa/resend"] = true,      -- 2FA resend OTP (pre-auth)
+        ["/auth/e2e/peek-otp"] = true,    -- TEST-ONLY: secret-gated in routes/e2e-otp.lua (no JWT; route only registered when E2E_OTP_PEEK_ENABLED=true)
         ["/auth/google"] = true,          -- Google OAuth initiation
         ["/auth/google/callback"] = true, -- Google OAuth callback
         ["/auth/oauth/validate"] = true,  -- OAuth token validation


### PR DESCRIPTION
Follow-up to #413. The test-only OTP peek endpoint was being blocked by the global `before_filter`, which runs `auth.authenticate()` (requires a JWT) on every non-public route. The broker calls it with **no JWT** (only `X-E2E-OTP-Secret` + a 2FA session token), so it got **401 before the endpoint's own 5 gates ran**.

Verified against acc: the route is deployed and `E2E_OTP_PEEK_ENABLED=true`, but `POST /auth/e2e/peek-otp` returns 401 from the filter.

**Fix:** add `/auth/e2e/peek-otp` to `public_auth_routes` (same treatment as `/auth/2fa/verify` — a pre-auth, secret-gated endpoint). It still enforces all 5 gates (shared secret, 2FA session, email allow-list, prod refuse) and is only **registered** when `E2E_OTP_PEEK_ENABLED=true`, so it stays inert in prod.

After merge, **redeploy acc** so the fix is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)