### PR TITLE
fix(auth): assign Google OAuth sign-ups to the project namespace

### DIFF
--- a/lapis/helper/namespace_assignment.lua
+++ b/lapis/helper/namespace_assignment.lua
@@ -1,0 +1,107 @@
+--[[
+    Namespace auto-assignment for newly created users
+    ==================================================
+
+    Adds a freshly-created user to the active project namespace (configured
+    via the `PROJECT_CODE` env var, default `tax_copilot`) with the default
+    `member` role, and sets that namespace as their default in
+    `user_namespace_settings`. Without this step the user has no namespace
+    context and the frontend's billing / settings pages 404 with "Namespace
+    not found" because `NamespaceMiddleware.requireNamespace` rejects them.
+
+    Idempotent — every INSERT carries an `ON CONFLICT … DO NOTHING/UPDATE`
+    clause, so repeating the call (e.g. after a partial earlier failure)
+    leaves the user in the correct end state without dupes.
+
+    Error-tolerant — the whole body runs in `pcall` and any failure is logged
+    but never raised. Sign-up has already succeeded in creating the user
+    by the time this is called; rolling back the user just because we
+    couldn't add the membership row would be worse than the namespace
+    being temporarily absent (an operator can backfill).
+
+    Callers:
+      - routes/register.lua  (email/password sign-up)
+      - routes/auth.lua      (Google OAuth sign-up — both GET callback and
+                              the POST sign-in-with-token variant)
+
+    History: extracted from routes/register.lua after acc-2026-05-29 surfaced
+    a Google-OAuth-only "Namespace not found" bug — the email/password flow
+    auto-assigned correctly via the in-file helper; OAuth signup called
+    UserQueries.createOAuthUser and stopped, leaving the user with zero
+    membership rows.
+]]
+
+local db = require("lapis.db")
+
+local M = {}
+
+--- Auto-assign a newly-created user to the active project namespace.
+-- @param user_id integer  users.id of the freshly-created user
+-- @param user_uuid string users.uuid of the same user (for log breadcrumbs)
+function M.assignUserToProjectNamespace(user_id, user_uuid)
+    local ok, err = pcall(function()
+        -- Resolve the target namespace by project_code, with a slug-based
+        -- fallback so an environment that hasn't set PROJECT_CODE still
+        -- gets the first non-system tenant.
+        local project_code = os.getenv("PROJECT_CODE") or "tax_copilot"
+        local ns = db.query([[
+            SELECT id FROM namespaces
+            WHERE status = 'active' AND project_code = ?
+            ORDER BY id ASC LIMIT 1
+        ]], project_code)
+
+        if not ns or #ns == 0 then
+            ns = db.query([[
+                SELECT id FROM namespaces
+                WHERE status = 'active' AND slug != 'system'
+                ORDER BY id ASC LIMIT 1
+            ]])
+        end
+
+        if not ns or #ns == 0 then return end
+        local namespace_id = ns[1].id
+
+        -- Membership (status = 'active', is_owner = false).
+        db.query([[
+            INSERT INTO namespace_members (uuid, namespace_id, user_id, status, is_owner, joined_at, created_at, updated_at)
+            VALUES (gen_random_uuid()::text, ?, ?, 'active', false, NOW(), NOW(), NOW())
+            ON CONFLICT (namespace_id, user_id) DO NOTHING
+        ]], namespace_id, user_id)
+
+        -- Default 'member' role binding (the namespace's own member role,
+        -- not the global users.role). Without this the user is a member
+        -- but has no permissions, and gated routes refuse them.
+        local member_role = db.query([[
+            SELECT nr.id as role_id, nm.id as member_id
+            FROM namespace_roles nr
+            JOIN namespace_members nm ON nm.namespace_id = nr.namespace_id AND nm.user_id = ?
+            WHERE nr.namespace_id = ? AND nr.role_name = 'member'
+            LIMIT 1
+        ]], user_id, namespace_id)
+        if member_role and #member_role > 0 then
+            db.query([[
+                INSERT INTO namespace_user_roles (uuid, namespace_member_id, namespace_role_id, created_at, updated_at)
+                VALUES (gen_random_uuid()::text, ?, ?, NOW(), NOW())
+                ON CONFLICT (namespace_member_id, namespace_role_id) DO NOTHING
+            ]], member_role[1].member_id, member_role[1].role_id)
+        end
+
+        -- Default namespace for the user's session — what the login
+        -- response reads from to seed the frontend's X-Namespace-Id.
+        db.query([[
+            INSERT INTO user_namespace_settings (user_id, default_namespace_id, last_active_namespace_id, created_at, updated_at)
+            VALUES (?, ?, ?, NOW(), NOW())
+            ON CONFLICT (user_id) DO UPDATE SET
+                default_namespace_id = EXCLUDED.default_namespace_id,
+                last_active_namespace_id = EXCLUDED.last_active_namespace_id,
+                updated_at = NOW()
+        ]], user_id, namespace_id, namespace_id)
+
+        ngx.log(ngx.NOTICE, "[Namespace] Auto-assigned user ", user_uuid, " to namespace ", namespace_id)
+    end)
+    if not ok then
+        ngx.log(ngx.ERR, "[Namespace] Failed to assign user ", tostring(user_uuid), ": ", tostring(err))
+    end
+end
+
+return M

