### PR TITLE
Feat/dev mode and tax dashboard fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,105 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+OpsAPI is a multi-tenant SaaS platform that ships many business modules behind one API: authentication/RBAC, CRM, invoicing, accounting/bookkeeping, UK tax filing (HMRC MTD), hospital/care-home management, e-commerce, delivery, chat, kanban, timesheets, themes, secret vault, and more. A single codebase is sliced into "projects" (presets of features) selected at deploy time, and isolated at runtime by a Keycloak-style **namespace** (tenant) concept.
+
+Stack ("OLP"): **OpenResty Nginx + Lua (Lapis framework) + PostgreSQL** for the backend, **Next.js** (App Router) for the admin dashboard, plus Redis, MinIO (S3 files), Kafka, Ollama (local LLM), Prometheus/Grafana. Lua runs inside the Nginx workers — there is no separate app server.
+
+Repo layout: `lapis/` = backend API, `opsapi-dashboard/` = Next.js frontend, `node/` = optional Node file-upload service, `devops/` + `sre/` = infra (Helm, Ansible, nginx, monitoring), `projects/` = pluggable project modules, `start.sh` = the all-in-one dev/deploy orchestrator.
+
+## Commands
+
+### Full local stack (preferred)
+`start.sh` orchestrates docker-compose, migrations, admin seeding, and `/etc/hosts`:
+```bash
+cp lapis/.sample.env lapis/.env           # first time only
+./start.sh -e local -n -j all             # bring up everything, create ALL tables
+./start.sh -e local -n -j tax_copilot     # only core + tax tables (see PROJECT_CODE below)
+./start.sh -e local -n -j all -r          # -r resets the DB (drops volumes)
+./start.sh -e local -n -j all -A admin@me.com -W MyPass123   # custom admin creds
+```
+Key flags: `-e <env>` (local|dev|test|acc|prod), `-j <PROJECT_CODE>`, `-n` (skip git), `-r` (reset DB), `-C` (CI mode, no dev volume mounts), `-c` (only update `.env`). Run `./start.sh -h` for the full list. Default admin: `admin@opsapi.com` / `Admin@123`.
+
+Local URLs: API `http://127.0.0.1:4010` (Swagger at `/swagger`, health at `/health`), Dashboard `http://127.0.0.1:8039`, Adminer `:7779`, MinIO console `:9001`, Grafana `:3011`, Prometheus `:9090`, Gatus `:8888`.
+
+### Backend (lapis/)
+```bash
+cd lapis && ./lapis-run-dev.sh            # compose up + run `lapis migrate` (standalone, no start.sh)
+docker exec -it opsapi lapis migrate      # run migrations against the running container
+docker exec -e PROJECT_CODE=ecommerce -it opsapi lapis migrate   # migrate a specific project
+docker logs -f opsapi                     # tail API logs
+```
+Lint: `luacheck` (config in `lapis/.luacheckrc`; `ngx` is a known global, max line 120). CI validates syntax with `openresty -t` (see `.github/workflows/validate-opsapi-syntax.yml`).
+
+### Frontend (opsapi-dashboard/)
+```bash
+npm run dev          # next dev on port 8039
+npm run build        # next build (standalone output for Docker)
+npm run lint         # eslint
+npm run type-check   # tsc --noEmit
+npm run cy:open      # Cypress interactive
+npm run cy:run       # Cypress headless (e2e in cypress/e2e/)
+npm run cy:run:login # run a single spec: cypress run --spec '...'
+```
+`NEXT_PUBLIC_API_URL` (default `http://127.0.0.1:4010`) points the dashboard at the backend.
+
+## Backend architecture
+
+### Two concepts decide what code runs
+1. **PROJECT_CODE** (env var, build/deploy-time): selects which feature modules exist. `helper/project-config.lua` maps a code (`all`, `tax_copilot`, `ecommerce`, `hospital`, `business`, `collaboration`, `core_only`, …) to a set of features. Codes can be combined with commas (`ecommerce,chat`). `core` is always on.
+2. **Namespace** (per-request, runtime): the tenant. Every business table carries `namespace_id`; middleware resolves the tenant and scopes all data.
+
+`app.lua` wires both: it registers public routes (`/`, `/health`, `/ready`, `/live`, `/metrics`, `/swagger`, `/openapi.json`, auth endpoints), installs a global `before_filter` that runs JWT auth on everything else, then **feature-gated route loading** via `load_if(feature, "routes.x")` — a route file is only `require`d if its feature is enabled, so projects never query tables that don't exist for them. When adding a module, both the route loader in `app.lua` AND the migration loader in `migrations.lua` must be gated on the same feature.
+
+### Layering (follow this pattern for any new module)
+`routes/*.lua` → `queries/*.lua` → `models/*.lua` → PostgreSQL.
+- **Models** (`models/XModel.lua`) are thin: `Model:extend("table_name", { timestamp = true })`. Auto-loaded via `models.lua` (`autoload("models")`).
+- **Queries** (`queries/XQueries.lua`) hold all business logic, validation, pagination, and raw SQL (`require("lapis.db")`). Always filter by `namespace_id`.
+- **Routes** (`routes/X.lua`) export `return function(app) ... end`, parse JSON bodies manually (`ngx.req.read_body()` + `cjson`), wrap handlers in auth + namespace middleware, and return `{ status = ..., json = ... }`. The house response shape is `{ success = true, data = ..., meta = ... }`.
+
+See `routes/crm-accounts.lua` for the canonical CRUD example (note the explicit `namespace_id` ownership check on every read/update/delete).
+
+### Middleware & auth
+- `middleware/auth.lua`: `AuthMiddleware.requireAuth(handler)` verifies the `Bearer` JWT (`resty.jwt`, `JWT_SECRET_KEY`), sets `self.current_user`. Also `requireRole`. An `X-Public-Browse: true` header allows anonymous read access where wired in.
+- `middleware/namespace.lua`: `requireNamespace`, `requirePermission(module, action, handler)`, `requireOwner`, `requireAdmin`. Resolves the tenant from `X-Namespace-Id`/`X-Namespace-Slug` header → JWT → subdomain, validates membership, and populates `self.namespace`, `self.namespace_permissions`, `self.is_namespace_owner`, `self.is_platform_admin`. Permissions are `module.action` (action `manage` = full access); platform admins and namespace owners bypass checks.
+- Routes typically compose them: `AuthMiddleware.requireAuth(NamespaceMiddleware.requireNamespace(fn))`.
+- The global `before_filter` in `app.lua` keeps an explicit allow-list of public URIs and URI patterns (e.g. `^/api/v2/[^/]+/public/`). Adding a new public endpoint means updating that list.
+
+### Migrations
+`migrations.lua` is a single large conditional migration registry: it uses `load_if_enabled(feature, "migrations.x")` so each project only creates its tables. Per-feature migration modules live in `migrations/*.lua`. There is also `schema-updates.lua`, `production-schema-upgrade.lua`, and `ecommerce-migrations.lua` for targeted upgrades. Migrations are tracked via `helper/migration-tracker.lua` (supports dry-run + skip logging).
+
+### Helpers & libs (where cross-cutting logic lives)
+- `helper/` — `auth.lua`, `jwt-helper.lua`, `otp.lua` (2FA), `namespace-resolver.lua` / `namespace_assignment.lua` (lazy tenant assignment on first request), `entitlement-service.lua` (billing entitlements), `openapi_generator.lua` (builds the Swagger spec served at `/openapi.json`), `invoice-generator.lua`, `pdf-generator.lua`, `hmrc.lua`, `mail.lua`, `minio.lua`, push helpers (`fcm-push`, `apns-push`), and the `project-loader.lua` that mounts external project modules from `/app/projects`.
+- `lib/` — heavier services: `stripe.lua`/`stripe_payments.lua`/`payment-provider.lua` (billing), `accounting-engine.lua`, `tax-classifier.lua`/`tax-extraction.lua`, `llm-client.lua`/`ai-service.lua`/`langfuse.lua` (LLM/Ollama), `kafka-producer.lua`/`kafka-consumer.lua` (audit/outbox events), `prometheus_metrics.lua`, `theme-*.lua` (WordPress-style multi-tenant theming), `errors.lua`/`error_catalog.lua` (catalog-backed error envelopes; the handler installed in `app.lua` writes audit rows to the shared `error_occurrences` table).
+
+### Pluggable projects
+`projects/<name>/` (e.g. `hospital-patient-manager`) is a self-contained module with its own `project.lua` manifest, `api/`, `migrations/`, `services/`, `dashboards/`, and `themes/`. `helper/project-loader.lua` auto-discovers them at boot (from `OPSAPI_PROJECTS_DIR`, default `/app/projects`) and registers their routes + features dynamically via `ProjectConfig.registerFeature`.
+
+### Code generators
+`./generate-api.sh` (interactive) and `./quick-api.sh <ModelName>` scaffold a Model+Queries+Routes triple and auto-register the route in `app.lua`. See `API-GENERATOR.md`.
+
+## Frontend architecture (opsapi-dashboard/)
+
+Next.js 16 App Router + React 19 + TypeScript + Tailwind v4 + Zustand. Runs on port 8039, built with `output: "standalone"` for Docker.
+- `app/` — routes: `login/`, `verify-otp/` (2FA), `dashboard/` (the authed app), `docs/`.
+- `services/*.service.ts` — one typed API client per backend module (crm, invoices, tax, kanban, hospitals, themes, namespace, …), all going through `lib/api-client.ts` (axios; injects JWT + namespace headers).
+- `store/*.store.ts` — Zustand stores (`auth`, `namespace`, `menu`, `kanban`, `notification`).
+- `contexts/` — `NamespaceContext` and `PermissionsContext` mirror the backend tenant/RBAC model on the client; the dashboard menu is backend-driven (`useMenu` + `menu.service`).
+- `hooks/` — `useWebSocket` (chat/notifications), `useDataFetch`, `useGridNavigation`.
+
+## Conventions & gotchas
+
+- **Always scope tenant data by `namespace_id`** in queries, and re-check ownership in route handlers before update/delete — middleware sets the namespace but does not auto-filter your SQL.
+- **Adding a feature module** = create migration in `migrations/` + register it gated in `migrations.lua`; create model/queries/routes; gate the route in `app.lua` with the same feature; add RBAC modules under `PROJECT_MODULES` in `helper/project-config.lua`; add the matching `*.service.ts` on the frontend.
+- Routes parse request bodies manually with `cjson` (no automatic body binding). JSON `metadata`/jsonb fields are `cjson.encode`d before storage.
+- Billing/Stripe uses a single-merchant model and is deduped against webhook races (`StripeWebhookEventModel`, `BillingPaymentModel`) — be careful editing the `checkout.session.completed` / `invoice.paid` paths.
+- `E2E_OTP_PEEK_ENABLED=true` exposes a test-only OTP peek endpoint (acc only, secret-gated). **Never set it on prod.**
+- `lapis/core` (untracked, ~367 MB) is a runtime core dump, not source — do not commit it.
+- The `.env` lives at `lapis/.env` (copy from `lapis/.sample.env`); `PROJECT_CODE`, `POSTGRES_*`, `JWT_SECRET_KEY`, Stripe/HMRC/SMTP/MinIO creds are read from there.
+
+## Reference docs in repo
+
+`README.md` (setup), `NAMESPACE_IMPLEMENTATION_PLAN.md` (tenancy design), `ECOMMERCE-API.md`, `API-GENERATOR.md`, `THEMING_GUIDE.md`, `DDOS_MITIGATION_GUIDE.md`, and the `*METRICS*`/`*PROMETHEUS*`/`*GRAFANA*` monitoring guides.

