### PR TITLE
fix(billing): stop duplicate payment rows from checkout.session.completed / invoice.paid race

### DIFF
--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -1721,6 +1721,7 @@ local _migrations = {
     ['706_billing_usage_meters'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, billing_system_migrations, 7),
     ['707_billing_audit_columns'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, billing_system_migrations, 8),
     ['708_billing_drop_payment_accounts'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, billing_system_migrations, 9),
+    ['709_billing_payments_invoice_unique'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, billing_system_migrations, 10),
 
     -- Theme system foundation (Phase 0): drop obsolete scaffold.
     -- Replaced by new tables in Phase 1 migration 621_create_theme_system.

--- a/lapis/migrations/billing-system.lua
+++ b/lapis/migrations/billing-system.lua
@@ -324,4 +324,72 @@ return {
     [9] = function()
         db.query("DROP TABLE IF EXISTS namespace_payment_accounts CASCADE")
     end,
+
+    -- ========================================================================
+    -- [10] Dedupe + unique index on stripe_invoice_id.
+    --
+    -- Webhooks `checkout.session.completed` and `invoice.paid` arrive
+    -- together (same second) for a successful subscription checkout and
+    -- both can attempt to insert a billing_payments row carrying the same
+    -- stripe_invoice_id. The checkout handler creates a row tied to the
+    -- session; the invoice handler races to look it up by invoice_id, finds
+    -- nothing (the other handler hasn't committed yet), and inserts a
+    -- second row. Result: two "succeeded" rows visible on the user's billing
+    -- page, even though Stripe only saw one transaction (acc 2026-05-29).
+    --
+    -- Fix: a unique partial index makes the race impossible at the DB level —
+    -- the losing handler's INSERT fails with a unique violation, and the
+    -- code path in routes/billing-webhook.lua catches that, looks up the
+    -- winner by invoice_id, and applies its enrichment fields to it instead.
+    --
+    -- Dedupe first so the index can be created on environments that already
+    -- accumulated duplicates. Strategy: keep the oldest row per invoice_id
+    -- (it carries the checkout session id), merge non-null fields from the
+    -- duplicate, delete the duplicate. No data is lost — just consolidated.
+    -- Idempotent: a re-run on a clean table is a no-op.
+    -- ========================================================================
+    [10] = function()
+        -- Defensive pre-dedup: any duplicate invoice rows get merged into
+        -- the oldest, then the duplicates are removed.
+        db.query([[
+            WITH dupes AS (
+              SELECT stripe_invoice_id,
+                     MIN(id) AS keep_id,
+                     MAX(id) AS drop_id
+              FROM billing_payments
+              WHERE stripe_invoice_id IS NOT NULL
+              GROUP BY stripe_invoice_id
+              HAVING COUNT(*) > 1
+            )
+            UPDATE billing_payments p
+            SET receipt_url              = COALESCE(p.receipt_url,              d_row.receipt_url),
+                stripe_customer_id       = COALESCE(p.stripe_customer_id,       d_row.stripe_customer_id),
+                stripe_payment_intent_id = COALESCE(p.stripe_payment_intent_id, d_row.stripe_payment_intent_id),
+                subscription_id          = COALESCE(p.subscription_id,          d_row.subscription_id),
+                updated_at = NOW()
+            FROM dupes d
+            JOIN billing_payments d_row ON d_row.id = d.drop_id
+            WHERE p.id = d.keep_id
+        ]])
+
+        db.query([[
+            DELETE FROM billing_payments p
+            USING (
+              SELECT stripe_invoice_id, MAX(id) AS drop_id
+              FROM billing_payments
+              WHERE stripe_invoice_id IS NOT NULL
+              GROUP BY stripe_invoice_id
+              HAVING COUNT(*) > 1
+            ) d
+            WHERE p.id = d.drop_id
+        ]])
+
+        -- Unique partial index. Permits unlimited NULL values (rows in the
+        -- pending pre-invoice state) but only one row per real invoice id.
+        db.query([[
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_billing_payments_invoice
+            ON billing_payments (stripe_invoice_id)
+            WHERE stripe_invoice_id IS NOT NULL
+        ]])
+    end,
 }

--- a/lapis/routes/billing-webhook.lua
+++ b/lapis/routes/billing-webhook.lua
@@ -119,7 +119,14 @@ function handlers.checkout_session_completed(session)
         BillingPaymentQueries.update(existing.uuid, fields)
     elseif ctx.namespace_id then
         -- No pending row (e.g. created out-of-band) — record it now.
-        BillingPaymentQueries.createPending({
+        -- Wrap to survive the same race documented in invoice_paid: if
+        -- invoice.paid already inserted a row with this stripe_invoice_id,
+        -- our INSERT trips the unique partial index on stripe_invoice_id
+        -- (migration 709). Catch the violation, look up the winner by
+        -- invoice id, and apply the fields we would have set instead —
+        -- specifically the session id, which the invoice handler can't
+        -- know on its own.
+        local ok, err = pcall(BillingPaymentQueries.createPending, {
             namespace_id = ctx.namespace_id,
             user_uuid = ctx.user_uuid,
             plan_id = ctx.plan_id,
@@ -133,6 +140,31 @@ function handlers.checkout_session_completed(session)
             currency = nz(session.currency) or "gbp",
             status = fields.status,
         })
+        if not ok then
+            local winner = fields.stripe_invoice_id
+                and BillingPaymentQueries.getByInvoiceId(fields.stripe_invoice_id)
+            if winner then
+                -- Layer the session-side fields onto the invoice-side row
+                -- so the merged row carries both the session id and the
+                -- invoice id. The other fields are already set or null-safe.
+                local merge = {
+                    stripe_checkout_session_id = session.id,
+                    subscription_id = subscription_row_id,
+                    stripe_payment_intent_id = fields.stripe_payment_intent_id,
+                    stripe_customer_id = fields.stripe_customer_id,
+                }
+                BillingPaymentQueries.update(winner.uuid, merge)
+                ngx.log(ngx.INFO,
+                    "checkout.session.completed: lost race with invoice.paid for invoice ",
+                    tostring(fields.stripe_invoice_id),
+                    " — merged session id onto winner's row")
+            else
+                ngx.log(ngx.ERR,
+                    "checkout.session.completed: createPending failed and no row found by invoice_id ",
+                    tostring(fields.stripe_invoice_id), ": ", tostring(err))
+                error(err)
+            end
+        end
     end
 end
 
@@ -215,7 +247,15 @@ function handlers.invoice_paid(invoice)
     local namespace_id = sub and sub.namespace_id or ctx.namespace_id
     local user_uuid = sub and sub.user_uuid or ctx.user_uuid
     if namespace_id and user_uuid then
-        BillingPaymentQueries.createPending({
+        -- Wrap the insert: checkout.session.completed and invoice.paid
+        -- frequently race for the same invoice (same Stripe event burst,
+        -- same second). The unique partial index on stripe_invoice_id
+        -- (migration 709) makes the second insert fail with a uniqueness
+        -- violation; we catch it, look up the row the other handler
+        -- already inserted, and apply our enrichment to it instead.
+        -- That way the visible state on /settings/billing is one row, not
+        -- two duplicate "succeeded" entries (acc 2026-05-29).
+        local ok, err = pcall(BillingPaymentQueries.createPending, {
             namespace_id = namespace_id,
             user_uuid = user_uuid,
             plan_id = (sub and sub.plan_id) or ctx.plan_id,
@@ -229,6 +269,20 @@ function handlers.invoice_paid(invoice)
             receipt_url = nz(invoice.hosted_invoice_url),
             status = "succeeded",
         })
+        if not ok then
+            local winner = invoice_id and BillingPaymentQueries.getByInvoiceId(invoice_id)
+            if winner then
+                BillingPaymentQueries.update(winner.uuid, enrich)
+                ngx.log(ngx.INFO,
+                    "invoice.paid: lost race with another handler for invoice ",
+                    tostring(invoice_id), " — enriched the winner's row instead")
+            else
+                ngx.log(ngx.ERR,
+                    "invoice.paid: createPending failed and no row found by invoice_id ",
+                    tostring(invoice_id), ": ", tostring(err))
+                error(err)  -- bubble up so the webhook returns 5xx and Stripe retries
+            end
+        end
     else
         ngx.log(ngx.WARN, "invoice.paid: no tenant context for invoice " .. tostring(invoice_id))
     end


### PR DESCRIPTION
## What

For a successful subscription checkout, Stripe fires `checkout.session.completed` and `invoice.paid` in the same second. Both webhook handlers try to write a `billing_payments` row carrying the same `stripe_invoice_id`. The checkout handler creates a row tied to the session; the invoice handler looks the row up by `invoice_id`, finds nothing (the other handler hasn't committed yet), and inserts a **second row**.

Symptom on acc 2026-05-29: user's `/settings/billing` showed **two "succeeded" entries** for the same £5.99 payment, even though Stripe only processed one transaction. DB:

```
id=6  session=cs_test_a1IlII…  invoice=in_1TcKVf…  no receipt
id=7                            invoice=in_1TcKVf…  has receipt
```

Same shape on every prior subscription checkout (id=4/5). The existing `idx_billing_payments_pi` enforces uniqueness on `payment_intent_id`, but subscription checkouts have **NULL** `payment_intent` on the session — so the existing safeguard never applied.

## Fix

**Migration `709_billing_payments_invoice_unique`** (`migrations/billing-system.lua` step `[10]`):

1. Dedupe any pre-existing duplicates — keep the oldest row, merge `receipt_url` / `stripe_customer_id` / `stripe_payment_intent_id` / `subscription_id` from the duplicate, delete the duplicate.
2. Add a `UNIQUE PARTIAL INDEX` on `stripe_invoice_id` (only `NOT NULL` values participate; pending pre-invoice rows are unconstrained).

**Handler guards** (`routes/billing-webhook.lua`):

Both `invoice_paid` and `checkout_session_completed` now wrap `createPending` in `pcall`. On a unique-violation (the other handler won the race), look up the winner's row by invoice id and apply this handler's fields to it instead. End state: **one merged row** carrying session id + invoice id + receipt url + tenant context. If neither create succeeds nor a winner row exists, raise so Stripe retries (true failure path, not a race).

## Already done on acc (separate SQL)

The 2 affected duplicate pairs on acc were deduped with the same merge logic. No data was lost — receipt URLs were preserved on the canonical rows. Verified `0` remaining duplicates before opening this PR.

## Verification

- `luajit -e "assert(loadfile(...))"` clean on all three changed files.
- Once deployed, a fresh subscription checkout on acc should land **one** row in `billing_payments` with both `stripe_checkout_session_id` and `stripe_invoice_id` populated, and a `receipt_url`. The `/settings/billing` payment history will show one entry, not two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)