### PR TITLE
feat(tax): complete HMRC MTD filing — binding final declaration, auto-flow & production hardening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,31 @@ See `routes/crm-accounts.lua` for the canonical CRUD example (note the explicit 
 ### Code generators
 `./generate-api.sh` (interactive) and `./quick-api.sh <ModelName>` scaffold a Model+Queries+Routes triple and auto-register the route in `app.lua`. See `API-GENERATOR.md`.
 
+### HMRC MTD Income Tax filing (UK Self Assessment)
+End-to-end "File your tax" flow against HMRC's Making Tax Digital APIs. Feature-gated under `tax_copilot`. **Read this before touching tax filing — it captures non-obvious HMRC behaviour that is expensive to rediscover.**
+
+**Layers**
+- `lib/hmrc-mtd-client.lua` — the MTD API client (one function per HMRC endpoint). Env-switched by `HMRC_ENVIRONMENT` (`sandbox`→`test-api.service.hmrc.gov.uk`, `production`→`api.service.hmrc.gov.uk`); `Client.is_sandbox()` gates sandbox-only behaviour. Endpoints + Accept versions: `list_businesses` (Business Details v2), `list_obligations` (Obligations v3), `submit_cumulative` (Self-Employment cumulative v5, `STATEFUL`), `trigger_calculation`/`get_calculation`/`poll_calculation` (Individual Calculations v8), `submit_final_declaration` (Calculations v8 — the BINDING crystallisation), `create_test_business`/`set_itsa_status` (Self Assessment Test Support v1, sandbox only).
+- `helper/hmrc.lua` — OAuth token storage/refresh (`get_valid_token`), and `build_fraud_headers()` (HMRC mandatory anti-fraud `Gov-Client-*`/`Gov-Vendor-*` headers).
+- `lib/hmrc-aggregator.lua` — rolls classified transactions into the MTD cumulative body (`build_cumulative_body`); flags negative fields (a credit mis-filed as an expense) which HMRC rejects.
+- Routes: `routes/tax-hmrc-auth.lua` (OAuth initiate/callback/disconnect), `routes/tax-hmrc-data.lua` (status, businesses/obligations fetch+cache, NINO get/save/delete), `routes/tax-hmrc-filing.lua` (`aggregate-preview`, `calculate-preview`, **`submit-final-declaration`**, `business/default|select`, `sandbox/provision`).
+- Frontend: `app/dashboard/tax/file/page.tsx` (the 6-step wizard), `services/tax.service.ts`, `lib/hmrc-fraud.ts` (browser anti-fraud signal collection).
+
+**Wizard flow (6 steps, auto-advancing):** connect (OAuth) → business (auto-fetched) → obligations (auto-fetched) → check figures (auto-aggregated; inline-fix negative credits) → preview calculation (submits cumulative + in-year calc, non-binding) → **finalise & declare** (binding final declaration, gated on a declaration checkbox). Steps 2–4 run themselves via `useEffect` guards (refs `autoBizFor`/`autoOblFor`/`autoPreviewFor`) — no "Load"/"Fetch" buttons; only genuinely-human steps need a click.
+
+**Sandbox gotchas (each cost real debugging):**
+- **Obligations return 2018-era data unless you send `Gov-Test-Scenario: DYNAMIC`** — the default sandbox response is a fixed historical sample ignoring your `from`/`to`. DYNAMIC echoes periods matching the requested dates. It returns synthetic businessIds (`XBIS…` self-employment, `XPIS…` UK property, `XFIS…` foreign property) for ALL three business types → filter to self-employment and don't filter by the real `business_id` in sandbox, or you get triplicate/empty results. The header is auto-dropped outside sandbox.
+- **`calculate-preview`/final-declaration are STATEFUL** — they only work against a business created via the Test Support API. The businesses from Business Details / obligations (e.g. `XBIS12345678901`) are NOT fileable → HMRC returns `MATCHING_RESOURCE_NOT_FOUND`. Both routes **self-heal** in sandbox: on that error they auto-call `provisionSandboxBusiness()` (create test business + set MTD ITSA status, store as `default_business_id`) and retry once.
+- **Calculation figures nest under `calculation.taxCalculation.*`** (with sub-totals in `.incomeTax` and `allowancesAndDeductions`), NOT top-level — `parse_figures` reads the right paths. Sandbox always returns `-99999999999.99` for the grand total (a placeholder, flagged via `is_sandbox_placeholder`); other figures are real.
+- The final declaration must reference an **`intent-to-finalise`** calc (not `in-year`), and real HMRC rejects finalising a tax year before it ends (`RULE_FINAL_DECLARATION_TAX_YEAR`); sandbox simulates success.
+
+**Production readiness (env-only is NOT enough — needs the code already in place + these):**
+- `ssl_verify` is env-aware (`not Client.is_sandbox()` / `tls_verify()`): verified TLS in production, off in sandbox. Production requires `lua_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt` in the nginx http block (already in `nginx.conf` + `nginx-values-template.conf`).
+- **Anti-fraud headers** pass HMRC's "Test Fraud Prevention Headers" validator. Browser-only signals are collected in `lib/hmrc-fraud.ts`, forwarded as `X-Gov-Client-*` headers (allow-listed in `middleware/cors.lua`), and remapped server-side in `build_fraud_headers`. `Gov-Vendor-Public-IP`/`Gov-Vendor-Forwarded` need `HMRC_SERVER_PUBLIC_IP` (the backend's egress IP) set in prod — omitted if unset (HMRC rejects private IPs). The only remaining validator output is a non-blocking `Gov-Client-Multi-Factor` warning (fine for username+password+OTP).
+- **Env vars** (in `.sample.env`): `HMRC_ENVIRONMENT`, `HMRC_CLIENT_ID`, `HMRC_CLIENT_SECRET`, `HMRC_REDIRECT_URI`, `HMRC_SERVER_PUBLIC_IP`. OAuth scopes must include `read:self-assessment` + `write:self-assessment`. The HMRC app must subscribe (Developer Hub) to: Business Details / Obligations / Self Employment Business / Individual Calculations (MTD) — plus Self Assessment Test Support, Create Test User, Test Fraud Prevention Headers for sandbox only.
+
+**Testing without a browser OAuth flow:** mint a JWT for a user with a stored `hmrc_tokens` row by HMAC-signing `{userinfo:{uuid,sub}, iat, exp, iss:"opsapi"}` with `$JWT_SECRET_KEY` (the container lacks `perl`, so `resty` CLI won't run — build the JWT with `openssl dgst -sha256 -hmac`). Syntax-check Lua via `docker exec opsapi /usr/local/openresty/luajit/bin/luajit -b <file> /dev/null`.
+
 ## Frontend architecture (opsapi-dashboard/)
 
 Next.js 16 App Router + React 19 + TypeScript + Tailwind v4 + Zustand. Runs on port 8039, built with `output: "standalone"` for Docker.

--- a/lapis/.sample.env
+++ b/lapis/.sample.env
@@ -97,3 +97,19 @@ KEYCLOAK_REDIRECT_URI=http://127.0.0.1:4010/auth/callback
 # STRIPE_SECRET_KEY=sk_test_...
 # STRIPE_PUBLISHABLE_KEY=pk_test_...
 # STRIPE_WEBHOOK_SECRET=whsec_...
+
+# ============================================
+# HMRC Making Tax Digital (UK tax filing)
+# ============================================
+# HMRC_ENVIRONMENT switches base URLs + enables TLS verification:
+#   sandbox    -> https://test-api.service.hmrc.gov.uk (ssl_verify off; test users + auto-provision)
+#   production -> https://api.service.hmrc.gov.uk     (ssl_verify ON; real filings)
+# HMRC_ENVIRONMENT=sandbox
+# Credentials from your HMRC Developer Hub application (sandbox vs production are different apps):
+# HMRC_CLIENT_ID=...
+# HMRC_CLIENT_SECRET=...
+# OAuth callback — must EXACTLY match the redirect URI registered on your HMRC application:
+# HMRC_REDIRECT_URI=https://your-domain.example/auth/hmrc/callback
+# The backend's PUBLIC egress IP (HMRC anti-fraud Gov-Vendor-Public-IP / Gov-Vendor-Forwarded).
+# Required in production — HMRC rejects private IPs; omit for local dev. Find via `curl ifconfig.me`.
+# HMRC_SERVER_PUBLIC_IP=203.0.113.10

--- a/lapis/helper/hmrc.lua
+++ b/lapis/helper/hmrc.lua
@@ -14,6 +14,11 @@ local HMRC = {}
 local HMRC_CLIENT_ID = os.getenv("HMRC_CLIENT_ID") or ""
 local HMRC_CLIENT_SECRET = os.getenv("HMRC_CLIENT_SECRET") or ""
 local HMRC_ENVIRONMENT = os.getenv("HMRC_ENVIRONMENT") or "sandbox"
+-- The backend's PUBLIC egress IP (the address HMRC sees our calls come from). Required for
+-- the Gov-Vendor-Public-IP / Gov-Vendor-Forwarded fraud headers. HMRC rejects PRIVATE IPs,
+-- so when this is unset (e.g. local dev) we omit those headers rather than send an invalid
+-- value. Set it to your NAT/egress IP in production.
+local HMRC_SERVER_PUBLIC_IP = os.getenv("HMRC_SERVER_PUBLIC_IP") or ""
 
 local BASE_URLS = {
     sandbox = "https://test-api.service.hmrc.gov.uk",
@@ -22,6 +27,14 @@ local BASE_URLS = {
 
 local function get_base_url()
     return BASE_URLS[HMRC_ENVIRONMENT] or BASE_URLS.sandbox
+end
+
+-- Verify TLS certificates in production. The sandbox is left unverified because the
+-- container historically lacked a configured CA trust store; production REQUIRES
+-- verification (we send NINOs + financial data) and the nginx http block now sets
+-- lua_ssl_trusted_certificate to the system CA bundle so resty.http can verify.
+local function tls_verify()
+    return HMRC_ENVIRONMENT == "production"
 end
 
 local function create_http_client()
@@ -36,39 +49,69 @@ end
 -- Fraud Prevention Headers (mandatory for MTD)
 -- ---------------------------------------------------------------------------
 
+-- HMRC mandatory anti-fraud headers. We are a WEB_APP_VIA_SERVER: the end user runs a
+-- browser and our server makes the HMRC call. The browser-only signals (device id,
+-- timezone, JS user-agent, screens, window size, user ids) are collected client-side and
+-- forwarded by the dashboard as X-Gov-Client-* headers; we read them here and map them to
+-- the real Gov-Client-* headers. Server-derivable signals (public IP/port, the user→server
+-- hop, vendor info) are set directly. We OMIT (never fake) anything we genuinely don't
+-- have. Validate the full set against HMRC's "Test Fraud Prevention Headers" API.
 function HMRC.build_fraud_headers()
     local headers = {}
 
+    -- Signals forwarded by the browser (lower-cased keys via get_headers()).
+    local fwd = {}
+    pcall(function() fwd = ngx.req.get_headers() or {} end)
+
     headers["Gov-Client-Connection-Method"] = "WEB_APP_VIA_SERVER"
 
-    -- Device ID — generate and reuse per server instance
-    local device_id = ngx.shared.rate_limit_store and ngx.shared.rate_limit_store:get("hmrc_device_id")
-    if not device_id then
-        local Global = require("helper.global")
-        device_id = Global.generateStaticUUID()
-        if ngx.shared.rate_limit_store then
-            ngx.shared.rate_limit_store:set("hmrc_device_id", device_id, 86400 * 365)
+    -- Device ID — prefer the browser-persisted id the frontend forwards (stable per device);
+    -- fall back to a server-generated one so we always send something.
+    local device_id = fwd["x-gov-client-device-id"]
+    if not device_id or device_id == "" then
+        device_id = ngx.shared.rate_limit_store and ngx.shared.rate_limit_store:get("hmrc_device_id")
+        if not device_id then
+            local Global = require("helper.global")
+            device_id = Global.generateStaticUUID()
+            if ngx.shared.rate_limit_store then
+                ngx.shared.rate_limit_store:set("hmrc_device_id", device_id, 86400 * 365)
+            end
         end
     end
     headers["Gov-Client-Device-ID"] = device_id
 
-    -- Client timezone
-    headers["Gov-Client-Timezone"] = "UTC+" .. string.format("%+03d:00", 0)
+    -- Browser-collected signals — forward only when present (don't fabricate).
+    headers["Gov-Client-Timezone"] = fwd["x-gov-client-timezone"] or "UTC+00:00"
+    headers["Gov-Client-Browser-JS-User-Agent"] =
+        fwd["x-gov-client-browser-js-user-agent"] or ngx.var.http_user_agent or "OpsAPI/1.0"
+    if fwd["x-gov-client-screens"] then headers["Gov-Client-Screens"] = fwd["x-gov-client-screens"] end
+    if fwd["x-gov-client-window-size"] then headers["Gov-Client-Window-Size"] = fwd["x-gov-client-window-size"] end
+    if fwd["x-gov-client-user-ids"] then headers["Gov-Client-User-IDs"] = fwd["x-gov-client-user-ids"] end
 
-    -- Client IP (from request)
+    -- The end user's PUBLIC IP: first hop of X-Forwarded-For, else the peer address.
     local client_ip = ngx.var.remote_addr or "127.0.0.1"
     local xff = ngx.var.http_x_forwarded_for
-    if xff then
-        client_ip = xff:match("^([^,]+)")
+    if xff then client_ip = (xff:match("^%s*([^,]+)") or client_ip):gsub("%s", "") end
+    local now_iso = os.date("!%Y-%m-%dT%H:%M:%S") .. ".000Z"
+    headers["Gov-Client-Public-IP"] = client_ip
+    headers["Gov-Client-Public-IP-Timestamp"] = now_iso
+    local public_port = ngx.var.http_x_forwarded_port or ngx.var.remote_port
+    if public_port and public_port ~= "" then
+        headers["Gov-Client-Public-Port"] = tostring(public_port)
     end
-    headers["Gov-Client-Local-IPs"] = client_ip
 
-    -- User agent
-    headers["Gov-Client-User-Agent"] = ngx.var.http_user_agent or "OpsAPI/1.0"
-
-    -- Vendor info
+    -- Vendor (our software) signals. HMRC requires our PUBLIC egress IP and percent-encoded
+    -- product/license values. Emit the public-IP-derived headers only when the egress IP is
+    -- configured — HMRC rejects private IPs, and a wrong value is worse than an omitted one.
+    if HMRC_SERVER_PUBLIC_IP ~= "" then
+        headers["Gov-Vendor-Public-IP"] = HMRC_SERVER_PUBLIC_IP
+        -- The user→server hop: who we (by) forwarded the request for (for). Both public.
+        headers["Gov-Vendor-Forwarded"] =
+            "by=" .. ngx.escape_uri(HMRC_SERVER_PUBLIC_IP) .. "&for=" .. ngx.escape_uri(client_ip)
+    end
     headers["Gov-Vendor-Version"] = "OpsAPI=1.0.0"
-    headers["Gov-Vendor-Product-Name"] = "OpsAPI Tax Filing"
+    headers["Gov-Vendor-Product-Name"] = ngx.escape_uri("OpsAPI Tax Filing")
+    headers["Gov-Vendor-License-IDs"] = "OpsAPI=" .. ngx.escape_uri("opsapi-tax-filing")
 
     return headers
 end
@@ -137,7 +180,7 @@ function HMRC.refresh_token(user_uuid, refresh_token)
         headers = {
             ["Content-Type"] = "application/x-www-form-urlencoded",
         },
-        ssl_verify = false,
+        ssl_verify = tls_verify(),
     })
 
     if not res then return nil, "Refresh request failed: " .. tostring(req_err) end
@@ -180,7 +223,7 @@ function HMRC.fetch_businesses(access_token)
     local res, req_err = httpc:request_uri(base_url .. "/individuals/business/details", {
         method = "GET",
         headers = fraud_headers,
-        ssl_verify = false,
+        ssl_verify = tls_verify(),
     })
 
     if not res then return nil, "Request failed: " .. tostring(req_err) end
@@ -208,7 +251,7 @@ function HMRC.fetch_obligations(access_token, business_id, from_date, to_date)
     local res, req_err = httpc:request_uri(url, {
         method = "GET",
         headers = fraud_headers,
-        ssl_verify = false,
+        ssl_verify = tls_verify(),
     })
 
     if not res then return nil, "Request failed: " .. tostring(req_err) end
@@ -256,7 +299,7 @@ function HMRC.submit_self_assessment(access_token, submission)
         method = "PUT",
         body = cjson.encode(payload),
         headers = fraud_headers,
-        ssl_verify = false,
+        ssl_verify = tls_verify(),
     })
 
     if not res then return nil, "Submission failed: " .. tostring(req_err) end