--- a/lapis/routes/auth.lua
+++ b/lapis/routes/auth.lua
@@ -6,6 +6,7 @@ local Global = require "helper.global"
 local JWTHelper = require "helper.jwt-helper"
 local NamespaceQueries = require "queries.NamespaceQueries"
 local NamespaceMemberQueries = require "queries.NamespaceMemberQueries"
+local NamespaceAssignment = require "helper.namespace_assignment"
 local DeviceTokenQueries = require "queries.DeviceTokenQueries"
 local RateLimit = require("middleware.rate-limit")
 local Errors = require("lib.errors")
@@ -824,6 +825,15 @@ return function(app)
                 oauth_id = google_user.id,
                 active = true
             })
+
+            -- Mirror the email/password sign-up flow: a brand-new user must
+            -- be added to the project namespace and given a default, or the
+            -- frontend's billing / settings pages 4xx with "Namespace not
+            -- found". Only runs on first-time sign-up — returning Google
+            -- users hit the early `if not user` branch and skip this.
+            if user then
+                NamespaceAssignment.assignUserToProjectNamespace(user.id, user.uuid)
+            end
         end
 
         -- Get user with roles
@@ -1100,6 +1110,12 @@ return function(app)
                         json = { error = "Failed to create user" }
                     }
                 end
+
+                -- Mirror the email/password sign-up flow: a brand-new user
+                -- must be added to the project namespace and given a default,
+                -- or the frontend's billing / settings pages 4xx with
+                -- "Namespace not found". Only on first-time sign-up.
+                NamespaceAssignment.assignUserToProjectNamespace(user.id, user.uuid)
             end
 
             -- Get user with roles

--- a/lapis/routes/register.lua
+++ b/lapis/routes/register.lua
@@ -5,6 +5,7 @@ local jwt = require("resty.jwt")
 local Global = require("helper.global")
 local db = require("lapis.db")
 local Errors = require("lib.errors")
+local NamespaceAssignment = require("helper.namespace_assignment")
 
 --- Validate that a business profile key is acceptable.
 -- @param profile_key string|nil The candidate key (e.g. "amazon_seller")
@@ -82,68 +83,9 @@ local function save_default_profile_key(user_id, user_uuid, profile_key)
     end
 end
 