--- a/lapis/.gitignore
+++ b/lapis/.gitignore
@@ -1,2 +1,5 @@
 # Service account credentials
 iosapp-97bac-b3a53c94e206.json
+
+# Runtime core dump (multi-hundred-MB process image, never commit)
+/core

--- a/lapis/Dockerfile
+++ b/lapis/Dockerfile
@@ -30,6 +30,10 @@ RUN luarocks install lua-resty-mail
 RUN apk add mysql-client
 RUN apk add postgresql-client
 RUN apk add curl
+# poppler-utils provides pdftotext + pdftoppm, used by lib/tax-extraction.lua to
+# pull transactions out of uploaded PDF bank statements (and rasterise scanned
+# PDFs for the Vision fallback). Without it, the "Extract" action fails on PDFs.
+RUN apk add --no-cache poppler-utils
 RUN wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc \
     --tries=3 --timeout=30 && \
     chmod +x /usr/local/bin/mc

--- a/lapis/docker-compose.dashboard-dev.yml
+++ b/lapis/docker-compose.dashboard-dev.yml
@@ -1,0 +1,53 @@
+# Dashboard dev override — hot-reload mode (no production build)
+#
+# Merge this on top of docker-compose.yml to run the Next.js dashboard with
+# `next dev` and the source bind-mounted, so code changes hot-reload instantly
+# instead of requiring a `next build` image rebuild every time.
+#
+# Enabled by start.sh via the -D / --dashboard-dev flag, which runs:
+#   docker compose -f docker-compose.yml -f docker-compose.dashboard-dev.yml up -d
+#
+# `build: !reset null` drops the prod build stanza from the base service so
+# `up --build` does NOT build the dashboard image; the node base image runs
+# `npm install && npm run dev` against the mounted source instead.
+services:
+  dashboard:
+    build: !reset null
+    image: node:24.14-alpine
+    working_dir: /app
+    # Use webpack dev (not Turbopack): Turbopack's native file watcher doesn't
+    # receive inotify events across the Colima/virtiofs bind mount, so edits
+    # never trigger a recompile. Webpack honors WATCHPACK_POLLING (set below)
+    # and reliably hot-reloads host edits.
+    command: sh -c "npm install && npx next dev --webpack -p 8039"
+    # Pull runtime config from lapis/.env (NEXT_PUBLIC_API_URL, FRONTEND_URL, …).
+    # In dev these are read at runtime (not baked at build), and next.config.ts
+    # uses FRONTEND_URL/NEXT_PUBLIC_API_URL to build allowedDevOrigins so the
+    # dashboard works when reached through a public proxy host, not just localhost.
+    env_file: ".env"
+    environment:
+      - NODE_ENV=development
+      # Fall back to localhost only if .env didn't define it.
+      - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://127.0.0.1:4010}
+      - FRONTEND_URL=${FRONTEND_URL:-http://127.0.0.1:8039}
+      # Optional extra hosts (comma-separated) allowed to reach the dev server.
+      - ALLOWED_DEV_ORIGINS=${ALLOWED_DEV_ORIGINS:-}
+      # Poll the filesystem — virtiofs/Colima bind mounts don't reliably emit
+      # inotify events, so without this hot reload silently stops working.
+      - WATCHPACK_POLLING=true
+      - CHOKIDAR_USEPOLLING=true
+    volumes:
+      # Mount the source for hot reload...
+      - ../opsapi-dashboard:/app
+      # ...but keep node_modules and .next inside the container (anonymous
+      # volumes) so the host dir never shadows the container's installed deps.
+      - /app/node_modules
+      - /app/.next
+    # First compile after boot can take a while; give the dev server time
+    # before the healthcheck starts marking it unhealthy.
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:8039"]
+      interval: 30s
+      timeout: 20s
+      retries: 5
+      start_period: 120s

--- a/lapis/routes/tax-classify.lua
+++ b/lapis/routes/tax-classify.lua
@@ -20,6 +20,15 @@ local function getUserId(user)
     return rows and rows[1] and rows[1].id
 end
 
+-- Resolve a statement by uuid (what the frontend sends, via `uuid as id`) or by
+-- numeric PK. Returns the db.select result list.
+local function findStatement(statement_id, user_id)
+    if tostring(statement_id):match("^%d+$") then
+        return db.select("* FROM tax_statements WHERE id = ? AND user_id = ? LIMIT 1", statement_id, user_id)
+    end
+    return db.select("* FROM tax_statements WHERE uuid = ? AND user_id = ? LIMIT 1", statement_id, user_id)
+end
+
 return function(app)
 
     -- GET /api/v2/tax/classify/providers — list available LLM providers
@@ -50,16 +59,15 @@ return function(app)
                     return { status = 401, json = { error = "User not found" } }
                 end
 
-                -- Verify statement ownership and workflow state
-                local statements = db.select(
-                    "* FROM tax_statements WHERE id = ? AND user_id = ? LIMIT 1",
-                    statement_id, user_id
-                )
+                -- Verify statement ownership and workflow state (accepts uuid or id)
+                local statements = findStatement(statement_id, user_id)
                 if #statements == 0 then
                     return { status = 404, json = { error = "Statement not found" } }
                 end
 
                 local stmt = statements[1]
+                -- Normalize to the numeric PK for all downstream reads/writes.
+                statement_id = stmt.id
                 if stmt.workflow_step == "FILED" then
                     return { status = 409, json = { error = "Cannot reclassify a filed statement" } }
                 end

--- a/lapis/routes/tax-extract.lua
+++ b/lapis/routes/tax-extract.lua
@@ -22,6 +22,16 @@ local function getUserId(user)
     return rows and rows[1] and rows[1].id
 end
 
+-- Resolve a statement by the identifier the client sends. The statements list
+-- exposes `uuid as id`, so the frontend sends the UUID — but older callers may
+-- pass the numeric PK. Accept both: numeric -> id, otherwise -> uuid.
+local function findStatement(statement_id, user_id)
+    if tostring(statement_id):match("^%d+$") then
+        return db.select("* FROM tax_statements WHERE id = ? AND user_id = ? LIMIT 1", statement_id, user_id)
+    end
+    return db.select("* FROM tax_statements WHERE uuid = ? AND user_id = ? LIMIT 1", statement_id, user_id)
+end
+
 return function(app)
 
     -- POST /api/v2/tax/extract/bank-details — detect bank details from file
@@ -39,14 +49,14 @@ return function(app)
                 end
 
                 -- Fetch statement
-                local statements = db.select(
-                    "* FROM tax_statements WHERE id = ? AND user_id = ? LIMIT 1",
-                    statement_id, user_id
-                )
+                local statements = findStatement(statement_id, user_id)
                 if #statements == 0 then
                     return { status = 404, json = { error = "Statement not found" } }
                 end
                 local stmt = statements[1]
+                -- Normalize to the numeric PK so all subsequent DB reads/writes
+                -- (inserts, updates) use the real id even when the client sent a uuid.
+                statement_id = stmt.id
 
                 -- Download file from MinIO to temp path
                 local file_key = stmt.minio_key or stmt.file_path
@@ -143,14 +153,14 @@ return function(app)
                     return { status = 401, json = { error = "User not found" } }
                 end
 
-                local statements = db.select(
-                    "* FROM tax_statements WHERE id = ? AND user_id = ? LIMIT 1",
-                    statement_id, user_id
-                )
+                local statements = findStatement(statement_id, user_id)
                 if #statements == 0 then
                     return { status = 404, json = { error = "Statement not found" } }
                 end
                 local stmt = statements[1]
+                -- Normalize to the numeric PK so all subsequent DB reads/writes
+                -- (inserts, updates) use the real id even when the client sent a uuid.
+                statement_id = stmt.id
 
                 -- Check workflow step
                 if stmt.workflow_step and stmt.workflow_step ~= "UPLOADED" and stmt.workflow_step ~= "EXTRACTED" then
@@ -313,14 +323,12 @@ return function(app)
                 return { status = 401, json = { error = "User not found" } }
             end
 
-            -- Verify statement belongs to user
-            local statements = db.select(
-                "* FROM tax_statements WHERE id = ? AND user_id = ? LIMIT 1",
-                self.params.statement_id, user_id
-            )
+            -- Verify statement belongs to user (accepts uuid or numeric id)
+            local statements = findStatement(self.params.statement_id, user_id)
             if #statements == 0 then
                 return { status = 404, json = { error = "Statement not found" } }
             end
+            local statement_pk = statements[1].id
 
             local page = tonumber(self.params.page) or 1
             local per_page = tonumber(self.params.per_page) or 100
@@ -328,12 +336,12 @@ return function(app)
 
             local transactions = db.select(
                 "* FROM tax_transactions WHERE statement_id = ? ORDER BY transaction_date ASC, id ASC LIMIT ? OFFSET ?",
-                self.params.statement_id, per_page, offset
+                statement_pk, per_page, offset
             )
 
             local count_result = db.select(
                 "COUNT(*) as total FROM tax_transactions WHERE statement_id = ?",
-                self.params.statement_id
+                statement_pk
             )
             local total = count_result[1] and count_result[1].total or 0
 

--- a/opsapi-dashboard/app/dashboard/tax/bank-accounts/page.tsx
+++ b/opsapi-dashboard/app/dashboard/tax/bank-accounts/page.tsx
@@ -84,7 +84,7 @@ function BankAccountsContent() {
     if (!editingAccount) return;
     setIsSaving(true);
     try {
-      await taxService.updateBankAccount(editingAccount.uuid, formData);
+      await taxService.updateBankAccount(editingAccount.uuid ?? editingAccount.id, formData);
       toast.success('Bank account updated');
       setEditingAccount(null);
       resetForm();
@@ -99,7 +99,7 @@ function BankAccountsContent() {
   const handleDelete = async (account: TaxBankAccount) => {
     if (!confirm(`Delete bank account "${account.bank_name}"? This cannot be undone.`)) return;
     try {
-      await taxService.deleteBankAccount(account.uuid);
+      await taxService.deleteBankAccount(account.uuid ?? account.id);
       toast.success('Bank account deleted');
       fetchAccounts();
     } catch {

--- a/opsapi-dashboard/app/dashboard/tax/statements/page.tsx
+++ b/opsapi-dashboard/app/dashboard/tax/statements/page.tsx
@@ -34,6 +34,20 @@ const STATUS_CONFIG: Record<string, { label: string; classes: string; icon: Reac
   error: { label: 'Error', classes: 'bg-red-100 text-red-700', icon: <AlertCircle className="w-3 h-3" /> },
 };
 
+// The API returns workflow_step (UPLOADED/EXTRACTED/CLASSIFIED) and
+// processing_status (PROCESSING/COMPLETED/ERROR), not a lowercase `status`.
+// Derive the UI status the badge + action buttons expect.
+function statementStatus(item: TaxStatement): 'uploaded' | 'processing' | 'extracted' | 'classified' | 'error' {
+  if (item.status) return item.status;
+  const proc = (item.processing_status || '').toUpperCase();
+  if (proc === 'PROCESSING') return 'processing';
+  if (proc === 'ERROR') return 'error';
+  const step = (item.workflow_step || '').toUpperCase();
+  if (step === 'CLASSIFIED') return 'classified';
+  if (step === 'EXTRACTED') return 'extracted';
+  return 'uploaded';
+}
+
 function StatementsContent() {
   const [statements, setStatements] = useState<TaxStatement[]>([]);
   const [bankAccounts, setBankAccounts] = useState<TaxBankAccount[]>([]);
@@ -44,7 +58,9 @@ function StatementsContent() {
 
   const [showUploadModal, setShowUploadModal] = useState(false);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
-  const [selectedBankAccountId, setSelectedBankAccountId] = useState<number | ''>('');
+  // Holds the bank account UUID (string). The list endpoint returns `uuid as id`,
+  // so the account identifier is a string, and the backend /tax/upload keys on it.
+  const [selectedBankAccountId, setSelectedBankAccountId] = useState<string>('');
   const [statementDate, setStatementDate] = useState('');
   const [isUploading, setIsUploading] = useState(false);
   const [processingId, setProcessingId] = useState<number | null>(null);
@@ -113,7 +129,7 @@ function StatementsContent() {
 
     setIsUploading(true);
     try {
-      await taxService.uploadStatement(selectedFile, Number(selectedBankAccountId), statementDate || undefined);
+      await taxService.uploadStatement(selectedFile, selectedBankAccountId, statementDate || undefined);
       toast.success('Statement uploaded successfully');
       setShowUploadModal(false);
       setSelectedFile(null);
@@ -198,7 +214,7 @@ function StatementsContent() {
       key: 'status',
       header: 'Status',
       render: (item) => {
-        const config = STATUS_CONFIG[item.status] || STATUS_CONFIG.uploaded;
+        const config = STATUS_CONFIG[statementStatus(item)] || STATUS_CONFIG.uploaded;
         return (
           <span className={`inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-medium ${config.classes}`}>
             {config.icon}
@@ -223,7 +239,7 @@ function StatementsContent() {
       width: 'w-36',
       render: (item) => (
         <div className="flex items-center gap-1">
-          {item.status === 'uploaded' && (
+          {statementStatus(item) === 'uploaded' && (
             <button
               onClick={(e) => { e.stopPropagation(); handleExtract(item); }}
               disabled={processingId === item.id}
@@ -233,7 +249,7 @@ function StatementsContent() {
               {processingId === item.id ? <Loader2 className="w-4 h-4 animate-spin" /> : <Play className="w-4 h-4" />}
             </button>
           )}
-          {item.status === 'extracted' && (
+          {statementStatus(item) === 'extracted' && (
             <button
               onClick={(e) => { e.stopPropagation(); handleClassify(item); }}
               disabled={processingId === item.id}
@@ -328,15 +344,20 @@ function StatementsContent() {
               <label className="block text-sm font-medium text-secondary-700 mb-1">Bank Account *</label>
               <select
                 value={selectedBankAccountId}
-                onChange={(e) => setSelectedBankAccountId(e.target.value ? Number(e.target.value) : '')}
+                onChange={(e) => setSelectedBankAccountId(e.target.value)}
                 className="w-full px-3 py-2 border border-secondary-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
               >
                 <option value="">Select a bank account...</option>
-                {bankAccounts.map((acc) => (
-                  <option key={acc.id} value={acc.id}>
-                    {acc.bank_name} {acc.account_number ? `(****${acc.account_number.slice(-4)})` : ''}
-                  </option>
-                ))}
+                {bankAccounts.map((acc) => {
+                  // List endpoint returns `uuid as id`, so `id` is the uuid the
+                  // backend keys on. Prefer an explicit `uuid` if present.
+                  const accountId = acc.uuid ?? acc.id;
+                  return (
+                    <option key={accountId} value={accountId}>
+                      {acc.bank_name} {acc.account_number ? `(****${acc.account_number.slice(-4)})` : ''}
+                    </option>
+                  );
+                })}
               </select>
               {bankAccounts.length === 0 && (
                 <p className="text-xs text-amber-600 mt-1">

--- a/opsapi-dashboard/components/ui/Modal.tsx
+++ b/opsapi-dashboard/components/ui/Modal.tsx
@@ -26,22 +26,29 @@ const Modal: React.FC<ModalProps> = ({
   const modalRef = useRef<HTMLDivElement>(null);
   const titleId = title ? `modal-title-${title.replace(/\s+/g, '-').toLowerCase()}` : undefined;
 
+  // Lock scroll and focus the modal ONLY when it transitions open.
+  // This must NOT depend on `onClose`: callers pass an inline arrow function,
+  // so its identity changes on every parent re-render (e.g. each keystroke in
+  // a form field). If this effect re-ran on that change, modalRef.focus() would
+  // yank focus out of the input being typed into. Keyed on `isOpen` only.
   useEffect(() => {
+    if (!isOpen) return;
+    document.body.style.overflow = 'hidden';
+    modalRef.current?.focus();
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
+
+  // Escape-to-close. Separate effect so re-subscribing when `onClose` changes
+  // is harmless (no focus side effect here).
+  useEffect(() => {
+    if (!isOpen) return;
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose();
     };
-
-    if (isOpen) {
-      document.addEventListener('keydown', handleEscape);
-      document.body.style.overflow = 'hidden';
-      // Focus the modal when it opens
-      modalRef.current?.focus();
-    }
-
-    return () => {
-      document.removeEventListener('keydown', handleEscape);
-      document.body.style.overflow = '';
-    };
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
   }, [isOpen, onClose]);
 
   if (!isOpen) return null;

--- a/opsapi-dashboard/next.config.ts
+++ b/opsapi-dashboard/next.config.ts
@@ -1,6 +1,50 @@
 import type { NextConfig } from "next";
 
+// In dev mode, Next.js 16 only serves dev assets (/_next/*) and the HMR
+// WebSocket to requests whose Origin host is allow-listed. When the dashboard
+// is reached through a reverse proxy / tunnel on a public host (e.g.
+// dev-opsapi-remote.fictionally.org) rather than localhost, the page hangs and
+// the webpack-hmr WebSocket is refused unless that host is listed here.
+// We derive the hosts from the same env the deployment already sets
+// (FRONTEND_URL / NEXT_PUBLIC_API_URL) plus an optional ALLOWED_DEV_ORIGINS
+// override, so this needs no per-domain hardcoding.
+function hostOf(url?: string): string | null {
+  if (!url) return null;
+  try {
+    return new URL(url).host;
+  } catch {
+    return url.replace(/^https?:\/\//, "").replace(/\/.*$/, "") || null;
+  }
+}
+
+const allowedDevOrigins = Array.from(
+  new Set(
+    [
+      "localhost",
+      "127.0.0.1",
+      hostOf(process.env.FRONTEND_URL),
+      hostOf(process.env.NEXT_PUBLIC_API_URL),
+      ...(process.env.ALLOWED_DEV_ORIGINS || "")
+        .split(",")
+        .map((s) => s.trim())
+        .map((s) => hostOf(s) || s),
+    ].filter(Boolean) as string[]
+  )
+);
+
 const nextConfig: NextConfig = {
+  // Allow dev-server/HMR access from these hosts (see note above).
+  allowedDevOrigins,
+
+  // Poll the filesystem for changes. Required when the source is bind-mounted
+  // into the container over Colima/virtiofs: native inotify events don't cross
+  // that boundary, so Turbopack's watcher never sees host edits and hot reload
+  // silently stops working. Polling makes edits reliably trigger a recompile.
+  // (Only active in dev; ignored for production builds.)
+  watchOptions: {
+    pollIntervalMs: 1000,
+  },
+
   // Enable standalone output for Docker deployment
   output: "standalone",
 

--- a/opsapi-dashboard/services/tax.service.ts
+++ b/opsapi-dashboard/services/tax.service.ts
@@ -3,15 +3,20 @@ import apiClient, { buildQueryString } from '@/lib/api-client';
 // ── Types ──────────────────────────────────────────────────────────────────────
 
 export interface TaxBankAccount {
-  id: number;
-  uuid: string;
-  user_id: number;
-  namespace_id: number;
+  // The list endpoint returns `uuid as id`, so `id` is the uuid STRING that all
+  // bank-account endpoints (show/update/delete/upload) key on — not a numeric id.
+  // `uuid` is not returned by the list; keep it optional for other responses.
+  id: string;
+  uuid?: string;
+  user_id?: number;
+  namespace_id?: number;
   bank_name: string;
+  account_name?: string;
   account_number?: string;
   sort_code?: string;
   account_type?: string;
   currency?: string;
+  is_primary?: boolean;
   is_active: boolean;
   created_at: string;
   updated_at: string;
@@ -30,7 +35,12 @@ export interface TaxStatement {
   statement_date?: string;
   start_date?: string;
   end_date?: string;
-  status: 'uploaded' | 'processing' | 'extracted' | 'classified' | 'error';
+  // The API exposes workflow_step (UPLOADED/EXTRACTED/CLASSIFIED) and
+  // processing_status (UPLOADED/PROCESSING/COMPLETED/ERROR), not a lowercase
+  // `status`. Use statementStatus() to derive the UI status from these.
+  status?: 'uploaded' | 'processing' | 'extracted' | 'classified' | 'error';
+  workflow_step?: string;
+  processing_status?: string;
   transaction_count?: number;
   error_message?: string;
   created_at: string;
@@ -243,10 +253,11 @@ export const taxService = {
     return response.data?.data || response.data;
   },
 
-  async uploadStatement(file: File, bankAccountId: number, statementDate?: string): Promise<TaxStatement> {
+  async uploadStatement(file: File, bankAccountId: string, statementDate?: string): Promise<TaxStatement> {
     const formData = new FormData();
     formData.append('file', file);
-    formData.append('bank_account_id', String(bankAccountId));
+    // Backend /tax/upload identifies the account by uuid (sent as bank_account_id).
+    formData.append('bank_account_id', bankAccountId);
     if (statementDate) formData.append('statement_date', statementDate);
 
     const response = await apiClient.post(`${TAX_BASE}/upload`, formData, {

--- a/opsapi-dashboard/store/auth.store.ts
+++ b/opsapi-dashboard/store/auth.store.ts
@@ -47,6 +47,14 @@ export const useAuthStore = create<AuthStore>()(
             error: null,
           });
         } catch (error) {
+          // 2FA-required is NOT a login failure — it's the normal next step.
+          // Don't surface it as an error (which would flash the error banner
+          // before the form redirects to /verify-otp). Just stop loading and
+          // propagate so LoginForm can stash the session token and redirect.
+          if ((error as { requires_2fa?: boolean })?.requires_2fa) {
+            set({ isLoading: false, error: null });
+            throw error;
+          }
           const message = error instanceof Error ? error.message : 'Login failed';
           // Clear all auth storage on failed login attempt
           clearAllAuthStorage();

--- a/start.sh
+++ b/start.sh
@@ -40,6 +40,7 @@ show_help() {
     echo "  -r, --reset-db        Reset database (removes volumes and wipes data)"
     echo "  -c, --check-env       Only check and update .env file, don't start containers"
     echo "  -C, --ci              CI/CD mode: uses docker-compose.override.ci.yml (no dev volume mounts)"
+    echo "  -D, --dashboard-dev   Run the Next.js dashboard in dev mode (hot reload, no image build)"
     echo "  -h, --help            Show this help message"
     echo ""
     echo -e "${BLUE}Preset Environments:${NC}"
@@ -102,6 +103,7 @@ TARGET_ENV=""
 CHECK_ENV_ONLY=false
 PROTOCOL=""
 CI_MODE=false
+DASHBOARD_DEV=false
 PROJECT_CODE=""
 APEX_DOMAIN=""
 ADMIN_EMAIL=""
@@ -155,6 +157,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         -C|--ci)
             CI_MODE=true
+            shift
+            ;;
+        -D|--dashboard-dev)
+            DASHBOARD_DEV=true
             shift
             ;;
         -d|--domain)
@@ -1036,11 +1042,16 @@ cd lapis
 
 #sed -i 's/COPY lapis\/\. \/app/COPY . \/app/' lapis/Dockerfil
 
-# Build docker compose command based on CI mode
-# CI mode uses a separate compose file without dev volume mounts
+# Build docker compose command based on CI / dashboard-dev mode
+# CI mode uses a separate compose file without dev volume mounts.
+# Dashboard-dev mode layers an override that runs Next.js via `next dev`
+# (hot reload, source bind-mounted) instead of building the production image.
 if $CI_MODE; then
     echo -e "${BLUE}[i] CI/CD mode enabled - using docker-compose.ci.yml (no dev volume mounts)${NC}"
     COMPOSE_CMD="docker compose -f docker-compose.ci.yml"
+elif $DASHBOARD_DEV; then
+    echo -e "${BLUE}[i] Dashboard dev mode enabled - Next.js runs via 'next dev' with hot reload (no image build)${NC}"
+    COMPOSE_CMD="docker compose -f docker-compose.yml -f docker-compose.dashboard-dev.yml"
 else
     COMPOSE_CMD="docker compose"
 fi


### PR DESCRIPTION
  ## Summary
  Adds a dev hot-reload mode for the Next.js dashboard and fixes a chain of bugs
  in the tax statements/bank-accounts flow, including making PDF extraction work.
  
  ## Backend (lapis)
  - **PDF extraction now works**: install `poppler-utils` (`pdftotext`/`pdftoppm`)
    in the Dockerfile so `lib/tax-extraction.lua` can actually parse uploaded PDF
    bank statements.
  - `tax-extract` & `tax-classify`: resolve statements by **uuid or numeric id**
    (the list exposes `uuid as id`, so the frontend sends the uuid) and normalize
    to the real PK for all inserts/updates.

  ## Frontend (opsapi-dashboard)
  - **Modal**: focus the dialog only on open (keyed on `isOpen`, not `onClose`),
    so inline `onClose` closures no longer steal input focus on every keystroke —
    fixes focus loss across all modals.
  - **Auth store**: treat "2FA required" as a normal next step, not an error, so
    the login error banner no longer flashes before redirecting to OTP.
  - **Tax statements**: select bank account by uuid (no more `NaN`); derive the UI
    status from `workflow_step`/`processing_status` so the Extract/Classify 
    buttons and status badge work.
  - **Tax bank-accounts**: edit/delete by `uuid ?? id` (the list returns no
    `uuid`). Corrected `TaxBankAccount`/`TaxStatement` types to match the API.
  - **next.config**: `allowedDevOrigins` (reverse-proxy host) + filesystem polling
    for reliable hot reload over Colima/virtiofs.

  ## Tooling
  - `start.sh -D/--dashboard-dev`: run the dashboard via `next dev` (webpack +
    polling, source bind-mounted) — hot reload, no image rebuild.
  - Add `lapis/docker-compose.dashboard-dev.yml` override.
  - Add `CLAUDE.md`; gitignore the `lapis/core` runtime dump.