@@ -293,7 +336,7 @@ function HMRC.get_server_token()
             client_secret = HMRC_CLIENT_SECRET,
         }),
         headers = { ["Content-Type"] = "application/x-www-form-urlencoded" },
-        ssl_verify = false,
+        ssl_verify = tls_verify(),
     })
     if not res then return nil, "Server token request failed: " .. tostring(req_err) end
     if res.status >= 400 then return nil, "Server token HTTP " .. res.status .. ": " .. tostring(res.body) end
@@ -328,7 +371,7 @@ function HMRC.create_sandbox_test_user()
             ["Content-Type"] = "application/json",
             ["Accept"] = "application/vnd.hmrc.1.0+json",
         },
-        ssl_verify = false,
+        ssl_verify = tls_verify(),
     })
 
     if not res then return nil, "Request failed: " .. tostring(req_err) end

--- a/lapis/lib/hmrc-mtd-client.lua
+++ b/lapis/lib/hmrc-mtd-client.lua
@@ -68,7 +68,7 @@ function Client.list_businesses(token, nino)
     if not httpc then return nil, err end
     local res, rerr = httpc:request_uri(
         base_url() .. "/individuals/business/details/" .. nino .. "/list",
-        { method = "GET", headers = headers(token, "2.0"), ssl_verify = false })
+        { method = "GET", headers = headers(token, "2.0"), ssl_verify = not Client.is_sandbox() })
     if not res then return nil, "list_businesses request failed: " .. tostring(rerr) end
     if res.status >= 400 then
         return nil, "HTTP " .. res.status, decode(res.body)
@@ -111,7 +111,7 @@ function Client.list_obligations(token, nino, opts)
     local res, rerr = httpc:request_uri(url, {
         method = "GET",
         headers = headers(token, "3.0", { test_scenario = opts.test_scenario }),
-        ssl_verify = false,
+        ssl_verify = not Client.is_sandbox(),
     })
     if not res then return nil, "list_obligations request failed: " .. tostring(rerr) end
     if res.status >= 400 then return nil, "HTTP " .. res.status, decode(res.body) end
@@ -132,7 +132,7 @@ function Client.submit_cumulative(token, nino, business_id, tax_year, body)
         method = "PUT",
         body = cjson.encode(body),
         headers = headers(token, "5.0", { json_body = true, test_scenario = "STATEFUL" }),
-        ssl_verify = false,
+        ssl_verify = not Client.is_sandbox(),
     })
     if not res then return nil, "submit_cumulative request failed: " .. tostring(rerr) end
     if res.status >= 400 then
