### PR TITLE
feat(health): runtime/system info in /health + dashboard transactions list fix

### DIFF
--- a/lapis/helper/health-check.lua
+++ b/lapis/helper/health-check.lua
@@ -20,6 +20,71 @@ local function is_kubernetes()
     return false
 end
 
+-- ── Runtime / platform introspection helpers ─────────────────────────────────
+-- Used by getSystemInfo(); all reads are defensive (return nil on absence) so
+-- the health endpoint still works on bare metal / minimal containers.
+local function read_first_line(path)
+    local f = io.open(path, "r"); if not f then return nil end
+    local line = f:read("*l"); f:close()
+    return line
+end
+
+local function read_all(path)
+    local f = io.open(path, "r"); if not f then return nil end
+    local s = f:read("*a"); f:close()
+    return s
+end
+
+local function read_kv_kb(path, key)
+    -- Parse "Key: 12345 kB" style lines (/proc/meminfo, /proc/self/status).
+    local f = io.open(path, "r"); if not f then return nil end
+    for line in f:lines() do
+        local v = line:match("^" .. key .. ":%s+(%d+)")
+        if v then f:close(); return tonumber(v) end
+    end
+    f:close(); return nil
+end
+
+local function detect_platform()
+    -- K8s first (most specific): SA token is always projected into pods.
+    if is_kubernetes() then return "kubernetes" end
+    -- Docker indicators.
+    if io.open("/.dockerenv", "r") then return "docker" end
+    local cg = read_all("/proc/self/cgroup")
+    if cg and (cg:find("docker", 1, true) or cg:find("containerd", 1, true)) then
+        return "docker"
+    end
+    if cg and cg:find("kubepods", 1, true) then return "kubernetes" end
+    return "bare-metal"
+end
+
+-- Process uptime (seconds since this process — typically PID 1 of the
+-- container — started). Approximates container/pod uptime.
+local function process_uptime_seconds()
+    local host_line = read_first_line("/proc/uptime")
+    local stat_line = read_first_line("/proc/self/stat")
+    if not host_line or not stat_line then return nil end
+    local host_uptime = tonumber(host_line:match("^(%S+)"))
+    -- Field 22 of /proc/[pid]/stat is starttime in clock ticks. The comm
+    -- (field 2) is parenthesised and may contain spaces, so skip past ") ".
+    local after_comm = stat_line:match("%)%s+(.+)$")
+    if not host_uptime or not after_comm then return nil end
+    local idx, starttime = 0, nil
+    for tok in after_comm:gmatch("%S+") do
+        idx = idx + 1
+        if idx == 20 then starttime = tonumber(tok); break end
+    end
+    if not starttime then return nil end
+    return math.floor(host_uptime - (starttime / 100)) -- CLK_TCK is 100 on Linux
+end
+
+local function openresty_version_string()
+    local v = ngx.config.nginx_version
+    if not v then return nil end
+    return string.format("%d.%d.%d",
+        math.floor(v / 1000000), math.floor(v / 1000) % 1000, v % 1000)
+end
+
 local function resolve_for_health_check(url)
     if not url or url == "" then return url end
     if not is_kubernetes() then return url end
@@ -410,6 +475,64 @@ function HealthCheck.checkSystemResources()
     return status
 end
 