--- Auto-assign new user to the active project namespace
-local function assignUserToNamespace(user_id, user_uuid)
-    local ok, err = pcall(function()
-        -- Find the active project namespace (not "system")
-        local project_code = os.getenv("PROJECT_CODE") or "tax_copilot"
-        local ns = db.query([[
-            SELECT id FROM namespaces
-            WHERE status = 'active' AND project_code = ?
-            ORDER BY id ASC LIMIT 1
-        ]], project_code)
-
-        -- Fallback: first non-system active namespace
-        if not ns or #ns == 0 then
-            ns = db.query([[
-                SELECT id FROM namespaces
-                WHERE status = 'active' AND slug != 'system'
-                ORDER BY id ASC LIMIT 1
-            ]])
-        end
-
-        if not ns or #ns == 0 then return end
-        local namespace_id = ns[1].id
-
-        -- Add as namespace member (with "member" role)
-        db.query([[
-            INSERT INTO namespace_members (uuid, namespace_id, user_id, status, is_owner, joined_at, created_at, updated_at)
-            VALUES (gen_random_uuid()::text, ?, ?, 'active', false, NOW(), NOW(), NOW())
-            ON CONFLICT (namespace_id, user_id) DO NOTHING
-        ]], namespace_id, user_id)
-
-        -- Assign default "member" namespace role
-        local member_role = db.query([[
-            SELECT nr.id as role_id, nm.id as member_id
-            FROM namespace_roles nr
-            JOIN namespace_members nm ON nm.namespace_id = nr.namespace_id AND nm.user_id = ?
-            WHERE nr.namespace_id = ? AND nr.role_name = 'member'
-            LIMIT 1
-        ]], user_id, namespace_id)
-        if member_role and #member_role > 0 then
-            db.query([[
-                INSERT INTO namespace_user_roles (uuid, namespace_member_id, namespace_role_id, created_at, updated_at)
-                VALUES (gen_random_uuid()::text, ?, ?, NOW(), NOW())
-                ON CONFLICT (namespace_member_id, namespace_role_id) DO NOTHING
-            ]], member_role[1].member_id, member_role[1].role_id)
-        end
-
-        -- Set as default namespace
-        db.query([[
-            INSERT INTO user_namespace_settings (user_id, default_namespace_id, last_active_namespace_id, created_at, updated_at)
-            VALUES (?, ?, ?, NOW(), NOW())
-            ON CONFLICT (user_id) DO UPDATE SET
-                default_namespace_id = EXCLUDED.default_namespace_id,
-                last_active_namespace_id = EXCLUDED.last_active_namespace_id,
-                updated_at = NOW()
-        ]], user_id, namespace_id, namespace_id)
-
-        ngx.log(ngx.NOTICE, "[Register] Auto-assigned user ", user_uuid, " to namespace ", namespace_id)
-    end)
-    if not ok then
-        ngx.log(ngx.ERR, "[Register] Failed to assign namespace: ", tostring(err))
-    end
-end
+-- Auto-assignment of a fresh user to the project namespace lives in the
+-- shared helper.namespace_assignment so the Google-OAuth sign-up flow in
+-- routes/auth.lua can call the exact same code path.
 
 return function(app)
     app:match("register", "/api/v2/register", respond_to({
@@ -242,7 +184,7 @@ return function(app)
             user.password = nil
 
             -- Auto-assign to project namespace (member role + default namespace)
-            assignUserToNamespace(user.id, user.uuid)
+            NamespaceAssignment.assignUserToProjectNamespace(user.id, user.uuid)
 
             -- Persist the validated profile key onto tax_user_profiles.
             -- Runs after assignUserToNamespace so the profile row's


### PR DESCRIPTION
## What

A user who signs up with Google ended up with **zero** namespace context — no `namespace_members` row, no `user_namespace_settings` row. The frontend's billing / settings / anywhere that calls `NamespaceMiddleware.requireNamespace` then 4xx'd with **"Namespace not found"**, even though the email/password sign-up flow worked correctly.

Reported on acc with the user `honeymankoo22@gmail.com` (id=31) — a fresh DB query confirmed:

```
namespace_id | slug | status | is_owner | joined_at
-------------+------+--------+----------+-----------
(0 rows)

default_namespace_id | last_active_namespace_id
---------------------+--------------------------
(0 rows)
```

Audit of acc found **6 OAuth users** in the same broken state.

## Root cause

`routes/register.lua` had a local `assignUserToNamespace()` called right after `UserQueries.create`. The equivalent OAuth sign-up path in `routes/auth.lua` (both the `GET /auth/google/callback` flow and the POST sign-in-with-token variant) called `UserQueries.createOAuthUser` and stopped — neither OAuth site ever attempted to add the user to a namespace.

The contract was unwritten and easy to miss: "any new-user code path must also call `assignUserToNamespace`". This PR makes it explicit by giving it its own helper module.

## Fix

- **New `helper/namespace_assignment.lua`** exposing `assignUserToProjectNamespace(user_id, user_uuid)`. Pure refactor of the existing `register.lua` function — same SQL, same idempotent `ON CONFLICT` clauses, same `pcall`-guarded error handling. Log prefix changed from `[Register]` to `[Namespace]` so the callers don't have to be lied about.
- **`routes/register.lua`** now calls the helper. No behaviour change for email/password sign-up.
- **`routes/auth.lua`** calls the helper at **both** Google OAuth sign-up sites — line ~835 (`/auth/google/callback`) and line ~1118 (POST sign-in-with-token) — immediately after `UserQueries.createOAuthUser`. Gated so it only runs on *first-time* sign-up (returning OAuth users already short-circuit at `if not user`).

## Already done on acc (separate SQL)

To unblock the affected users without waiting on a deploy:

- `honeymankoo22@gmail.com` and the other 5 orphaned OAuth users on acc were added to `namespace_members` (ns=2, member role) and `user_namespace_settings` (default=2) via an idempotent `BEGIN; ... COMMIT;` block.
- Post-backfill query confirms zero remaining orphaned OAuth users on acc.

Affected users need to **log out and log back in** so the login response re-seeds `tax_return_namespace_id` in their browser localStorage. After that the billing page works.

## Verification

- All three Lua files load clean (`luajit -e "assert(loadfile(...))"`).
- All three call sites confirmed to invoke the helper:
  ```
  routes/register.lua:187:  NamespaceAssignment.assignUserToProjectNamespace(user.id, user.uuid)
  routes/auth.lua:835:      NamespaceAssignment.assignUserToProjectNamespace(user.id, user.uuid)
  routes/auth.lua:1118:     NamespaceAssignment.assignUserToProjectNamespace(user.id, user.uuid)
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)