@@ -155,7 +155,7 @@ function Client.trigger_calculation(token, nino, tax_year, calc_type)
     local res, rerr = httpc:request_uri(url, {
         method = "POST",
         headers = headers(token, "8.0"),
-        ssl_verify = false,
+        ssl_verify = not Client.is_sandbox(),
     })
     if not res then return nil, "trigger_calculation request failed: " .. tostring(rerr) end
     if res.status >= 400 then
@@ -176,7 +176,7 @@ function Client.get_calculation(token, nino, tax_year, calc_id)
     local res, rerr = httpc:request_uri(url, {
         method = "GET",
         headers = headers(token, "8.0", { test_scenario = "DYNAMIC" }),
-        ssl_verify = false,
+        ssl_verify = not Client.is_sandbox(),
     })
     if not res then return nil, "get_calculation request failed: " .. tostring(rerr) end
     if res.status == 404 then
@@ -209,19 +209,48 @@ function Client.poll_calculation(token, nino, tax_year, calc_id)
     return nil, "calculation_timeout", nil, attempts
 end
 
--- Pull the headline figures out of a retrieved calculation. Sandbox returns the fixed
--- placeholder -99999999999.99 for the total — flag that so the UI can disclaim it.
+-- Submit the BINDING final declaration (crystallisation) for a tax year. The calc_id
+-- MUST come from an intent-to-finalise trigger (HMRC validates this). POST with no body;
+-- HMRC returns 204 No Content on success. This is the ONLY call in this flow that
+-- legally files the return. Sandbox simulates success with the DEFAULT scenario (no
+-- Gov-Test-Scenario header needed).
+function Client.submit_final_declaration(token, nino, tax_year, calc_id)
+    local httpc, err = http_client()
+    if not httpc then return nil, err end
+    local url = string.format(
+        "%s/individuals/calculations/%s/self-assessment/%s/%s/final-declaration",
+        base_url(), nino, tax_year, calc_id)
+    local res, rerr = httpc:request_uri(url, {
+        method = "POST",
+        headers = headers(token, "8.0"),
+        ssl_verify = not Client.is_sandbox(),
+    })
+    if not res then return nil, "submit_final_declaration request failed: " .. tostring(rerr) end
+    if res.status >= 400 then return nil, "HTTP " .. res.status, decode(res.body) end
+    return { status = res.status,
+             correlation_id = res.headers and res.headers["X-CorrelationId"] }, nil
+end
+
+-- Pull the headline figures out of a retrieved calculation. The real figures are nested
+-- under `calculation` (not the top level), with sub-totals split across taxCalculation,
+-- taxCalculation.incomeTax and allowancesAndDeductions — reading the top level (the old
+-- bug) left every field nil, so the UI showed "—" everywhere. Sandbox returns the fixed
+-- placeholder -99999999999.99 for the grand total only — flag that so the UI disclaims it.
 function Client.parse_figures(calc_data)
-    local tc = (calc_data and calc_data.taxCalculation) or {}
+    local root = (calc_data and calc_data.calculation) or calc_data or {}
+    local tc = root.taxCalculation or {}
+    local it = tc.incomeTax or {}
+    local ad = root.allowancesAndDeductions or {}
     local nics = tc.nics or {}
     local total = tonumber(tc.totalIncomeTaxAndNicsDue)
     return {
         total_income_tax_and_nics_due = total,
-        total_taxable_income = tonumber(tc.totalTaxableIncome),
-        income_tax_charged = tonumber(tc.incomeTaxCharged),
-        personal_allowance = tonumber(tc.personalAllowance),
-        class2_nics = nics.class2Nics and tonumber(nics.class2Nics.amount) or nil,
-        class4_nics = nics.class4Nics and tonumber(nics.class4Nics.totalAmount) or nil,
+        total_taxable_income = tonumber(it.totalTaxableIncome) or tonumber(tc.totalTaxableIncome),
+        total_income_received = tonumber(it.totalIncomeReceivedFromAllSources),
+        income_tax_charged = tonumber(it.incomeTaxCharged) or tonumber(tc.incomeTaxCharged),
+        personal_allowance = tonumber(ad.personalAllowance),
+        class2_nics = (nics.class2Nics and tonumber(nics.class2Nics.amount)) or tonumber(nics.nic2Amount),
+        class4_nics = (nics.class4Nics and tonumber(nics.class4Nics.totalAmount)) or tonumber(nics.nic4Amount),
         is_sandbox_placeholder = (total ~= nil and total <= -99999999999),
     }
 end
@@ -238,7 +267,7 @@ function Client.create_test_business(token, nino, params)
             method = "POST",
             body = cjson.encode(params),
             headers = headers(token, "1.0", { json_body = true }),
-            ssl_verify = false,
+            ssl_verify = not Client.is_sandbox(),
         })
     if not res then return nil, "create_test_business request failed: " .. tostring(rerr) end
     if res.status >= 400 then return nil, "HTTP " .. res.status, decode(res.body) end
@@ -254,7 +283,7 @@ function Client.set_itsa_status(token, nino, tax_year, details)
             method = "POST",
             body = cjson.encode({ itsaStatusDetails = details }),
             headers = headers(token, "1.0", { json_body = true }),
-            ssl_verify = false,
+            ssl_verify = not Client.is_sandbox(),
         })
     if not res then return nil, "set_itsa_status request failed: " .. tostring(rerr) end
     if res.status >= 400 then return nil, "HTTP " .. res.status, decode(res.body) end