+-- Runtime / platform information about *where* this process is running.
+-- Informational only (no checks, never "unhealthy") — surfaces what operators
+-- usually paste into incident channels: kind of host (docker / k8s / bare),
+-- container/pod identity, uptime, OpenResty/Lua versions, memory footprint.
+-- For the k8s pod_namespace/pod_ip/node_name fields to populate, the
+-- deployment must expose POD_NAMESPACE/POD_IP/NODE_NAME via the downward API
+-- AND those names must be declared in nginx.conf (`env POD_NAMESPACE;` …).
+function HealthCheck.getSystemInfo()
+    local platform = detect_platform()
+    local hostname = os.getenv("HOSTNAME") or read_first_line("/etc/hostname")
+    local info = {
+        platform = platform,
+        hostname = hostname,
+        machine_id = read_first_line("/etc/machine-id"),
+        process = {
+            pid = ngx.worker.pid(),
+            -- Seconds since the container/pod's main process started.
+            uptime_seconds = process_uptime_seconds(),
+            nginx_workers = ngx.worker.count(),
+        },
+        runtime = {
+            openresty = openresty_version_string(),
+            lua = _VERSION,
+            jit = (jit and jit.version) or nil,
+        },
+        environment = {
+            lapis_environment = os.getenv("LAPIS_ENVIRONMENT") or "development",
+            deploy_env = os.getenv("OPSAPI_DEPLOY_ENV"),
+            project_code = os.getenv("PROJECT_CODE"),
+            app_version = os.getenv("VERSION") or "1.0.0",
+            stack = os.getenv("STACK"),
+            deployment_time = os.getenv("VITE_DEPLOYMENT_TIME"),
+        },
+        memory = {
+            lua_kb = math.floor(collectgarbage("count")),
+            rss_kb = read_kv_kb("/proc/self/status", "VmRSS"),
+            vsz_kb = read_kv_kb("/proc/self/status", "VmSize"),
+            host_total_kb = read_kv_kb("/proc/meminfo", "MemTotal"),
+            host_available_kb = read_kv_kb("/proc/meminfo", "MemAvailable"),
+        },
+    }
+
+    if platform == "kubernetes" then
+        info.kubernetes = {
+            pod_name = os.getenv("POD_NAME") or hostname,
+            pod_namespace = os.getenv("POD_NAMESPACE"),
+            pod_ip = os.getenv("POD_IP"),
+            node_name = os.getenv("NODE_NAME"),
+        }
+    elseif platform == "docker" then
+        -- In docker the hostname is typically the first 12 chars of the
+        -- container id; if it's shorter (custom hostname) we return it as-is.
+        info.docker = { container_id = hostname }
+    end
+
+    return info
+end
+
 -- Comprehensive health check
 function HealthCheck.getFullStatus()
     local overall_start = ngx.now()
@@ -448,6 +571,7 @@ function HealthCheck.getFullStatus()
         timestamp_iso = os.date("!%Y-%m-%dT%H:%M:%SZ"),
         version = "1.0.0",
         environment = os.getenv("LAPIS_ENVIRONMENT") or "development",
+        system_info = HealthCheck.getSystemInfo(),
         total_checks = #checks,
         unhealthy_checks = unhealthy_count,
         degraded_checks = degraded_count,
@@ -478,6 +602,7 @@ function HealthCheck.getQuickStatus()
         timestamp_iso = os.date("!%Y-%m-%dT%H:%M:%SZ"),
         version = "1.0.0",
         environment = os.getenv("LAPIS_ENVIRONMENT") or "development",