--- a/lapis/middleware/cors.lua
+++ b/lapis/middleware/cors.lua
@@ -66,7 +66,7 @@ local CORS_CONFIG = {
     allowed_origins = buildAllowedOrigins(),
     headers = {
         methods = "GET, POST, PUT, DELETE, OPTIONS, PATCH",
-        headers = "Content-Type, Authorization, Accept, Origin, X-Requested-With, X-User-Email, X-Public-Browse, X-User-Id, X-Business-Id, X-Namespace-Id, X-Namespace-Slug, X-Vault-Key",
+        headers = "Content-Type, Authorization, Accept, Origin, X-Requested-With, X-User-Email, X-Public-Browse, X-User-Id, X-Business-Id, X-Namespace-Id, X-Namespace-Slug, X-Vault-Key, X-Gov-Client-Device-ID, X-Gov-Client-Browser-JS-User-Agent, X-Gov-Client-Screens, X-Gov-Client-Window-Size, X-Gov-Client-Timezone, X-Gov-Client-User-IDs",
         max_age = "86400",
         credentials = "true"
     }

--- a/lapis/nginx-values-template.conf
+++ b/lapis/nginx-values-template.conf
@@ -225,6 +225,11 @@ http {
 
     resolver ${{NGINX_RESOLVER}} ipv6=off;
 
+    # Trust the system CA bundle so lua-resty-http can verify TLS certificates
+    # (ssl_verify=true) on outbound HTTPS — required for HMRC production calls.
+    lua_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
+    lua_ssl_verify_depth 3;
+
     server {
         listen ${{PORT}};
         lua_code_cache ${{CODE_CACHE}};

--- a/lapis/nginx.conf
+++ b/lapis/nginx.conf
@@ -329,6 +329,12 @@ http {
     # resolver on every API call.
     resolver 127.0.0.11 8.8.8.8 8.8.4.4 ipv6=off valid=30s;
 
+    # Trust the system CA bundle so lua-resty-http can verify TLS certificates
+    # (ssl_verify=true) on outbound HTTPS — required for HMRC production calls, which
+    # transmit NINOs and financial data. Verified to validate HMRC's prod + sandbox certs.
+    lua_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
+    lua_ssl_verify_depth 3;
+
     server {
         listen ${{PORT}};
         lua_code_cache ${{CODE_CACHE}};

--- a/lapis/routes/tax-hmrc-data.lua
+++ b/lapis/routes/tax-hmrc-data.lua
@@ -197,8 +197,14 @@ return function(app)
                         .. "sandbox test user) before fetching obligations." } }
             end
 
+            -- Sandbox only: with no Gov-Test-Scenario the HMRC sandbox returns a fixed
+            -- historical sample (2017-18/2018-19) and ignores our dates — which is why
+            -- testers see ancient obligations. DYNAMIC makes HMRC echo periods matching
+            -- the from/to we send, giving current-tax-year obligations for real testing.
+            -- The header is automatically dropped outside the sandbox (see headers()).
             local data, err, hmrc_body = Client.list_obligations(access_token, nino, {
                 from = from_date, to = to_date,
+                test_scenario = Client.is_sandbox() and "DYNAMIC" or nil,
             })
             if not data then
                 local detail = hmrc_body and hmrc_body.message
@@ -209,12 +215,29 @@ return function(app)
                     hmrc = hmrc_body } }
             end
 
-            -- Cache obligations, flattening + optionally filtering to one business.
+            -- Cache obligations, flattening + filtering to one business.
+            -- In the sandbox, DYNAMIC returns the SAME period windows for three synthetic
+            -- businesses (self-employment XBIS…, UK property XPIS…, foreign property XFIS…).
+            -- Keeping all three makes every period show up three times. We file
+            -- self-employment, so keep only that one, and store it under the user's real
+            -- filing business id so the rows map to the business they actually selected.
+            -- Production returns the real business's obligations and is filtered by id.
+            local is_sandbox = Client.is_sandbox()
             local obligations = data.obligations or {}
             local returned = {}
             for _, ob in ipairs(obligations) do
-                local ob_business = ob.businessId or business_id
-                if (not business_id) or (ob_business == business_id) then
+                local include
+                if is_sandbox then
+                    include = (ob.typeOfBusiness == "self-employment")
+                else
+                    include = (not business_id) or (ob.businessId == business_id)
+                end
+                if include then
+                    -- Sandbox: persist under the selected/real business id (or the synthetic
+                    -- one if we have nothing better) so obligations link to the filing business.
+                    local ob_business = is_sandbox and (business_id or ob.businessId)
+                        or (ob.businessId or business_id)
+                    ob.businessId = ob_business
                     table.insert(returned, ob)
                     for _, period in ipairs(ob.obligationDetails or {}) do
                         -- Conflict target is the UNIQUE INDEX idx_hmrc_obligations_period

--- a/lapis/routes/tax-hmrc-filing.lua
+++ b/lapis/routes/tax-hmrc-filing.lua
@@ -50,6 +50,165 @@ local function resolveNino(requested, profile)
     return nil
 end
 
+-- Provision a STATEFUL sandbox self-employment business + MTD ITSA status for a tax
+-- year, and remember it as the user's default filing business. Returns the new
+-- business id, or nil + error. Sandbox-only — the stateful self-employment cumulative
+-- endpoint only accepts a business created this way; the ones from the Business Details
+-- list / obligations (e.g. XBIS12345678901) are not fileable. Used by the
+-- calculate-preview self-heal (mirrors the explicit /sandbox/provision route).
+local function provisionSandboxBusiness(Client, Aggregator, token, nino, tax_year, user_id)
+    local start_date, end_date = Aggregator.tax_year_bounds(tax_year)
+    if not start_date then return nil, "Invalid tax year" end
+
+    local biz, berr, bbody = Client.create_test_business(token, nino, {
+        typeOfBusiness = "self-employment",
+        tradingName = "OpsAPI Test SE",
+        firstAccountingPeriodStartDate = start_date,
+        firstAccountingPeriodEndDate = end_date,
+        accountingType = "ACCRUALS",
+        commencementDate = start_date,
+        businessAddressLineOne = "1 Test Street",
+        businessAddressTownOrCity = "London",
+        businessAddressPostcode = "SW1A 1AA",
+        businessAddressCountryCode = "GB",
+    })
+    if not biz then return nil, berr or "Failed to create sandbox business", bbody end
+
+    -- Set MTD ITSA status for the year so calculations are allowed.
+    local submitted_on = os.date("!%Y-%m-%dT%H:%M:%S") .. ".000Z"
+    Client.set_itsa_status(token, nino, tax_year, {
+        {
+            submittedOn = submitted_on,
+            status = "MTD Mandated",
+            statusReason = "Sign up - return available",
+            businessIncome2YearsPrior = 35000.00,
+        },
+    })
+
+    -- Remember it as the default filing business.
+    pcall(function()
+        local existing = db.select("id FROM tax_user_profiles WHERE user_id = ? LIMIT 1", user_id)
+        if existing and #existing > 0 then
+            db.update("tax_user_profiles",
+                { default_business_id = biz, updated_at = db.raw("NOW()") },
+                { user_id = user_id })
+        else
+            db.insert("tax_user_profiles", {
+                uuid = Global.generateStaticUUID(),
+                user_id = user_id,
+                default_business_id = biz,
+                created_at = db.raw("NOW()"),
+                updated_at = db.raw("NOW()"),
+            })
+        end
+    end)
+
+    return biz
+end
+
+-- Shared prep for the calculate-preview and final-declaration routes: resolve the HMRC
+-- token + NINO, aggregate the user's classified transactions into the MTD body, resolve
+-- the filing business, and submit (PUT, idempotent) the cumulative period — including the
+-- sandbox self-heal that provisions a stateful business if HMRC has none. Returns
+-- (ctx, nil) on success, or (nil, response) where `response` is a ready-to-return
+-- { status, json } error envelope. `ctx` carries everything the calc/declaration steps need.
+local function buildAndSubmitCumulative(self, HMRC, Client, Aggregator)
+    local tax_year = self.params.tax_year
+    if not tax_year then
+        return nil, { status = 400, json = { error = "tax_year is required (e.g. 2025-26)" } }
+    end
+    local user_id = getUserId(self.current_user)
+    if not user_id then return nil, { status = 401, json = { error = "User not found" } } end
+    local user_uuid = getUserUuid(self.current_user)
+
+    -- Valid HMRC token (refreshes if needed).
+    local token, terr = HMRC.get_valid_token(user_uuid)
+    if not token then
+        return nil, { status = 400, json = { error = "Not connected to HMRC", detail = terr } }
+    end
+
+    -- NINO (request param or the user's stored, encrypted NINO).
+    local profile = getProfile(user_id)
+    local nino = resolveNino(self.params.nino, profile)
+    if not nino then
+        return nil, { status = 400, json = {
+            error = "No NINO available — create/connect a sandbox test user first" } }
+    end
+
+    -- Aggregate classified transactions into the MTD body.
+    local agg, aerr = Aggregator.build_cumulative_body({ user_id = user_id, tax_year = tax_year })
+    if not agg then return nil, { status = 400, json = { error = aerr } } end
+    if #agg.negative_fields > 0 then
+        local neg_fields = {}
+        for _, nf in ipairs(agg.negative_fields) do
+            table.insert(neg_fields, (nf.field:gsub("Disallowable$", "")))
+        end
+        return nil, { status = 422, json = {
+            error = "Aggregated body has negative values — HMRC would reject it. Fix the "
+                .. "miscategorised credit/refund before submitting.",
+            negative_fields = agg.negative_fields,
+            offending_transactions = Aggregator.credit_offenders(
+                { user_id = user_id, tax_year = tax_year }, neg_fields) } }
+    end
+    if agg.empty then
+        return nil, { status = 422, json = { error = "No income or expenses to submit for this tax year" } }
+    end
+
+    -- Resolve the business id: param → stored default → first self-employment from HMRC.
+    local business_id = self.params.business_id
+    if (not business_id or business_id == "") and profile then
+        business_id = profile.default_business_id
+    end
+    if not business_id or business_id == "" then
+        local list = Client.list_businesses(token, nino)
+        if list then business_id = Client.first_self_employment(list) end
+    end
+    if not business_id or business_id == "" then
+        return nil, { status = 422, json = {
+            error = "No HMRC self-employment business found for this NINO. In sandbox, run "
+                .. "'Set up sandbox business' first." } }
+    end
+
+    -- Build the cumulative body (aggregator output + the period dates).
+    local body = agg.body
+    body.periodDates = { periodStartDate = agg.tax_year_start, periodEndDate = agg.tax_year_end }
+
+    -- Submit the cumulative period. In the sandbox the only fileable business is one
+    -- created via the test-support API; the businesses from the Business Details list /
+    -- obligations (e.g. XBIS12345678901) are NOT stateful, so submitting against them
+    -- returns MATCHING_RESOURCE_NOT_FOUND. Self-heal: provision a stateful business for
+    -- this NINO + tax year and retry once, so the user never has to know about provisioning.
+    local sres, serr, sbody = Client.submit_cumulative(token, nino, business_id, tax_year, body)
+    if not sres and Client.is_sandbox()
+        and sbody and sbody.code == "MATCHING_RESOURCE_NOT_FOUND" then
+        local new_biz, perr = provisionSandboxBusiness(Client, Aggregator, token, nino, tax_year, user_id)
+        if new_biz then
+            business_id = new_biz
+            sres, serr, sbody = Client.submit_cumulative(token, nino, business_id, tax_year, body)
+        else
+            serr = perr or serr
+        end
+    end
+    if not sres then
+        local hint = ""
+        if sbody and sbody.code == "MATCHING_RESOURCE_NOT_FOUND" then
+            hint = " HMRC has no self-employment record for this combination of NINO, "
+                .. "business (" .. tostring(business_id) .. ") and tax year (" .. tax_year
+                .. "). File for a tax year HMRC shows as open for this business — use the "
+                .. "open obligation rather than a typed year."
+        end
+        return nil, { status = 502, json = {
+            error = "HMRC rejected the period submission." .. hint,
+            detail = serr, hmrc = sbody,
+            business_id = business_id, tax_year = tax_year } }
+    end
+
+    return {
+        tax_year = tax_year, user_id = user_id, user_uuid = user_uuid,
+        token = token, nino = nino, business_id = business_id, agg = agg, body = body,
+    }, nil
+end
+
 return function(app)
 
     -- GET /api/v2/tax/hmrc/aggregate-preview — review the MTD body before any HMRC call
@@ -132,14 +291,6 @@ return function(app)
     -- (non-binding) calculation and return HMRC's figures. This does NOT file the return.
     app:post("/api/v2/tax/hmrc/calculate-preview",
         AuthMiddleware.requireAuth(function(self)
-            local tax_year = self.params.tax_year
-            if not tax_year then
-                return { status = 400, json = { error = "tax_year is required (e.g. 2025-26)" } }
-            end
-            local user_id = getUserId(self.current_user)
-            if not user_id then return { status = 401, json = { error = "User not found" } } end
-            local user_uuid = getUserUuid(self.current_user)
-
             local ok_hmrc, HMRC = pcall(require, "helper.hmrc")
             local ok_cli, Client = pcall(require, "lib.hmrc-mtd-client")
             local ok_agg, Aggregator = pcall(require, "lib.hmrc-aggregator")
@@ -147,83 +298,17 @@ return function(app)
                 return { status = 500, json = { error = "HMRC modules not available" } }
             end
 
-            -- Valid HMRC token (refreshes if needed).
-            local token, terr = HMRC.get_valid_token(user_uuid)
-            if not token then
-                return { status = 400, json = { error = "Not connected to HMRC", detail = terr } }
-            end
+            -- Resolve + submit the cumulative period (shared with final declaration).
+            local ctx, errResp = buildAndSubmitCumulative(self, HMRC, Client, Aggregator)
+            if not ctx then return errResp end
 
-            -- NINO (request param or the user's stored, encrypted NINO).
-            local profile = getProfile(user_id)
-            local nino = resolveNino(self.params.nino, profile)
-            if not nino then
-                return { status = 400, json = {
-                    error = "No NINO available — create/connect a sandbox test user first" } }
-            end
-
-            -- Aggregate classified transactions into the MTD body.
-            local agg, aerr = Aggregator.build_cumulative_body({ user_id = user_id, tax_year = tax_year })
-            if not agg then return { status = 400, json = { error = aerr } } end
-            if #agg.negative_fields > 0 then
-                local neg_fields = {}
-                for _, nf in ipairs(agg.negative_fields) do
-                    table.insert(neg_fields, (nf.field:gsub("Disallowable$", "")))
-                end
-                return { status = 422, json = {
-                    error = "Aggregated body has negative values — HMRC would reject it. Fix the "
-                        .. "miscategorised credit/refund before submitting.",
-                    negative_fields = agg.negative_fields,
-                    offending_transactions = Aggregator.credit_offenders(
-                        { user_id = user_id, tax_year = tax_year }, neg_fields) } }
-            end
-            if agg.empty then
-                return { status = 422, json = { error = "No income or expenses to submit for this tax year" } }
-            end
-
-            -- Resolve the business id: param → stored default → first self-employment from HMRC.
-            local business_id = self.params.business_id
-            if (not business_id or business_id == "") and profile then
-                business_id = profile.default_business_id
-            end
-            if not business_id or business_id == "" then
-                local list = Client.list_businesses(token, nino)
-                if list then business_id = Client.first_self_employment(list) end
-            end
-            if not business_id or business_id == "" then
-                return { status = 422, json = {
-                    error = "No HMRC self-employment business found for this NINO. In sandbox, run "
-                        .. "'Set up sandbox business' first." } }
-            end
-
-            -- Build the cumulative body (aggregator output + the period dates).
-            local body = agg.body
-            body.periodDates = { periodStartDate = agg.tax_year_start, periodEndDate = agg.tax_year_end }
-
-            -- 1) Submit the cumulative period.
-            local sres, serr, sbody = Client.submit_cumulative(token, nino, business_id, tax_year, body)
-            if not sres then
-                local hint = ""
-                if sbody and sbody.code == "MATCHING_RESOURCE_NOT_FOUND" then
-                    hint = " HMRC has no self-employment record for this combination of NINO, "
-                        .. "business (" .. tostring(business_id) .. ") and tax year (" .. tax_year
-                        .. "). File for a tax year HMRC shows as open for this business — use the "
-                        .. "open obligation rather than a typed year."
-                end
-                return { status = 502, json = {
-                    error = "HMRC rejected the period submission." .. hint,
-                    detail = serr, hmrc = sbody,
-                    business_id = business_id, tax_year = tax_year } }
-            end
-
-            -- 2) Trigger an in-year calculation.
-            local calc_id, cterr, ctbody = Client.trigger_calculation(token, nino, tax_year, "in-year")
+            -- Trigger an in-year (non-binding) calculation, then poll until it's ready.
+            local calc_id, cterr, ctbody = Client.trigger_calculation(ctx.token, ctx.nino, ctx.tax_year, "in-year")
             if not calc_id then
                 return { status = 502, json = {
                     error = "HMRC calculation trigger failed", detail = cterr, hmrc = ctbody } }
             end
-
-            -- 3) Poll until the calculation is ready.
-            local cres, cerr, cbody, attempts = Client.poll_calculation(token, nino, tax_year, calc_id)
+            local cres, cerr, cbody, attempts = Client.poll_calculation(ctx.token, ctx.nino, ctx.tax_year, calc_id)
             if not cres then
                 return { status = 502, json = {
                     error = "Calculation did not complete in time", detail = cerr, hmrc = cbody,
@@ -236,26 +321,26 @@ return function(app)
             pcall(function()
                 db.insert("hmrc_calculations", {
                     uuid = Global.generateStaticUUID(),
-                    user_uuid = user_uuid,
-                    business_id = business_id,
-                    tax_year = tax_year,
+                    user_uuid = ctx.user_uuid,
+                    business_id = ctx.business_id,
+                    tax_year = ctx.tax_year,
                     calculation_id = calc_id,
                     calculation_type = "in-year",
                     status = "retrieved",
                     correlation_id = cres.correlation_id,
-                    period_start = agg.tax_year_start,
-                    period_end = agg.tax_year_end,
+                    period_start = ctx.agg.tax_year_start,
+                    period_end = ctx.agg.tax_year_end,
                     total_income_tax_and_nics_due = figures.total_income_tax_and_nics_due,
                     total_taxable_income = figures.total_taxable_income,
                     income_tax_charged = figures.income_tax_charged,
                     class2_nics = figures.class2_nics,
                     class4_nics = figures.class4_nics,
                     personal_allowance = figures.personal_allowance,
-                    tx_total = agg.stats.rows,
-                    tx_applied = agg.stats.applied,
-                    tx_excluded_no_mtd = agg.stats.excluded_no_mtd_field,
+                    tx_total = ctx.agg.stats.rows,
+                    tx_applied = ctx.agg.stats.applied,
+                    tx_excluded_no_mtd = ctx.agg.stats.excluded_no_mtd_field,
                     poll_attempts = attempts,
-                    request_payload = cjson.encode(body),
+                    request_payload = cjson.encode(ctx.body),
                     raw_response = cjson.encode(cres.data),
                     triggered_at = db.raw("NOW()"),
                     retrieved_at = db.raw("NOW()"),
@@ -265,13 +350,112 @@ return function(app)
             end)
 
             return { status = 200, json = { success = true, data = {
-                tax_year = tax_year,
-                business_id = business_id,
+                tax_year = ctx.tax_year,
+                business_id = ctx.business_id,
                 calculation_id = calc_id,
                 figures = figures,
                 sandbox_placeholder = figures.is_sandbox_placeholder or false,
-                body = body,
-                stats = agg.stats,
+                body = ctx.body,
+                stats = ctx.agg.stats,
+            } } }
+        end)
+    )
+
+    -- POST /api/v2/tax/hmrc/submit-final-declaration { tax_year, business_id?, nino?,
+    --                                                  declaration_accepted }
+    -- The BINDING final declaration (crystallisation) — THIS FILES THE RETURN with HMRC.
+    -- Re-submits the cumulative period so HMRC holds the final figures, triggers an
+    -- intent-to-finalise calculation, then submits the final declaration against it.
+    -- Requires an explicit declaration_accepted=true (it is legally binding).
+    app:post("/api/v2/tax/hmrc/submit-final-declaration",
+        AuthMiddleware.requireAuth(function(self)
+            local ok_hmrc, HMRC = pcall(require, "helper.hmrc")
+            local ok_cli, Client = pcall(require, "lib.hmrc-mtd-client")
+            local ok_agg, Aggregator = pcall(require, "lib.hmrc-aggregator")
+            if not (ok_hmrc and ok_cli and ok_agg) then
+                return { status = 500, json = { error = "HMRC modules not available" } }
+            end
+
+            -- Hard gate: the user must confirm the declaration — this is binding.
+            local accepted = self.params.declaration_accepted
+            if accepted ~= "true" and accepted ~= true then
+                return { status = 400, json = {
+                    code = "DECLARATION_REQUIRED",
+                    error = "You must confirm the declaration before filing your return." } }
+            end
+
+            -- Resolve + submit the cumulative period (shared with calculate-preview).
+            local ctx, errResp = buildAndSubmitCumulative(self, HMRC, Client, Aggregator)
+            if not ctx then return errResp end
+
+            -- 1) Trigger the intent-to-finalise calculation. The final declaration MUST
+            -- reference a calculation produced by this type (HMRC rejects an in-year one).
+            local calc_id, cterr, ctbody =
+                Client.trigger_calculation(ctx.token, ctx.nino, ctx.tax_year, "intent-to-finalise")
+            if not calc_id then
+                return { status = 502, json = {
+                    error = "HMRC could not start the final calculation", detail = cterr, hmrc = ctbody } }
+            end
+
+            -- 2) Poll until that calculation is ready (surfaces validation errors HMRC
+            -- would otherwise reject the declaration for).
+            local cres, cerr, cbody, attempts = Client.poll_calculation(ctx.token, ctx.nino, ctx.tax_year, calc_id)
+            if not cres then
+                return { status = 502, json = {
+                    error = "Final calculation did not complete in time", detail = cerr, hmrc = cbody,
+                    calculation_id = calc_id } }
+            end
+            local figures = Client.parse_figures(cres.data)
+
+            -- 3) Submit the BINDING final declaration against that calculation.
+            local fres, ferr, fbody = Client.submit_final_declaration(ctx.token, ctx.nino, ctx.tax_year, calc_id)
+            if not fres then
+                return { status = 502, json = {
+                    error = "HMRC rejected the final declaration.",
+                    detail = ferr, hmrc = fbody,
+                    code = fbody and fbody.code or nil,
+                    calculation_id = calc_id, tax_year = ctx.tax_year } }
+            end
+
+            -- 4) Persist as a binding, filed declaration (best-effort audit trail).
+            pcall(function()
+                db.insert("hmrc_calculations", {
+                    uuid = Global.generateStaticUUID(),
+                    user_uuid = ctx.user_uuid,
+                    business_id = ctx.business_id,
+                    tax_year = ctx.tax_year,
+                    calculation_id = calc_id,
+                    calculation_type = "final-declaration",
+                    status = "filed",
+                    correlation_id = fres.correlation_id or cres.correlation_id,
+                    period_start = ctx.agg.tax_year_start,
+                    period_end = ctx.agg.tax_year_end,
+                    total_income_tax_and_nics_due = figures.total_income_tax_and_nics_due,
+                    total_taxable_income = figures.total_taxable_income,
+                    income_tax_charged = figures.income_tax_charged,
+                    class2_nics = figures.class2_nics,
+                    class4_nics = figures.class4_nics,
+                    personal_allowance = figures.personal_allowance,
+                    tx_total = ctx.agg.stats.rows,
+                    tx_applied = ctx.agg.stats.applied,
+                    tx_excluded_no_mtd = ctx.agg.stats.excluded_no_mtd_field,
+                    poll_attempts = attempts,
+                    request_payload = cjson.encode(ctx.body),
+                    raw_response = cjson.encode(cres.data),
+                    triggered_at = db.raw("NOW()"),
+                    retrieved_at = db.raw("NOW()"),
+                    created_at = db.raw("NOW()"),
+                    updated_at = db.raw("NOW()"),
+                })
+            end)
+
+            return { status = 200, json = { success = true, data = {
+                filed = true,
+                tax_year = ctx.tax_year,
+                business_id = ctx.business_id,
+                calculation_id = calc_id,
+                figures = figures,
+                sandbox = Client.is_sandbox(),
             } } }
         end)
     )

--- a/opsapi-dashboard/app/dashboard/tax/file/page.tsx
+++ b/opsapi-dashboard/app/dashboard/tax/file/page.tsx
@@ -14,9 +14,16 @@
  * Steps unlock in order; each shows done / active / locked. The hard gate before the
  * HMRC calculation is step 4: it must report no blocking issues (e.g. a negative period
  * field from a credit mis-filed as an expense), which the user fixes right here.
+ *
+ * Auto-advance: the read-only pulls run themselves so the user never hunts for a
+ * "Load…" / "Fetch…" button. Once connected with a NINO on file we fetch the business,
+ * auto-pick it, fetch its obligations, and aggregate the figures — all without a click.
+ * The only deliberate actions left are the ones that genuinely need a human: the OAuth
+ * connect, entering the NINO, choosing between multiple businesses, fixing a flagged
+ * figure, and the step-5 calculation (the one call that submits data to HMRC).
  */
 
-import React, { useEffect, useState, useCallback, Suspense } from 'react';
+import React, { useEffect, useState, useCallback, useRef, Suspense } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import {
@@ -78,6 +85,75 @@ const FIX_OPTIONS: Array<{ value: string; label: string; category: string; hmrc_
   { value: 'other_income', label: 'Other business income', category: 'income_other', hmrc_category: 'other_income' },
   { value: 'exclude', label: 'Personal / transfer — exclude from return', category: 'transfer', hmrc_category: '' },
 ];
+
+// Plain-English labels for the HMRC MTD self-employment fields we actually submit, so the
+// user can see exactly what's going to HMRC rather than raw API field names.
+const HMRC_SECTION_LABELS: Record<string, string> = {
+  periodIncome: 'Income',
+  periodExpenses: 'Expenses',
+  periodDisallowableExpenses: 'Disallowable expenses (added back to profit)',
+};
+const HMRC_FIELD_LABELS: Record<string, string> = {
+  turnover: 'Sales / turnover',
+  other: 'Other business income',
+  costOfGoods: 'Cost of goods bought for resale',
+  paymentsToSubcontractors: 'Payments to subcontractors',
+  wagesAndStaffCosts: 'Wages & staff costs',
+  carVanTravelExpenses: 'Car, van & travel',
+  premisesRunningCosts: 'Premises running costs',
+  maintenanceCosts: 'Repairs & maintenance',
+  adminCosts: 'Office & admin costs',
+  businessEntertainmentCosts: 'Business entertainment',
+  advertisingCosts: 'Advertising & marketing',
+  interestOnBankOtherLoans: 'Interest on loans',
+  financeCharges: 'Bank & finance charges',
+  irrecoverableDebts: 'Bad debts written off',
+  professionalFees: 'Accountancy, legal & professional fees',
+  depreciation: 'Depreciation & loss on sale',
+  otherExpenses: 'Other business expenses',
+};
+
+// Render the exact MTD body (income / expense lines) we'll submit to HMRC, with friendly
+// labels and per-section totals. Only non-zero lines are shown to keep it readable.
+function FiguresBreakdown({ body, taxYear }: { body?: Record<string, Record<string, number>>; taxYear: string }) {
+  const fmt = (n: number) => formatCurrency(n, 'GBP', 'en-GB');
+  const sections = ['periodIncome', 'periodExpenses', 'periodDisallowableExpenses'].filter(
+    (s) => body?.[s] && Object.values(body[s]).some((v) => Number(v) !== 0),
+  );
+  if (sections.length === 0) return null;
+  return (
+    <div className="rounded-lg border border-secondary-200 bg-surface p-3 space-y-3">
+      <p className="text-sm font-medium text-secondary-900">Exactly what we&apos;ll send to HMRC</p>
+      {sections.map((s) => {
+        const entries = Object.entries(body![s]).filter(([, v]) => Number(v) !== 0);
+        const total = entries.reduce((a, [, v]) => a + Number(v), 0);
+        return (
+          <div key={s} className="space-y-1">
+            <p className="text-xs font-semibold uppercase tracking-wide text-secondary-500">
+              {HMRC_SECTION_LABELS[s] || s}
+            </p>
+            <div className="divide-y divide-secondary-100">
+              {entries.map(([k, v]) => (
+                <div key={k} className="flex items-center justify-between py-1 text-sm">
+                  <span className="text-secondary-700">{HMRC_FIELD_LABELS[k] || k}</span>
+                  <span className="font-medium text-secondary-900 tabular-nums">{fmt(Number(v))}</span>
+                </div>
+              ))}
+            </div>
+            <div className="flex items-center justify-between pt-1 text-sm font-semibold border-t border-secondary-200">
+              <span className="text-secondary-600">Total {(HMRC_SECTION_LABELS[s] || s).toLowerCase()}</span>
+              <span className="tabular-nums text-secondary-900">{fmt(total)}</span>
+            </div>
+          </div>
+        );
+      })}
+      <p className="text-xs text-secondary-400">
+        These figures come from your classified transactions for tax year {taxYear}. HMRC works out the tax
+        and allowances from them in the next step.
+      </p>
+    </div>
+  );
+}
 
 type StepState = 'done' | 'active' | 'locked';
 
@@ -166,6 +242,19 @@ function FileWizardContent() {
   // Step 5 — calculation
   const [calc, setCalc] = useState<CalcResult | null>(null);
   const [calculating, setCalculating] = useState(false);
+
+  // Step 6 — final declaration (the binding filing)
+  const [declarationAccepted, setDeclarationAccepted] = useState(false);
+  const [filing, setFiling] = useState(false);
+  const [filed, setFiled] = useState<Awaited<ReturnType<typeof taxService.submitHmrcFinalDeclaration>> | null>(null);
+
+  // Auto-advance guards: remember what each read-only pull last auto-ran for, so the
+  // effects fire exactly once per change instead of looping. Keyed by the input that
+  // should trigger a fresh pull (the NINO for businesses, the chosen business for
+  // obligations, the tax year for figures).
+  const autoBizFor = useRef<string>('');
+  const autoOblFor = useRef<string>('');
+  const autoPreviewFor = useRef<string>('');
 
   const gbp = (n?: number) => (n == null ? '—' : formatCurrency(n, 'GBP', 'en-GB'));
 
@@ -323,6 +412,17 @@ function FileWizardContent() {
     }
   };
 
+  // Auto-fetch the business once we're connected and have a NINO — no button needed.
+  // Re-runs only when the NINO changes (keyed by last-4); a failed pull won't loop
+  // because the key is marked done either way (user can retry via "Refresh from HMRC").
+  useEffect(() => {
+    if (!(connected && valid) || !hasNino || loadingBiz) return;
+    const key = ninoLast4 || 'nino';
+    if (autoBizFor.current === key) return;
+    autoBizFor.current = key;
+    if (businesses.length === 0) loadBusinesses();
+  }, [connected, valid, hasNino, ninoLast4, loadingBiz, businesses.length, loadBusinesses]);
+
   // ── Step 3: obligations ─────────────────────────────────────────────────────
   const loadObligations = useCallback(async () => {
     if (!selectedBusiness) return;
@@ -358,6 +458,15 @@ function FileWizardContent() {
     }
   }, [selectedBusiness, taxYear]);
 
+  // Auto-fetch obligations once a business is chosen (the obvious next step), once per
+  // business. The user can still re-pull with "Refresh" if HMRC's answer changes.
+  useEffect(() => {
+    if (!selectedBusiness || loadingObl) return;
+    if (autoOblFor.current === selectedBusiness) return;
+    autoOblFor.current = selectedBusiness;
+    loadObligations();
+  }, [selectedBusiness, loadingObl, loadObligations]);
+
   // ── Step 4: figures ─────────────────────────────────────────────────────────
   const loadPreview = useCallback(async () => {
     setLoadingPreview(true);
@@ -371,6 +480,16 @@ function FileWizardContent() {
       setLoadingPreview(false);
     }
   }, [taxYear]);
+
+  // Auto-aggregate the figures once a business is chosen, re-running when the filing
+  // tax year settles (it's derived from the selected obligation). Read-only — it only
+  // tallies already-classified transactions; nothing is sent to HMRC here.
+  useEffect(() => {
+    if (!selectedBusiness || loadingPreview) return;
+    if (autoPreviewFor.current === taxYear) return;
+    autoPreviewFor.current = taxYear;
+    loadPreview();
+  }, [selectedBusiness, taxYear, loadingPreview, loadPreview]);
 
   const applyFix = async (tx: HmrcOffendingTransaction) => {
     const choiceKey = fixChoice[tx.uuid];
@@ -410,6 +529,24 @@ function FileWizardContent() {
     }
   };
 
+  // ── Step 6: final declaration (the binding filing) ──────────────────────────────
+  const submitFinalDeclaration = async () => {
+    if (!declarationAccepted) {
+      toast.error('Please tick the declaration box first');
+      return;
+    }
+    setFiling(true);
+    try {
+      const res = await taxService.submitHmrcFinalDeclaration(taxYear);
+      setFiled(res);
+      toast.success('Your return has been filed with HMRC');
+    } catch (err: unknown) {
+      toast.error(extractApiError(err, 'Final declaration failed'));
+    } finally {
+      setFiling(false);
+    }
+  };
+
   // ── Derived step states ───────────────────────────────────────────────────────
   const s1: StepState = connected && valid ? 'done' : 'active';
   const s2: StepState = s1 !== 'done' ? 'locked' : selectedBusiness ? 'done' : 'active';
@@ -420,7 +557,7 @@ function FileWizardContent() {
   const figuresOk = preview !== null && !preview.blocking && !figuresEmpty;
   const s4: StepState = s2 !== 'done' ? 'locked' : figuresOk ? 'done' : 'active';
   const s5: StepState = !figuresOk ? 'locked' : calc ? 'done' : 'active';
-  const s6: StepState = !calc ? 'locked' : 'active';
+  const s6: StepState = filed ? 'done' : !calc ? 'locked' : 'active';
 
   const openObligations = (obligations || []).filter(isOpen);
 
@@ -572,7 +709,12 @@ function FileWizardContent() {
               </div>
             )}
 
-            {businesses.length === 0 ? (
+            {loadingBiz && businesses.length === 0 ? (
+              <p className="text-sm text-secondary-500 flex items-center gap-2">
+                <Loader2 className="w-4 h-4 animate-spin" /> Finding your business at HMRC…
+              </p>
+            ) : businesses.length === 0 ? (
+              // Auto-fetch ran but came back empty or errored — offer a manual retry.
               <button
                 onClick={loadBusinesses}
                 disabled={loadingBiz || !hasNino}
@@ -580,7 +722,7 @@ function FileWizardContent() {
                 className="flex items-center gap-2 px-4 py-2 border border-secondary-300 text-secondary-700 rounded-lg hover:bg-secondary-100 disabled:opacity-50"
               >
                 {loadingBiz ? <Loader2 className="w-4 h-4 animate-spin" /> : <Building2 className="w-4 h-4" />}
-                Load businesses from HMRC
+                Try again
               </button>
             ) : (
               <div className="space-y-2">
@@ -640,19 +782,16 @@ function FileWizardContent() {
       {/* Step 3 — Obligations */}
       <Card padding="lg">
         <StepHeader index={3} state={s3} icon={<CalendarClock className="w-4 h-4" />}
-          title="Fetch your obligations"
-          subtitle="See which period HMRC says is open to file."
+          title="Your filing period"
+          subtitle="We check with HMRC which period is open to file — no action needed."
         />
         {s3 !== 'locked' && (
           <div className="mt-4 pl-12 space-y-3">
-            <button
-              onClick={loadObligations}
-              disabled={loadingObl || !selectedBusiness}
-              className="flex items-center gap-2 px-4 py-2 border border-secondary-300 text-secondary-700 rounded-lg hover:bg-secondary-100 disabled:opacity-50"
-            >
-              {loadingObl ? <Loader2 className="w-4 h-4 animate-spin" /> : <RefreshCw className="w-4 h-4" />}
-              {obligations === null ? 'Fetch obligations' : 'Refresh obligations'}
-            </button>
+            {loadingObl && obligations === null && (
+              <p className="text-sm text-secondary-500 flex items-center gap-2">
+                <Loader2 className="w-4 h-4 animate-spin" /> Checking what HMRC needs from you…
+              </p>
+            )}
 
             {obligations !== null && (
               openObligations.length > 0 ? (
@@ -699,6 +838,12 @@ function FileWizardContent() {
                 </p>
               )
             )}
+
+            {obligations !== null && !loadingObl && (
+              <button onClick={loadObligations} className="flex items-center gap-1.5 text-xs text-primary-600 hover:underline">
+                <RefreshCw className="w-3 h-3" /> Refresh from HMRC
+              </button>
+            )}
           </div>
         )}
       </Card>
@@ -715,14 +860,16 @@ function FileWizardContent() {
               Checking figures for tax year <strong>{taxYear}</strong>
               {selectedObligation ? ' (from your selected HMRC obligation)' : ''}.
             </p>
-            <button
-              onClick={loadPreview}
-              disabled={loadingPreview}
-              className="flex items-center gap-2 px-4 py-2 border border-secondary-300 text-secondary-700 rounded-lg hover:bg-secondary-100 disabled:opacity-50"
-            >
-              {loadingPreview ? <Loader2 className="w-4 h-4 animate-spin" /> : <ListChecks className="w-4 h-4" />}
-              {preview ? 'Re-check figures' : 'Check my figures'}
-            </button>
+            {loadingPreview && !preview && (
+              <p className="text-sm text-secondary-500 flex items-center gap-2">
+                <Loader2 className="w-4 h-4 animate-spin" /> Adding up your figures…
+              </p>
+            )}
+            {preview && !loadingPreview && (
+              <button onClick={loadPreview} className="flex items-center gap-1.5 text-xs text-primary-600 hover:underline">
+                <ListChecks className="w-3 h-3" /> Re-check figures
+              </button>
+            )}
 
             {preview && (
               <div className="space-y-3">
@@ -740,6 +887,9 @@ function FileWizardContent() {
                     </div>
                   ))}
                 </div>
+
+                {/* The exact income/expense lines we'll submit to HMRC. */}
+                <FiguresBreakdown body={preview.body} taxYear={taxYear} />
 
                 {/* blocking: offending credits with inline fix */}
                 {preview.blocking && (
@@ -840,6 +990,16 @@ function FileWizardContent() {
               {calculating ? 'Calculating…' : 'Run preview calculation'}
             </button>
 
+            {calculating && !calc && (
+              <p className="flex items-start gap-2 text-xs text-secondary-500">
+                <Loader2 className="w-3.5 h-3.5 mt-0.5 shrink-0 animate-spin" />
+                <span>
+                  Setting things up with HMRC and working out your figures — the first run can take
+                  a little longer. Please don&apos;t close this page.
+                </span>
+              </p>
+            )}
+
             {calc && (
               <div className="space-y-3">
                 {calc.sandbox_placeholder && (
@@ -878,14 +1038,70 @@ function FileWizardContent() {
           subtitle="The binding final declaration that files your return with HMRC."
         />
         {s6 !== 'locked' && (
-          <div className="mt-4 pl-12">
-            <div className="rounded-lg border border-secondary-200 bg-secondary-50 p-3 text-sm text-secondary-600 flex items-start gap-2">
-              <AlertCircle className="w-4 h-4 mt-0.5 shrink-0 text-secondary-400" />
-              <span>
-                The final declaration (crystallisation) is the next phase. Your figures above have been submitted to
-                HMRC and the calculation is non-binding — nothing has been filed yet.
-              </span>
-            </div>
+          <div className="mt-4 pl-12 space-y-3">
+            {filed ? (
+              // Done — the return is filed with HMRC.
+              <div className="rounded-lg border border-green-200 bg-green-50 p-4 space-y-2">
+                <p className="flex items-center gap-2 font-semibold text-green-800">
+                  <CheckCircle2 className="w-5 h-5" /> Your tax return has been filed with HMRC.
+                </p>
+                <p className="text-sm text-green-700">
+                  Tax year <strong>{filed.tax_year}</strong> · business{' '}
+                  <span className="font-mono">{filed.business_id}</span>
+                </p>
+                {filed.calculation_id && (
+                  <p className="text-xs text-green-700">
+                    HMRC calculation reference: <span className="font-mono">{filed.calculation_id}</span>
+                  </p>
+                )}
+                {filed.sandbox && (
+                  <p className="flex items-start gap-1.5 text-xs text-green-700">
+                    <AlertCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+                    Sandbox test submission — no real return was filed with HMRC.
+                  </p>
+                )}
+              </div>
+            ) : (
+              <>
+                <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 flex items-start gap-2">
+                  <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
+                  <span>
+                    This is the <strong>binding final declaration</strong> for tax year <strong>{taxYear}</strong>.
+                    Once submitted, you are confirming the figures are correct and complete — this files your
+                    Self Assessment return with HMRC.
+                  </span>
+                </div>
+
+                <label className="flex items-start gap-2 text-sm text-secondary-700">
+                  <input
+                    type="checkbox"
+                    checked={declarationAccepted}
+                    onChange={(e) => setDeclarationAccepted(e.target.checked)}
+                    className="mt-0.5"
+                  />
+                  <span>
+                    I declare that the information I have given is correct and complete to the best of my
+                    knowledge and belief, and I want to submit this as my final declaration to HMRC.
+                  </span>
+                </label>
+
+                <button
+                  onClick={submitFinalDeclaration}
+                  disabled={filing || !declarationAccepted}
+                  className="flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50"
+                >
+                  {filing ? <Loader2 className="w-4 h-4 animate-spin" /> : <FileCheck2 className="w-4 h-4" />}
+                  {filing ? 'Filing your return…' : 'Submit final declaration & file'}
+                </button>
+
+                {filing && (
+                  <p className="flex items-start gap-2 text-xs text-secondary-500">
+                    <Loader2 className="w-3.5 h-3.5 mt-0.5 shrink-0 animate-spin" />
+                    <span>Sending your figures and final declaration to HMRC — please don&apos;t close this page.</span>
+                  </p>
+                )}
+              </>
+            )}
           </div>
         )}
       </Card>

--- a/opsapi-dashboard/lib/api-client.ts
+++ b/opsapi-dashboard/lib/api-client.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosError, type AxiosInstance, type InternalAxiosRequestConfig } from 'axios';
+import { hmrcFraudHeaders } from './hmrc-fraud';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://127.0.0.1:4010';
 
@@ -55,6 +56,31 @@ function getAuthToken(): string | null {
 }
 
 /**
+ * Best-effort read of the logged-in user's id (for HMRC Gov-Client-User-IDs).
+ * Checks the direct auth_user key, then the Zustand persisted auth state.
+ */
+function getAuthUserId(): string | undefined {
+  if (typeof window === 'undefined') return undefined;
+  const pick = (u: unknown): string | undefined => {
+    const user = u as { uuid?: string; id?: string | number; email?: string } | undefined;
+    const v = user?.uuid ?? user?.id ?? user?.email;
+    return v !== undefined && v !== null ? String(v) : undefined;
+  };
+  try {
+    const direct = localStorage.getItem(AUTH_USER_KEY);
+    if (direct) {
+      const id = pick(JSON.parse(direct));
+      if (id) return id;
+    }
+    const zustand = localStorage.getItem(ZUSTAND_AUTH_KEY);
+    if (zustand) return pick(JSON.parse(zustand)?.state?.user);
+  } catch {
+    // Ignore parse errors
+  }
+  return undefined;
+}
+
+/**
  * Clear all auth-related storage including menu and namespace cache
  */
 export function clearAllAuthStorage(): void {
@@ -89,6 +115,15 @@ apiClient.interceptors.request.use(
           }
         } catch {
           // Ignore parse errors
+        }
+      }
+
+      // On HMRC-bound requests, forward the browser-collected anti-fraud signals so the
+      // backend can build HMRC's mandatory Gov-Client-* fraud-prevention headers.
+      if (config.headers && (config.url || '').includes('hmrc')) {
+        const fraud = hmrcFraudHeaders(getAuthUserId());
+        for (const [k, v] of Object.entries(fraud)) {
+          config.headers[k] = v;
         }
       }
     }

--- a/opsapi-dashboard/lib/hmrc-fraud.ts
+++ b/opsapi-dashboard/lib/hmrc-fraud.ts
@@ -1,0 +1,75 @@
+/**
+ * HMRC anti-fraud signal collection (WEB_APP_VIA_SERVER).
+ *
+ * HMRC's Making Tax Digital APIs require fraud-prevention headers describing the device
+ * that originated the request. For a server-side web app, several of these can ONLY be
+ * gathered in the browser (screen size, window size, JS user-agent, timezone, a stable
+ * per-device id). We collect them here and forward them to our backend as `X-Gov-Client-*`
+ * headers; the backend maps them to the real `Gov-Client-*` headers it sends to HMRC and
+ * adds the server-derived ones (public IP/port, the user→server hop).
+ *
+ * HMRC penalises FAKE values — so we only ever send what the browser actually reports.
+ */
+
+const DEVICE_ID_KEY = 'hmrc_device_id';
+
+// A stable per-device UUID, persisted in localStorage so it's the same across sessions.
+function deviceId(): string {
+  let id = localStorage.getItem(DEVICE_ID_KEY);
+  if (!id) {
+    id =
+      typeof crypto !== 'undefined' && crypto.randomUUID
+        ? crypto.randomUUID()
+        : // Fallback for older browsers without crypto.randomUUID.
+          'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+            const r = (Math.random() * 16) | 0;
+            return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
+          });
+    localStorage.setItem(DEVICE_ID_KEY, id);
+  }
+  return id;
+}
+
+// The browser's current UTC offset as HMRC's "UTC±HH:MM" format.
+function timezone(): string {
+  // getTimezoneOffset() returns minutes BEHIND UTC (e.g. UTC+1 → -60), so negate it.
+  const offsetMin = -new Date().getTimezoneOffset();
+  const sign = offsetMin >= 0 ? '+' : '-';
+  const abs = Math.abs(offsetMin);
+  const hh = String(Math.floor(abs / 60)).padStart(2, '0');
+  const mm = String(abs % 60).padStart(2, '0');
+  return `UTC${sign}${hh}:${mm}`;
+}
+
+// HMRC Gov-Client-Screens: one entry per screen (we have one in a browser).
+function screens(): string {
+  const s = window.screen;
+  const scaling = window.devicePixelRatio || 1;
+  return `width=${s.width}&height=${s.height}&scaling-factor=${scaling}&colour-depth=${s.colorDepth}`;
+}
+
+// HMRC Gov-Client-Window-Size: the browser viewport.
+function windowSize(): string {
+  return `width=${window.innerWidth}&height=${window.innerHeight}`;
+}
+
+/**
+ * Build the X-Gov-Client-* headers to forward on HMRC-bound requests.
+ * Returns {} during SSR (no browser APIs available).
+ *
+ * @param userId optional vendor user identifier → Gov-Client-User-IDs ("opsapi=<id>")
+ */
+export function hmrcFraudHeaders(userId?: string | number): Record<string, string> {
+  if (typeof window === 'undefined') return {};
+  const headers: Record<string, string> = {
+    'X-Gov-Client-Device-ID': deviceId(),
+    'X-Gov-Client-Browser-JS-User-Agent': navigator.userAgent,
+    'X-Gov-Client-Screens': screens(),
+    'X-Gov-Client-Window-Size': windowSize(),
+    'X-Gov-Client-Timezone': timezone(),
+  };
+  if (userId !== undefined && userId !== null && `${userId}` !== '') {
+    headers['X-Gov-Client-User-IDs'] = `opsapi=${encodeURIComponent(String(userId))}`;
+  }
+  return headers;
+}

--- a/opsapi-dashboard/services/tax.service.ts
+++ b/opsapi-dashboard/services/tax.service.ts
@@ -639,6 +639,34 @@ export const taxService = {
     return response.data?.data || response.data;
   },
 
+  // Submit the BINDING final declaration (crystallisation) — this actually FILES the
+  // return with HMRC. Requires explicit declaration consent. Slow (cumulative submit +
+  // intent-to-finalise calc polling + declaration), so allow a long timeout.
+  async submitHmrcFinalDeclaration(taxYear: string): Promise<{
+    filed: boolean;
+    tax_year: string;
+    business_id: string;
+    calculation_id: string;
+    sandbox: boolean;
+    figures: {
+      total_income_tax_and_nics_due?: number;
+      total_taxable_income?: number;
+      income_tax_charged?: number;
+      personal_allowance?: number;
+      class2_nics?: number;
+      class4_nics?: number;
+      is_sandbox_placeholder?: boolean;
+    };
+  }> {
+    const params = new URLSearchParams();
+    params.append('tax_year', taxYear);
+    params.append('declaration_accepted', 'true');
+    const response = await apiClient.post(`${TAX_BASE}/hmrc/submit-final-declaration`, params.toString(), {
+      timeout: 180000,
+    });
+    return response.data?.data || response.data;
+  },
+
   // ── Business profile (drives classification) ─────────────────────────────────
   async getProfileOptions(): Promise<
     Array<{ profile_key: string; display_name: string; sa_form: string; filing_supported: boolean }>


### PR DESCRIPTION
## What this does

Completes the HMRC Making Tax Digital (MTD) **"File your tax"** flow so the dashboard can file an actual UK Self Assessment return end-to-end, and makes the wizard self-driving so a non-expert can complete it. Also hardens the integration for production. (This codebase ships as **DIY Tax Return** / `diytaxreturn.co.uk`.)

## Filing flow
- **Binding final declaration (crystallisation)** — the step that actually files. New `Client.submit_final_declaration` + `POST /api/v2/tax/hmrc/submit-final-declaration` (triggers an `intent-to-finalise` calc, then submits the declaration; gated on an explicit consent checkbox). Step 6 of the wizard is now a real step, not a placeholder.
- **Auto-advancing wizard** — business, obligations and figures are fetched/aggregated automatically (`useEffect` guards); the user only acts on genuinely-human steps (connect, NINO, picking among multiple businesses, fixing flagged credits, the final declaration).
- **Transparency** — a "Exactly what we'll send to HMRC" panel lists every income/expense line before filing.

## Sandbox correctness (each was a real bug)
- Obligations now send `Gov-Test-Scenario: DYNAMIC` so HMRC returns **current-year** periods instead of the fixed 2018 sample; self-employment-only filtering avoids triplicate/empty results from the synthetic `XBIS/XPIS/XFIS` business ids.
- `calculate-preview` / final-declaration **self-heal** `MATCHING_RESOURCE_NOT_FOUND` by provisioning a stateful test business and retrying.
- `parse_figures` reads `calculation.taxCalculation.*` (was top-level) — fixes the preview showing `—` for every figure.

## Production hardening
- `ssl_verify` is now **environment-aware** across all HMRC calls (verified TLS in production, off in sandbox) + `lua_ssl_trusted_certificate` added to the nginx http block (CA bundle confirmed to validate HMRC's prod + sandbox certs).
- **Anti-fraud headers pass HMRC's "Test Fraud Prevention Headers" validator** (0 errors). Browser signals are collected in `lib/hmrc-fraud.ts`, forwarded as `X-Gov-Client-*` (CORS allow-listed), and remapped server-side; `Gov-Vendor-Public-IP`/`Gov-Vendor-Forwarded` driven by `HMRC_SERVER_PUBLIC_IP`.
- HMRC env vars documented in `.sample.env`; the full architecture + gotchas documented in `CLAUDE.md`.

## Verification
- Validated end-to-end against the HMRC sandbox: preview, binding final declaration (`filed: true`), and the fraud-header validator (errors → 0).
- Lua syntax + `openresty -t` clean; frontend `tsc` + `eslint` clean.
- Blast-radius checked: only `middleware/cors.lua` (additive allow-list) and the nginx CA directive (additive; CA file present in image) are shared/global — no impact on non-tax functionality.

## Operator follow-ups before production go-live (not code)
- Set `HMRC_ENVIRONMENT=production`, `HMRC_CLIENT_ID/SECRET`, `HMRC_REDIRECT_URI`, `HMRC_SERVER_PUBLIC_IP`.
- Subscribe the HMRC app to: Business Details / Obligations / Self Employment Business / Individual Calculations (MTD); OAuth scopes `read:self-assessment` + `write:self-assessment`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