+        system_info = HealthCheck.getSystemInfo(),
         services = {
             database = {
                 status = db_check.status,

--- a/lapis/nginx.conf
+++ b/lapis/nginx.conf
@@ -118,6 +118,15 @@ env LAPIS_ENVIRONMENT;
 env E2E_OTP_PEEK_ENABLED;
 env E2E_OTP_PEEK_SECRET;
 
+# Kubernetes downward-API fields surfaced by helper/health-check.lua's
+# getSystemInfo() in the /health response. Populate them in the deployment
+# via env from fieldRef (metadata.name, metadata.namespace, status.podIP,
+# spec.nodeName); they're harmless when unset (the JSON fields just go nil).
+env POD_NAME;
+env POD_NAMESPACE;
+env POD_IP;
+env NODE_NAME;
+
 # helper/auth-cookies.lua reads these to compose the Set-Cookie header
 # for the opaque refresh token. See helper/auth-cookies.lua and the
 # .env.example block for the full multi-tenant / dev / prod matrix.

--- a/opsapi-dashboard/services/tax.service.ts
+++ b/opsapi-dashboard/services/tax.service.ts
@@ -280,11 +280,16 @@ export const taxService = {
   async getTransactions(filters: TaxTransactionFilters = {}): Promise<PaginatedResponse<TaxTransaction>> {
     const response = await apiClient.get(`${TAX_BASE}/transactions`, { params: buildParams(filters as unknown as Record<string, unknown>) });
     const d = response.data;
+    // The transactions list route returns the array under `items` (and the page
+    // size as `limit`), unlike most list endpoints which use `data`/`per_page`.
+    // Accept both shapes so the table doesn't silently render empty when only
+    // `total` is read correctly (the symptom: "60 results" header with no rows).
+    const list = Array.isArray(d?.items) ? d.items : (Array.isArray(d?.data) ? d.data : []);
     return {
-      data: Array.isArray(d?.data) ? d.data : [],
+      data: list,
       total: d?.total || 0,
       page: d?.page || 1,
-      per_page: d?.per_page || 20,
+      per_page: d?.limit || d?.per_page || 20,
       total_pages: d?.total_pages || 0,
     };
   },


### PR DESCRIPTION
## Summary

Two small, independent changes bundled in one PR (different files, no overlap):

### 1. `feat(health): expose runtime/system info from /health`
Add a `system_info` block to both quick and detailed health responses so we can answer *"where is this request running, on what image, for how long, and with how much headroom?"* without shelling into a container or pod.

The detection is platform-aware:
- **Docker** → emits `platform: "docker"` + `docker.container_id`
- **Kubernetes** → emits `platform: "kubernetes"` + `kubernetes.{pod_name,pod_namespace,pod_ip,node_name}` (populated via downward API — see deploy note below)
- **Bare metal** → emits `platform: "bare-metal"` with no container/pod block

Always reports:
- `process` — pid, container/pod uptime in seconds (from `/proc/uptime` minus `/proc/self/stat` jiffies), nginx worker count
- `runtime` — OpenResty, Lua, LuaJIT versions
- `environment` — `lapis_environment`, `deploy_env`, `project_code`, `app_version`, `stack`, `deployment_time`
- `memory` — Lua heap, process RSS/VSZ, host total/available (KB)
- `hostname`, `machine_id`

Verified locally:
\`\`\`json
"system_info": {
  "platform": "docker",
  "hostname": "400854be134d",
  "docker":      { "container_id": "400854be134d" },
  "process":     { "pid": 19, "uptime_seconds": 27, "nginx_workers": 1 },
  "runtime":     { "openresty": "1.29.2", "lua": "Lua 5.1", "jit": "LuaJIT 2.1.ROLLING" },
  "environment": { "project_code": "tax_copilot", "lapis_environment": "int", "app_version": "1.0.0" },
  "memory":      { "lua_kb": 5472, "rss_kb": 29324, "vsz_kb": 258900,
                   "host_total_kb": 12244408, "host_available_kb": 7893516 }
}
\`\`\`

**Cost:** zero — only `/proc` and `os.getenv` reads; no DB, no network, no syscalls beyond file open.

**To enable the k8s pod fields** on acc/prod, the helm `deployment.yaml` needs to inject them via downward API (no-op if absent — fields just stay `nil`):
\`\`\`yaml
env:
  - { name: POD_NAME,       valueFrom: { fieldRef: { fieldPath: metadata.name } } }
  - { name: POD_NAMESPACE,  valueFrom: { fieldRef: { fieldPath: metadata.namespace } } }
  - { name: POD_IP,         valueFrom: { fieldRef: { fieldPath: status.podIP } } }
  - { name: NODE_NAME,      valueFrom: { fieldRef: { fieldPath: spec.nodeName } } }
\`\`\`

### 2. `fix(dashboard): read transactions list from items/limit`
The transactions list page showed *"60 transactions"* in the header but rendered an empty table. Root cause: `GET /api/v2/tax/transactions` returns its array under `items` (page size `limit`), while every other list endpoint in this service returns `data`/`per_page` — so `getTransactions` was reading the wrong keys for the row data but the right key for `total`.

Fix accepts both shapes (`items` first, `data` fallback; `limit` first, `per_page` fallback) so the table renders regardless of which response normalisation the backend lands on.

## Test plan
- [x] `/health` on local docker returns the new `system_info` block (verified above)
- [x] `/health?detailed=true` includes it alongside existing checks
- [x] Lua byte-compiles cleanly in the container
- [x] Container restart + first request is fast (no syscall regression)
- [ ] After merge → deploy to acc → confirm `platform: "kubernetes"` once the downward-API envs land in the helm chart
- [ ] Tax → Transactions page renders rows (not just header count) after dashboard rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)