### PR TITLE
Customer-period invoicing, branded invoice PDF, invoice CRUD fixes + tenancy/migration hardening

### DIFF
--- a/lapis/helper/theme-presets.lua
+++ b/lapis/helper/theme-presets.lua
@@ -100,15 +100,16 @@ end
 ThemePresets.LIST = {
     {
         slug         = "light",
-        name         = "Light",
-        description  = "Clean, bright default with blue brand accents. Suitable for most dashboards.",
+        name         = "OpsAPI Bright",
+        description  = "The signature OpsAPI look — vivid #ff004e on clean white. The platform default.",
         project_code = "*",
         tokens = build_tokens({
+            -- Brand pink scale (must mirror opsapi-dashboard/app/globals.css :root)
             primary = {
-                ["50"]  = "#eff6ff", ["100"] = "#dbeafe", ["200"] = "#bfdbfe",
-                ["300"] = "#93c5fd", ["400"] = "#60a5fa", ["500"] = "#3b82f6",
-                ["600"] = "#2563eb", ["700"] = "#1d4ed8", ["800"] = "#1e40af",
-                ["900"] = "#1e3a8a",
+                ["50"]  = "#fff0f3", ["100"] = "#ffe0e8", ["200"] = "#ffc6d5",
+                ["300"] = "#ff9fb5", ["400"] = "#ff6088", ["500"] = "#ff004e",
+                ["600"] = "#e6003f", ["700"] = "#c20035", ["800"] = "#a00030",
+                ["900"] = "#84002c",
             },
             secondary = {
                 ["50"]  = "#f8fafc", ["100"] = "#f1f5f9", ["200"] = "#e2e8f0",
@@ -116,7 +117,7 @@ ThemePresets.LIST = {
                 ["600"] = "#475569", ["700"] = "#334155", ["800"] = "#1e293b",
                 ["900"] = "#0f172a",
             },
-            accent           = "#3b82f6",
+            accent           = "#ff004e",
             background       = "#ffffff",
             foreground       = "#0f172a",
             surface          = "#ffffff",

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -1021,6 +1021,15 @@ local _migrations = {
         kanban_project_migrations, 39),
     ['249_create_kanban_comment_reply_trigger'] = conditional_array(ProjectConfig.FEATURES.KANBAN,
         kanban_project_migrations, 40),
+    -- Deferred FK-default repairs. Keyed in the 76x range so they run after every
+    -- table/column above has been created (migrations run in sorted-key order).
+    -- [41] drops the bogus DEFAULT 0 on kanban_tasks.parent_task_id / sprint_id
+    -- (a 0 violates the self/sprint FK on tasks created without a parent/sprint).
+    ['760_kanban_drop_fk_defaults'] = conditional_array(ProjectConfig.FEATURES.KANBAN,
+        kanban_project_migrations, 41),
+    -- [29] sweeps the bogus DEFAULT 0 off every namespace_id FK column (customers,
+    -- kanban_projects, …) so tenant-less inserts fail loudly instead of writing 0.
+    ['761_drop_namespace_id_defaults'] = namespace_system_migrations[29],
     ['250_create_kanban_time_entries_table'] = conditional_array(ProjectConfig.FEATURES.KANBAN,
         kanban_enhancement_migrations, 1),
     ['251_add_kanban_time_entries_indexes'] = conditional_array(ProjectConfig.FEATURES.KANBAN,
@@ -1536,6 +1545,7 @@ local _migrations = {
     ['542_inv_create_payments'] = conditional_array(ProjectConfig.FEATURES.INVOICING, invoicing_system_migrations, 3),
     ['543_inv_create_tax_rates'] = conditional_array(ProjectConfig.FEATURES.INVOICING, invoicing_system_migrations, 4),
     ['544_inv_create_sequences'] = conditional_array(ProjectConfig.FEATURES.INVOICING, invoicing_system_migrations, 5),
+    ['545_inv_widen_tax_rate'] = conditional_array(ProjectConfig.FEATURES.INVOICING, invoicing_system_migrations, 6),
 
     -- Invoicing menu items (740-743): surface Invoices in the sidebar
     ['740_seed_invoicing_menu_items'] = conditional_array(ProjectConfig.FEATURES.INVOICING, invoicing_menu_items_migrations, 1),

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -153,12 +153,15 @@ local billing_system_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COP
 -- CRM
 local crm_system_migrations = load_if_enabled(ProjectConfig.FEATURES.CRM, "migrations.crm-system") or {}
 local crm_leads_migrations = load_if_enabled(ProjectConfig.FEATURES.CRM, "migrations.crm-leads") or {}
+local crm_menu_items_migrations = load_if_enabled(ProjectConfig.FEATURES.CRM, "migrations.crm-menu-items") or {}
 
 -- Timesheets
 local timesheet_system_migrations = load_if_enabled(ProjectConfig.FEATURES.TIMESHEETS, "migrations.timesheet-system") or {}
+local timesheet_menu_items_migrations = load_if_enabled(ProjectConfig.FEATURES.TIMESHEETS, "migrations.timesheet-menu-items") or {}
 
 -- Invoicing
 local invoicing_system_migrations = load_if_enabled(ProjectConfig.FEATURES.INVOICING, "migrations.invoicing-system") or {}
+local invoicing_menu_items_migrations = load_if_enabled(ProjectConfig.FEATURES.INVOICING, "migrations.invoicing-menu-items") or {}
 
 -- Document Templates (loaded with invoicing feature)
 local document_template_migrations = load_if_enabled(ProjectConfig.FEATURES.INVOICING, "migrations.document-templates") or {}
@@ -166,6 +169,7 @@ local document_template_migrations = load_if_enabled(ProjectConfig.FEATURES.INVO
 -- Accounting/Bookkeeping
 local accounting_system_migrations = load_if_enabled(ProjectConfig.FEATURES.ACCOUNTING, "migrations.accounting-system") or {}
 local accounting_hmrc_migrations = load_if_enabled(ProjectConfig.FEATURES.ACCOUNTING, "migrations.accounting-hmrc-categories") or {}
+local accounting_menu_items_migrations = load_if_enabled(ProjectConfig.FEATURES.ACCOUNTING, "migrations.accounting-menu-items") or {}
 
 -- Theme system (platform-level; enabled for every preset)
 local theme_system_migrations = load_if_enabled(ProjectConfig.FEATURES.THEMES, "migrations.theme-system") or {}
@@ -1503,12 +1507,26 @@ local _migrations = {
     ['510_crm_create_leads'] = conditional_array(ProjectConfig.FEATURES.CRM, crm_leads_migrations, 1),
     ['511_crm_leads_enquiry_link'] = conditional_array(ProjectConfig.FEATURES.CRM, crm_leads_migrations, 2),
 
+    -- CRM menu items (720-723): surface CRM in the backend-driven sidebar
+    ['720_seed_crm_menu_items'] = conditional_array(ProjectConfig.FEATURES.CRM, crm_menu_items_migrations, 1),
+    ['721_seed_crm_modules'] = conditional_array(ProjectConfig.FEATURES.CRM, crm_menu_items_migrations, 2),
+    ['722_grant_crm_permissions'] = conditional_array(ProjectConfig.FEATURES.CRM, crm_menu_items_migrations, 3),
+    ['723_enable_crm_menu_per_namespace'] = conditional_array(ProjectConfig.FEATURES.CRM, crm_menu_items_migrations, 4),
+
     -- =========================================================================
     -- TIMESHEET SYSTEM (520-529)
     -- =========================================================================
     ['520_ts_create_timesheets'] = conditional_array(ProjectConfig.FEATURES.TIMESHEETS, timesheet_system_migrations, 1),
     ['521_ts_create_entries'] = conditional_array(ProjectConfig.FEATURES.TIMESHEETS, timesheet_system_migrations, 2),
     ['522_ts_create_approvals'] = conditional_array(ProjectConfig.FEATURES.TIMESHEETS, timesheet_system_migrations, 3),
+    ['523_ts_enrich_client_fields'] = conditional_array(ProjectConfig.FEATURES.TIMESHEETS, timesheet_system_migrations, 4),
+    ['524_ts_link_customer_task'] = conditional_array(ProjectConfig.FEATURES.TIMESHEETS, timesheet_system_migrations, 5),
+
+    -- Timesheet menu items (730-733): surface Timesheets in the sidebar
+    ['730_seed_timesheet_menu_items'] = conditional_array(ProjectConfig.FEATURES.TIMESHEETS, timesheet_menu_items_migrations, 1),
+    ['731_seed_timesheet_modules'] = conditional_array(ProjectConfig.FEATURES.TIMESHEETS, timesheet_menu_items_migrations, 2),
+    ['732_grant_timesheet_permissions'] = conditional_array(ProjectConfig.FEATURES.TIMESHEETS, timesheet_menu_items_migrations, 3),
+    ['733_enable_timesheet_menu_per_namespace'] = conditional_array(ProjectConfig.FEATURES.TIMESHEETS, timesheet_menu_items_migrations, 4),
 
     -- =========================================================================
     -- INVOICING SYSTEM (540-549)
@@ -1518,6 +1536,12 @@ local _migrations = {
     ['542_inv_create_payments'] = conditional_array(ProjectConfig.FEATURES.INVOICING, invoicing_system_migrations, 3),
     ['543_inv_create_tax_rates'] = conditional_array(ProjectConfig.FEATURES.INVOICING, invoicing_system_migrations, 4),
     ['544_inv_create_sequences'] = conditional_array(ProjectConfig.FEATURES.INVOICING, invoicing_system_migrations, 5),
+
+    -- Invoicing menu items (740-743): surface Invoices in the sidebar
+    ['740_seed_invoicing_menu_items'] = conditional_array(ProjectConfig.FEATURES.INVOICING, invoicing_menu_items_migrations, 1),
+    ['741_seed_invoicing_modules'] = conditional_array(ProjectConfig.FEATURES.INVOICING, invoicing_menu_items_migrations, 2),
+    ['742_grant_invoicing_permissions'] = conditional_array(ProjectConfig.FEATURES.INVOICING, invoicing_menu_items_migrations, 3),
+    ['743_enable_invoicing_menu_per_namespace'] = conditional_array(ProjectConfig.FEATURES.INVOICING, invoicing_menu_items_migrations, 4),
 
     -- =========================================================================
     -- KAFKA / AUDIT SYSTEM (560-561)
@@ -1554,6 +1578,12 @@ local _migrations = {
     ['608_acct_bank_txn_tags_columns'] = conditional_array(ProjectConfig.FEATURES.ACCOUNTING, accounting_hmrc_migrations, 2),
     ['609_acct_seed_hmrc_categories'] = conditional_array(ProjectConfig.FEATURES.ACCOUNTING, accounting_hmrc_migrations, 3),
     ['610_acct_seed_dummy_transactions'] = conditional_array(ProjectConfig.FEATURES.ACCOUNTING, accounting_hmrc_migrations, 4),
+
+    -- Accounting menu items (750-753): surface Bookkeeping in the sidebar
+    ['750_seed_accounting_menu_items'] = conditional_array(ProjectConfig.FEATURES.ACCOUNTING, accounting_menu_items_migrations, 1),
+    ['751_seed_accounting_modules'] = conditional_array(ProjectConfig.FEATURES.ACCOUNTING, accounting_menu_items_migrations, 2),
+    ['752_grant_accounting_permissions'] = conditional_array(ProjectConfig.FEATURES.ACCOUNTING, accounting_menu_items_migrations, 3),
+    ['753_enable_accounting_menu_per_namespace'] = conditional_array(ProjectConfig.FEATURES.ACCOUNTING, accounting_menu_items_migrations, 4),
 
     -- =========================================================================
     -- Theme System (Phase 1) — tables for multi-tenant theming

--- a/lapis/migrations/accounting-menu-items.lua
+++ b/lapis/migrations/accounting-menu-items.lua
@@ -1,0 +1,154 @@
+--[[
+    Accounting Menu Items Seeding Migration
+
+    Bookkeeping/accounting had backend, DB tables, RBAC modules and a frontend
+    page (/dashboard/accounting) but no menu_items row. Mirrors the
+    tax-copilot-menu-items pattern. Feature-gated under FEATURES.ACCOUNTING.
+]]
+
+local db = require("lapis.db")
+
+return {
+    -- [1] Insert the Bookkeeping menu item
+    [1] = function()
+        local MigrationUtils = require("helper.migration-utils")
+        local timestamp = MigrationUtils.getCurrentTimestamp()
+
+        local items = {
+            {
+                key = "accounting",
+                name = "Bookkeeping",
+                icon = "BookOpen",
+                path = "/dashboard/accounting",
+                module = "accounting",
+                required_action = "read",
+                priority = 44,
+            },
+        }
+
+        for _, item in ipairs(items) do
+            local existing = db.select("* FROM menu_items WHERE key = ?", item.key)
+            if #existing == 0 then
+                db.insert("menu_items", {
+                    uuid = MigrationUtils.generateUUID(),
+                    key = item.key,
+                    name = item.name,
+                    icon = item.icon,
+                    path = item.path,
+                    module = item.module,
+                    required_action = item.required_action,
+                    priority = item.priority,
+                    is_active = true,
+                    is_admin_only = false,
+                    always_show = false,
+                    settings = "{}",
+                    created_at = timestamp,
+                    updated_at = timestamp,
+                })
+                print("[Accounting] Added menu item: " .. item.key)
+            end
+        end
+    end,
+
+    -- [2] Register the accounting RBAC modules
+    [2] = function()
+        local MigrationUtils = require("helper.migration-utils")
+        local timestamp = MigrationUtils.getCurrentTimestamp()
+
+        local modules = {
+            { machine_name = "accounting", name = "Bookkeeping", description = "Chart of accounts, journal entries, and financial reports", priority = 44 },
+            { machine_name = "bank_reconciliation", name = "Bank Reconciliation", description = "Import and reconcile bank transactions", priority = 45 },
+            { machine_name = "expense_management", name = "Expenses", description = "Expense tracking and approval", priority = 46 },
+            { machine_name = "vat_returns", name = "VAT Returns", description = "UK VAT return calculation and submission", priority = 47 },
+            { machine_name = "financial_reports", name = "Financial Reports", description = "Trial balance, balance sheet, P&L", priority = 48 },
+        }
+
+        for _, mod in ipairs(modules) do
+            local existing = db.select("* FROM modules WHERE machine_name = ?", mod.machine_name)
+            if #existing == 0 then
+                db.insert("modules", {
+                    uuid = MigrationUtils.generateUUID(),
+                    machine_name = mod.machine_name,
+                    name = mod.name,
+                    description = mod.description,
+                    priority = mod.priority,
+                    created_at = timestamp,
+                    updated_at = timestamp,
+                })
+                print("[Accounting] Registered module: " .. mod.machine_name)
+            end
+        end
+    end,
+
+    -- [3] Grant permissions to owner + admin roles
+    [3] = function()
+        local cjson_ok, cjson = pcall(require, "cjson")
+        if not cjson_ok then return end
+
+        local accounting_modules = {
+            "accounting", "bank_reconciliation", "expense_management", "vat_returns", "financial_reports"
+        }
+
+        local owner_roles = db.select(
+            "* FROM namespace_roles WHERE role_name IN ('Owner', 'owner', 'Namespace Owner')"
+        )
+        local owner_actions = { "create", "read", "update", "delete", "manage" }
+        for _, role in ipairs(owner_roles) do
+            local perms = {}
+            if role.permissions and role.permissions ~= "" then
+                local ok, decoded = pcall(cjson.decode, role.permissions)
+                if ok and type(decoded) == "table" then perms = decoded end
+            end
+            for _, mod_name in ipairs(accounting_modules) do
+                if not perms[mod_name] then perms[mod_name] = owner_actions end
+            end
+            db.update("namespace_roles", { permissions = cjson.encode(perms) }, { id = role.id })
+        end
+
+        local admin_roles = db.select(
+            "* FROM namespace_roles WHERE role_name IN ('Admin', 'admin', 'Namespace Admin')"
+        )
+        local admin_actions = { "create", "read", "update", "delete" }
+        for _, role in ipairs(admin_roles) do
+            local perms = {}
+            if role.permissions and role.permissions ~= "" then
+                local ok, decoded = pcall(cjson.decode, role.permissions)
+                if ok and type(decoded) == "table" then perms = decoded end
+            end
+            for _, mod_name in ipairs(accounting_modules) do
+                if not perms[mod_name] then perms[mod_name] = admin_actions end
+            end
+            db.update("namespace_roles", { permissions = cjson.encode(perms) }, { id = role.id })
+        end
+    end,
+
+    -- [4] Enable the menu item for all existing namespaces
+    [4] = function()
+        local MigrationUtils = require("helper.migration-utils")
+        local timestamp = MigrationUtils.getCurrentTimestamp()
+
+        for _, key in ipairs({ "accounting" }) do
+            local menu_rows = db.select("* FROM menu_items WHERE key = ?", key)
+            if #menu_rows > 0 then
+                local menu_item = menu_rows[1]
+                local namespaces = db.select("* FROM namespaces")
+                for _, ns in ipairs(namespaces) do
+                    local exists = db.select([[
+                        * FROM namespace_menu_config
+                        WHERE namespace_id = ? AND menu_item_id = ?
+                    ]], ns.id, menu_item.id)
+                    if #exists == 0 then
+                        db.insert("namespace_menu_config", {
+                            uuid = MigrationUtils.generateUUID(),
+                            namespace_id = ns.id,
+                            menu_item_id = menu_item.id,
+                            is_enabled = true,
+                            created_at = timestamp,
+                            updated_at = timestamp,
+                        })
+                    end
+                end
+            end
+        end
+    end,
+}

--- a/lapis/migrations/crm-menu-items.lua
+++ b/lapis/migrations/crm-menu-items.lua
@@ -1,0 +1,157 @@
+--[[
+    CRM Menu Items Seeding Migration
+
+    CRM had backend (routes/crm-accounts.lua etc.), DB tables, RBAC modules and a
+    frontend page (/dashboard/crm) but no menu_items row. Mirrors the
+    tax-copilot-menu-items pattern. Feature-gated under FEATURES.CRM.
+
+    The menu item's `module` is crm_accounts (the entry-point module), matching
+    PROJECT_MODULES.crm so it passes the PROJECT_CODE gate in MenuQueries.
+]]
+
+local db = require("lapis.db")
+
+return {
+    -- [1] Insert the CRM menu item
+    [1] = function()
+        local MigrationUtils = require("helper.migration-utils")
+        local timestamp = MigrationUtils.getCurrentTimestamp()
+
+        local items = {
+            {
+                key = "crm",
+                name = "CRM",
+                icon = "Contact",
+                path = "/dashboard/crm",
+                module = "crm_accounts",
+                required_action = "read",
+                priority = 46,
+            },
+        }
+
+        for _, item in ipairs(items) do
+            local existing = db.select("* FROM menu_items WHERE key = ?", item.key)
+            if #existing == 0 then
+                db.insert("menu_items", {
+                    uuid = MigrationUtils.generateUUID(),
+                    key = item.key,
+                    name = item.name,
+                    icon = item.icon,
+                    path = item.path,
+                    module = item.module,
+                    required_action = item.required_action,
+                    priority = item.priority,
+                    is_active = true,
+                    is_admin_only = false,
+                    always_show = false,
+                    settings = "{}",
+                    created_at = timestamp,
+                    updated_at = timestamp,
+                })
+                print("[CRM] Added menu item: " .. item.key)
+            end
+        end
+    end,
+
+    -- [2] Register the CRM RBAC modules
+    [2] = function()
+        local MigrationUtils = require("helper.migration-utils")
+        local timestamp = MigrationUtils.getCurrentTimestamp()
+
+        local modules = {
+            { machine_name = "crm_accounts", name = "CRM Accounts", description = "Company/organization management", priority = 46 },
+            { machine_name = "crm_contacts", name = "CRM Contacts", description = "Contact management", priority = 47 },
+            { machine_name = "crm_deals", name = "CRM Deals", description = "Deal pipeline management", priority = 48 },
+            { machine_name = "crm_pipelines", name = "CRM Pipelines", description = "Sales pipeline configuration", priority = 49 },
+            { machine_name = "crm_activities", name = "CRM Activities", description = "Activity tracking", priority = 50 },
+        }
+
+        for _, mod in ipairs(modules) do
+            local existing = db.select("* FROM modules WHERE machine_name = ?", mod.machine_name)
+            if #existing == 0 then
+                db.insert("modules", {
+                    uuid = MigrationUtils.generateUUID(),
+                    machine_name = mod.machine_name,
+                    name = mod.name,
+                    description = mod.description,
+                    priority = mod.priority,
+                    created_at = timestamp,
+                    updated_at = timestamp,
+                })
+                print("[CRM] Registered module: " .. mod.machine_name)
+            end
+        end
+    end,
+
+    -- [3] Grant permissions to owner + admin roles
+    [3] = function()
+        local cjson_ok, cjson = pcall(require, "cjson")
+        if not cjson_ok then return end
+
+        local crm_modules = {
+            "crm_accounts", "crm_contacts", "crm_deals", "crm_pipelines", "crm_activities"
+        }
+
+        local owner_roles = db.select(
+            "* FROM namespace_roles WHERE role_name IN ('Owner', 'owner', 'Namespace Owner')"
+        )
+        local owner_actions = { "create", "read", "update", "delete", "manage" }
+        for _, role in ipairs(owner_roles) do
+            local perms = {}
+            if role.permissions and role.permissions ~= "" then
+                local ok, decoded = pcall(cjson.decode, role.permissions)
+                if ok and type(decoded) == "table" then perms = decoded end
+            end
+            for _, mod_name in ipairs(crm_modules) do
+                if not perms[mod_name] then perms[mod_name] = owner_actions end
+            end
+            db.update("namespace_roles", { permissions = cjson.encode(perms) }, { id = role.id })
+        end
+
+        local admin_roles = db.select(
+            "* FROM namespace_roles WHERE role_name IN ('Admin', 'admin', 'Namespace Admin')"
+        )
+        local admin_actions = { "create", "read", "update", "delete" }
+        for _, role in ipairs(admin_roles) do
+            local perms = {}
+            if role.permissions and role.permissions ~= "" then
+                local ok, decoded = pcall(cjson.decode, role.permissions)
+                if ok and type(decoded) == "table" then perms = decoded end
+            end
+            for _, mod_name in ipairs(crm_modules) do
+                if not perms[mod_name] then perms[mod_name] = admin_actions end
+            end
+            db.update("namespace_roles", { permissions = cjson.encode(perms) }, { id = role.id })
+        end
+    end,
+
+    -- [4] Enable the menu item for all existing namespaces
+    [4] = function()
+        local MigrationUtils = require("helper.migration-utils")
+        local timestamp = MigrationUtils.getCurrentTimestamp()
+
+        for _, key in ipairs({ "crm" }) do
+            local menu_rows = db.select("* FROM menu_items WHERE key = ?", key)
+            if #menu_rows > 0 then
+                local menu_item = menu_rows[1]
+                local namespaces = db.select("* FROM namespaces")
+                for _, ns in ipairs(namespaces) do
+                    local exists = db.select([[
+                        * FROM namespace_menu_config
+                        WHERE namespace_id = ? AND menu_item_id = ?
+                    ]], ns.id, menu_item.id)
+                    if #exists == 0 then
+                        db.insert("namespace_menu_config", {
+                            uuid = MigrationUtils.generateUUID(),
+                            namespace_id = ns.id,
+                            menu_item_id = menu_item.id,
+                            is_enabled = true,
+                            created_at = timestamp,
+                            updated_at = timestamp,
+                        })
+                    end
+                end
+            end
+        end
+    end,
+}

--- a/lapis/migrations/invoicing-menu-items.lua
+++ b/lapis/migrations/invoicing-menu-items.lua
@@ -1,0 +1,167 @@
+--[[
+    Invoicing Menu Items Seeding Migration
+
+    The invoicing feature had a full backend (routes/invoices.lua), DB tables,
+    RBAC modules and a frontend page (/dashboard/invoices) — but no menu_items
+    row, so it never appeared in the sidebar. This migration closes that gap the
+    same way tax-copilot-menu-items.lua does:
+      [1] insert the menu item(s)
+      [2] register the RBAC modules in the modules table
+      [3] grant owner/admin roles permission on those modules
+      [4] enable the menu item for every existing namespace
+
+    Feature-gated under FEATURES.INVOICING in migrations.lua, so it only seeds
+    where invoicing is part of the project. PROJECT_CODE gating in
+    MenuQueries.getForNamespace then hides it for projects that don't include it.
+]]
+
+local db = require("lapis.db")
+
+return {
+    -- =========================================================================
+    -- [1] Insert the Invoices menu item
+    -- =========================================================================
+    [1] = function()
+        local MigrationUtils = require("helper.migration-utils")
+        local timestamp = MigrationUtils.getCurrentTimestamp()
+
+        local items = {
+            {
+                key = "invoices",
+                name = "Invoices",
+                icon = "FileText",
+                path = "/dashboard/invoices",
+                module = "invoices",
+                required_action = "read",
+                priority = 40,
+            },
+        }
+
+        for _, item in ipairs(items) do
+            local existing = db.select("* FROM menu_items WHERE key = ?", item.key)
+            if #existing == 0 then
+                db.insert("menu_items", {
+                    uuid = MigrationUtils.generateUUID(),
+                    key = item.key,
+                    name = item.name,
+                    icon = item.icon,
+                    path = item.path,
+                    module = item.module,
+                    required_action = item.required_action,
+                    priority = item.priority,
+                    is_active = true,
+                    is_admin_only = false,
+                    always_show = false,
+                    settings = "{}",
+                    created_at = timestamp,
+                    updated_at = timestamp,
+                })
+                print("[Invoicing] Added menu item: " .. item.key)
+            end
+        end
+    end,
+
+    -- =========================================================================
+    -- [2] Register the invoicing RBAC modules
+    -- =========================================================================
+    [2] = function()
+        local MigrationUtils = require("helper.migration-utils")
+        local timestamp = MigrationUtils.getCurrentTimestamp()
+
+        local modules = {
+            { machine_name = "invoices", name = "Invoices", description = "Invoice creation and management", priority = 40 },
+            { machine_name = "payments", name = "Payments", description = "Payment recording and tracking", priority = 41 },
+            { machine_name = "tax_rates_config", name = "Tax Rates", description = "Tax rate configuration", priority = 42 },
+        }
+
+        for _, mod in ipairs(modules) do
+            local existing = db.select("* FROM modules WHERE machine_name = ?", mod.machine_name)
+            if #existing == 0 then
+                db.insert("modules", {
+                    uuid = MigrationUtils.generateUUID(),
+                    machine_name = mod.machine_name,
+                    name = mod.name,
+                    description = mod.description,
+                    priority = mod.priority,
+                    created_at = timestamp,
+                    updated_at = timestamp,
+                })
+                print("[Invoicing] Registered module: " .. mod.machine_name)
+            end
+        end
+    end,
+
+    -- =========================================================================
+    -- [3] Grant permissions to namespace owner + admin roles
+    -- =========================================================================
+    [3] = function()
+        local cjson_ok, cjson = pcall(require, "cjson")
+        if not cjson_ok then return end
+
+        local invoicing_modules = { "invoices", "payments", "tax_rates_config" }
+
+        local owner_roles = db.select(
+            "* FROM namespace_roles WHERE role_name IN ('Owner', 'owner', 'Namespace Owner')"
+        )
+        local owner_actions = { "create", "read", "update", "delete", "manage" }
+        for _, role in ipairs(owner_roles) do
+            local perms = {}
+            if role.permissions and role.permissions ~= "" then
+                local ok, decoded = pcall(cjson.decode, role.permissions)
+                if ok and type(decoded) == "table" then perms = decoded end
+            end
+            for _, mod_name in ipairs(invoicing_modules) do
+                if not perms[mod_name] then perms[mod_name] = owner_actions end
+            end
+            db.update("namespace_roles", { permissions = cjson.encode(perms) }, { id = role.id })
+        end
+
+        local admin_roles = db.select(
+            "* FROM namespace_roles WHERE role_name IN ('Admin', 'admin', 'Namespace Admin')"
+        )
+        local admin_actions = { "create", "read", "update", "delete" }
+        for _, role in ipairs(admin_roles) do
+            local perms = {}
+            if role.permissions and role.permissions ~= "" then
+                local ok, decoded = pcall(cjson.decode, role.permissions)
+                if ok and type(decoded) == "table" then perms = decoded end
+            end
+            for _, mod_name in ipairs(invoicing_modules) do
+                if not perms[mod_name] then perms[mod_name] = admin_actions end
+            end
+            db.update("namespace_roles", { permissions = cjson.encode(perms) }, { id = role.id })
+        end
+    end,
+
+    -- =========================================================================
+    -- [4] Enable the menu item for all existing namespaces
+    -- =========================================================================
+    [4] = function()
+        local MigrationUtils = require("helper.migration-utils")
+        local timestamp = MigrationUtils.getCurrentTimestamp()
+
+        for _, key in ipairs({ "invoices" }) do
+            local menu_rows = db.select("* FROM menu_items WHERE key = ?", key)
+            if #menu_rows > 0 then
+                local menu_item = menu_rows[1]
+                local namespaces = db.select("* FROM namespaces")
+                for _, ns in ipairs(namespaces) do
+                    local exists = db.select([[
+                        * FROM namespace_menu_config
+                        WHERE namespace_id = ? AND menu_item_id = ?
+                    ]], ns.id, menu_item.id)
+                    if #exists == 0 then
+                        db.insert("namespace_menu_config", {
+                            uuid = MigrationUtils.generateUUID(),
+                            namespace_id = ns.id,
+                            menu_item_id = menu_item.id,
+                            is_enabled = true,
+                            created_at = timestamp,
+                            updated_at = timestamp,
+                        })
+                    end
+                end
+            end
+        end
+    end,
+}

--- a/lapis/migrations/invoicing-system.lua
+++ b/lapis/migrations/invoicing-system.lua
@@ -199,7 +199,10 @@ return {
                 uuid TEXT UNIQUE NOT NULL,
                 namespace_id BIGINT NOT NULL REFERENCES namespaces(id) ON DELETE CASCADE,
                 name TEXT NOT NULL,
-                rate DECIMAL(5,4) NOT NULL,
+                -- Stored as a PERCENT (e.g. 20.00 = 20%), matching how line-item
+                -- tax_rate is applied (tax = subtotal * rate/100). DECIMAL(5,4)
+                -- here would overflow on any rate >= 10%.
+                rate DECIMAL(6,2) NOT NULL,
                 description TEXT,
                 is_default BOOLEAN DEFAULT false,
                 is_active BOOLEAN DEFAULT true,
@@ -236,5 +239,17 @@ return {
                 UNIQUE (namespace_id)
             )
         ]])
+    end,
+
+    -- ========================================
+    -- [6] Widen invoice_tax_rates.rate from DECIMAL(5,4) to DECIMAL(6,2)
+    -- ========================================
+    -- The original DECIMAL(5,4) (max 9.9999) could not store a percent rate of
+    -- 10 or more — createTaxRate({rate=20}) failed with "numeric field overflow".
+    -- Rates are percents (20 = 20%), so widen to hold up to 9999.99.
+    [6] = function()
+        pcall(function()
+            db.query("ALTER TABLE invoice_tax_rates ALTER COLUMN rate TYPE DECIMAL(6,2)")
+        end)
     end
 }

--- a/lapis/migrations/kanban-project-system.lua
+++ b/lapis/migrations/kanban-project-system.lua
@@ -456,7 +456,10 @@ return {
             { "uuid", types.varchar({ unique = true }) },
             { "board_id", types.integer },
             { "column_id", types.integer },
-            { "parent_task_id", types.integer({ null = true }) },
+            -- Nullable self-FK: use a raw type so it has NO `DEFAULT 0`.
+            -- types.integer({ null = true }) still emits DEFAULT 0, which violates
+            -- kanban_tasks_parent_fk (no task with id=0) on every top-level task insert.
+            { "parent_task_id", "integer" },
             { "task_number", types.integer },
             { "title", types.varchar },
             { "description", types.text({ null = true }) },
@@ -1203,7 +1206,9 @@ return {
     [29] = function()
         if column_exists("kanban_tasks", "sprint_id") then return end
 
-        schema.add_column("kanban_tasks", "sprint_id", types.integer({ null = true }))
+        -- Raw "integer" (no `DEFAULT 0`): a default of 0 would violate
+        -- kanban_tasks_sprint_fk (no sprint with id=0) on tasks without a sprint.
+        schema.add_column("kanban_tasks", "sprint_id", "integer")
 
         pcall(function()
             db.query([[
@@ -2078,6 +2083,28 @@ return {
                 FOR EACH ROW
                 EXECUTE FUNCTION update_kanban_comment_reply_count()
             ]])
+        end)
+    end,
+
+    -- ========================================
+    -- [41] Fix nullable FK columns that carried a `DEFAULT 0` from
+    --      types.integer({ null = true }). A 0 default violates the
+    --      self/sprint FK constraints on every task created without a
+    --      parent or sprint (the 500 on POST .../boards/:uuid/tasks).
+    -- ========================================
+    [41] = function()
+        pcall(function()
+            db.query("ALTER TABLE kanban_tasks ALTER COLUMN parent_task_id DROP DEFAULT")
+        end)
+        pcall(function()
+            db.query("ALTER TABLE kanban_tasks ALTER COLUMN sprint_id DROP DEFAULT")
+        end)
+        -- Repair any rows that already stored the bad 0 sentinel.
+        pcall(function()
+            db.query("UPDATE kanban_tasks SET parent_task_id = NULL WHERE parent_task_id = 0")
+        end)
+        pcall(function()
+            db.query("UPDATE kanban_tasks SET sprint_id = NULL WHERE sprint_id = 0")
         end)
     end
 }

--- a/lapis/migrations/namespace-system.lua
+++ b/lapis/migrations/namespace-system.lua
@@ -714,4 +714,31 @@ return {
             end
         end
     end,
+
+    -- ========================================
+    -- [29] Drop the bogus `DEFAULT 0` on every namespace_id FK column
+    -- ========================================
+    -- Lapis' types.integer (and types.integer({ null = true })) emit a
+    -- `DEFAULT 0` that the namespace_id columns inherited across many tables
+    -- (e.g. customers, kanban_projects). A namespace_id of 0 references a
+    -- namespace that never exists (serial ids start at 1), so any insert that
+    -- omits namespace_id silently writes 0 instead of failing — either
+    -- FK-violating or slipping past tenant scoping. Strip the default everywhere
+    -- so such inserts fail loudly. Keyed to run after all namespace_id columns
+    -- have been added (see migrations.lua). Idempotent: DROP DEFAULT is a no-op
+    -- once the default is gone.
+    [29] = function()
+        local cols = db.query([[
+            SELECT table_name
+            FROM information_schema.columns
+            WHERE column_name = 'namespace_id'
+              AND column_default = '0'
+              AND table_schema = 'public'
+        ]])
+        for _, row in ipairs(cols or {}) do
+            pcall(function()
+                db.query("ALTER TABLE " .. row.table_name .. " ALTER COLUMN namespace_id DROP DEFAULT")
+            end)
+        end
+    end,
 }

--- a/lapis/migrations/timesheet-menu-items.lua
+++ b/lapis/migrations/timesheet-menu-items.lua
@@ -1,0 +1,152 @@
+--[[
+    Timesheet Menu Items Seeding Migration
+
+    Timesheets had backend (routes/timesheets.lua), DB tables, RBAC modules and a
+    frontend page (/dashboard/timesheets) but no menu_items row. Mirrors the
+    tax-copilot-menu-items pattern. Feature-gated under FEATURES.TIMESHEETS.
+]]
+
+local db = require("lapis.db")
+
+return {
+    -- [1] Insert the Timesheets menu item
+    [1] = function()
+        local MigrationUtils = require("helper.migration-utils")
+        local timestamp = MigrationUtils.getCurrentTimestamp()
+
+        local items = {
+            {
+                key = "timesheets",
+                name = "Timesheets",
+                icon = "Clock",
+                path = "/dashboard/timesheets",
+                module = "timesheets",
+                required_action = "read",
+                priority = 42,
+            },
+        }
+
+        for _, item in ipairs(items) do
+            local existing = db.select("* FROM menu_items WHERE key = ?", item.key)
+            if #existing == 0 then
+                db.insert("menu_items", {
+                    uuid = MigrationUtils.generateUUID(),
+                    key = item.key,
+                    name = item.name,
+                    icon = item.icon,
+                    path = item.path,
+                    module = item.module,
+                    required_action = item.required_action,
+                    priority = item.priority,
+                    is_active = true,
+                    is_admin_only = false,
+                    always_show = false,
+                    settings = "{}",
+                    created_at = timestamp,
+                    updated_at = timestamp,
+                })
+                print("[Timesheets] Added menu item: " .. item.key)
+            end
+        end
+    end,
+
+    -- [2] Register the timesheet RBAC modules
+    [2] = function()
+        local MigrationUtils = require("helper.migration-utils")
+        local timestamp = MigrationUtils.getCurrentTimestamp()
+
+        local modules = {
+            { machine_name = "timesheets", name = "Timesheets", description = "Time tracking and approval", priority = 42 },
+            { machine_name = "timesheet_approvals", name = "Timesheet Approvals", description = "Approve/reject timesheets", priority = 43 },
+        }
+
+        for _, mod in ipairs(modules) do
+            local existing = db.select("* FROM modules WHERE machine_name = ?", mod.machine_name)
+            if #existing == 0 then
+                db.insert("modules", {
+                    uuid = MigrationUtils.generateUUID(),
+                    machine_name = mod.machine_name,
+                    name = mod.name,
+                    description = mod.description,
+                    priority = mod.priority,
+                    created_at = timestamp,
+                    updated_at = timestamp,
+                })
+                print("[Timesheets] Registered module: " .. mod.machine_name)
+            end
+        end
+    end,
+
+    -- [3] Grant permissions to owner + admin roles
+    [3] = function()
+        local cjson_ok, cjson = pcall(require, "cjson")
+        if not cjson_ok then return end
+
+        local full_modules = { "timesheets" }
+        local approval_actions = { "approve", "reject", "read" }
+
+        local owner_roles = db.select(
+            "* FROM namespace_roles WHERE role_name IN ('Owner', 'owner', 'Namespace Owner')"
+        )
+        local owner_actions = { "create", "read", "update", "delete", "manage" }
+        for _, role in ipairs(owner_roles) do
+            local perms = {}
+            if role.permissions and role.permissions ~= "" then
+                local ok, decoded = pcall(cjson.decode, role.permissions)
+                if ok and type(decoded) == "table" then perms = decoded end
+            end
+            for _, mod_name in ipairs(full_modules) do
+                if not perms[mod_name] then perms[mod_name] = owner_actions end
+            end
+            if not perms.timesheet_approvals then perms.timesheet_approvals = approval_actions end
+            db.update("namespace_roles", { permissions = cjson.encode(perms) }, { id = role.id })
+        end
+
+        local admin_roles = db.select(
+            "* FROM namespace_roles WHERE role_name IN ('Admin', 'admin', 'Namespace Admin')"
+        )
+        local admin_actions = { "create", "read", "update", "delete" }
+        for _, role in ipairs(admin_roles) do
+            local perms = {}
+            if role.permissions and role.permissions ~= "" then
+                local ok, decoded = pcall(cjson.decode, role.permissions)
+                if ok and type(decoded) == "table" then perms = decoded end
+            end
+            for _, mod_name in ipairs(full_modules) do
+                if not perms[mod_name] then perms[mod_name] = admin_actions end
+            end
+            if not perms.timesheet_approvals then perms.timesheet_approvals = approval_actions end
+            db.update("namespace_roles", { permissions = cjson.encode(perms) }, { id = role.id })
+        end
+    end,
+
+    -- [4] Enable the menu item for all existing namespaces
+    [4] = function()
+        local MigrationUtils = require("helper.migration-utils")
+        local timestamp = MigrationUtils.getCurrentTimestamp()
+
+        for _, key in ipairs({ "timesheets" }) do
+            local menu_rows = db.select("* FROM menu_items WHERE key = ?", key)
+            if #menu_rows > 0 then
+                local menu_item = menu_rows[1]
+                local namespaces = db.select("* FROM namespaces")
+                for _, ns in ipairs(namespaces) do
+                    local exists = db.select([[
+                        * FROM namespace_menu_config
+                        WHERE namespace_id = ? AND menu_item_id = ?
+                    ]], ns.id, menu_item.id)
+                    if #exists == 0 then
+                        db.insert("namespace_menu_config", {
+                            uuid = MigrationUtils.generateUUID(),
+                            namespace_id = ns.id,
+                            menu_item_id = menu_item.id,
+                            is_enabled = true,
+                            created_at = timestamp,
+                            updated_at = timestamp,
+                        })
+                    end
+                end
+            end
+        end
+    end,
+}

--- a/lapis/migrations/timesheet-system.lua
+++ b/lapis/migrations/timesheet-system.lua
@@ -170,4 +170,58 @@ return {
             ]])
         end)
     end,
+
+    -- ========================================
+    -- [4] Enrich timesheets for client work logging + invoicing
+    --     (customer link, task, single-session time, rate/billable)
+    --     Idempotent: ADD COLUMN IF NOT EXISTS so it is safe to re-run.
+    -- ========================================
+    [4] = function()
+        if not table_exists("timesheets") then return end
+
+        db.query([[
+            ALTER TABLE timesheets
+                ADD COLUMN IF NOT EXISTS client_account_id BIGINT,
+                ADD COLUMN IF NOT EXISTS client_name       TEXT,
+                ADD COLUMN IF NOT EXISTS task               TEXT,
+                ADD COLUMN IF NOT EXISTS work_date          DATE,
+                ADD COLUMN IF NOT EXISTS start_time         TIME,
+                ADD COLUMN IF NOT EXISTS end_time           TIME,
+                ADD COLUMN IF NOT EXISTS hourly_rate        DECIMAL(10,2),
+                ADD COLUMN IF NOT EXISTS is_billable        BOOLEAN NOT NULL DEFAULT true
+        ]])
+
+        pcall(function()
+            db.query([[
+                CREATE INDEX IF NOT EXISTS timesheets_client_account_idx
+                ON timesheets (namespace_id, client_account_id)
+            ]])
+        end)
+    end,
+
+    -- ========================================
+    -- [5] Relate a timesheet to a Customer (ecommerce) and a Task (kanban).
+    --     Soft references (id + uuid + name snapshot) rather than hard FKs, so
+    --     timesheets keep working when the customers/kanban modules aren't
+    --     enabled for a given PROJECT_CODE. Idempotent.
+    -- ========================================
+    [5] = function()
+        if not table_exists("timesheets") then return end
+
+        db.query([[
+            ALTER TABLE timesheets
+                ADD COLUMN IF NOT EXISTS customer_id   BIGINT,
+                ADD COLUMN IF NOT EXISTS customer_uuid TEXT,
+                ADD COLUMN IF NOT EXISTS task_uuid     TEXT,
+                ADD COLUMN IF NOT EXISTS project_uuid  TEXT,
+                ADD COLUMN IF NOT EXISTS project_name  TEXT
+        ]])
+
+        pcall(function()
+            db.query([[
+                CREATE INDEX IF NOT EXISTS timesheets_customer_idx
+                ON timesheets (namespace_id, customer_id)
+            ]])
+        end)
+    end,
 }

--- a/lapis/queries/AccountingQueries.lua
+++ b/lapis/queries/AccountingQueries.lua
@@ -270,7 +270,7 @@ function AccountingQueries.createJournalEntry(params)
         reference = params.reference,
         status = params.status or "posted",
         total_amount = total_debits,
-        created_by_user_uuid = params.created_by_user_uuid,
+        created_by_uuid = params.created_by_user_uuid,
         created_at = db.raw("NOW()"),
         updated_at = db.raw("NOW()")
     }, { returning = "*" })
@@ -283,6 +283,7 @@ function AccountingQueries.createJournalEntry(params)
     local AccountingJournalLineModel = require("models.AccountingJournalLineModel")
     for _, line in ipairs(params.lines) do
         AccountingJournalLineModel:create({
+            uuid = Global.generateUUID(),
             journal_entry_id = entry.id,
             account_id = line.account_id,
             debit_amount = tonumber(line.debit_amount) or 0,
@@ -318,7 +319,7 @@ function AccountingQueries.voidJournalEntry(uuid, reason, user_uuid)
     local entry = AccountingQueries.getJournalEntry(uuid)
     if not entry then return nil, "Journal entry not found" end
 
-    if entry.status == "voided" then
+    if entry.status == "void" then
         return nil, "Journal entry is already voided"
     end
 
@@ -339,13 +340,12 @@ function AccountingQueries.voidJournalEntry(uuid, reason, user_uuid)
     -- Mark as voided
     db.query([[
         UPDATE accounting_journal_entries
-        SET status = 'voided',
+        SET status = 'void',
             void_reason = ?,
-            voided_by_user_uuid = ?,
             voided_at = NOW(),
             updated_at = NOW()
         WHERE uuid = ?
-    ]], reason, user_uuid, uuid)
+    ]], reason, uuid)
 
     return AccountingQueries.getJournalEntry(uuid)
 end
@@ -370,14 +370,7 @@ function AccountingQueries.importBankTransactions(namespace_id, transactions, im
 
     for _, txn in ipairs(transactions) do
         local amount = tonumber(txn.amount) or 0
-        local debit_amount = 0
-        local credit_amount = 0
-
-        if amount < 0 then
-            debit_amount = math.abs(amount)
-        else
-            credit_amount = amount
-        end
+        local transaction_type = amount < 0 and "debit" or "credit"
 
         AccountingBankTransactionModel:create({
             uuid = Global.generateUUID(),
@@ -385,14 +378,13 @@ function AccountingQueries.importBankTransactions(namespace_id, transactions, im
             transaction_date = txn.date,
             description = txn.description or "",
             amount = amount,
-            debit_amount = debit_amount,
-            credit_amount = credit_amount,
+            transaction_type = transaction_type,
             balance = txn.balance,
             category = txn.category,
             import_source = import_source or "manual",
             import_batch_id = import_batch_id,
             is_reconciled = false,
-            imported_by_user_uuid = user_uuid,
+            created_by_uuid = user_uuid,
             created_at = db.raw("NOW()"),
             updated_at = db.raw("NOW()")
         })
@@ -401,9 +393,11 @@ function AccountingQueries.importBankTransactions(namespace_id, transactions, im
     end
 
     return {
+        imported = imported,
         count = imported,
         batch_id = import_batch_id,
-        import_source = import_source
+        import_source = import_source,
+        message = string.format("Imported %d transaction(s)", imported)
     }
 end
 
@@ -545,8 +539,7 @@ function AccountingQueries.reconcileBankTransaction(uuid, account_id, user_uuid)
     db.query([[
         UPDATE accounting_bank_transactions
         SET is_reconciled = true,
-            reconciled_journal_entry_id = ?,
-            reconciled_at = NOW(),
+            reconciled_journal_id = ?,
             updated_at = NOW()
         WHERE uuid = ?
     ]], entry.id, uuid)
@@ -734,8 +727,7 @@ function AccountingQueries.approveExpense(uuid, approver_uuid)
     db.query([[
         UPDATE accounting_expenses
         SET status = 'approved',
-            approved_by_user_uuid = ?,
-            approved_at = NOW(),
+            approved_by_uuid = ?,
             updated_at = NOW()
         WHERE uuid = ?
     ]], approver_uuid, uuid)
@@ -756,11 +748,11 @@ function AccountingQueries.rejectExpense(uuid, approver_uuid, reason)
     db.query([[
         UPDATE accounting_expenses
         SET status = 'rejected',
-            approved_by_user_uuid = ?,
-            rejection_reason = ?,
+            approved_by_uuid = ?,
+            notes = COALESCE(NULLIF(?, ''), notes),
             updated_at = NOW()
         WHERE uuid = ?
-    ]], approver_uuid, reason, uuid)
+    ]], approver_uuid, reason and ("Rejected: " .. reason) or "", uuid)
 
     return AccountingQueries.getExpense(uuid)
 end
@@ -797,18 +789,19 @@ function AccountingQueries.createVatReturn(namespace_id, period_start, period_en
     local output_vat = tonumber(vat_data[1].output_vat) or 0
     local input_vat = tonumber(vat_data[1].input_vat) or 0
     local net_vat = output_vat - input_vat
+    local total_sales = tonumber(vat_data[1].total_sales) or 0
 
     local vat_return = AccountingVatReturnModel:create({
         uuid = Global.generateUUID(),
         namespace_id = namespace_id,
         period_start = period_start,
         period_end = period_end,
-        output_vat = output_vat,
-        input_vat = input_vat,
-        net_vat = net_vat,
-        total_sales = tonumber(vat_data[1].total_sales) or 0,
+        box1_vat_due_sales = output_vat,
+        box3_total_vat_due = output_vat,
+        box4_vat_reclaimed = input_vat,
+        box5_net_vat = net_vat,
+        box6_total_sales = total_sales,
         status = "draft",
-        created_by_user_uuid = user_uuid,
         created_at = db.raw("NOW()"),
         updated_at = db.raw("NOW()")
     }, { returning = "*" })
@@ -855,7 +848,7 @@ function AccountingQueries.submitVatReturn(uuid, user_uuid)
         UPDATE accounting_vat_returns
         SET status = 'submitted',
             submitted_at = NOW(),
-            submitted_by_user_uuid = ?,
+            submitted_by_uuid = ?,
             updated_at = NOW()
         WHERE uuid = ?
     ]], user_uuid, uuid)
@@ -881,7 +874,7 @@ function AccountingQueries.getTrialBalance(namespace_id, as_of_date)
             aa.account_type,
             COALESCE(SUM(jl.debit_amount), 0) as total_debits,
             COALESCE(SUM(jl.credit_amount), 0) as total_credits,
-            COALESCE(SUM(jl.debit_amount), 0) - COALESCE(SUM(jl.credit_amount), 0) as balance
+            COALESCE(SUM(jl.debit_amount), 0) - COALESCE(SUM(jl.credit_amount), 0) as net_balance
         FROM accounting_accounts aa
         LEFT JOIN accounting_journal_lines jl ON jl.account_id = aa.id
         LEFT JOIN accounting_journal_entries je ON je.id = jl.journal_entry_id
@@ -902,11 +895,9 @@ function AccountingQueries.getTrialBalance(namespace_id, as_of_date)
 
     return {
         accounts = result,
-        totals = {
-            total_debits = total_debits,
-            total_credits = total_credits,
-            is_balanced = math.abs(total_debits - total_credits) < 0.01
-        },
+        total_debits = total_debits,
+        total_credits = total_credits,
+        is_balanced = math.abs(total_debits - total_credits) < 0.01,
         as_of_date = as_of_date
     }
 end
@@ -957,9 +948,12 @@ function AccountingQueries.getBalanceSheet(namespace_id, as_of_date)
     end
 
     return {
-        assets = { accounts = assets, total = total_assets },
-        liabilities = { accounts = liabilities, total = total_liabilities },
-        equity = { accounts = equity, total = total_equity },
+        assets = assets,
+        liabilities = liabilities,
+        equity = equity,
+        total_assets = total_assets,
+        total_liabilities = total_liabilities,
+        total_equity = total_equity,
         as_of_date = as_of_date
     }
 end
@@ -999,20 +993,22 @@ function AccountingQueries.getProfitAndLoss(namespace_id, start_date, end_date)
     for _, row in ipairs(result) do
         local balance = tonumber(row.balance) or 0
         if row.account_type == "revenue" then
-            table.insert(revenue, row)
+            table.insert(revenue, { code = row.code, name = row.name, amount = balance })
             total_revenue = total_revenue + balance
         elseif row.account_type == "expense" then
-            table.insert(expenses, row)
+            table.insert(expenses, { code = row.code, name = row.name, amount = math.abs(balance) })
             total_expenses = total_expenses + math.abs(balance)
         end
     end
 
     return {
-        revenue = { accounts = revenue, total = total_revenue },
-        expenses = { accounts = expenses, total = total_expenses },
+        revenue = revenue,
+        expenses = expenses,
+        total_revenue = total_revenue,
+        total_expenses = total_expenses,
         net_profit = total_revenue - total_expenses,
-        start_date = start_date,
-        end_date = end_date
+        period_start = start_date,
+        period_end = end_date
     }
 end
 
@@ -1051,11 +1047,24 @@ function AccountingQueries.getExpenseSummary(namespace_id, start_date, end_date)
         ORDER BY month ASC
     ]], namespace_id, start_date, end_date)
 
+    local categories = {}
+    local grand_total = 0
+    for _, row in ipairs(by_category or {}) do
+        local amt = tonumber(row.total_amount) or 0
+        table.insert(categories, {
+            category = row.category,
+            total = amt,
+            count = tonumber(row.transaction_count) or 0
+        })
+        grand_total = grand_total + amt
+    end
+
     return {
-        by_category = by_category or {},
-        by_month = by_month or {},
-        start_date = start_date,
-        end_date = end_date
+        categories = categories,
+        total = grand_total,
+        period_start = start_date,
+        period_end = end_date,
+        by_month = by_month or {}
     }
 end
 
@@ -1082,11 +1091,11 @@ function AccountingQueries.getDashboardStats(namespace_id)
 
     -- VAT owed (latest draft VAT return)
     local vat_result = db.query([[
-        SELECT net_vat FROM accounting_vat_returns
+        SELECT box5_net_vat FROM accounting_vat_returns
         WHERE namespace_id = ? AND status = 'draft'
         ORDER BY period_end DESC LIMIT 1
     ]], namespace_id)
-    local vat_owed = vat_result and vat_result[1] and tonumber(vat_result[1].net_vat) or 0
+    local vat_owed = vat_result and vat_result[1] and tonumber(vat_result[1].box5_net_vat) or 0
 
     -- Unreconciled count
     local unreconciled = AccountingQueries.getUnreconciledCount(namespace_id)
@@ -1098,10 +1107,17 @@ function AccountingQueries.getDashboardStats(namespace_id)
     ]], namespace_id)
     local total_accounts = tonumber(accounts_result[1].cnt) or 0
 
+    -- Revenue & expenses for the current month (from posted journal entries)
+    local pl = AccountingQueries.getProfitAndLoss(namespace_id, month_start, os.date("%Y-%m-%d"))
+
     return {
         cash_balance = cash_balance,
         expenses_this_month = expenses_this_month,
         vat_owed = vat_owed,
+        unreconciled_count = unreconciled,
+        total_revenue = pl.total_revenue or 0,
+        total_expenses = pl.total_expenses or 0,
+        -- extra fields (not in the client type, harmless)
         unreconciled_transactions = unreconciled,
         total_accounts = total_accounts,
         period = os.date("%B %Y")

--- a/lapis/queries/CrmQueries.lua
+++ b/lapis/queries/CrmQueries.lua
@@ -67,14 +67,15 @@ function CrmQueries.getPipelines(namespace_id, params)
     }
 end
 
---- Get a single pipeline by UUID
+--- Get a single pipeline by UUID (scoped to the tenant)
+-- @param namespace_id number Namespace ID
 -- @param uuid string Pipeline UUID
 -- @return table|nil Pipeline
-function CrmQueries.getPipeline(uuid)
+function CrmQueries.getPipeline(namespace_id, uuid)
     local result = db.query([[
         SELECT * FROM crm_pipelines
-        WHERE uuid = ? AND deleted_at IS NULL
-    ]], uuid)
+        WHERE uuid = ? AND namespace_id = ? AND deleted_at IS NULL
+    ]], uuid, namespace_id)
     return result and result[1] or nil
 end
 
@@ -180,18 +181,19 @@ function CrmQueries.getAccounts(namespace_id, params)
     }
 end
 
---- Get a single account by UUID with aggregated stats
+--- Get a single account by UUID with aggregated stats (scoped to the tenant)
+-- @param namespace_id number Namespace ID
 -- @param uuid string Account UUID
 -- @return table|nil Account with stats
-function CrmQueries.getAccount(uuid)
+function CrmQueries.getAccount(namespace_id, uuid)
     local result = db.query([[
         SELECT a.*,
                (SELECT COUNT(*) FROM crm_contacts WHERE account_id = a.id AND deleted_at IS NULL) as contact_count,
                (SELECT COUNT(*) FROM crm_deals WHERE account_id = a.id AND deleted_at IS NULL) as deal_count,
                (SELECT COALESCE(SUM(value), 0) FROM crm_deals WHERE account_id = a.id AND deleted_at IS NULL) as total_deal_value
         FROM crm_accounts a
-        WHERE a.uuid = ? AND a.deleted_at IS NULL
-    ]], uuid)
+        WHERE a.uuid = ? AND a.namespace_id = ? AND a.deleted_at IS NULL
+    ]], uuid, namespace_id)
     return result and result[1] or nil
 end
 
@@ -300,16 +302,17 @@ function CrmQueries.getContacts(namespace_id, params)
     }
 end
 
---- Get a single contact by UUID with account name
+--- Get a single contact by UUID with account name (scoped to the tenant)
+-- @param namespace_id number Namespace ID
 -- @param uuid string Contact UUID
 -- @return table|nil Contact
-function CrmQueries.getContact(uuid)
+function CrmQueries.getContact(namespace_id, uuid)
     local result = db.query([[
         SELECT c.*, a.name as account_name
         FROM crm_contacts c
         LEFT JOIN crm_accounts a ON a.id = c.account_id
-        WHERE c.uuid = ? AND c.deleted_at IS NULL
-    ]], uuid)
+        WHERE c.uuid = ? AND c.namespace_id = ? AND c.deleted_at IS NULL
+    ]], uuid, namespace_id)
     return result and result[1] or nil
 end
 
@@ -431,10 +434,11 @@ function CrmQueries.getDeals(namespace_id, params)
     }
 end
 
---- Get a single deal by UUID with account/contact/pipeline joins
+--- Get a single deal by UUID with account/contact/pipeline joins (scoped to the tenant)
+-- @param namespace_id number Namespace ID
 -- @param uuid string Deal UUID
 -- @return table|nil Deal
-function CrmQueries.getDeal(uuid)
+function CrmQueries.getDeal(namespace_id, uuid)
     local result = db.query([[
         SELECT d.*,
                a.name as account_name,
@@ -447,8 +451,8 @@ function CrmQueries.getDeal(uuid)
         LEFT JOIN crm_accounts a ON a.id = d.account_id
         LEFT JOIN crm_contacts ct ON ct.id = d.contact_id
         LEFT JOIN crm_pipelines p ON p.id = d.pipeline_id
-        WHERE d.uuid = ? AND d.deleted_at IS NULL
-    ]], uuid)
+        WHERE d.uuid = ? AND d.namespace_id = ? AND d.deleted_at IS NULL
+    ]], uuid, namespace_id)
     return result and result[1] or nil
 end
 
@@ -556,12 +560,68 @@ function CrmQueries.getDashboardStats(namespace_id)
 
     stats.deals_by_stage = by_stage or {}
 
+    -- Account count (frontend CrmDashboardStats.total_accounts)
+    local acc_result = db.query([[
+        SELECT COUNT(*) as total_accounts
+        FROM crm_accounts
+        WHERE namespace_id = ? AND deleted_at IS NULL
+    ]], namespace_id)
+    stats.total_accounts = acc_result and tonumber(acc_result[1].total_accounts) or 0
+
+    -- Activities scheduled today (frontend CrmDashboardStats.activities_today)
+    local act_result = db.query([[
+        SELECT COUNT(*) as activities_today
+        FROM crm_activities
+        WHERE namespace_id = ? AND deleted_at IS NULL
+          AND activity_date::date = CURRENT_DATE
+    ]], namespace_id)
+    stats.activities_today = act_result and tonumber(act_result[1].activities_today) or 0
+
+    -- Aliases matching the frontend interface field names
+    stats.active_deals = tonumber(stats.open_deals) or 0
+    stats.total_deal_value = tonumber(stats.total_value) or 0
+
     return stats
 end
 
 --------------------------------------------------------------------------------
 -- Activity CRUD
 --------------------------------------------------------------------------------
+
+--- Map a raw crm_activities row to the API shape expected by the frontend.
+-- Aliases activity_type -> type, activity_date -> due_date, derives related_*
+-- from whichever FK is set, and maps the DB status (planned) to the UI status
+-- (pending). Mutates and returns the row.
+-- @param row table|nil Raw activity row (may contain joined *_name columns)
+-- @return table|nil Reshaped activity
+function CrmQueries.shapeActivity(row)
+    if not row then return row end
+
+    row.type = row.activity_type
+    row.due_date = row.activity_date
+
+    -- Map DB status to the UI status vocabulary
+    if row.status == "planned" then
+        row.status = "pending"
+    end
+
+    -- Derive a single related_* descriptor from whichever entity is linked
+    if row.deal_id then
+        row.related_type = "deal"
+        row.related_name = row.deal_name
+    elseif row.contact_id then
+        row.related_type = "contact"
+        local first = row.contact_first_name or ""
+        local last = row.contact_last_name or ""
+        local name = (first .. " " .. last):gsub("^%s+", ""):gsub("%s+$", "")
+        row.related_name = name ~= "" and name or nil
+    elseif row.account_id then
+        row.related_type = "account"
+        row.related_name = row.account_name
+    end
+
+    return row
+end
 
 --- Create a new activity
 -- @param params table Activity parameters
@@ -573,7 +633,7 @@ function CrmQueries.createActivity(params)
     params.created_at = db.raw("NOW()")
     params.updated_at = db.raw("NOW()")
 
-    return CrmActivityModel:create(params, { returning = "*" })
+    return CrmQueries.shapeActivity(CrmActivityModel:create(params, { returning = "*" }))
 end
 
 --- List activities for a namespace with pagination and filters
@@ -641,6 +701,10 @@ function CrmQueries.getActivities(namespace_id, params)
     ]], where_clause)
     local activities = db.query(data_sql, unpack(data_values))
 
+    for _, act in ipairs(activities or {}) do
+        CrmQueries.shapeActivity(act)
+    end
+
     return {
         items = activities,
         meta = {
@@ -668,7 +732,7 @@ function CrmQueries.getActivity(uuid)
         LEFT JOIN crm_deals d ON d.id = act.deal_id
         WHERE act.uuid = ? AND act.deleted_at IS NULL
     ]], uuid)
-    return result and result[1] or nil
+    return CrmQueries.shapeActivity(result and result[1] or nil)
 end
 
 --- Update an activity
@@ -680,7 +744,7 @@ function CrmQueries.updateActivity(uuid, params)
     if not activity then return nil end
 
     params.updated_at = db.raw("NOW()")
-    return activity:update(params, { returning = "*" })
+    return CrmQueries.shapeActivity(activity:update(params, { returning = "*" }))
 end
 
 --- Soft-delete an activity
@@ -703,11 +767,11 @@ function CrmQueries.completeActivity(uuid)
     local activity = CrmActivityModel:find({ uuid = uuid })
     if not activity then return nil end
 
-    return activity:update({
+    return CrmQueries.shapeActivity(activity:update({
         completed_at = db.raw("NOW()"),
         status = "completed",
         updated_at = db.raw("NOW()")
-    }, { returning = "*" })
+    }, { returning = "*" }))
 end
 
 return CrmQueries

--- a/lapis/queries/CustomerQueries.lua
+++ b/lapis/queries/CustomerQueries.lua
@@ -1,7 +1,21 @@
 local CustomerModel = require "models.CustomerModel"
 local Global = require "helper.global"
+local cjson = require "cjson"
 
 local CustomerQueries = {}
+
+-- These columns are TEXT but the client sends structured data (e.g. addresses as
+-- a JSON array). RequestParser decodes such values into Lua tables, which Postgres
+-- cannot escape ("unknown table passed to escape_literal"). Serialize any
+-- table-valued field back to a JSON string before it reaches the DB.
+local JSON_TEXT_FIELDS = { "addresses", "tags" }
+local function encode_json_text_fields(p)
+    for _, field in ipairs(JSON_TEXT_FIELDS) do
+        if type(p[field]) == "table" then
+            p[field] = cjson.encode(p[field])
+        end
+    end
+end
 
 -- Valid fields for customer creation (matches database schema)
 local VALID_CUSTOMER_FIELDS = {
@@ -53,6 +67,8 @@ function CustomerQueries.create(params)
             filtered_params.tax_exempt = filtered_params.tax_exempt == "true"
         end
     end
+
+    encode_json_text_fields(filtered_params)
 
     return CustomerModel:create(filtered_params, { returning = "*" })
 end
@@ -117,7 +133,13 @@ function CustomerQueries.update(id, params)
         end
     end
 
-    return record:update(filtered_params, { returning = "*" })
+    encode_json_text_fields(filtered_params)
+
+    -- record:update() returns a boolean; with returning="*" it refreshes the
+    -- instance in place, so hand back the record itself (callers/route expect the
+    -- updated customer object, not `true`).
+    record:update(filtered_params, { returning = "*" })
+    return record
 end
 
 function CustomerQueries.destroy(id)

--- a/lapis/queries/InvoiceQueries.lua
+++ b/lapis/queries/InvoiceQueries.lua
@@ -30,9 +30,8 @@ function InvoiceQueries._getNextInvoiceNumber(namespace_id)
     local seq = InvoiceSequenceModel:find({ namespace_id = namespace_id })
 
     if not seq then
-        -- Create sequence starting at 1
+        -- Create sequence starting at 1 (invoice_sequences has no uuid column)
         seq = InvoiceSequenceModel:create({
-            uuid = Global.generateUUID(),
             namespace_id = namespace_id,
             prefix = "INV",
             current_number = 1,
@@ -223,7 +222,6 @@ function InvoiceQueries.get(uuid)
             tax_rate,
             tax_amount,
             discount_percent,
-            discount_amount,
             line_total,
             sort_order,
             created_at,
@@ -241,7 +239,7 @@ function InvoiceQueries.get(uuid)
             invoice_id,
             amount,
             payment_method,
-            payment_reference,
+            reference_number,
             payment_date,
             notes,
             created_at
@@ -397,8 +395,10 @@ end
 --- Recalculate invoice totals from line items and payments
 -- @param invoice_id number (internal id)
 function InvoiceQueries.recalculateTotals(invoice_id)
+    -- invoice_line_items has no discount_amount column; the per-line discount is
+    -- already folded into line_total by addLineItem, so totals stay correct.
     local line_items = db.query([[
-        SELECT quantity, unit_price, tax_amount, discount_amount, line_total
+        SELECT quantity, unit_price, tax_amount, line_total
         FROM invoice_line_items
         WHERE invoice_id = ?
     ]], invoice_id)
@@ -424,59 +424,295 @@ function InvoiceQueries.recalculateTotals(invoice_id)
        amount_paid, balance_due, invoice_id)
 end
 
---- Create an invoice from an approved timesheet
+--- Create an invoice from an APPROVED timesheet.
+-- Tenant-scoped: the timesheet must belong to `namespace_id`. Only billable entries
+-- that have NOT already been invoiced are included (idempotent — re-running bills only
+-- new hours). Each line item is linked back to its timesheet_entry via timesheet_entry_id.
+-- Per-entry rate falls back to the timesheet's hourly_rate, then `opts.hourly_rate`.
 -- @param namespace_id number
--- @param timesheet_id number|string timesheet UUID or ID
+-- @param timesheet_uuid string timesheet UUID (preferred) — also accepts the public id
 -- @param owner_user_uuid string
--- @param hourly_rate number
--- @return table { data = invoice }
--- @return string|nil error message
-function InvoiceQueries.createFromTimesheet(namespace_id, timesheet_id, owner_user_uuid, hourly_rate)
-    hourly_rate = tonumber(hourly_rate) or 0
+-- @param opts table { hourly_rate?, due_date?, currency? }
+-- @return table { data = invoice } | nil, string error
+function InvoiceQueries.createFromTimesheet(namespace_id, timesheet_uuid, owner_user_uuid, opts)
+    opts = opts or {}
+    local fallback_rate = tonumber(opts.hourly_rate) or 0
 
-    -- Get billable timesheet entries
-    local entries = db.query([[
-        SELECT te.id, te.description, te.hours, te.date, te.task_name
-        FROM timesheet_entries te
-        WHERE te.timesheet_id = ?
-          AND te.is_billable = true
-        ORDER BY te.date ASC
-    ]], timesheet_id)
-
-    if not entries or #entries == 0 then
-        return nil, "No billable timesheet entries found"
+    -- Resolve the timesheet, strictly tenant-scoped (this IS the ownership check).
+    local ts_rows = db.query([[
+        SELECT id, uuid, status, hourly_rate, client_name, customer_uuid
+        FROM timesheets
+        WHERE namespace_id = ? AND uuid = ? AND deleted_at IS NULL
+        LIMIT 1
+    ]], namespace_id, tostring(timesheet_uuid))
+    local timesheet = ts_rows and ts_rows[1]
+    if not timesheet then
+        return nil, "Timesheet not found"
     end
 
-    -- Build line items from entries
+    -- Only approved timesheets can be billed to a client.
+    if timesheet.status ~= "approved" then
+        return nil, "Only approved timesheets can be invoiced"
+    end
+
+    local ts_rate = tonumber(timesheet.hourly_rate) or 0
+
+    -- Billable entries not already invoiced (LEFT JOIN guard = idempotency).
+    local entries = db.query([[
+        SELECT te.id, te.description, te.hours, te.entry_date,
+               te.task_reference, te.project_reference, te.hourly_rate
+        FROM timesheet_entries te
+        LEFT JOIN invoice_line_items ili ON ili.timesheet_entry_id = te.id
+        WHERE te.timesheet_id = ?
+          AND te.namespace_id = ?
+          AND te.is_billable = true
+          AND te.deleted_at IS NULL
+          AND ili.id IS NULL
+        ORDER BY te.entry_date ASC
+    ]], timesheet.id, namespace_id)
+
+    if not entries or #entries == 0 then
+        return nil, "No un-invoiced billable entries found for this timesheet"
+    end
+
+    -- Build line items; resolve a per-entry rate first.
     local line_items = {}
     for i, entry in ipairs(entries) do
-        local description = (entry.task_name or "Work") .. " - " .. (entry.description or entry.date or "")
+        local rate = tonumber(entry.hourly_rate)
+        if not rate or rate <= 0 then rate = ts_rate end
+        if rate <= 0 then rate = fallback_rate end
+        if rate <= 0 then
+            return nil, "No hourly rate found. Set a rate on the timesheet/entries or pass hourly_rate."
+        end
+
         local hours = tonumber(entry.hours) or 0
-        local calc = InvoiceGenerator.calculateLineTotal(hours, hourly_rate, 0, 0)
+        local label = entry.task_reference or entry.project_reference or "Work"
+        local detail = entry.description or (entry.entry_date and tostring(entry.entry_date)) or ""
+        local description = label .. (detail ~= "" and (" - " .. detail) or "")
+        local calc = InvoiceGenerator.calculateLineTotal(hours, rate, 0, 0)
 
         table.insert(line_items, {
             description = description,
             quantity = hours,
-            unit_price = hourly_rate,
+            unit_price = rate,
             tax_rate = 0,
             discount_percent = 0,
-            tax_amount = 0,
-            discount_amount = 0,
             line_total = calc.total,
-            sort_order = i
+            sort_order = i,
+            timesheet_entry_id = entry.id,
         })
     end
 
-    -- Create invoice with line items
-    local result = InvoiceQueries.create({
+    -- Best-effort customer email snapshot (tenant-scoped; customers module may be absent).
+    local customer_email = nil
+    if timesheet.customer_uuid then
+        local ok, c = pcall(function()
+            return db.query([[SELECT email FROM customers WHERE uuid = ? AND namespace_id = ? LIMIT 1]],
+                timesheet.customer_uuid, namespace_id)
+        end)
+        if ok and c and c[1] then customer_email = c[1].email end
+    end
+
+    return InvoiceQueries.create({
         namespace_id = namespace_id,
-        customer_name = "Timesheet Invoice",
+        customer_name = timesheet.client_name or "Timesheet Invoice",
+        customer_email = customer_email,
         owner_user_uuid = owner_user_uuid,
-        notes = "Generated from timesheet #" .. tostring(timesheet_id),
+        due_date = opts.due_date,
+        currency = opts.currency,
+        notes = "Generated from timesheet " .. tostring(timesheet.uuid),
         line_items = line_items
     })
+end
 
-    return result
+-- ============================================================
+-- Invoice from a customer's approved timesheets over a period
+-- ============================================================
+
+-- Resolve a per-entry billing rate: entry rate → timesheet rate → fallback.
+local function _resolve_rate(entry_rate, ts_rate, fallback_rate)
+    local rate = tonumber(entry_rate)
+    if not rate or rate <= 0 then rate = tonumber(ts_rate) or 0 end
+    if rate <= 0 then rate = tonumber(fallback_rate) or 0 end
+    return rate
+end
+
+-- Collect a customer's billable, un-invoiced, APPROVED timesheet entries over an
+-- optional [period_start, period_end] window (filtered on the entry's work date).
+-- Tenant-scoped via the parent timesheet's namespace_id + customer_uuid. The
+-- LEFT JOIN on invoice_line_items.timesheet_entry_id is the idempotency guard:
+-- an entry already on an invoice is excluded, so re-running only bills new hours.
+local function _collect_customer_entries(namespace_id, customer_uuid, period_start, period_end)
+    local conds = {
+        "t.namespace_id = " .. db.escape_literal(namespace_id),
+        "t.customer_uuid = " .. db.escape_literal(tostring(customer_uuid)),
+        "t.status = 'approved'",
+        "t.deleted_at IS NULL",
+        "te.is_billable = true",
+        "te.deleted_at IS NULL",
+        "ili.id IS NULL",
+    }
+    if period_start and period_start ~= "" then
+        table.insert(conds, "te.entry_date >= " .. db.escape_literal(period_start))
+    end
+    if period_end and period_end ~= "" then
+        table.insert(conds, "te.entry_date <= " .. db.escape_literal(period_end))
+    end
+    return db.query([[
+        SELECT te.id, te.description, te.hours, te.entry_date,
+               te.task_reference, te.project_reference, te.hourly_rate,
+               t.uuid AS timesheet_uuid, t.hourly_rate AS ts_rate,
+               t.client_name
+        FROM timesheet_entries te
+        JOIN timesheets t ON t.id = te.timesheet_id
+        LEFT JOIN invoice_line_items ili ON ili.timesheet_entry_id = te.id
+        WHERE ]] .. table.concat(conds, " AND ") .. [[
+        ORDER BY te.entry_date ASC, te.id ASC
+    ]])
+end
+
+-- Round to 2dp the same way the line-item totals do.
+local function _round2(n) return math.floor((tonumber(n) or 0) * 100 + 0.5) / 100 end
+
+--- Preview the un-invoiced billable work for a customer over a period.
+-- Read-only: creates nothing, so the UI can show "here's all the work, hours,
+-- rate and total" before the user commits to generating the invoice.
+-- @param namespace_id number
+-- @param customer_uuid string
+-- @param period_start string|nil  (YYYY-MM-DD)
+-- @param period_end string|nil    (YYYY-MM-DD)
+-- @param opts table { hourly_rate?, currency? }
+-- @return table { customer, period, currency, entries[], totals }
+function InvoiceQueries.getCustomerBillablePreview(namespace_id, customer_uuid, period_start, period_end, opts)
+    opts = opts or {}
+    local fallback_rate = tonumber(opts.hourly_rate) or 0
+    local entries = _collect_customer_entries(namespace_id, customer_uuid, period_start, period_end)
+
+    -- Customer name/email snapshot (tenant-scoped; customers module may be absent).
+    local customer = { uuid = customer_uuid, name = nil, email = nil }
+    local ok, c = pcall(function()
+        return db.query([[SELECT first_name, last_name, email FROM customers
+                          WHERE uuid = ? AND namespace_id = ? LIMIT 1]], customer_uuid, namespace_id)
+    end)
+    if ok and c and c[1] then
+        local name = ((c[1].first_name or "") .. " " .. (c[1].last_name or "")):gsub("^%s+", ""):gsub("%s+$", "")
+        customer.name = name ~= "" and name or c[1].email
+        customer.email = c[1].email
+    end
+
+    local lines = {}
+    local total_hours, total_amount, missing_rate = 0, 0, false
+    for _, e in ipairs(entries or {}) do
+        local rate = _resolve_rate(e.hourly_rate, e.ts_rate, fallback_rate)
+        local hours = tonumber(e.hours) or 0
+        local amount = _round2(hours * rate)
+        if not customer.name and e.client_name then customer.name = e.client_name end
+        if rate <= 0 then missing_rate = true end
+        total_hours = total_hours + hours
+        total_amount = total_amount + amount
+        table.insert(lines, {
+            entry_id = e.id,
+            timesheet_uuid = e.timesheet_uuid,
+            entry_date = e.entry_date,
+            description = e.description,
+            task_reference = e.task_reference,
+            project_reference = e.project_reference,
+            hours = hours,
+            rate = rate,
+            amount = amount,
+            has_rate = rate > 0,
+        })
+    end
+
+    return {
+        customer = customer,
+        period = { from = period_start, to = period_end },
+        currency = opts.currency or "GBP",
+        entries = lines,
+        totals = {
+            count = #lines,
+            total_hours = _round2(total_hours),
+            total_amount = _round2(total_amount),
+            missing_rate = missing_rate,
+        },
+    }
+end
+
+--- Create one invoice aggregating ALL of a customer's un-invoiced billable hours
+-- over a period (across however many approved timesheets). One line item per
+-- entry, each linked back to its timesheet_entry_id (so it can't be billed twice).
+-- @param namespace_id number
+-- @param customer_uuid string
+-- @param owner_user_uuid string
+-- @param opts table { period_start?, period_end?, hourly_rate?, due_date?, currency? }
+-- @return table { data = invoice } | nil, string error
+function InvoiceQueries.createFromCustomerTimesheets(namespace_id, customer_uuid, owner_user_uuid, opts)
+    opts = opts or {}
+    if not customer_uuid or customer_uuid == "" then
+        return nil, "customer_uuid is required"
+    end
+    local fallback_rate = tonumber(opts.hourly_rate) or 0
+
+    local entries = _collect_customer_entries(namespace_id, customer_uuid, opts.period_start, opts.period_end)
+    if not entries or #entries == 0 then
+        return nil, "No un-invoiced billable hours found for this customer in the selected period"
+    end
+
+    local line_items = {}
+    local customer_name = nil
+    for i, entry in ipairs(entries) do
+        local rate = _resolve_rate(entry.hourly_rate, entry.ts_rate, fallback_rate)
+        if rate <= 0 then
+            return nil, "No hourly rate found for some hours. Set a rate on the timesheet/entries or pass an hourly_rate."
+        end
+        customer_name = customer_name or entry.client_name
+        local hours = tonumber(entry.hours) or 0
+        local label = entry.task_reference or entry.project_reference or "Work"
+        local detail = entry.description or ""
+        local date_prefix = entry.entry_date and (tostring(entry.entry_date) .. ": ") or ""
+        local description = date_prefix .. label .. (detail ~= "" and (" - " .. detail) or "")
+        local calc = InvoiceGenerator.calculateLineTotal(hours, rate, 0, 0)
+        table.insert(line_items, {
+            description = description,
+            quantity = hours,
+            unit_price = rate,
+            tax_rate = 0,
+            discount_percent = 0,
+            line_total = calc.total,
+            sort_order = i,
+            timesheet_entry_id = entry.id,
+        })
+    end
+
+    -- Customer email + name fallback snapshot.
+    local customer_email = nil
+    local ok, c = pcall(function()
+        return db.query([[SELECT first_name, last_name, email FROM customers
+                          WHERE uuid = ? AND namespace_id = ? LIMIT 1]], customer_uuid, namespace_id)
+    end)
+    if ok and c and c[1] then
+        customer_email = c[1].email
+        if not customer_name then
+            local name = ((c[1].first_name or "") .. " " .. (c[1].last_name or "")):gsub("^%s+", ""):gsub("%s+$", "")
+            customer_name = name ~= "" and name or c[1].email
+        end
+    end
+
+    local period_note = ""
+    if opts.period_start or opts.period_end then
+        period_note = " (" .. tostring(opts.period_start or "…") .. " to " .. tostring(opts.period_end or "…") .. ")"
+    end
+
+    return InvoiceQueries.create({
+        namespace_id = namespace_id,
+        customer_name = customer_name or "Customer Invoice",
+        customer_email = customer_email,
+        owner_user_uuid = owner_user_uuid,
+        due_date = opts.due_date,
+        currency = opts.currency,
+        notes = "Generated from approved timesheets" .. period_note,
+        line_items = line_items,
+    })
 end
 
 --- Get dashboard statistics for a namespace
@@ -495,9 +731,9 @@ function InvoiceQueries.getDashboardStats(namespace_id)
           AND status != 'void'
     ]], namespace_id)
 
-    -- Overdue count
+    -- Overdue count + outstanding amount on overdue invoices
     local overdue = db.query([[
-        SELECT COUNT(*) as count
+        SELECT COUNT(*) as count, COALESCE(SUM(balance_due), 0) as amount
         FROM invoices
         WHERE namespace_id = ?
           AND deleted_at IS NULL
@@ -520,6 +756,7 @@ function InvoiceQueries.getDashboardStats(namespace_id)
         total_invoiced = tonumber(stats_totals.total_invoiced) or 0,
         total_paid = tonumber(stats_totals.total_paid) or 0,
         total_outstanding = tonumber(stats_totals.total_outstanding) or 0,
+        total_overdue = overdue and overdue[1] and tonumber(overdue[1].amount) or 0,
         overdue_count = overdue and overdue[1] and tonumber(overdue[1].count) or 0,
         by_status = by_status or {}
     }
@@ -550,9 +787,9 @@ function InvoiceQueries.addLineItem(invoice_id, params)
         tax_rate = tax_rate,
         tax_amount = calc.tax,
         discount_percent = discount_percent,
-        discount_amount = calc.discount,
         line_total = calc.total,
         sort_order = params.sort_order or 0,
+        timesheet_entry_id = params.timesheet_entry_id,
         created_at = db.raw("NOW()"),
         updated_at = db.raw("NOW()")
     }, { returning = "*" })
@@ -591,7 +828,6 @@ function InvoiceQueries.updateLineItem(uuid, params)
         tax_rate = tax_rate,
         tax_amount = calc.tax,
         discount_percent = discount_percent,
-        discount_amount = calc.discount,
         line_total = calc.total,
         sort_order = params.sort_order or item.sort_order,
         updated_at = db.raw("NOW()")
@@ -642,7 +878,6 @@ function InvoiceQueries.getLineItems(invoice_id)
             tax_rate,
             tax_amount,
             discount_percent,
-            discount_amount,
             line_total,
             sort_order,
             created_at,
@@ -664,13 +899,18 @@ end
 -- @return table payment
 -- @return string|nil error message
 function InvoiceQueries.recordPayment(params)
-    local invoice = InvoiceModel:find({ id = params.invoice_id })
-    if not invoice then
-        -- Try by uuid
+    -- Resolve the invoice by whichever identifier was supplied. Never call
+    -- find({ id = nil }) — Lapis turns an all-nil clause into an empty WHERE and
+    -- throws "db.encode_clause: passed an empty table".
+    local invoice
+    if params.invoice_id then
+        invoice = InvoiceModel:find({ id = params.invoice_id })
+    end
+    if not invoice and params.invoice_uuid then
         invoice = InvoiceModel:find({ uuid = params.invoice_uuid })
-        if not invoice then
-            return nil, "Invoice not found"
-        end
+    end
+    if not invoice then
+        return nil, "Invoice not found"
     end
 
     if invoice.status == "void" then
@@ -688,10 +928,12 @@ function InvoiceQueries.recordPayment(params)
 
     local payment = InvoicePaymentModel:create({
         uuid = Global.generateUUID(),
+        namespace_id = invoice.namespace_id,  -- NOT NULL on invoice_payments
         invoice_id = invoice.id,
         amount = amount,
+        currency = params.currency or invoice.currency,
         payment_method = params.payment_method,
-        payment_reference = params.payment_reference,
+        reference_number = params.reference_number or params.payment_reference,
         payment_date = params.payment_date or db.raw("CURRENT_DATE"),
         notes = params.notes,
         created_at = db.raw("NOW()"),
@@ -728,7 +970,7 @@ function InvoiceQueries.getPayments(invoice_id)
             invoice_id,
             amount,
             payment_method,
-            payment_reference,
+            reference_number,
             payment_date,
             notes,
             created_at

--- a/lapis/queries/InvoiceQueries.lua
+++ b/lapis/queries/InvoiceQueries.lua
@@ -58,7 +58,7 @@ end
 -- ============================================================
 
 --- Create a new invoice
--- @param params table { namespace_id, customer_name, customer_email, customer_address, account_id, invoice_date, due_date, currency, notes, payment_terms, owner_user_uuid, line_items }
+-- @param params table { namespace_id, customer_name, customer_email, customer_address, account_id, issue_date, due_date, currency, notes, payment_terms_days, owner_user_uuid, line_items }
 -- @return table { data = invoice }
 function InvoiceQueries.create(params)
     local invoice_number = InvoiceQueries._getNextInvoiceNumber(params.namespace_id)
@@ -72,11 +72,11 @@ function InvoiceQueries.create(params)
         customer_email = params.customer_email,
         customer_address = params.customer_address,
         account_id = params.account_id,
-        invoice_date = params.invoice_date or db.raw("CURRENT_DATE"),
+        issue_date = params.issue_date or params.invoice_date or db.raw("CURRENT_DATE"),
         due_date = params.due_date,
         currency = params.currency or "GBP",
         notes = params.notes,
-        payment_terms = params.payment_terms,
+        payment_terms_days = params.payment_terms_days or params.payment_terms,
         owner_user_uuid = params.owner_user_uuid,
         subtotal = 0,
         tax_amount = 0,
@@ -133,10 +133,10 @@ function InvoiceQueries.list(namespace_id, params)
 
     -- Filter by date range
     if params.from_date and params.from_date ~= "" then
-        table.insert(conditions, "i.invoice_date >= " .. db.escape_literal(params.from_date))
+        table.insert(conditions, "i.issue_date >= " .. db.escape_literal(params.from_date))
     end
     if params.to_date and params.to_date ~= "" then
-        table.insert(conditions, "i.invoice_date <= " .. db.escape_literal(params.to_date))
+        table.insert(conditions, "i.issue_date <= " .. db.escape_literal(params.to_date))
     end
 
     -- Filter by owner
@@ -165,7 +165,7 @@ function InvoiceQueries.list(namespace_id, params)
             i.status,
             i.customer_name,
             i.customer_email,
-            i.invoice_date,
+            i.issue_date,
             i.due_date,
             i.currency,
             i.subtotal,
@@ -275,7 +275,7 @@ function InvoiceQueries.update(uuid, params)
     local update_data = {}
     local allowed_fields = {
         "customer_name", "customer_email", "customer_address", "account_id",
-        "invoice_date", "due_date", "currency", "notes", "payment_terms"
+        "issue_date", "due_date", "currency", "notes", "payment_terms_days"
     }
 
     for _, field in ipairs(allowed_fields) do

--- a/lapis/queries/KanbanSprintQueries.lua
+++ b/lapis/queries/KanbanSprintQueries.lua
@@ -237,7 +237,8 @@ function KanbanSprintQueries.start(uuid)
         KanbanSprintQueries.recordBurndown(sprint.id)
     end
 
-    return updated
+    -- :update() returns a boolean; the refreshed row was merged into `sprint` via returning = "*"
+    return sprint
 end
 
 --- Complete a sprint

--- a/lapis/queries/KanbanTaskQueries.lua
+++ b/lapis/queries/KanbanTaskQueries.lua
@@ -314,7 +314,8 @@ function KanbanTaskQueries.update(uuid, params, user_uuid)
         end
     end
 
-    return updated
+    -- :update() returns a boolean; the refreshed row was merged into `task` via returning = "*"
+    return task
 end
 
 --- Move task to different column
@@ -355,7 +356,8 @@ function KanbanTaskQueries.moveToColumn(uuid, column_id, position, user_uuid)
             tostring(old_column_id), tostring(column_id))
     end
 
-    return updated
+    -- :update() returns a boolean; the refreshed row was merged into `task` via returning = "*"
+    return task
 end
 
 --- Archive task

--- a/lapis/queries/TemplateQueries.lua
+++ b/lapis/queries/TemplateQueries.lua
@@ -86,10 +86,11 @@ function TemplateQueries.update(id, params)
             template_type = reqData.template_type,
             description = reqData.description
         }
-        local updateData = template:update(tempData, {
+        -- :update() returns a boolean; the refreshed row was merged into `template` via returning = "*"
+        template:update(tempData, {
             returning = "*"
         })
-        return { data = updateData }
+        return { data = template }
     end
 end
 

--- a/lapis/queries/TimesheetQueries.lua
+++ b/lapis/queries/TimesheetQueries.lua
@@ -154,6 +154,29 @@ function TimesheetQueries.create(params)
         returning = "*"
     })
     timesheet.internal_id = timesheet.id
+
+    -- Seed the create-time working session as the first entry, so the hours the
+    -- user enters on creation are counted consistently. total_hours is ALWAYS the
+    -- SUM of entries (_recalculate_totals runs on every entry change and on submit);
+    -- without a seed entry those create-time hours would be silently overwritten to 0.
+    if hours and hours > 0 and hours <= 24 then
+        TimesheetQueries.createEntry({
+            timesheet_id      = timesheet.internal_id,
+            namespace_id      = params.namespace_id,
+            user_uuid         = params.user_uuid,
+            entry_date        = params.work_date or params.period_start or db.raw("CURRENT_DATE"),
+            hours             = hours,
+            is_billable       = params.is_billable,
+            description       = nilify(params.notes) or params.task or "Work session",
+            project_reference = params.project_name,
+            task_reference    = params.task,
+            hourly_rate       = nilify(params.hourly_rate),
+        })
+        -- createEntry recalculated totals from entries; reflect that on our snapshot.
+        timesheet.total_hours = hours
+        timesheet.billable_hours = params.is_billable and hours or 0
+    end
+
     timesheet.id = timesheet.uuid
     return timesheet
 end
@@ -363,8 +386,10 @@ function TimesheetQueries.get(uuid)
         SELECT
             id as internal_id,
             uuid as id,
+            uuid,
             timesheet_id,
             entry_date,
+            entry_date as date,
             hours,
             is_billable,
             description,
@@ -469,15 +494,20 @@ function TimesheetQueries.update(uuid, params, namespace_id)
 
     params.updated_at = db.raw("NOW()")
 
-    local updated = timesheet:update(params, { returning = "*" })
-    updated.internal_id = updated.id
-    updated.id = updated.uuid
-    return updated
+    timesheet:update(params, { returning = "*" })
+    timesheet.internal_id = timesheet.id
+    timesheet.id = timesheet.uuid
+    return timesheet
 end
 
-function TimesheetQueries.delete(uuid)
+function TimesheetQueries.delete(uuid, namespace_id)
     local timesheet = TimesheetModel:find({ uuid = uuid })
     if not timesheet then
+        return nil, "Timesheet not found"
+    end
+
+    -- Tenant ownership guard: never let one namespace delete another's timesheet.
+    if namespace_id and tonumber(timesheet.namespace_id) ~= tonumber(namespace_id) then
         return nil, "Timesheet not found"
     end
 
@@ -496,13 +526,18 @@ end
 -- WORKFLOW
 -- ============================================================
 
-function TimesheetQueries.submit(uuid, user_uuid)
+function TimesheetQueries.submit(uuid, user_uuid, namespace_id)
     local timesheet = TimesheetModel:find({ uuid = uuid })
     if not timesheet then
         return nil, "Timesheet not found"
     end
 
     if timesheet.deleted_at then
+        return nil, "Timesheet not found"
+    end
+
+    -- Tenant ownership guard.
+    if namespace_id and tonumber(timesheet.namespace_id) ~= tonumber(namespace_id) then
         return nil, "Timesheet not found"
     end
 
@@ -517,18 +552,18 @@ function TimesheetQueries.submit(uuid, user_uuid)
     -- Recalculate totals from entries before submitting
     _recalculate_totals(timesheet.id)
 
-    local updated = timesheet:update({
+    timesheet:update({
         status = "submitted",
         submitted_at = db.raw("NOW()"),
         updated_at = db.raw("NOW()")
     }, { returning = "*" })
 
-    updated.internal_id = updated.id
-    updated.id = updated.uuid
-    return updated
+    timesheet.internal_id = timesheet.id
+    timesheet.id = timesheet.uuid
+    return timesheet
 end
 
-function TimesheetQueries.approve(uuid, approver_uuid, comments)
+function TimesheetQueries.approve(uuid, approver_uuid, comments, namespace_id)
     local timesheet = TimesheetModel:find({ uuid = uuid })
     if not timesheet then
         return nil, "Timesheet not found"
@@ -538,11 +573,16 @@ function TimesheetQueries.approve(uuid, approver_uuid, comments)
         return nil, "Timesheet not found"
     end
 
+    -- Tenant ownership guard.
+    if namespace_id and tonumber(timesheet.namespace_id) ~= tonumber(namespace_id) then
+        return nil, "Timesheet not found"
+    end
+
     if timesheet.status ~= "submitted" then
         return nil, "Only submitted timesheets can be approved"
     end
 
-    local updated = timesheet:update({
+    timesheet:update({
         status = "approved",
         approved_at = db.raw("NOW()"),
         approved_by_uuid = approver_uuid,
@@ -551,6 +591,8 @@ function TimesheetQueries.approve(uuid, approver_uuid, comments)
 
     -- Create approval record
     TimesheetApprovalModel:create({
+        uuid = Global.generateUUID(),
+        namespace_id = timesheet.namespace_id,
         timesheet_id = timesheet.id,
         approver_uuid = approver_uuid,
         action = "approved",
@@ -558,12 +600,12 @@ function TimesheetQueries.approve(uuid, approver_uuid, comments)
         created_at = db.raw("NOW()")
     })
 
-    updated.internal_id = updated.id
-    updated.id = updated.uuid
-    return updated
+    timesheet.internal_id = timesheet.id
+    timesheet.id = timesheet.uuid
+    return timesheet
 end
 
-function TimesheetQueries.reject(uuid, approver_uuid, reason, comments)
+function TimesheetQueries.reject(uuid, approver_uuid, reason, comments, namespace_id)
     local timesheet = TimesheetModel:find({ uuid = uuid })
     if not timesheet then
         return nil, "Timesheet not found"
@@ -573,11 +615,16 @@ function TimesheetQueries.reject(uuid, approver_uuid, reason, comments)
         return nil, "Timesheet not found"
     end
 
+    -- Tenant ownership guard.
+    if namespace_id and tonumber(timesheet.namespace_id) ~= tonumber(namespace_id) then
+        return nil, "Timesheet not found"
+    end
+
     if timesheet.status ~= "submitted" then
         return nil, "Only submitted timesheets can be rejected"
     end
 
-    local updated = timesheet:update({
+    timesheet:update({
         status = "rejected",
         rejected_at = db.raw("NOW()"),
         rejected_by_uuid = approver_uuid,
@@ -587,6 +634,8 @@ function TimesheetQueries.reject(uuid, approver_uuid, reason, comments)
 
     -- Create approval record
     TimesheetApprovalModel:create({
+        uuid = Global.generateUUID(),
+        namespace_id = timesheet.namespace_id,
         timesheet_id = timesheet.id,
         approver_uuid = approver_uuid,
         action = "rejected",
@@ -594,12 +643,12 @@ function TimesheetQueries.reject(uuid, approver_uuid, reason, comments)
         created_at = db.raw("NOW()")
     })
 
-    updated.internal_id = updated.id
-    updated.id = updated.uuid
-    return updated
+    timesheet.internal_id = timesheet.id
+    timesheet.id = timesheet.uuid
+    return timesheet
 end
 
-function TimesheetQueries.reopen(uuid)
+function TimesheetQueries.reopen(uuid, namespace_id)
     local timesheet = TimesheetModel:find({ uuid = uuid })
     if not timesheet then
         return nil, "Timesheet not found"
@@ -609,11 +658,16 @@ function TimesheetQueries.reopen(uuid)
         return nil, "Timesheet not found"
     end
 
+    -- Tenant ownership guard.
+    if namespace_id and tonumber(timesheet.namespace_id) ~= tonumber(namespace_id) then
+        return nil, "Timesheet not found"
+    end
+
     if timesheet.status ~= "rejected" then
         return nil, "Only rejected timesheets can be reopened"
     end
 
-    local updated = timesheet:update({
+    timesheet:update({
         status = "draft",
         submitted_at = db.raw("NULL"),
         approved_at = db.raw("NULL"),
@@ -624,9 +678,9 @@ function TimesheetQueries.reopen(uuid)
         updated_at = db.raw("NOW()")
     }, { returning = "*" })
 
-    updated.internal_id = updated.id
-    updated.id = updated.uuid
-    return updated
+    timesheet.internal_id = timesheet.id
+    timesheet.id = timesheet.uuid
+    return timesheet
 end
 
 function TimesheetQueries.getApprovalQueue(namespace_id, approver_uuid, params)
@@ -845,6 +899,14 @@ end
 -- ============================================================
 
 function TimesheetQueries.createEntry(params)
+    -- Validate the NOT NULL columns up front. The HTTP route guards these, but
+    -- internal/direct callers (e.g. the create-time seed entry) rely on this so
+    -- a missing field fails with a clear message instead of a raw NOT NULL 500.
+    if not params.timesheet_id then return nil, "timesheet_id is required" end
+    if not params.namespace_id then return nil, "namespace_id is required" end
+    if not params.user_uuid or params.user_uuid == "" then return nil, "user_uuid is required" end
+    if not params.entry_date or params.entry_date == "" then return nil, "entry_date is required" end
+
     -- Validate hours
     local hours = tonumber(params.hours)
     if not hours or hours < 0 or hours > 24 then
@@ -883,13 +945,18 @@ function TimesheetQueries.createEntry(params)
     return entry
 end
 
-function TimesheetQueries.updateEntry(uuid, params)
+function TimesheetQueries.updateEntry(uuid, params, namespace_id)
     local entry = TimesheetEntryModel:find({ uuid = uuid })
     if not entry then
         return nil, "Entry not found"
     end
 
     if entry.deleted_at then
+        return nil, "Entry not found"
+    end
+
+    -- Tenant isolation: never touch an entry from another namespace.
+    if namespace_id and entry.namespace_id ~= namespace_id then
         return nil, "Entry not found"
     end
 
@@ -912,23 +979,28 @@ function TimesheetQueries.updateEntry(uuid, params)
     params.timesheet_id = nil
     params.updated_at = db.raw("NOW()")
 
-    local updated = entry:update(params, { returning = "*" })
+    entry:update(params, { returning = "*" })
 
     -- Recalculate timesheet totals
     _recalculate_totals(entry.timesheet_id)
 
-    updated.internal_id = updated.id
-    updated.id = updated.uuid
-    return updated
+    entry.internal_id = entry.id
+    entry.id = entry.uuid
+    return entry
 end
 
-function TimesheetQueries.deleteEntry(uuid)
+function TimesheetQueries.deleteEntry(uuid, namespace_id)
     local entry = TimesheetEntryModel:find({ uuid = uuid })
     if not entry then
         return nil, "Entry not found"
     end
 
     if entry.deleted_at then
+        return nil, "Entry not found"
+    end
+
+    -- Tenant isolation: never touch an entry from another namespace.
+    if namespace_id and entry.namespace_id ~= namespace_id then
         return nil, "Entry not found"
     end
 
@@ -954,8 +1026,10 @@ function TimesheetQueries.getEntriesByTimesheet(timesheet_id)
         SELECT
             id as internal_id,
             uuid as id,
+            uuid,
             timesheet_id,
             entry_date,
+            entry_date as date,
             hours,
             is_billable,
             description,

--- a/lapis/queries/TimesheetQueries.lua
+++ b/lapis/queries/TimesheetQueries.lua
@@ -14,7 +14,7 @@ local function _recalculate_totals(timesheet_id)
     local result = db.query([[
         SELECT
             COALESCE(SUM(hours), 0) as total_hours,
-            COALESCE(SUM(CASE WHEN billable = true THEN hours ELSE 0 END), 0) as billable_hours
+            COALESCE(SUM(CASE WHEN is_billable = true THEN hours ELSE 0 END), 0) as billable_hours
         FROM timesheet_entries
         WHERE timesheet_id = ? AND deleted_at IS NULL
     ]], timesheet_id)
@@ -32,13 +32,121 @@ end
 -- TIMESHEET CRUD
 -- ============================================================
 
+-- Parse a "HH:MM" (or "HH:MM:SS") clock string into minutes-since-midnight.
+local function time_to_minutes(t)
+    if not t or t == "" then return nil end
+    local h, m = tostring(t):match("^(%d%d?):(%d%d)")
+    if not h then return nil end
+    return tonumber(h) * 60 + tonumber(m)
+end
+
+-- Compute worked hours from a start/end clock pair (handles overnight spans).
+local function hours_from_times(start_time, end_time)
+    local sm, em = time_to_minutes(start_time), time_to_minutes(end_time)
+    if not sm or not em then return nil end
+    local diff = em - sm
+    if diff < 0 then diff = diff + 24 * 60 end -- crossed midnight
+    return math.floor((diff / 60) * 100 + 0.5) / 100
+end
+
+-- Coerce a form/string boolean into a real boolean (defaulting when absent).
+local function to_bool(v, default_value)
+    if v == nil or v == "" then return default_value end
+    if type(v) == "boolean" then return v end
+    v = tostring(v):lower()
+    return v == "true" or v == "1" or v == "yes"
+end
+
+-- Treat empty strings as NULL so DATE/TIME/NUMERIC columns don't choke.
+local function nilify(v)
+    if v == nil or v == "" then return nil end
+    return v
+end
+
+-- Resolve a customer UUID to its internal id + display name (tenant-scoped).
+-- pcall-guarded so timesheets work even when the customers module isn't enabled.
+local function resolve_customer(namespace_id, customer_uuid)
+    local ok, rows = pcall(function()
+        return db.query([[
+            SELECT id, first_name, last_name, email FROM customers
+            WHERE uuid = ? AND namespace_id = ? LIMIT 1
+        ]], customer_uuid, namespace_id)
+    end)
+    if not ok or not rows or not rows[1] then return nil end
+    local c = rows[1]
+    local name = ((c.first_name or "") .. " " .. (c.last_name or "")):gsub("^%s+", ""):gsub("%s+$", "")
+    if name == "" then name = c.email end
+    return { id = c.id, name = name }
+end
+
+-- Resolve a kanban task UUID to its title + parent project (tenant-scoped via the
+-- project's namespace_id). pcall-guarded so timesheets work without the kanban module.
+local function resolve_task(namespace_id, task_uuid)
+    local ok, rows = pcall(function()
+        return db.query([[
+            SELECT t.uuid AS task_uuid, t.title,
+                   p.uuid AS project_uuid, p.name AS project_name
+            FROM kanban_tasks t
+            JOIN kanban_boards b ON b.id = t.board_id
+            JOIN kanban_projects p ON p.id = b.project_id
+            WHERE t.uuid = ? AND p.namespace_id = ? AND t.deleted_at IS NULL
+            LIMIT 1
+        ]], task_uuid, namespace_id)
+    end)
+    if not ok or not rows or not rows[1] then return nil end
+    return rows[1]
+end
+
 function TimesheetQueries.create(params)
     if not params.uuid then
         params.uuid = Global.generateUUID()
     end
-    params.status = "draft"
-    params.total_hours = 0
-    params.billable_hours = 0
+
+    -- Resolve the customer (ecommerce customers.uuid -> id + name snapshot).
+    local customer_uuid = nilify(params.customer_uuid)
+    params.customer_uuid = customer_uuid
+    if customer_uuid then
+        local cust = resolve_customer(params.namespace_id, customer_uuid)
+        if cust then
+            params.customer_id = cust.id
+            if not nilify(params.client_name) then params.client_name = cust.name end
+        end
+    end
+
+    -- Resolve the task (kanban task.uuid -> title + project), tenant-scoped.
+    local task_uuid = nilify(params.task_uuid)
+    params.task_uuid = task_uuid
+    if task_uuid then
+        local t = resolve_task(params.namespace_id, task_uuid)
+        if t then
+            params.project_uuid = t.project_uuid
+            params.project_name = t.project_name
+            if not nilify(params.task) then params.task = t.title end
+        end
+    end
+    params.client_account_uuid = nil -- legacy; not a column
+
+    -- Normalise the optional single-session work fields.
+    params.work_date   = nilify(params.work_date)
+    params.start_time  = nilify(params.start_time)
+    params.end_time    = nilify(params.end_time)
+    params.task        = nilify(params.task)
+    params.client_name = nilify(params.client_name)
+    params.hourly_rate = nilify(params.hourly_rate)
+    params.is_billable = to_bool(params.is_billable, true)
+
+    -- Hours: derive from start/end time when given, else accept an explicit value.
+    local hours = hours_from_times(params.start_time, params.end_time)
+        or tonumber(params.total_hours) or 0
+    params.total_hours    = hours
+    params.billable_hours = params.is_billable and hours or 0
+
+    -- A single-session log only needs a work_date; mirror it into the (NOT NULL)
+    -- period columns so the existing period-based reports keep working.
+    if not nilify(params.period_start) then params.period_start = params.work_date end
+    if not nilify(params.period_end)   then params.period_end   = params.work_date end
+
+    params.status     = "draft"
     params.created_at = db.raw("NOW()")
     params.updated_at = db.raw("NOW()")
 
@@ -48,6 +156,57 @@ function TimesheetQueries.create(params)
     timesheet.internal_id = timesheet.id
     timesheet.id = timesheet.uuid
     return timesheet
+end
+
+-- Namespace-scoped customer lookup for the timesheet customer dropdown.
+-- Returns up to 100 customers (optionally filtered by `q`). Empty list if the
+-- customers module isn't enabled.
+function TimesheetQueries.lookupCustomers(namespace_id, q)
+    local ok, rows = pcall(function()
+        local where = "namespace_id = ?"
+        local args = { namespace_id }
+        if q and q ~= "" then
+            where = where .. " AND (first_name ILIKE ? OR last_name ILIKE ? OR email ILIKE ?)"
+            local like = "%" .. q .. "%"
+            table.insert(args, like); table.insert(args, like); table.insert(args, like)
+        end
+        table.insert(args, 100)
+        return db.query([[
+            SELECT uuid, first_name, last_name, email
+            FROM customers
+            WHERE ]] .. where .. [[
+            ORDER BY created_at DESC
+            LIMIT ?
+        ]], unpack(args))
+    end)
+    if not ok or not rows then return {} end
+    return rows
+end
+
+-- Namespace-scoped kanban task lookup (joined to its project) for the task
+-- dropdown. Tenant isolation is enforced via the project's namespace_id.
+function TimesheetQueries.lookupTasks(namespace_id, q)
+    local ok, rows = pcall(function()
+        local where = "p.namespace_id = ? AND t.deleted_at IS NULL"
+        local args = { namespace_id }
+        if q and q ~= "" then
+            where = where .. " AND t.title ILIKE ?"
+            table.insert(args, "%" .. q .. "%")
+        end
+        table.insert(args, 100)
+        return db.query([[
+            SELECT t.uuid AS task_uuid, t.title,
+                   p.uuid AS project_uuid, p.name AS project_name
+            FROM kanban_tasks t
+            JOIN kanban_boards b ON b.id = t.board_id
+            JOIN kanban_projects p ON p.id = b.project_id
+            WHERE ]] .. where .. [[
+            ORDER BY t.updated_at DESC
+            LIMIT ?
+        ]], unpack(args))
+    end)
+    if not ok or not rows then return {} end
+    return rows
 end
 
 function TimesheetQueries.list(namespace_id, params)
@@ -101,15 +260,28 @@ function TimesheetQueries.list(namespace_id, params)
         SELECT
             t.id as internal_id,
             t.uuid as id,
+            t.uuid as uuid,
             t.namespace_id,
             t.user_uuid,
-            t.title,
-            t.description,
+            t.notes,
             t.period_start,
             t.period_end,
             t.status,
             t.total_hours,
             t.billable_hours,
+            t.client_account_id,
+            t.client_name,
+            t.task,
+            t.work_date,
+            t.start_time,
+            t.end_time,
+            t.hourly_rate,
+            t.is_billable,
+            t.customer_id,
+            t.customer_uuid,
+            t.task_uuid,
+            t.project_uuid,
+            t.project_name,
             t.submitted_at,
             t.approved_at,
             t.rejected_at,
@@ -142,15 +314,28 @@ function TimesheetQueries.get(uuid)
         SELECT
             t.id as internal_id,
             t.uuid as id,
+            t.uuid as uuid,
             t.namespace_id,
             t.user_uuid,
-            t.title,
-            t.description,
+            t.notes,
             t.period_start,
             t.period_end,
             t.status,
             t.total_hours,
             t.billable_hours,
+            t.client_account_id,
+            t.client_name,
+            t.task,
+            t.work_date,
+            t.start_time,
+            t.end_time,
+            t.hourly_rate,
+            t.is_billable,
+            t.customer_id,
+            t.customer_uuid,
+            t.task_uuid,
+            t.project_uuid,
+            t.project_name,
             t.submitted_at,
             t.approved_at,
             t.approved_by_uuid,
@@ -181,9 +366,9 @@ function TimesheetQueries.get(uuid)
             timesheet_id,
             entry_date,
             hours,
-            billable,
+            is_billable,
             description,
-            project_uuid,
+            project_reference,
             category,
             task_reference,
             created_at,
@@ -215,9 +400,14 @@ function TimesheetQueries.get(uuid)
     return timesheet
 end
 
-function TimesheetQueries.update(uuid, params)
+function TimesheetQueries.update(uuid, params, namespace_id)
     local timesheet = TimesheetModel:find({ uuid = uuid })
     if not timesheet then
+        return nil, "Timesheet not found"
+    end
+
+    -- Tenant ownership guard: never let one namespace edit another's timesheet.
+    if namespace_id and tonumber(timesheet.namespace_id) ~= tonumber(namespace_id) then
         return nil, "Timesheet not found"
     end
 
@@ -234,6 +424,49 @@ function TimesheetQueries.update(uuid, params)
     params.status = nil
     params.namespace_id = nil
     params.user_uuid = nil
+
+    -- Resolve customer + task the same way create does (tenant-scoped, module-optional).
+    local customer_uuid = nilify(params.customer_uuid)
+    if customer_uuid then
+        params.customer_uuid = customer_uuid
+        local cust = resolve_customer(timesheet.namespace_id, customer_uuid)
+        if cust then
+            params.customer_id = cust.id
+            if not nilify(params.client_name) then params.client_name = cust.name end
+        end
+    end
+    local task_uuid = nilify(params.task_uuid)
+    if task_uuid then
+        params.task_uuid = task_uuid
+        local t = resolve_task(timesheet.namespace_id, task_uuid)
+        if t then
+            params.project_uuid = t.project_uuid
+            params.project_name = t.project_name
+            if not nilify(params.task) then params.task = t.title end
+        end
+    end
+    params.client_account_uuid = nil -- legacy; not a column
+
+    -- Normalise optional fields and recompute hours when a time span is supplied.
+    for _, k in ipairs({ "work_date", "start_time", "end_time", "task", "client_name", "hourly_rate" }) do
+        params[k] = nilify(params[k])
+    end
+    if params.is_billable ~= nil then
+        params.is_billable = to_bool(params.is_billable, true)
+    end
+    local hours = hours_from_times(params.start_time, params.end_time)
+    if hours then
+        params.total_hours = hours
+        local billable = params.is_billable
+        if billable == nil then billable = timesheet.is_billable end
+        params.billable_hours = billable and hours or 0
+    end
+    -- Keep the (NOT NULL) period columns in step with a single-session work_date.
+    if params.work_date then
+        if not nilify(params.period_start) then params.period_start = params.work_date end
+        if not nilify(params.period_end)   then params.period_end   = params.work_date end
+    end
+
     params.updated_at = db.raw("NOW()")
 
     local updated = timesheet:update(params, { returning = "*" })
@@ -414,10 +647,10 @@ function TimesheetQueries.getApprovalQueue(namespace_id, approver_uuid, params)
         SELECT
             t.id as internal_id,
             t.uuid as id,
+            t.uuid as uuid,
             t.namespace_id,
             t.user_uuid,
-            t.title,
-            t.description,
+            t.notes,
             t.period_start,
             t.period_end,
             t.status,
@@ -482,15 +715,28 @@ function TimesheetQueries.getMyTimesheets(namespace_id, user_uuid, params)
         SELECT
             t.id as internal_id,
             t.uuid as id,
+            t.uuid as uuid,
             t.namespace_id,
             t.user_uuid,
-            t.title,
-            t.description,
+            t.notes,
             t.period_start,
             t.period_end,
             t.status,
             t.total_hours,
             t.billable_hours,
+            t.client_account_id,
+            t.client_name,
+            t.task,
+            t.work_date,
+            t.start_time,
+            t.end_time,
+            t.hourly_rate,
+            t.is_billable,
+            t.customer_id,
+            t.customer_uuid,
+            t.task_uuid,
+            t.project_uuid,
+            t.project_name,
             t.submitted_at,
             t.approved_at,
             t.rejected_at,
@@ -559,13 +805,13 @@ function TimesheetQueries.getSummary(namespace_id, user_uuid, start_date, end_da
 
     local by_project = db.query([[
         SELECT
-            te.project_uuid,
+            te.project_reference,
             COALESCE(SUM(te.hours), 0) as total_hours,
-            COALESCE(SUM(CASE WHEN te.billable = true THEN te.hours ELSE 0 END), 0) as billable_hours
+            COALESCE(SUM(CASE WHEN te.is_billable = true THEN te.hours ELSE 0 END), 0) as billable_hours
         FROM timesheet_entries te
         JOIN timesheets t ON te.timesheet_id = t.id
         WHERE ]] .. where_sql .. [[ AND te.deleted_at IS NULL
-        GROUP BY te.project_uuid
+        GROUP BY te.project_reference
         ORDER BY total_hours DESC
     ]], unpack(by_project_params))
 
@@ -579,7 +825,7 @@ function TimesheetQueries.getSummary(namespace_id, user_uuid, start_date, end_da
         SELECT
             te.category,
             COALESCE(SUM(te.hours), 0) as total_hours,
-            COALESCE(SUM(CASE WHEN te.billable = true THEN te.hours ELSE 0 END), 0) as billable_hours
+            COALESCE(SUM(CASE WHEN te.is_billable = true THEN te.hours ELSE 0 END), 0) as billable_hours
         FROM timesheet_entries te
         JOIN timesheets t ON te.timesheet_id = t.id
         WHERE ]] .. where_sql .. [[ AND te.deleted_at IS NULL
@@ -711,9 +957,9 @@ function TimesheetQueries.getEntriesByTimesheet(timesheet_id)
             timesheet_id,
             entry_date,
             hours,
-            billable,
+            is_billable,
             description,
-            project_uuid,
+            project_reference,
             category,
             task_reference,
             created_at,
@@ -734,15 +980,15 @@ function TimesheetQueries.getEntriesByDate(namespace_id, user_uuid, date)
             te.timesheet_id,
             te.entry_date,
             te.hours,
-            te.billable,
+            te.is_billable,
             te.description,
-            te.project_uuid,
+            te.project_reference,
             te.category,
             te.task_reference,
             te.created_at,
             te.updated_at,
             t.uuid as timesheet_uuid,
-            t.title as timesheet_title
+            t.notes as timesheet_title
         FROM timesheet_entries te
         JOIN timesheets t ON te.timesheet_id = t.id
         WHERE t.namespace_id = ?

--- a/lapis/routes/accounting.lua
+++ b/lapis/routes/accounting.lua
@@ -55,6 +55,12 @@
 ]]
 
 local cjson = require("cjson")
+-- Encode empty Lua tables as JSON arrays ([]) rather than objects ({}); report
+-- payloads (balance sheet assets/liabilities/equity, trial balance, P&L, expense
+-- summary) carry list fields that may be empty, and the dashboard calls .map() on
+-- them. Without this an empty section serialises to {} and crashes the UI.
+cjson.encode_empty_table_as_object(false)
+local db = require("lapis.db")
 local AuthMiddleware = require("middleware.auth")
 local NamespaceMiddleware = require("middleware.namespace")
 local AccountingQueries = require("queries.AccountingQueries")
@@ -204,15 +210,26 @@ return function(app)
                 return api_response(400, nil, "account_type is required")
             end
 
+            -- Normal balance follows the account type (assets/expenses are debit-normal)
+            local normal_balance = data.normal_balance
+            if not normal_balance or normal_balance == "" then
+                if data.account_type == "asset" or data.account_type == "expense" then
+                    normal_balance = "debit"
+                else
+                    normal_balance = "credit"
+                end
+            end
+
             local account = AccountingQueries.createAccount({
                 namespace_id = self.namespace.id,
                 code = data.code,
                 name = data.name,
                 account_type = data.account_type,
+                sub_type = data.sub_type,
                 description = data.description,
-                parent_account_id = data.parent_account_id,
+                normal_balance = normal_balance,
+                parent_id = data.parent_id or data.parent_account_id,
                 is_active = data.is_active ~= false,
-                tax_rate = data.tax_rate,
                 currency = data.currency or "GBP"
             })
 
@@ -255,14 +272,21 @@ return function(app)
             local data = parse_json_body()
             local update_params = {}
             local allowed_fields = {
-                "code", "name", "account_type", "description",
-                "parent_account_id", "is_active", "tax_rate", "currency"
+                "code", "name", "account_type", "sub_type", "description",
+                "normal_balance", "is_active", "currency"
             }
 
             for _, field in ipairs(allowed_fields) do
                 if data[field] ~= nil then
                     update_params[field] = data[field]
                 end
+            end
+
+            -- Map parent_id (accept legacy parent_account_id alias)
+            if data.parent_id ~= nil then
+                update_params.parent_id = data.parent_id
+            elseif data.parent_account_id ~= nil then
+                update_params.parent_id = data.parent_account_id
             end
 
             if next(update_params) == nil then
@@ -517,7 +541,8 @@ return function(app)
             local data = parse_json_body()
             local update_params = {}
             local allowed_fields = {
-                "category", "description", "vat_rate", "vat_amount", "notes"
+                "category", "description", "vat_rate", "vat_amount",
+                "payee", "reference", "user_category"
             }
 
             for _, field in ipairs(allowed_fields) do
@@ -620,11 +645,12 @@ return function(app)
                 category = data.category,
                 vat_rate = data.vat_rate,
                 vat_amount = data.vat_amount,
-                supplier = data.supplier,
+                is_vat_reclaimable = data.is_vat_reclaimable,
+                vendor = data.vendor or data.supplier,
                 receipt_url = data.receipt_url,
                 notes = data.notes,
                 status = data.status or "pending",
-                submitted_by_user_uuid = self.current_user.uuid
+                submitted_by_uuid = self.current_user.uuid
             })
 
             if not expense then
@@ -667,13 +693,19 @@ return function(app)
             local update_params = {}
             local allowed_fields = {
                 "expense_date", "description", "amount", "category",
-                "vat_rate", "vat_amount", "supplier", "receipt_url", "notes"
+                "vat_rate", "vat_amount", "is_vat_reclaimable",
+                "vendor", "receipt_url", "notes"
             }
 
             for _, field in ipairs(allowed_fields) do
                 if data[field] ~= nil then
                     update_params[field] = data[field]
                 end
+            end
+
+            -- Accept legacy "supplier" alias from older clients
+            if data.supplier ~= nil and update_params.vendor == nil then
+                update_params.vendor = data.supplier
             end
 
             if next(update_params) == nil then
@@ -739,10 +771,6 @@ return function(app)
     app:post("/api/v2/accounting/expenses/:uuid/reject", AuthMiddleware.requireAuth(
         NamespaceMiddleware.requireNamespace(function(self)
             local data = parse_json_body()
-
-            if not data.reason or data.reason == "" then
-                return api_response(400, nil, "reason is required")
-            end
 
             local expense = AccountingQueries.getExpense(self.params.uuid)
             if not expense then
@@ -884,7 +912,8 @@ return function(app)
     ))
 
     -- GET /api/v2/accounting/reports/profit-loss - Profit & loss
-    app:get("/api/v2/accounting/reports/profit-loss", AuthMiddleware.requireAuth(
+    -- (also served at /reports/profit-and-loss to match the dashboard client)
+    local profit_loss_handler = AuthMiddleware.requireAuth(
         NamespaceMiddleware.requireNamespace(function(self)
             local result = AccountingQueries.getProfitAndLoss(
                 self.namespace.id,
@@ -894,7 +923,9 @@ return function(app)
 
             return api_response(200, result)
         end)
-    ))
+    )
+    app:get("/api/v2/accounting/reports/profit-loss", profit_loss_handler)
+    app:get("/api/v2/accounting/reports/profit-and-loss", profit_loss_handler)
 
     -- GET /api/v2/accounting/reports/expense-summary - Expense summary
     app:get("/api/v2/accounting/reports/expense-summary", AuthMiddleware.requireAuth(
@@ -910,12 +941,15 @@ return function(app)
     ))
 
     -- GET /api/v2/accounting/dashboard/stats - Dashboard statistics
-    app:get("/api/v2/accounting/dashboard/stats", AuthMiddleware.requireAuth(
+    -- (also served at /reports/dashboard-stats to match the dashboard client)
+    local dashboard_stats_handler = AuthMiddleware.requireAuth(
         NamespaceMiddleware.requireNamespace(function(self)
             local stats = AccountingQueries.getDashboardStats(self.namespace.id)
             return api_response(200, stats)
         end)
-    ))
+    )
+    app:get("/api/v2/accounting/dashboard/stats", dashboard_stats_handler)
+    app:get("/api/v2/accounting/reports/dashboard-stats", dashboard_stats_handler)
 
     ---------------------------------------------------------------------------
     -- AI Integration
@@ -956,7 +990,8 @@ return function(app)
     ))
 
     -- POST /api/v2/accounting/ai/vat-suggest - VAT suggestion
-    app:post("/api/v2/accounting/ai/vat-suggest", AuthMiddleware.requireAuth(
+    -- (also served at /ai/suggest-vat to match the dashboard client)
+    local vat_suggest_handler = AuthMiddleware.requireAuth(
         NamespaceMiddleware.requireNamespace(function(self)
             local data = parse_json_body()
 
@@ -986,20 +1021,24 @@ return function(app)
 
             return api_response(200, result_or_err)
         end)
-    ))
+    )
+    app:post("/api/v2/accounting/ai/vat-suggest", vat_suggest_handler)
+    app:post("/api/v2/accounting/ai/suggest-vat", vat_suggest_handler)
 
     -- POST /api/v2/accounting/ai/query - Natural language query
     app:post("/api/v2/accounting/ai/query", AuthMiddleware.requireAuth(
         NamespaceMiddleware.requireNamespace(function(self)
             local data = parse_json_body()
 
-            if not data.question or data.question == "" then
+            local question = data.question or data.query
+
+            if not question or question == "" then
                 return api_response(400, nil, "question is required")
             end
 
             local ok, result_or_err = pcall(function()
                 return AccountingQueries.aiQuery(
-                    data.question,
+                    question,
                     self.namespace.id
                 )
             end)
@@ -1012,7 +1051,20 @@ return function(app)
                 return api_response(503, nil, "AI service unavailable")
             end
 
-            return api_response(200, result_or_err)
+            -- Reshape to the client AiQueryResponse contract { answer, data }
+            local payload = result_or_err
+            if type(payload) == "table" and payload.answer == nil then
+                payload = {
+                    answer = payload.interpretation or "",
+                    data = {
+                        query_type = payload.query_type,
+                        sql_hint = payload.sql_hint,
+                        parameters = payload.parameters
+                    }
+                }
+            end
+
+            return api_response(200, payload)
         end)
     ))
 

--- a/lapis/routes/crm-accounts.lua
+++ b/lapis/routes/crm-accounts.lua
@@ -101,7 +101,7 @@ return function(app)
     -- GET /api/v2/crm/accounts/:uuid - Get account with stats
     app:get("/api/v2/crm/accounts/:uuid", AuthMiddleware.requireAuth(
         NamespaceMiddleware.requireNamespace(function(self)
-            local account = CrmQueries.getAccount(self.params.uuid)
+            local account = CrmQueries.getAccount(self.namespace.id, self.params.uuid)
             if not account then
                 return api_response(404, nil, "Account not found")
             end
@@ -117,7 +117,7 @@ return function(app)
     -- PUT /api/v2/crm/accounts/:uuid - Update account
     app:put("/api/v2/crm/accounts/:uuid", AuthMiddleware.requireAuth(
         NamespaceMiddleware.requireNamespace(function(self)
-            local account = CrmQueries.getAccount(self.params.uuid)
+            local account = CrmQueries.getAccount(self.namespace.id, self.params.uuid)
             if not account then
                 return api_response(404, nil, "Account not found")
             end
@@ -161,7 +161,7 @@ return function(app)
     -- DELETE /api/v2/crm/accounts/:uuid - Soft delete account
     app:delete("/api/v2/crm/accounts/:uuid", AuthMiddleware.requireAuth(
         NamespaceMiddleware.requireNamespace(function(self)
-            local account = CrmQueries.getAccount(self.params.uuid)
+            local account = CrmQueries.getAccount(self.namespace.id, self.params.uuid)
             if not account then
                 return api_response(404, nil, "Account not found")
             end

--- a/lapis/routes/crm-activities.lua
+++ b/lapis/routes/crm-activities.lua
@@ -35,10 +35,10 @@ return function(app)
         return { status = status, json = { success = true, data = data } }
     end
 
-    -- POST /api/v2/crm/activities/:uuid/complete - Mark activity as completed
+    -- POST/PUT /api/v2/crm/activities/:uuid/complete - Mark activity as completed
     -- NOTE: This route must be defined before /api/v2/crm/activities/:uuid to avoid
-    -- route conflicts.
-    app:post("/api/v2/crm/activities/:uuid/complete", AuthMiddleware.requireAuth(
+    -- route conflicts. The frontend calls this with PUT; POST kept for compatibility.
+    local complete_handler = AuthMiddleware.requireAuth(
         NamespaceMiddleware.requireNamespace(function(self)
             local activity = CrmQueries.getActivity(self.params.uuid)
             if not activity then
@@ -56,7 +56,9 @@ return function(app)
 
             return api_response(200, completed)
         end)
-    ))
+    )
+    app:post("/api/v2/crm/activities/:uuid/complete", complete_handler)
+    app:put("/api/v2/crm/activities/:uuid/complete", complete_handler)
 
     -- GET /api/v2/crm/activities - List activities
     app:get("/api/v2/crm/activities", AuthMiddleware.requireAuth(
@@ -91,7 +93,9 @@ return function(app)
                 return api_response(400, nil, "subject is required")
             end
 
-            if not data.activity_type or data.activity_type == "" then
+            -- Frontend sends `type`; backend column is `activity_type`. Accept both.
+            local activity_type = data.activity_type or data.type
+            if not activity_type or activity_type == "" then
                 return api_response(400, nil, "activity_type is required")
             end
 
@@ -100,16 +104,37 @@ return function(app)
                 metadata = cjson.encode(metadata)
             end
 
+            -- Frontend sends `due_date`; backend column is `activity_date`. Accept both.
+            local activity_date = data.activity_date or data.due_date
+
+            -- Frontend links via related_type/related_uuid; resolve to the
+            -- matching FK (account_id/contact_id/deal_id) by looking up the UUID.
+            local account_id = data.account_id
+            local contact_id = data.contact_id
+            local deal_id = data.deal_id
+            if data.related_type and data.related_uuid and data.related_uuid ~= "" then
+                if data.related_type == "account" then
+                    local a = CrmQueries.getAccount(self.namespace.id, data.related_uuid)
+                    if a then account_id = a.id end
+                elseif data.related_type == "contact" then
+                    local c = CrmQueries.getContact(self.namespace.id, data.related_uuid)
+                    if c then contact_id = c.id end
+                elseif data.related_type == "deal" then
+                    local d = CrmQueries.getDeal(self.namespace.id, data.related_uuid)
+                    if d then deal_id = d.id end
+                end
+            end
+
             local activity = CrmQueries.createActivity({
                 namespace_id = self.namespace.id,
-                activity_type = data.activity_type,
+                activity_type = activity_type,
                 subject = data.subject,
                 description = data.description,
-                account_id = data.account_id,
-                contact_id = data.contact_id,
-                deal_id = data.deal_id,
+                account_id = account_id,
+                contact_id = contact_id,
+                deal_id = deal_id,
                 owner_user_uuid = data.owner_user_uuid or self.current_user.uuid,
-                activity_date = data.activity_date,
+                activity_date = activity_date,
                 duration_minutes = data.duration_minutes,
                 status = data.status or "planned",
                 metadata = metadata or "{}"

--- a/lapis/routes/crm-contacts.lua
+++ b/lapis/routes/crm-contacts.lua
@@ -70,9 +70,17 @@ return function(app)
                 metadata = cjson.encode(metadata)
             end
 
+            -- Frontend links the account by UUID (account_uuid); resolve to the
+            -- integer FK the table stores.
+            local account_id = data.account_id
+            if (not account_id) and data.account_uuid and data.account_uuid ~= "" then
+                local a = CrmQueries.getAccount(self.namespace.id, data.account_uuid)
+                if a then account_id = a.id end
+            end
+
             local contact = CrmQueries.createContact({
                 namespace_id = self.namespace.id,
-                account_id = data.account_id,
+                account_id = account_id,
                 first_name = data.first_name,
                 last_name = data.last_name,
                 email = data.email,
@@ -96,7 +104,7 @@ return function(app)
     -- GET /api/v2/crm/contacts/:uuid - Get contact
     app:get("/api/v2/crm/contacts/:uuid", AuthMiddleware.requireAuth(
         NamespaceMiddleware.requireNamespace(function(self)
-            local contact = CrmQueries.getContact(self.params.uuid)
+            local contact = CrmQueries.getContact(self.namespace.id, self.params.uuid)
             if not contact then
                 return api_response(404, nil, "Contact not found")
             end
@@ -112,7 +120,7 @@ return function(app)
     -- PUT /api/v2/crm/contacts/:uuid - Update contact
     app:put("/api/v2/crm/contacts/:uuid", AuthMiddleware.requireAuth(
         NamespaceMiddleware.requireNamespace(function(self)
-            local contact = CrmQueries.getContact(self.params.uuid)
+            local contact = CrmQueries.getContact(self.namespace.id, self.params.uuid)
             if not contact then
                 return api_response(404, nil, "Contact not found")
             end
@@ -154,7 +162,7 @@ return function(app)
     -- DELETE /api/v2/crm/contacts/:uuid - Soft delete contact
     app:delete("/api/v2/crm/contacts/:uuid", AuthMiddleware.requireAuth(
         NamespaceMiddleware.requireNamespace(function(self)
-            local contact = CrmQueries.getContact(self.params.uuid)
+            local contact = CrmQueries.getContact(self.namespace.id, self.params.uuid)
             if not contact then
                 return api_response(404, nil, "Contact not found")
             end

--- a/lapis/routes/crm-deals.lua
+++ b/lapis/routes/crm-deals.lua
@@ -46,12 +46,12 @@ return function(app)
         end)
     ))
 
-    -- GET /api/v2/crm/deals/pipeline/:pipeline_uuid - Deals grouped by stage (kanban)
-    -- NOTE: This route must be defined before /api/v2/crm/deals/:uuid to avoid
+    -- GET deals grouped by stage (kanban) for a pipeline.
+    -- NOTE: These must be defined before /api/v2/crm/deals/:uuid to avoid
     -- "pipeline" being captured as a :uuid parameter.
-    app:get("/api/v2/crm/deals/pipeline/:pipeline_uuid", AuthMiddleware.requireAuth(
+    local deals_by_pipeline = AuthMiddleware.requireAuth(
         NamespaceMiddleware.requireNamespace(function(self)
-            local pipeline = CrmQueries.getPipeline(self.params.pipeline_uuid)
+            local pipeline = CrmQueries.getPipeline(self.namespace.id, self.params.pipeline_uuid)
             if not pipeline then
                 return api_response(404, nil, "Pipeline not found")
             end
@@ -63,7 +63,11 @@ return function(app)
             local stages = CrmQueries.getDealsByPipeline(self.namespace.id, pipeline.id)
             return api_response(200, stages)
         end)
-    ))
+    )
+    -- Original path:
+    app:get("/api/v2/crm/deals/pipeline/:pipeline_uuid", deals_by_pipeline)
+    -- Alias matching the frontend service (crm.service.ts getDealsByPipeline):
+    app:get("/api/v2/crm/pipelines/:pipeline_uuid/deals", deals_by_pipeline)
 
     -- GET /api/v2/crm/deals - List deals
     app:get("/api/v2/crm/deals", AuthMiddleware.requireAuth(
@@ -103,11 +107,29 @@ return function(app)
                 metadata = cjson.encode(metadata)
             end
 
+            -- Frontend links related records by UUID (account_uuid/contact_uuid/
+            -- pipeline_uuid); resolve to the integer FKs the table stores.
+            local account_id = data.account_id
+            local contact_id = data.contact_id
+            local pipeline_id = data.pipeline_id
+            if (not account_id) and data.account_uuid and data.account_uuid ~= "" then
+                local a = CrmQueries.getAccount(self.namespace.id, data.account_uuid)
+                if a then account_id = a.id end
+            end
+            if (not contact_id) and data.contact_uuid and data.contact_uuid ~= "" then
+                local c = CrmQueries.getContact(self.namespace.id, data.contact_uuid)
+                if c then contact_id = c.id end
+            end
+            if (not pipeline_id) and data.pipeline_uuid and data.pipeline_uuid ~= "" then
+                local p = CrmQueries.getPipeline(self.namespace.id, data.pipeline_uuid)
+                if p then pipeline_id = p.id end
+            end
+
             local deal = CrmQueries.createDeal({
                 namespace_id = self.namespace.id,
-                pipeline_id = data.pipeline_id,
-                account_id = data.account_id,
-                contact_id = data.contact_id,
+                pipeline_id = pipeline_id,
+                account_id = account_id,
+                contact_id = contact_id,
                 name = data.name,
                 value = data.value or 0,
                 currency = data.currency or "USD",
@@ -130,7 +152,7 @@ return function(app)
     -- GET /api/v2/crm/deals/:uuid - Get deal with joins
     app:get("/api/v2/crm/deals/:uuid", AuthMiddleware.requireAuth(
         NamespaceMiddleware.requireNamespace(function(self)
-            local deal = CrmQueries.getDeal(self.params.uuid)
+            local deal = CrmQueries.getDeal(self.namespace.id, self.params.uuid)
             if not deal then
                 return api_response(404, nil, "Deal not found")
             end
@@ -146,7 +168,7 @@ return function(app)
     -- PUT /api/v2/crm/deals/:uuid - Update deal
     app:put("/api/v2/crm/deals/:uuid", AuthMiddleware.requireAuth(
         NamespaceMiddleware.requireNamespace(function(self)
-            local deal = CrmQueries.getDeal(self.params.uuid)
+            local deal = CrmQueries.getDeal(self.namespace.id, self.params.uuid)
             if not deal then
                 return api_response(404, nil, "Deal not found")
             end
@@ -190,7 +212,7 @@ return function(app)
     -- DELETE /api/v2/crm/deals/:uuid - Soft delete deal
     app:delete("/api/v2/crm/deals/:uuid", AuthMiddleware.requireAuth(
         NamespaceMiddleware.requireNamespace(function(self)
-            local deal = CrmQueries.getDeal(self.params.uuid)
+            local deal = CrmQueries.getDeal(self.namespace.id, self.params.uuid)
             if not deal then
                 return api_response(404, nil, "Deal not found")
             end

--- a/lapis/routes/crm-pipelines.lua
+++ b/lapis/routes/crm-pipelines.lua
@@ -86,7 +86,7 @@ return function(app)
     -- GET /api/v2/crm/pipelines/:uuid - Get pipeline
     app:get("/api/v2/crm/pipelines/:uuid", AuthMiddleware.requireAuth(
         NamespaceMiddleware.requireNamespace(function(self)
-            local pipeline = CrmQueries.getPipeline(self.params.uuid)
+            local pipeline = CrmQueries.getPipeline(self.namespace.id, self.params.uuid)
             if not pipeline then
                 return api_response(404, nil, "Pipeline not found")
             end
@@ -102,7 +102,7 @@ return function(app)
     -- PUT /api/v2/crm/pipelines/:uuid - Update pipeline
     app:put("/api/v2/crm/pipelines/:uuid", AuthMiddleware.requireAuth(
         NamespaceMiddleware.requireNamespace(function(self)
-            local pipeline = CrmQueries.getPipeline(self.params.uuid)
+            local pipeline = CrmQueries.getPipeline(self.namespace.id, self.params.uuid)
             if not pipeline then
                 return api_response(404, nil, "Pipeline not found")
             end
@@ -141,7 +141,7 @@ return function(app)
     -- DELETE /api/v2/crm/pipelines/:uuid - Soft delete pipeline
     app:delete("/api/v2/crm/pipelines/:uuid", AuthMiddleware.requireAuth(
         NamespaceMiddleware.requireNamespace(function(self)
-            local pipeline = CrmQueries.getPipeline(self.params.uuid)
+            local pipeline = CrmQueries.getPipeline(self.namespace.id, self.params.uuid)
             if not pipeline then
                 return api_response(404, nil, "Pipeline not found")
             end

--- a/lapis/routes/invoices.lua
+++ b/lapis/routes/invoices.lua
@@ -47,13 +47,26 @@ return function(app)
     local function parse_request_body()
         ngx.req.read_body()
 
-        -- First, check if we have form params
+        local content_type = ngx.req.get_headers()["content-type"] or ""
+
+        -- JSON body: parse explicitly. We must NOT call get_post_args() for JSON —
+        -- it parses the raw JSON string as urlencoded form data and returns a single
+        -- garbage key, which masks the real fields (every JSON POST then looks empty).
+        if content_type:find("application/json", 1, true) then
+            local body = ngx.req.get_body_data()
+            if not body or body == "" then return {} end
+            local ok, result = pcall(cjson.decode, body)
+            if ok and type(result) == "table" then return result end
+            return {}
+        end
+
+        -- Form-encoded / multipart
         local post_args = ngx.req.get_post_args()
         if post_args and next(post_args) then
             return post_args
         end
 
-        -- Fallback to JSON parsing
+        -- Last-resort: attempt JSON even without the header
         local ok, result = pcall(function()
             local body = ngx.req.get_body_data()
             if not body or body == "" then
@@ -177,21 +190,78 @@ return function(app)
         NamespaceMiddleware.requireNamespace(function(self)
             local body = parse_json_body()
 
-            local valid, err = validate_required(body, { "timesheet_id" })
-            if not valid then
-                return api_response(400, nil, err)
+            local ts_ref = body.timesheet_uuid or body.timesheet_id
+            if not ts_ref or ts_ref == "" then
+                return api_response(400, nil, "timesheet_uuid is required")
             end
 
-            local hourly_rate = tonumber(body.hourly_rate) or 0
-            if hourly_rate <= 0 then
-                return api_response(400, nil, "hourly_rate must be greater than zero")
-            end
-
+            -- hourly_rate is optional: per-entry / timesheet rate is used when present.
             local result, create_err = InvoiceQueries.createFromTimesheet(
                 self.namespace.id,
-                body.timesheet_id,
+                ts_ref,
                 self.current_user.uuid,
-                hourly_rate
+                {
+                    hourly_rate = body.hourly_rate,
+                    due_date = body.due_date,
+                    currency = body.currency,
+                }
+            )
+
+            if not result then
+                return api_response(400, nil, create_err)
+            end
+
+            return api_response(201, result.data)
+        end)
+    ))
+
+    -- ============================================================
+    -- FROM CUSTOMER TIMESHEETS (must be before :uuid routes)
+    -- ============================================================
+
+    -- GET /api/v2/invoices/customer-billable - Preview a customer's un-invoiced
+    -- billable work over a period (read-only; nothing is created).
+    -- Query: customer_uuid (required), from, to, hourly_rate, currency
+    app:get("/api/v2/invoices/customer-billable", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requireNamespace(function(self)
+            local customer_uuid = self.params.customer_uuid
+            if not customer_uuid or customer_uuid == "" then
+                return api_response(400, nil, "customer_uuid is required")
+            end
+            local preview = InvoiceQueries.getCustomerBillablePreview(
+                self.namespace.id,
+                customer_uuid,
+                self.params.from,
+                self.params.to,
+                { hourly_rate = self.params.hourly_rate, currency = self.params.currency }
+            )
+            return api_response(200, preview)
+        end)
+    ))
+
+    -- POST /api/v2/invoices/from-customer - Generate one invoice aggregating all of
+    -- a customer's un-invoiced billable hours over a period.
+    -- Body: { customer_uuid (required), period_start, period_end, hourly_rate, due_date, currency }
+    app:post("/api/v2/invoices/from-customer", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requireNamespace(function(self)
+            local body = parse_json_body()
+
+            local customer_uuid = body.customer_uuid
+            if not customer_uuid or customer_uuid == "" then
+                return api_response(400, nil, "customer_uuid is required")
+            end
+
+            local result, create_err = InvoiceQueries.createFromCustomerTimesheets(
+                self.namespace.id,
+                customer_uuid,
+                self.current_user.uuid,
+                {
+                    period_start = body.period_start or body.from,
+                    period_end = body.period_end or body.to,
+                    hourly_rate = body.hourly_rate,
+                    due_date = body.due_date,
+                    currency = body.currency,
+                }
             )
 
             if not result then

--- a/lapis/routes/timesheets.lua
+++ b/lapis/routes/timesheets.lua
@@ -112,24 +112,48 @@ return function(app)
         end)
     ))
 
+    -- Lookup: customers in this namespace (for the timesheet customer dropdown).
+    -- Namespace-gated only (no module permission) so the timesheet author can
+    -- populate the dropdown regardless of customers.read grants.
+    app:get("/api/v2/timesheets/lookups/customers", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requireNamespace(function(self)
+            local rows = TimesheetQueries.lookupCustomers(self.namespace.id, self.params.q)
+            return success_response(rows)
+        end)
+    ))
+
+    -- Lookup: kanban tasks (with their project) in this namespace, for the task dropdown.
+    app:get("/api/v2/timesheets/lookups/tasks", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requireNamespace(function(self)
+            local rows = TimesheetQueries.lookupTasks(self.namespace.id, self.params.q)
+            return success_response(rows)
+        end)
+    ))
+
     -- Create timesheet
     app:post("/api/v2/timesheets", AuthMiddleware.requireAuth(
         NamespaceMiddleware.requireNamespace(function(self)
             local params = RequestParser.parse_request(self)
 
-            if not params.period_start or params.period_start == "" then
-                return error_response(400, "period_start is required")
-            end
-
-            if not params.period_end or params.period_end == "" then
-                return error_response(400, "period_end is required")
+            local has_work_date = params.work_date and params.work_date ~= ""
+            local has_period = params.period_start and params.period_start ~= ""
+            if not has_work_date and not has_period then
+                return error_response(400, "A work date (or a period start) is required")
             end
 
             local ok, timesheet = pcall(TimesheetQueries.create, {
                 namespace_id = self.namespace.id,
                 user_uuid = self.current_user.uuid,
-                title = params.title,
-                description = params.description,
+                customer_uuid = params.customer_uuid,
+                client_name = params.client_name,
+                task_uuid = params.task_uuid,
+                task = params.task,
+                work_date = params.work_date,
+                start_time = params.start_time,
+                end_time = params.end_time,
+                hourly_rate = params.hourly_rate,
+                is_billable = params.is_billable,
+                notes = params.notes,
                 period_start = params.period_start,
                 period_end = params.period_end
             })
@@ -164,11 +188,19 @@ return function(app)
             local params = RequestParser.parse_request(self)
 
             local updated, err = TimesheetQueries.update(self.params.uuid, {
-                title = params.title,
-                description = params.description,
+                customer_uuid = params.customer_uuid,
+                client_name = params.client_name,
+                task_uuid = params.task_uuid,
+                task = params.task,
+                work_date = params.work_date,
+                start_time = params.start_time,
+                end_time = params.end_time,
+                hourly_rate = params.hourly_rate,
+                is_billable = params.is_billable,
+                notes = params.notes,
                 period_start = params.period_start,
                 period_end = params.period_end
-            })
+            }, self.namespace.id)
 
             if err then
                 if err == "Timesheet not found" then

--- a/lapis/routes/timesheets.lua
+++ b/lapis/routes/timesheets.lua
@@ -216,7 +216,7 @@ return function(app)
     -- Soft delete timesheet (draft only)
     app:delete("/api/v2/timesheets/:uuid", AuthMiddleware.requireAuth(
         NamespaceMiddleware.requireNamespace(function(self)
-            local deleted, err = TimesheetQueries.delete(self.params.uuid)
+            local deleted, err = TimesheetQueries.delete(self.params.uuid, self.namespace.id)
 
             if err then
                 if err == "Timesheet not found" then
@@ -236,7 +236,7 @@ return function(app)
     -- Submit timesheet for approval
     app:post("/api/v2/timesheets/:uuid/submit", AuthMiddleware.requireAuth(
         NamespaceMiddleware.requireNamespace(function(self)
-            local result, err = TimesheetQueries.submit(self.params.uuid, self.current_user.uuid)
+            local result, err = TimesheetQueries.submit(self.params.uuid, self.current_user.uuid, self.namespace.id)
 
             if err then
                 if err == "Timesheet not found" then
@@ -249,15 +249,16 @@ return function(app)
         end)
     ))
 
-    -- Approve timesheet (manager action)
+    -- Approve timesheet (manager action — requires timesheet_approvals.approve)
     app:post("/api/v2/timesheets/:uuid/approve", AuthMiddleware.requireAuth(
-        NamespaceMiddleware.requireNamespace(function(self)
+        NamespaceMiddleware.requirePermission("timesheet_approvals", "approve", function(self)
             local params = RequestParser.parse_request(self)
 
             local result, err = TimesheetQueries.approve(
                 self.params.uuid,
                 self.current_user.uuid,
-                params.comments
+                params.comments,
+                self.namespace.id
             )
 
             if err then
@@ -271,9 +272,9 @@ return function(app)
         end)
     ))
 
-    -- Reject timesheet with reason
+    -- Reject timesheet with reason (manager action — requires timesheet_approvals.reject)
     app:post("/api/v2/timesheets/:uuid/reject", AuthMiddleware.requireAuth(
-        NamespaceMiddleware.requireNamespace(function(self)
+        NamespaceMiddleware.requirePermission("timesheet_approvals", "reject", function(self)
             local params = RequestParser.parse_request(self)
 
             if not params.reason or params.reason == "" then
@@ -284,7 +285,8 @@ return function(app)
                 self.params.uuid,
                 self.current_user.uuid,
                 params.reason,
-                params.comments
+                params.comments,
+                self.namespace.id
             )
 
             if err then
@@ -301,7 +303,7 @@ return function(app)
     -- Reopen rejected timesheet
     app:post("/api/v2/timesheets/:uuid/reopen", AuthMiddleware.requireAuth(
         NamespaceMiddleware.requireNamespace(function(self)
-            local result, err = TimesheetQueries.reopen(self.params.uuid)
+            local result, err = TimesheetQueries.reopen(self.params.uuid, self.namespace.id)
 
             if err then
                 if err == "Timesheet not found" then
@@ -340,7 +342,11 @@ return function(app)
         NamespaceMiddleware.requireNamespace(function(self)
             local params = RequestParser.parse_request(self)
 
-            if not params.entry_date or params.entry_date == "" then
+            -- Frontend sends `date`; accept either field name.
+            local entry_date = params.entry_date
+            if not entry_date or entry_date == "" then entry_date = params.date end
+
+            if not entry_date or entry_date == "" then
                 return error_response(400, "entry_date is required")
             end
 
@@ -362,13 +368,23 @@ return function(app)
                 return error_response(403, "Timesheet not found in this namespace")
             end
 
+            -- is_billable defaults to true; accept is_billable (frontend) or legacy billable.
+            local is_billable = true
+            local billable_param = params.is_billable
+            if billable_param == nil then billable_param = params.billable end
+            if billable_param ~= nil then
+                is_billable = billable_param == true or billable_param == "true"
+            end
+
             local entry, err = TimesheetQueries.createEntry({
                 timesheet_id = timesheet.internal_id,
-                entry_date = params.entry_date,
+                namespace_id = self.namespace.id,
+                user_uuid = timesheet.user_uuid,
+                entry_date = entry_date,
                 hours = tonumber(params.hours),
-                billable = params.billable == true or params.billable == "true",
+                is_billable = is_billable,
                 description = params.description,
-                project_uuid = params.project_uuid,
+                project_reference = params.project_reference,
                 category = params.category,
                 task_reference = params.task_reference
             })
@@ -386,15 +402,22 @@ return function(app)
         NamespaceMiddleware.requireNamespace(function(self)
             local params = RequestParser.parse_request(self)
 
-            local updated, err = TimesheetQueries.updateEntry(self.params.entry_uuid, {
-                entry_date = params.entry_date,
-                hours = params.hours and tonumber(params.hours),
-                billable = params.billable == true or params.billable == "true",
-                description = params.description,
-                project_uuid = params.project_uuid,
-                category = params.category,
-                task_reference = params.task_reference
-            })
+            -- Only forward fields that were actually provided, mapped to real columns.
+            local update_fields = {}
+            local entry_date = params.entry_date or params.date
+            if entry_date and entry_date ~= "" then update_fields.entry_date = entry_date end
+            if params.hours ~= nil then update_fields.hours = tonumber(params.hours) end
+            if params.description ~= nil then update_fields.description = params.description end
+            if params.project_reference ~= nil then update_fields.project_reference = params.project_reference end
+            if params.task_reference ~= nil then update_fields.task_reference = params.task_reference end
+            if params.category ~= nil then update_fields.category = params.category end
+            local billable_param = params.is_billable
+            if billable_param == nil then billable_param = params.billable end
+            if billable_param ~= nil then
+                update_fields.is_billable = billable_param == true or billable_param == "true"
+            end
+
+            local updated, err = TimesheetQueries.updateEntry(self.params.entry_uuid, update_fields, self.namespace.id)
 
             if err then
                 if err == "Entry not found" then
@@ -410,7 +433,7 @@ return function(app)
     -- Delete entry
     app:delete("/api/v2/timesheets/entries/:entry_uuid", AuthMiddleware.requireAuth(
         NamespaceMiddleware.requireNamespace(function(self)
-            local deleted, err = TimesheetQueries.deleteEntry(self.params.entry_uuid)
+            local deleted, err = TimesheetQueries.deleteEntry(self.params.entry_uuid, self.namespace.id)
 
             if err then
                 if err == "Entry not found" then

--- a/opsapi-dashboard/app/dashboard/customers/[uuid]/page.tsx
+++ b/opsapi-dashboard/app/dashboard/customers/[uuid]/page.tsx
@@ -1,0 +1,465 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import {
+  ArrowLeft,
+  Save,
+  Trash2,
+  Mail,
+  Phone,
+  ShoppingBag,
+  DollarSign,
+  Loader2,
+  User,
+} from 'lucide-react';
+import { Card, Badge, Button, ConfirmDialog } from '@/components/ui';
+import { customersService } from '@/services/customers.service';
+import { formatCurrency, formatDate } from '@/lib/utils';
+import type {
+  Customer,
+  CustomerAddress,
+  CreateCustomerDto,
+  MarketingOptInLevel,
+  CustomerState,
+} from '@/types';
+import toast from 'react-hot-toast';
+
+const inputClass =
+  'w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 bg-surface';
+const labelClass = 'block text-sm font-medium text-secondary-700 mb-1';
+
+// Stored defaults sometimes arrive wrapped in literal quotes (e.g. "'single_opt_in'").
+const clean = (v?: string | null) => (v || '').replace(/^'+|'+$/g, '');
+
+// addresses is stored as a JSON text column, so it may come back as a string.
+function parseAddresses(addresses: Customer['addresses']): CustomerAddress[] {
+  if (Array.isArray(addresses)) return addresses;
+  if (typeof addresses === 'string' && addresses.trim()) {
+    try {
+      const parsed = JSON.parse(addresses);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+interface FormState {
+  first_name: string;
+  last_name: string;
+  email: string;
+  phone: string;
+  date_of_birth: string;
+  address1: string;
+  address2: string;
+  city: string;
+  province: string;
+  country: string;
+  zip: string;
+  notes: string;
+  tags: string;
+  accepts_marketing: boolean;
+  verified_email: boolean;
+  tax_exempt: boolean;
+  marketing_opt_in_level: MarketingOptInLevel;
+  state: CustomerState;
+}
+
+const EMPTY_FORM: FormState = {
+  first_name: '',
+  last_name: '',
+  email: '',
+  phone: '',
+  date_of_birth: '',
+  address1: '',
+  address2: '',
+  city: '',
+  province: '',
+  country: '',
+  zip: '',
+  notes: '',
+  tags: '',
+  accepts_marketing: false,
+  verified_email: false,
+  tax_exempt: false,
+  marketing_opt_in_level: 'single_opt_in',
+  state: 'enabled',
+};
+
+function customerToForm(c: Customer): FormState {
+  const addresses = parseAddresses(c.addresses);
+  const primary = addresses.find((a) => a.is_default) || addresses[0] || {};
+  return {
+    first_name: c.first_name || '',
+    last_name: c.last_name || '',
+    email: c.email || '',
+    phone: c.phone || '',
+    date_of_birth: c.date_of_birth ? c.date_of_birth.slice(0, 10) : '',
+    address1: primary.address1 || '',
+    address2: primary.address2 || '',
+    city: primary.city || '',
+    province: primary.province || '',
+    country: primary.country || '',
+    zip: primary.zip || '',
+    notes: c.notes || '',
+    tags: c.tags || '',
+    accepts_marketing: !!c.accepts_marketing,
+    verified_email: !!c.verified_email,
+    tax_exempt: !!c.tax_exempt,
+    marketing_opt_in_level: (clean(c.marketing_opt_in_level) as MarketingOptInLevel) || 'single_opt_in',
+    state: (clean(c.state) as CustomerState) || 'enabled',
+  };
+}
+
+const STATE_OPTIONS: CustomerState[] = ['enabled', 'disabled', 'invited', 'declined'];
+const OPT_IN_OPTIONS: MarketingOptInLevel[] = ['single_opt_in', 'confirmed_opt_in', 'unknown'];
+
+export default function CustomerDetailPage() {
+  const router = useRouter();
+  const params = useParams();
+  const uuid = params?.uuid as string;
+
+  const [customer, setCustomer] = useState<Customer | null>(null);
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [isLoading, setIsLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const c = await customersService.getCustomer(uuid);
+      if (!c || !c.uuid) {
+        setNotFound(true);
+      } else {
+        setCustomer(c);
+        setForm(customerToForm(c));
+      }
+    } catch (err) {
+      console.error('Failed to load customer:', err);
+      setNotFound(true);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [uuid]);
+
+  useEffect(() => {
+    if (uuid) load();
+  }, [uuid, load]);
+
+  const setField = <K extends keyof FormState>(key: K, value: FormState[K]) =>
+    setForm((prev) => ({ ...prev, [key]: value }));
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.email.trim()) {
+      toast.error('Email is required');
+      return;
+    }
+
+    // Rebuild the addresses array, preserving any extra addresses beyond the primary.
+    const existing = customer ? parseAddresses(customer.addresses) : [];
+    const hasAddress =
+      form.address1 || form.city || form.province || form.country || form.zip;
+    const primary: CustomerAddress | null = hasAddress
+      ? {
+          address1: form.address1 || undefined,
+          address2: form.address2 || undefined,
+          city: form.city || undefined,
+          province: form.province || undefined,
+          country: form.country || undefined,
+          zip: form.zip || undefined,
+          is_default: true,
+        }
+      : null;
+    const rest = existing.filter((a) => !a.is_default).slice(0, 9);
+    const addresses = primary ? [primary, ...rest] : rest;
+
+    const dto: Partial<CreateCustomerDto> = {
+      first_name: form.first_name || undefined,
+      last_name: form.last_name || undefined,
+      email: form.email.trim(),
+      phone: form.phone || undefined,
+      date_of_birth: form.date_of_birth || undefined,
+      addresses,
+      notes: form.notes || undefined,
+      tags: form.tags || undefined,
+      accepts_marketing: form.accepts_marketing,
+      verified_email: form.verified_email,
+      tax_exempt: form.tax_exempt,
+      marketing_opt_in_level: form.marketing_opt_in_level,
+      state: form.state,
+    };
+
+    setIsSaving(true);
+    try {
+      const updated = await customersService.updateCustomer(uuid, dto);
+      setCustomer(updated);
+      setForm(customerToForm(updated));
+      toast.success('Customer updated');
+    } catch (err) {
+      console.error('Failed to update customer:', err);
+      toast.error('Failed to update customer');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    try {
+      await customersService.deleteCustomer(uuid);
+      toast.success('Customer deleted');
+      router.push('/dashboard/customers');
+    } catch (err) {
+      console.error('Failed to delete customer:', err);
+      toast.error('Failed to delete customer');
+      setIsDeleting(false);
+      setDeleteOpen(false);
+    }
+  };
+
+  const fullName =
+    [form.first_name, form.last_name].filter(Boolean).join(' ') || form.email || 'Customer';
+  const initials =
+    `${(form.first_name || form.email)[0] || ''}${form.last_name[0] || ''}`.toUpperCase();
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <Loader2 className="w-8 h-8 text-primary-500 animate-spin" />
+      </div>
+    );
+  }
+
+  if (notFound) {
+    return (
+      <div className="space-y-4">
+        <button
+          onClick={() => router.push('/dashboard/customers')}
+          className="inline-flex items-center gap-2 text-sm text-secondary-500 hover:text-secondary-700"
+        >
+          <ArrowLeft className="w-4 h-4" /> Back to customers
+        </button>
+        <Card className="text-center py-16">
+          <User className="w-10 h-10 text-secondary-300 mx-auto mb-3" />
+          <p className="text-secondary-700 font-medium">Customer not found</p>
+          <p className="text-sm text-secondary-500 mt-1">It may have been deleted or the link is invalid.</p>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSave} className="space-y-5 sm:space-y-6 pb-4">
+      {/* Top bar */}
+      <div className="flex items-center justify-between gap-3">
+        <button
+          type="button"
+          onClick={() => router.push('/dashboard/customers')}
+          className="inline-flex items-center gap-2 text-sm text-secondary-500 hover:text-secondary-700"
+        >
+          <ArrowLeft className="w-4 h-4" /> Customers
+        </button>
+        <div className="flex items-center gap-2">
+          <Button type="button" variant="danger" size="sm" onClick={() => setDeleteOpen(true)}>
+            <Trash2 className="w-4 h-4 mr-1.5" /> Delete
+          </Button>
+          <Button type="submit" size="sm" isLoading={isSaving}>
+            {!isSaving && <Save className="w-4 h-4 mr-1.5" />} Save changes
+          </Button>
+        </div>
+      </div>
+
+      {/* Header / summary */}
+      <div className="relative overflow-hidden rounded-2xl gradient-primary text-white p-6 shadow-lg shadow-primary-500/20">
+        <div className="pointer-events-none absolute -top-16 -right-10 w-64 h-64 rounded-full bg-white/10 blur-3xl" />
+        <div className="relative flex flex-col sm:flex-row sm:items-center gap-4">
+          <div className="w-16 h-16 rounded-2xl bg-white/15 ring-1 ring-white/25 flex items-center justify-center text-2xl font-bold flex-shrink-0">
+            {initials || <User className="w-7 h-7" />}
+          </div>
+          <div className="min-w-0">
+            <div className="flex items-center gap-3 flex-wrap">
+              <h1 className="text-2xl font-bold tracking-tight truncate">{fullName}</h1>
+              <Badge size="sm" status={form.state} />
+            </div>
+            <div className="flex items-center gap-4 mt-1.5 text-white/85 text-sm flex-wrap">
+              {form.email && (
+                <span className="inline-flex items-center gap-1.5">
+                  <Mail className="w-4 h-4" /> {form.email}
+                </span>
+              )}
+              {form.phone && (
+                <span className="inline-flex items-center gap-1.5">
+                  <Phone className="w-4 h-4" /> {form.phone}
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
+        <Card padding="sm" className="shadow-sm">
+          <p className="text-xs font-medium text-secondary-500">Orders</p>
+          <p className="text-xl font-bold text-secondary-900 mt-1 flex items-center gap-2">
+            <ShoppingBag className="w-4 h-4 text-primary-500" />
+            {customer?.orders_count ?? 0}
+          </p>
+        </Card>
+        <Card padding="sm" className="shadow-sm">
+          <p className="text-xs font-medium text-secondary-500">Total spent</p>
+          <p className="text-xl font-bold text-secondary-900 mt-1 flex items-center gap-2">
+            <DollarSign className="w-4 h-4 text-primary-500" />
+            {formatCurrency(customer?.total_spent ?? 0)}
+          </p>
+        </Card>
+        <Card padding="sm" className="shadow-sm">
+          <p className="text-xs font-medium text-secondary-500">Avg. order</p>
+          <p className="text-xl font-bold text-secondary-900 mt-1">
+            {formatCurrency(customer?.average_order_value ?? 0)}
+          </p>
+        </Card>
+        <Card padding="sm" className="shadow-sm">
+          <p className="text-xs font-medium text-secondary-500">Last order</p>
+          <p className="text-sm font-semibold text-secondary-900 mt-2">
+            {customer?.last_order_date ? formatDate(customer.last_order_date) : '—'}
+          </p>
+        </Card>
+      </div>
+
+      {/* Basic info */}
+      <Card className="shadow-sm">
+        <h2 className="text-base font-semibold text-secondary-900 mb-4">Basic information</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <label className={labelClass}>First name</label>
+            <input className={inputClass} value={form.first_name} onChange={(e) => setField('first_name', e.target.value)} />
+          </div>
+          <div>
+            <label className={labelClass}>Last name</label>
+            <input className={inputClass} value={form.last_name} onChange={(e) => setField('last_name', e.target.value)} />
+          </div>
+          <div>
+            <label className={labelClass}>Email *</label>
+            <input type="email" className={inputClass} value={form.email} onChange={(e) => setField('email', e.target.value)} required />
+          </div>
+          <div>
+            <label className={labelClass}>Phone</label>
+            <input className={inputClass} value={form.phone} onChange={(e) => setField('phone', e.target.value)} />
+          </div>
+          <div>
+            <label className={labelClass}>Date of birth</label>
+            <input type="date" className={inputClass} value={form.date_of_birth} onChange={(e) => setField('date_of_birth', e.target.value)} />
+          </div>
+        </div>
+      </Card>
+
+      {/* Address */}
+      <Card className="shadow-sm">
+        <h2 className="text-base font-semibold text-secondary-900 mb-4">Primary address</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div className="sm:col-span-2">
+            <label className={labelClass}>Address line 1</label>
+            <input className={inputClass} value={form.address1} onChange={(e) => setField('address1', e.target.value)} />
+          </div>
+          <div className="sm:col-span-2">
+            <label className={labelClass}>Address line 2</label>
+            <input className={inputClass} value={form.address2} onChange={(e) => setField('address2', e.target.value)} />
+          </div>
+          <div>
+            <label className={labelClass}>City</label>
+            <input className={inputClass} value={form.city} onChange={(e) => setField('city', e.target.value)} />
+          </div>
+          <div>
+            <label className={labelClass}>State / Province</label>
+            <input className={inputClass} value={form.province} onChange={(e) => setField('province', e.target.value)} />
+          </div>
+          <div>
+            <label className={labelClass}>Country</label>
+            <input className={inputClass} value={form.country} onChange={(e) => setField('country', e.target.value)} />
+          </div>
+          <div>
+            <label className={labelClass}>Postal code</label>
+            <input className={inputClass} value={form.zip} onChange={(e) => setField('zip', e.target.value)} />
+          </div>
+        </div>
+      </Card>
+
+      {/* Preferences */}
+      <Card className="shadow-sm">
+        <h2 className="text-base font-semibold text-secondary-900 mb-4">Preferences & notes</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <label className={labelClass}>Tags (comma-separated)</label>
+            <input className={inputClass} value={form.tags} onChange={(e) => setField('tags', e.target.value)} placeholder="vip, wholesale" />
+          </div>
+          <div>
+            <label className={labelClass}>Account status</label>
+            <select className={inputClass} value={form.state} onChange={(e) => setField('state', e.target.value as CustomerState)}>
+              {STATE_OPTIONS.map((s) => (
+                <option key={s} value={s} className="capitalize">{s}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className={labelClass}>Marketing opt-in level</label>
+            <select
+              className={inputClass}
+              value={form.marketing_opt_in_level}
+              onChange={(e) => setField('marketing_opt_in_level', e.target.value as MarketingOptInLevel)}
+            >
+              {OPT_IN_OPTIONS.map((o) => (
+                <option key={o} value={o}>{o.replace(/_/g, ' ')}</option>
+              ))}
+            </select>
+          </div>
+          <div className="sm:col-span-2">
+            <label className={labelClass}>Notes</label>
+            <textarea
+              className={`${inputClass} resize-none`}
+              rows={3}
+              value={form.notes}
+              onChange={(e) => setField('notes', e.target.value)}
+              placeholder="Internal notes about this customer…"
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-x-6 gap-y-3 mt-4 pt-4 border-t border-secondary-200">
+          <label className="flex items-center gap-2 text-sm text-secondary-700 cursor-pointer select-none">
+            <input type="checkbox" className="w-4 h-4 rounded border-secondary-300 text-primary-600 focus:ring-primary-500/30"
+              checked={form.accepts_marketing} onChange={(e) => setField('accepts_marketing', e.target.checked)} />
+            Accepts marketing
+          </label>
+          <label className="flex items-center gap-2 text-sm text-secondary-700 cursor-pointer select-none">
+            <input type="checkbox" className="w-4 h-4 rounded border-secondary-300 text-primary-600 focus:ring-primary-500/30"
+              checked={form.verified_email} onChange={(e) => setField('verified_email', e.target.checked)} />
+            Email verified
+          </label>
+          <label className="flex items-center gap-2 text-sm text-secondary-700 cursor-pointer select-none">
+            <input type="checkbox" className="w-4 h-4 rounded border-secondary-300 text-primary-600 focus:ring-primary-500/30"
+              checked={form.tax_exempt} onChange={(e) => setField('tax_exempt', e.target.checked)} />
+            Tax exempt
+          </label>
+        </div>
+      </Card>
+
+      <ConfirmDialog
+        isOpen={deleteOpen}
+        onClose={() => setDeleteOpen(false)}
+        onConfirm={handleDelete}
+        title="Delete customer"
+        message={`Are you sure you want to delete "${fullName}"? This action cannot be undone.`}
+        confirmText="Delete"
+        variant="danger"
+        isLoading={isDeleting}
+      />
+    </form>
+  );
+}

--- a/opsapi-dashboard/app/dashboard/invoices/[uuid]/page.tsx
+++ b/opsapi-dashboard/app/dashboard/invoices/[uuid]/page.tsx
@@ -12,6 +12,8 @@ import {
   DollarSign,
   Edit2,
   X,
+  Download,
+  Eye,
 } from 'lucide-react';
 import { Modal } from '@/components/ui';
 import { ProtectedPage } from '@/components/permissions';
@@ -25,6 +27,8 @@ import {
   type PaymentPayload,
   type InvoicePayload,
 } from '@/services/invoices.service';
+import { generateInvoicePdf, previewInvoicePdfUrl } from '@/lib/invoice-pdf';
+import { useNamespace } from '@/contexts/NamespaceContext';
 import { formatDate, formatCurrency } from '@/lib/utils';
 import toast from 'react-hot-toast';
 
@@ -484,6 +488,7 @@ const EditInvoiceModal: React.FC<EditInvoiceModalProps> = ({ isOpen, onClose, on
 function InvoiceDetailContent() {
   const params = useParams();
   const router = useRouter();
+  const { currentNamespace } = useNamespace();
   const uuid = params.uuid as string;
 
   // State
@@ -493,6 +498,7 @@ function InvoiceDetailContent() {
   const [isAddItemModalOpen, setIsAddItemModalOpen] = useState(false);
   const [isPaymentModalOpen, setIsPaymentModalOpen] = useState(false);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
 
   // Fetch invoice data
   const fetchInvoice = useCallback(async () => {
@@ -515,6 +521,53 @@ function InvoiceDetailContent() {
   useEffect(() => {
     fetchInvoice();
   }, [fetchInvoice]);
+
+  // Download a polished, real-looking PDF of this invoice (client-side, no server).
+  const handleDownloadPdf = useCallback(() => {
+    if (!invoice) return;
+    try {
+      generateInvoicePdf(invoice, {
+        name: currentNamespace?.name || 'Your Company',
+      });
+    } catch (error) {
+      console.error('Failed to generate PDF:', error);
+      toast.error('Failed to generate PDF');
+    }
+  }, [invoice, currentNamespace]);
+
+  // Open an in-app preview of the same PDF (rendered to a blob URL for an iframe).
+  const handlePreviewPdf = useCallback(() => {
+    if (!invoice) return;
+    try {
+      const url = previewInvoicePdfUrl(invoice, {
+        name: currentNamespace?.name || 'Your Company',
+      });
+      setPreviewUrl((prev) => {
+        if (prev) URL.revokeObjectURL(prev);
+        return url;
+      });
+    } catch (error) {
+      console.error('Failed to preview PDF:', error);
+      toast.error('Failed to preview PDF');
+    }
+  }, [invoice, currentNamespace]);
+
+  const closePreview = useCallback(() => {
+    setPreviewUrl((prev) => {
+      if (prev) URL.revokeObjectURL(prev);
+      return null;
+    });
+  }, []);
+
+  // Revoke any outstanding preview URL on unmount.
+  useEffect(() => {
+    return () => {
+      setPreviewUrl((prev) => {
+        if (prev) URL.revokeObjectURL(prev);
+        return null;
+      });
+    };
+  }, []);
 
   // Action handlers
   const handleSendInvoice = useCallback(async () => {
@@ -645,6 +698,20 @@ function InvoiceDetailContent() {
 
         {/* Action Buttons */}
         <div className="flex items-center gap-2">
+          <button
+            onClick={handlePreviewPdf}
+            className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-secondary-700 bg-surface border border-secondary-300 rounded-lg hover:bg-secondary-50 transition-colors"
+          >
+            <Eye className="w-4 h-4" />
+            Preview
+          </button>
+          <button
+            onClick={handleDownloadPdf}
+            className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-secondary-700 bg-surface border border-secondary-300 rounded-lg hover:bg-secondary-50 transition-colors"
+          >
+            <Download className="w-4 h-4" />
+            Download PDF
+          </button>
           {canEdit && (
             <button
               onClick={() => setIsEditModalOpen(true)}
@@ -930,6 +997,37 @@ function InvoiceDetailContent() {
           invoice={invoice}
         />
       )}
+
+      {/* Invoice PDF Preview */}
+      <Modal
+        isOpen={!!previewUrl}
+        onClose={closePreview}
+        title={`Invoice ${invoice?.invoice_number || ''} — Preview`}
+        size="2xl"
+      >
+        <div className="space-y-3">
+          <div className="h-[70vh] w-full overflow-hidden rounded-lg border border-secondary-200 bg-secondary-50">
+            {previewUrl && (
+              <iframe src={previewUrl} title="Invoice preview" className="h-full w-full" />
+            )}
+          </div>
+          <div className="flex justify-end gap-3">
+            <button
+              onClick={closePreview}
+              className="px-4 py-2 text-sm font-medium text-secondary-700 bg-surface border border-secondary-300 rounded-lg hover:bg-secondary-50 transition-colors"
+            >
+              Close
+            </button>
+            <button
+              onClick={handleDownloadPdf}
+              className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 transition-colors"
+            >
+              <Download className="w-4 h-4" />
+              Download PDF
+            </button>
+          </div>
+        </div>
+      </Modal>
     </div>
   );
 }

--- a/opsapi-dashboard/app/dashboard/invoices/page.tsx
+++ b/opsapi-dashboard/app/dashboard/invoices/page.tsx
@@ -16,7 +16,7 @@ import {
   Plus,
   DollarSign,
 } from 'lucide-react';
-import { Input, Table, Pagination, Card, Modal } from '@/components/ui';
+import { Input, Table, Pagination, Card, Modal, SearchableSelect } from '@/components/ui';
 import { ProtectedPage } from '@/components/permissions';
 import {
   invoicesService,
@@ -25,10 +25,17 @@ import {
   type Invoice,
   type InvoiceStatus,
   type InvoicePayload,
+  type CustomerBillablePreview,
 } from '@/services/invoices.service';
+import { timesheetsService, type CustomerOption } from '@/services/timesheets.service';
 import { formatDate, formatCurrency } from '@/lib/utils';
 import type { TableColumn } from '@/types';
 import toast from 'react-hot-toast';
+
+// Shared form field styling for the modals on this page.
+const inputClass =
+  'w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 bg-surface';
+const labelClass = 'block text-sm font-medium text-secondary-700 mb-1';
 
 // Stats card component
 interface StatCardProps {
@@ -278,6 +285,264 @@ const CreateInvoiceModal: React.FC<CreateInvoiceModalProps> = ({ isOpen, onClose
   );
 };
 
+// ============================================
+// Generate Invoice From Timesheets Modal
+// ============================================
+// Search a customer, pick a period, see every un-invoiced billable hour logged
+// for them in that window (with rate + amount), then generate one invoice for
+// the lot. Mirrors "all the work I've done for this customer this period".
+
+const startOfMonthISO = () => {
+  const d = new Date();
+  return new Date(d.getFullYear(), d.getMonth(), 1).toISOString().slice(0, 10);
+};
+const todayISO = () => new Date().toISOString().slice(0, 10);
+
+interface GenerateFromTimesheetsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onGenerated: (uuid: string) => void;
+}
+
+const GenerateFromTimesheetsModal: React.FC<GenerateFromTimesheetsModalProps> = ({
+  isOpen,
+  onClose,
+  onGenerated,
+}) => {
+  const [customers, setCustomers] = useState<CustomerOption[]>([]);
+  const [customerUuid, setCustomerUuid] = useState('');
+  const [from, setFrom] = useState(startOfMonthISO());
+  const [to, setTo] = useState(todayISO());
+  const [preview, setPreview] = useState<CustomerBillablePreview | null>(null);
+  const [isLoadingPreview, setIsLoadingPreview] = useState(false);
+  const [isGenerating, setIsGenerating] = useState(false);
+
+  // Load an initial customer page on open; refine server-side as the user types.
+  useEffect(() => {
+    if (!isOpen) return;
+    let cancelled = false;
+    timesheetsService.lookupCustomers().then((c) => !cancelled && setCustomers(c)).catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen]);
+
+  // Reset when closed so the next open starts clean.
+  useEffect(() => {
+    if (!isOpen) {
+      setCustomerUuid('');
+      setPreview(null);
+      setFrom(startOfMonthISO());
+      setTo(todayISO());
+    }
+  }, [isOpen]);
+
+  const handleCustomerSearch = useCallback((q: string) => {
+    timesheetsService.lookupCustomers(q).then(setCustomers).catch(() => {});
+  }, []);
+
+  const customerOptions = useMemo(
+    () =>
+      customers.map((c) => ({
+        value: c.uuid,
+        label: [c.first_name, c.last_name].filter(Boolean).join(' ') || c.email || 'Unnamed',
+        hint: c.email,
+      })),
+    [customers]
+  );
+
+  // Auto-load the preview whenever the customer or period changes.
+  const loadPreview = useCallback(async () => {
+    if (!customerUuid) {
+      setPreview(null);
+      return;
+    }
+    setIsLoadingPreview(true);
+    try {
+      const p = await invoicesService.getCustomerBillable(customerUuid, from || undefined, to || undefined);
+      setPreview(p);
+    } catch {
+      toast.error('Failed to load the customer’s work');
+      setPreview(null);
+    } finally {
+      setIsLoadingPreview(false);
+    }
+  }, [customerUuid, from, to]);
+
+  useEffect(() => {
+    loadPreview();
+  }, [loadPreview]);
+
+  const currency = preview?.currency || 'GBP';
+  const canGenerate = !!preview && preview.totals.count > 0 && !preview.totals.missing_rate;
+
+  const handleGenerate = async () => {
+    if (!customerUuid) {
+      toast.error('Pick a customer first');
+      return;
+    }
+    if (!preview || preview.totals.count === 0) {
+      toast.error('No un-invoiced billable hours in this period');
+      return;
+    }
+    if (preview.totals.missing_rate) {
+      toast.error('Some hours have no rate — set an hourly rate on the timesheet first');
+      return;
+    }
+    setIsGenerating(true);
+    try {
+      const invoice = await invoicesService.createFromCustomer({
+        customer_uuid: customerUuid,
+        period_start: from || undefined,
+        period_end: to || undefined,
+      });
+      toast.success(`Invoice ${invoice.invoice_number} created`);
+      onGenerated(invoice.uuid);
+    } catch {
+      toast.error('Failed to generate invoice');
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Generate Invoice from Timesheets" size="lg">
+      <div className="space-y-4">
+        <p className="text-sm text-secondary-500">
+          Pick a customer and a period to bill every approved, un-invoiced hour logged for them.
+          Already-invoiced hours are skipped automatically.
+        </p>
+
+        {/* Customer + period */}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <div className="sm:col-span-3">
+            <label className={labelClass}>Customer</label>
+            <SearchableSelect
+              options={customerOptions}
+              value={customerUuid}
+              onChange={setCustomerUuid}
+              onSearch={handleCustomerSearch}
+              placeholder="Select a customer…"
+              searchPlaceholder="Search customers…"
+              emptyMessage="No customers found"
+              clearable
+            />
+          </div>
+          <div>
+            <label className={labelClass}>From</label>
+            <input type="date" value={from} onChange={(e) => setFrom(e.target.value)} className={inputClass} />
+          </div>
+          <div>
+            <label className={labelClass}>To</label>
+            <input type="date" value={to} onChange={(e) => setTo(e.target.value)} className={inputClass} />
+          </div>
+          <div className="flex items-end">
+            <button
+              type="button"
+              onClick={loadPreview}
+              disabled={!customerUuid || isLoadingPreview}
+              className="w-full px-3 py-2 text-sm font-medium text-secondary-700 bg-surface border border-secondary-300 rounded-lg hover:bg-secondary-50 disabled:opacity-50 transition-colors"
+            >
+              {isLoadingPreview ? 'Loading…' : 'Refresh'}
+            </button>
+          </div>
+        </div>
+
+        {/* Work preview */}
+        {!customerUuid ? (
+          <div className="rounded-xl border border-dashed border-secondary-300 px-4 py-8 text-center text-sm text-secondary-400">
+            Select a customer to see their billable work.
+          </div>
+        ) : isLoadingPreview ? (
+          <div className="rounded-xl border border-secondary-200 px-4 py-8 text-center text-sm text-secondary-400">
+            Loading work…
+          </div>
+        ) : !preview || preview.totals.count === 0 ? (
+          <div className="rounded-xl border border-secondary-200 px-4 py-8 text-center text-sm text-secondary-500">
+            No un-invoiced billable hours for this customer in the selected period.
+          </div>
+        ) : (
+          <div className="rounded-xl border border-secondary-200 overflow-hidden">
+            <div className="max-h-72 overflow-y-auto">
+              <table className="w-full text-sm">
+                <thead className="bg-secondary-50 text-secondary-500 sticky top-0">
+                  <tr>
+                    <th className="text-left font-medium px-3 py-2">Date</th>
+                    <th className="text-left font-medium px-3 py-2">Work</th>
+                    <th className="text-right font-medium px-3 py-2">Hours</th>
+                    <th className="text-right font-medium px-3 py-2">Rate</th>
+                    <th className="text-right font-medium px-3 py-2">Amount</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-secondary-100">
+                  {preview.entries.map((e) => (
+                    <tr key={e.entry_id}>
+                      <td className="px-3 py-2 text-secondary-600 whitespace-nowrap">{formatDate(e.entry_date)}</td>
+                      <td className="px-3 py-2 text-secondary-900">
+                        {e.task_reference || e.project_reference || e.description || 'Work'}
+                        {e.description && (e.task_reference || e.project_reference) && (
+                          <span className="block text-xs text-secondary-400">{e.description}</span>
+                        )}
+                      </td>
+                      <td className="px-3 py-2 text-right text-secondary-700">{e.hours.toFixed(2)}</td>
+                      <td className="px-3 py-2 text-right text-secondary-700">
+                        {e.has_rate ? formatCurrency(e.rate, currency) : <span className="text-red-500">no rate</span>}
+                      </td>
+                      <td className="px-3 py-2 text-right font-medium text-secondary-900">
+                        {formatCurrency(e.amount, currency)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+                <tfoot className="bg-secondary-50 sticky bottom-0">
+                  <tr className="font-semibold text-secondary-900">
+                    <td className="px-3 py-2" colSpan={2}>
+                      {preview.totals.count} item{preview.totals.count === 1 ? '' : 's'}
+                    </td>
+                    <td className="px-3 py-2 text-right">{preview.totals.total_hours.toFixed(2)}</td>
+                    <td className="px-3 py-2" />
+                    <td className="px-3 py-2 text-right text-primary-600">
+                      {formatCurrency(preview.totals.total_amount, currency)}
+                    </td>
+                  </tr>
+                </tfoot>
+              </table>
+            </div>
+          </div>
+        )}
+
+        {preview?.totals.missing_rate && (
+          <p className="text-xs text-red-600">
+            Some hours have no hourly rate. Set a rate on the timesheet (or its entries) before invoicing.
+          </p>
+        )}
+
+        <div className="flex justify-end gap-3 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 text-sm font-medium text-secondary-700 bg-surface border border-secondary-300 rounded-lg hover:bg-secondary-50 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleGenerate}
+            disabled={!canGenerate || isGenerating}
+            className="px-4 py-2 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 disabled:opacity-50 transition-colors"
+          >
+            {isGenerating
+              ? 'Generating…'
+              : preview && preview.totals.count > 0
+                ? `Generate Invoice · ${formatCurrency(preview.totals.total_amount, currency)}`
+                : 'Generate Invoice'}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
 function InvoicesPageContent() {
   const router = useRouter();
 
@@ -286,6 +551,7 @@ function InvoicesPageContent() {
   const [isLoading, setIsLoading] = useState(true);
   const [stats, setStats] = useState<InvoiceDashboardStats | null>(null);
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [isFromTimesheetsOpen, setIsFromTimesheetsOpen] = useState(false);
 
   // Filters
   const [searchQuery, setSearchQuery] = useState('');
@@ -516,6 +782,13 @@ function InvoicesPageContent() {
             Refresh
           </button>
           <button
+            onClick={() => setIsFromTimesheetsOpen(true)}
+            className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-primary-700 bg-primary-50 border border-primary-200 rounded-lg hover:bg-primary-100 transition-colors"
+          >
+            <Clock className="w-4 h-4" />
+            From Timesheets
+          </button>
+          <button
             onClick={() => setIsCreateModalOpen(true)}
             className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 transition-colors"
           >
@@ -682,6 +955,17 @@ function InvoicesPageContent() {
         isOpen={isCreateModalOpen}
         onClose={() => setIsCreateModalOpen(false)}
         onCreated={handleInvoiceCreated}
+      />
+
+      {/* Generate Invoice from Timesheets Modal */}
+      <GenerateFromTimesheetsModal
+        isOpen={isFromTimesheetsOpen}
+        onClose={() => setIsFromTimesheetsOpen(false)}
+        onGenerated={(uuid) => {
+          setIsFromTimesheetsOpen(false);
+          handleInvoiceCreated();
+          router.push(`/dashboard/invoices/${uuid}`);
+        }}
       />
     </div>
   );

--- a/opsapi-dashboard/app/dashboard/page.tsx
+++ b/opsapi-dashboard/app/dashboard/page.tsx
@@ -97,16 +97,28 @@ export default function DashboardPage() {
   }, [refetch]);
 
   return (
-    <div className="space-y-4 sm:space-y-6">
+    <div className="space-y-5 sm:space-y-6">
       {/* Pending Invitations Banner */}
       <PendingInvitationsBanner />
 
-      {/* Page Header */}
-      <div>
-        <h1 className="text-xl sm:text-2xl font-bold text-secondary-900">Dashboard</h1>
-        <p className="text-sm sm:text-base text-secondary-500 mt-1">
-          Welcome back! Here&apos;s what&apos;s happening with your business.
-        </p>
+      {/* Hero header — brand gradient welcome */}
+      <div className="relative overflow-hidden rounded-2xl gradient-primary text-white p-6 sm:p-8 shadow-lg shadow-primary-500/20">
+        <div className="pointer-events-none absolute -top-16 -right-10 w-72 h-72 rounded-full bg-white/10 blur-3xl" />
+        <div className="pointer-events-none absolute -bottom-24 -left-12 w-72 h-72 rounded-full bg-black/10 blur-3xl" />
+        <div className="relative flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div>
+            <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">Welcome back 👋</h1>
+            <p className="text-white/85 mt-1.5 text-sm sm:text-base max-w-xl">
+              Here&apos;s what&apos;s happening with your business today.
+            </p>
+          </div>
+          <div className="flex items-center gap-2 text-xs sm:text-sm">
+            <span className="inline-flex items-center gap-2 rounded-full bg-white/15 backdrop-blur-sm px-3 py-1.5 font-medium ring-1 ring-white/20">
+              <span className="w-2 h-2 rounded-full bg-emerald-300 animate-pulse" />
+              {health?.status === 'healthy' ? 'All systems operational' : 'Live overview'}
+            </span>
+          </div>
+        </div>
       </div>
 
       {/* Stats Cards - Responsive grid */}
@@ -124,15 +136,15 @@ export default function DashboardPage() {
         ))}
       </div>
 
-      {/* Charts and Health Status - Responsive layout */}
-      <div className="grid grid-cols-1 xl:grid-cols-3 gap-4 sm:gap-6">
+      {/* Charts and Health Status — equal-height columns on desktop, health scrolls internally */}
+      <div className="grid grid-cols-1 xl:grid-cols-3 gap-4 sm:gap-6 xl:h-[480px]">
         {/* Revenue Chart - Full width on mobile/tablet, 2/3 on desktop */}
-        <div className="xl:col-span-2 order-2 xl:order-1">
+        <div className="xl:col-span-2 order-2 xl:order-1 min-h-0">
           <OrdersChart data={chartData} isLoading={isLoading} />
         </div>
 
         {/* Health Status - Full width on mobile/tablet, 1/3 on desktop */}
-        <div className="order-1 xl:order-2">
+        <div className="order-1 xl:order-2 min-h-0">
           <HealthStatus health={health} isLoading={isLoading} onRefresh={handleRefresh} />
         </div>
       </div>

--- a/opsapi-dashboard/app/dashboard/timesheets/[uuid]/page.tsx
+++ b/opsapi-dashboard/app/dashboard/timesheets/[uuid]/page.tsx
@@ -17,6 +17,7 @@ import {
   RefreshCw,
   FileText,
   Loader2,
+  Info,
 } from 'lucide-react';
 import { Card, Badge, Modal } from '@/components/ui';
 import { ProtectedPage } from '@/components/permissions';
@@ -27,6 +28,7 @@ import {
   type CreateEntryData,
   type UpdateEntryData,
 } from '@/services/timesheets.service';
+import { invoicesService } from '@/services/invoices.service';
 import { formatDate } from '@/lib/utils';
 import toast from 'react-hot-toast';
 
@@ -121,6 +123,10 @@ const AddEntryModal: React.FC<AddEntryModalProps> = ({ isOpen, onClose, onSaved,
   return (
     <Modal isOpen={isOpen} onClose={onClose} title={editEntry ? 'Edit Time Entry' : 'Add Time Entry'}>
       <form onSubmit={handleSubmit} className="space-y-4">
+        <p className="text-xs text-secondary-500 bg-secondary-50 border border-secondary-200 rounded-lg px-3 py-2">
+          An entry is one chunk of work. Its hours are added to the timesheet&apos;s total — log a
+          separate entry for each day or task.
+        </p>
         <div className="grid grid-cols-2 gap-4">
           <div>
             <label className="block text-sm font-medium text-secondary-700 mb-1">Date</label>
@@ -138,12 +144,14 @@ const AddEntryModal: React.FC<AddEntryModalProps> = ({ isOpen, onClose, onSaved,
               type="number"
               step="0.25"
               min="0.25"
+              max="24"
               value={hours}
               onChange={(e) => setHours(e.target.value)}
               className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 bg-surface"
               placeholder="0.00"
               required
             />
+            <p className="text-xs text-secondary-400 mt-1">Hours worked on this entry (0–24)</p>
           </div>
         </div>
 
@@ -181,17 +189,23 @@ const AddEntryModal: React.FC<AddEntryModalProps> = ({ isOpen, onClose, onSaved,
           </div>
         </div>
 
-        <div className="flex items-center gap-2">
-          <input
-            type="checkbox"
-            id="is_billable"
-            checked={isBillable}
-            onChange={(e) => setIsBillable(e.target.checked)}
-            className="w-4 h-4 text-primary-600 border-secondary-300 rounded focus:ring-primary-500"
-          />
-          <label htmlFor="is_billable" className="text-sm font-medium text-secondary-700">
-            Billable
-          </label>
+        <div>
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="is_billable"
+              checked={isBillable}
+              onChange={(e) => setIsBillable(e.target.checked)}
+              className="w-4 h-4 text-primary-600 border-secondary-300 rounded focus:ring-primary-500"
+            />
+            <label htmlFor="is_billable" className="text-sm font-medium text-secondary-700">
+              Billable
+            </label>
+          </div>
+          <p className="text-xs text-secondary-400 mt-1 ml-6">
+            Tick if the client should be charged for these hours — they count toward the invoiceable
+            total. Leave unticked for internal time.
+          </p>
         </div>
 
         <div className="flex justify-end gap-3 pt-2">
@@ -372,6 +386,25 @@ function TimesheetDetailContent() {
     }
   }, [uuid, fetchTimesheet]);
 
+  const handleGenerateInvoice = useCallback(async () => {
+    setIsActioning(true);
+    try {
+      const invoice = await invoicesService.createFromTimesheet({ timesheet_uuid: uuid });
+      toast.success(`Invoice ${invoice?.invoice_number || ''} created from billable hours`);
+      if (invoice?.uuid) {
+        router.push(`/dashboard/invoices/${invoice.uuid}`);
+      }
+    } catch (error: unknown) {
+      const message =
+        (error as { response?: { data?: { error?: string } } })?.response?.data?.error ||
+        'Failed to generate invoice';
+      console.error('Failed to generate invoice from timesheet:', error);
+      toast.error(message);
+    } finally {
+      setIsActioning(false);
+    }
+  }, [uuid, router]);
+
   const handleDelete = useCallback(async () => {
     if (!confirm('Are you sure you want to delete this timesheet? This action cannot be undone.')) {
       return;
@@ -504,6 +537,31 @@ function TimesheetDetailContent() {
         </button>
       </div>
 
+      {/* What is this? — explainer */}
+      <div className="bg-blue-50 border border-blue-200 rounded-xl p-4">
+        <div className="flex items-start gap-3">
+          <Info className="w-5 h-5 text-blue-600 mt-0.5 flex-shrink-0" />
+          <div className="text-sm text-blue-900">
+            <p className="font-medium">How this timesheet works</p>
+            <p className="mt-1 text-blue-800">
+              A timesheet is a container for the work you log. Each{' '}
+              <span className="font-medium">entry</span> is one chunk of work — a date, the hours
+              spent, and what you did. The hours below are{' '}
+              <span className="font-medium">added up automatically from your entries</span>: adding
+              an entry increases the totals, deleting one decreases them. You don&apos;t edit the
+              totals directly.
+            </p>
+            <p className="mt-1 text-blue-800">
+              Mark an entry as <span className="font-medium">billable</span> if the client should be
+              charged for it — those hours roll into <span className="font-medium">Billable Hours</span>,
+              which is what gets invoiced. Entries can only be added or changed while the timesheet is
+              a <span className="font-medium">draft</span>; submitting it locks the entries and sends
+              it for approval.
+            </p>
+          </div>
+        </div>
+      </div>
+
       {/* Summary Cards */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
         <div className="bg-surface rounded-xl border border-secondary-200 p-5 shadow-sm">
@@ -513,6 +571,7 @@ function TimesheetDetailContent() {
               <p className="text-2xl font-bold text-secondary-900 mt-1">
                 {timesheet.total_hours?.toFixed(1) || '0.0'}
               </p>
+              <p className="text-xs text-secondary-400 mt-1">Auto-summed from all entries</p>
             </div>
             <div className="w-12 h-12 rounded-xl flex items-center justify-center bg-primary-50 text-primary-600">
               <Clock className="w-6 h-6" />
@@ -526,6 +585,7 @@ function TimesheetDetailContent() {
               <p className="text-2xl font-bold text-secondary-900 mt-1">
                 {timesheet.billable_hours?.toFixed(1) || '0.0'}
               </p>
+              <p className="text-xs text-secondary-400 mt-1">Billable entries only — what you invoice</p>
             </div>
             <div className="w-12 h-12 rounded-xl flex items-center justify-center bg-green-50 text-green-600">
               <DollarSign className="w-6 h-6" />
@@ -537,6 +597,7 @@ function TimesheetDetailContent() {
             <div>
               <p className="text-sm font-medium text-secondary-500">Entries</p>
               <p className="text-2xl font-bold text-secondary-900 mt-1">{entries.length}</p>
+              <p className="text-xs text-secondary-400 mt-1">Chunks of work logged</p>
             </div>
             <div className="w-12 h-12 rounded-xl flex items-center justify-center bg-blue-50 text-blue-600">
               <FileText className="w-6 h-6" />
@@ -633,13 +694,24 @@ function TimesheetDetailContent() {
             )}
 
             {isApproved && (
-              <div className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-green-600 bg-green-50 rounded-lg">
-                <CheckCircle className="w-4 h-4" />
-                Approved
-                {timesheet.approved_at && (
-                  <span className="text-green-500 ml-1">on {formatDate(timesheet.approved_at)}</span>
-                )}
-              </div>
+              <>
+                <div className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-green-600 bg-green-50 rounded-lg">
+                  <CheckCircle className="w-4 h-4" />
+                  Approved
+                  {timesheet.approved_at && (
+                    <span className="text-green-500 ml-1">on {formatDate(timesheet.approved_at)}</span>
+                  )}
+                </div>
+                <button
+                  onClick={handleGenerateInvoice}
+                  disabled={isActioning}
+                  title="Create a draft invoice from the billable hours on this timesheet"
+                  className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 disabled:opacity-50 transition-colors"
+                >
+                  <DollarSign className="w-4 h-4" />
+                  Generate Invoice
+                </button>
+              </>
             )}
 
             {isRejected && (

--- a/opsapi-dashboard/app/dashboard/timesheets/page.tsx
+++ b/opsapi-dashboard/app/dashboard/timesheets/page.tsx
@@ -15,7 +15,7 @@ import {
   X,
   FileText,
 } from 'lucide-react';
-import { Input, Table, Badge, Pagination, Card, Modal } from '@/components/ui';
+import { Input, Table, Badge, Pagination, Card, Modal, SearchableSelect } from '@/components/ui';
 import { ProtectedPage } from '@/components/permissions';
 import {
   timesheetsService,
@@ -23,11 +23,24 @@ import {
   type TimesheetStatus,
   type TimesheetsResponse,
   type TimesheetSummaryResponse,
+  type CustomerOption,
+  type TaskOption,
 } from '@/services/timesheets.service';
 import { formatDate } from '@/lib/utils';
 import type { TableColumn } from '@/types';
 import toast from 'react-hot-toast';
 import { useRouter } from 'next/navigation';
+
+// Compute decimal hours between two "HH:MM" clock strings (handles overnight).
+function computeHours(start: string, end: string): number | null {
+  if (!start || !end) return null;
+  const [sh, sm] = start.split(':').map(Number);
+  const [eh, em] = end.split(':').map(Number);
+  if ([sh, sm, eh, em].some((n) => Number.isNaN(n))) return null;
+  let diff = eh * 60 + em - (sh * 60 + sm);
+  if (diff < 0) diff += 24 * 60;
+  return Math.round((diff / 60) * 100) / 100;
+}
 
 // ============================================
 // Stats Card Component
@@ -87,30 +100,112 @@ interface CreateTimesheetModalProps {
   onCreated: () => void;
 }
 
+const inputClass =
+  'w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 bg-surface';
+const labelClass = 'block text-sm font-medium text-secondary-700 mb-1';
+
+const todayISO = () => new Date().toISOString().slice(0, 10);
+
 const CreateTimesheetModal: React.FC<CreateTimesheetModalProps> = ({ isOpen, onClose, onCreated }) => {
-  const [periodStart, setPeriodStart] = useState('');
-  const [periodEnd, setPeriodEnd] = useState('');
+  const [customers, setCustomers] = useState<CustomerOption[]>([]);
+  const [tasks, setTasks] = useState<TaskOption[]>([]);
+
+  const [customerUuid, setCustomerUuid] = useState('');
+  const [taskUuid, setTaskUuid] = useState('');
+  const [workDate, setWorkDate] = useState(todayISO());
+  const [startTime, setStartTime] = useState('09:00');
+  const [endTime, setEndTime] = useState('17:00');
+  const [isBillable, setIsBillable] = useState(true);
+  const [hourlyRate, setHourlyRate] = useState('');
   const [notes, setNotes] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  // Load namespace-scoped customers + tasks for the searchable dropdowns on open.
+  useEffect(() => {
+    if (!isOpen) return;
+    let cancelled = false;
+    (async () => {
+      const [cust, tsk] = await Promise.all([
+        timesheetsService.lookupCustomers().catch(() => []),
+        timesheetsService.lookupTasks().catch(() => []),
+      ]);
+      if (!cancelled) {
+        setCustomers(cust);
+        setTasks(tsk);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen]);
+
+  const customerOptions = useMemo(
+    () =>
+      customers.map((c) => ({
+        value: c.uuid,
+        label: [c.first_name, c.last_name].filter(Boolean).join(' ') || c.email || 'Unnamed',
+        hint: c.email,
+      })),
+    [customers]
+  );
+  const taskOptions = useMemo(
+    () =>
+      tasks.map((t) => ({
+        value: t.task_uuid,
+        label: t.title,
+        hint: t.project_name || undefined,
+      })),
+    [tasks]
+  );
+
+  const hours = useMemo(() => computeHours(startTime, endTime), [startTime, endTime]);
+  const rateNum = parseFloat(hourlyRate);
+  const amount = hours != null && !Number.isNaN(rateNum) ? hours * rateNum : null;
+
+  const resetForm = () => {
+    setCustomerUuid('');
+    setTaskUuid('');
+    setWorkDate(todayISO());
+    setStartTime('09:00');
+    setEndTime('17:00');
+    setIsBillable(true);
+    setHourlyRate('');
+    setNotes('');
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!periodStart || !periodEnd) {
-      toast.error('Please select both start and end dates');
+    if (!workDate) {
+      toast.error('Please pick the work date');
       return;
     }
+    if (hours == null || hours <= 0) {
+      toast.error('End time must be after start time');
+      return;
+    }
+
+    const selectedCustomer = customers.find((c) => c.uuid === customerUuid);
+    const selectedTask = tasks.find((t) => t.task_uuid === taskUuid);
 
     setIsSubmitting(true);
     try {
       await timesheetsService.createTimesheet({
-        period_start: periodStart,
-        period_end: periodEnd,
+        work_date: workDate,
+        customer_uuid: customerUuid || undefined,
+        client_name: selectedCustomer
+          ? [selectedCustomer.first_name, selectedCustomer.last_name].filter(Boolean).join(' ') ||
+            selectedCustomer.email
+          : undefined,
+        task_uuid: taskUuid || undefined,
+        task: selectedTask?.title || undefined,
+        start_time: startTime,
+        end_time: endTime,
+        is_billable: isBillable,
+        hourly_rate: Number.isNaN(rateNum) ? undefined : rateNum,
         notes: notes || undefined,
       });
-      toast.success('Timesheet created successfully');
-      setPeriodStart('');
-      setPeriodEnd('');
-      setNotes('');
+      toast.success('Timesheet logged successfully');
+      resetForm();
       onClose();
       onCreated();
     } catch (error) {
@@ -122,38 +217,107 @@ const CreateTimesheetModal: React.FC<CreateTimesheetModalProps> = ({ isOpen, onC
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} title="Create Timesheet">
+    <Modal isOpen={isOpen} onClose={onClose} title="Log Work / New Timesheet">
       <form onSubmit={handleSubmit} className="space-y-4">
+        {/* Customer — searchable, namespace-scoped */}
         <div>
-          <label className="block text-sm font-medium text-secondary-700 mb-1">Period Start</label>
-          <input
-            type="date"
-            value={periodStart}
-            onChange={(e) => setPeriodStart(e.target.value)}
-            className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 bg-surface"
-            required
+          <label className={labelClass}>Customer / Client</label>
+          <SearchableSelect
+            options={customerOptions}
+            value={customerUuid}
+            onChange={setCustomerUuid}
+            placeholder="Select a customer…"
+            searchPlaceholder="Search customers…"
+            emptyMessage="No customers found"
+            clearable
           />
         </div>
+
+        {/* Task — searchable, from kanban projects/tasks (namespace-scoped) */}
         <div>
-          <label className="block text-sm font-medium text-secondary-700 mb-1">Period End</label>
-          <input
-            type="date"
-            value={periodEnd}
-            onChange={(e) => setPeriodEnd(e.target.value)}
-            className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 bg-surface"
-            required
+          <label className={labelClass}>Task (from a project)</label>
+          <SearchableSelect
+            options={taskOptions}
+            value={taskUuid}
+            onChange={setTaskUuid}
+            placeholder="Select a task…"
+            searchPlaceholder="Search tasks…"
+            emptyMessage="No tasks found"
+            clearable
           />
         </div>
+
+        {/* Date + time */}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <div>
+            <label className={labelClass}>Work date</label>
+            <input type="date" value={workDate} onChange={(e) => setWorkDate(e.target.value)} className={inputClass} required />
+          </div>
+          <div>
+            <label className={labelClass}>Start time</label>
+            <input type="time" value={startTime} onChange={(e) => setStartTime(e.target.value)} className={inputClass} required />
+          </div>
+          <div>
+            <label className={labelClass}>End time</label>
+            <input type="time" value={endTime} onChange={(e) => setEndTime(e.target.value)} className={inputClass} required />
+          </div>
+        </div>
+
+        {/* Live hours + amount summary */}
+        <div className="flex items-center justify-between rounded-xl border border-primary-100 bg-primary-50/60 px-4 py-3">
+          <div className="flex items-center gap-2 text-secondary-700">
+            <Clock className="w-4 h-4 text-primary-500" />
+            <span className="text-sm font-medium">Worked hours</span>
+          </div>
+          <div className="text-right">
+            <span className="text-lg font-bold text-secondary-900">
+              {hours != null ? `${hours.toFixed(2)} h` : '—'}
+            </span>
+            {amount != null && (
+              <span className="block text-xs text-secondary-500">
+                ≈ {amount.toLocaleString(undefined, { style: 'currency', currency: 'GBP' })}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Billable + rate */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 items-end">
+          <label className="flex items-center gap-2 text-sm text-secondary-700 select-none cursor-pointer pb-2">
+            <input
+              type="checkbox"
+              checked={isBillable}
+              onChange={(e) => setIsBillable(e.target.checked)}
+              className="w-4 h-4 rounded border-secondary-300 text-primary-600 focus:ring-primary-500/30"
+            />
+            Billable to client
+          </label>
+          <div>
+            <label className={labelClass}>Hourly rate (optional)</label>
+            <input
+              type="number"
+              min="0"
+              step="0.01"
+              value={hourlyRate}
+              onChange={(e) => setHourlyRate(e.target.value)}
+              placeholder="e.g. 75"
+              className={inputClass}
+            />
+          </div>
+        </div>
+
+        {/* Notes */}
         <div>
-          <label className="block text-sm font-medium text-secondary-700 mb-1">Notes (optional)</label>
+          <label className={labelClass}>Notes (optional)</label>
           <textarea
             value={notes}
             onChange={(e) => setNotes(e.target.value)}
-            rows={3}
-            className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 bg-surface resize-none"
-            placeholder="Add any notes about this timesheet..."
+            rows={2}
+            className={`${inputClass} resize-none`}
+            placeholder="Anything else worth noting…"
           />
         </div>
+
         <div className="flex justify-end gap-3 pt-2">
           <button
             type="button"
@@ -167,7 +331,7 @@ const CreateTimesheetModal: React.FC<CreateTimesheetModalProps> = ({ isOpen, onC
             disabled={isSubmitting}
             className="px-4 py-2 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 disabled:opacity-50 transition-colors"
           >
-            {isSubmitting ? 'Creating...' : 'Create Timesheet'}
+            {isSubmitting ? 'Saving…' : 'Log Timesheet'}
           </button>
         </div>
       </form>
@@ -409,19 +573,22 @@ function TimesheetsPageContent() {
 
   const myTimesheetsColumns: TableColumn<Timesheet>[] = useMemo(() => [
     {
-      key: 'period',
-      header: 'Period',
+      key: 'work',
+      header: 'Customer / Work',
       render: (ts) => (
         <div className="flex items-center gap-3">
-          <div className="w-10 h-10 bg-secondary-100 rounded-lg flex items-center justify-center">
-            <FileText className="w-5 h-5 text-secondary-500" />
+          <div className="w-10 h-10 bg-primary-50 rounded-lg flex items-center justify-center flex-shrink-0">
+            <FileText className="w-5 h-5 text-primary-500" />
           </div>
-          <div>
-            <p className="font-medium text-secondary-900">
-              {formatDate(ts.period_start)} - {formatDate(ts.period_end)}
+          <div className="min-w-0">
+            <p className="font-medium text-secondary-900 truncate">
+              {ts.client_name || 'No customer'}
             </p>
-            <p className="text-xs text-secondary-500">
-              {ts.notes ? ts.notes.slice(0, 40) + (ts.notes.length > 40 ? '...' : '') : 'No notes'}
+            <p className="text-xs text-secondary-500 truncate">
+              {ts.task || (ts.notes ? ts.notes.slice(0, 40) : '—')}
+              {ts.project_name ? ` · ${ts.project_name}` : ''}
+              {' · '}
+              {ts.work_date ? formatDate(ts.work_date) : `${formatDate(ts.period_start)} – ${formatDate(ts.period_end)}`}
             </p>
           </div>
         </div>
@@ -434,17 +601,36 @@ function TimesheetsPageContent() {
     },
     {
       key: 'total_hours',
-      header: 'Total Hours',
+      header: 'Hours',
       render: (ts) => (
-        <span className="font-semibold text-secondary-900">{ts.total_hours?.toFixed(1) || '0.0'}</span>
+        <div>
+          <span className="font-semibold text-secondary-900">{ts.total_hours?.toFixed(2) || '0.00'}</span>
+          {ts.start_time && ts.end_time && (
+            <span className="block text-xs text-secondary-400">
+              {ts.start_time.slice(0, 5)}–{ts.end_time.slice(0, 5)}
+            </span>
+          )}
+        </div>
       ),
     },
     {
-      key: 'billable_hours',
-      header: 'Billable Hours',
-      render: (ts) => (
-        <span className="text-secondary-700">{ts.billable_hours?.toFixed(1) || '0.0'}</span>
-      ),
+      key: 'amount',
+      header: 'Amount',
+      render: (ts) => {
+        const rate = typeof ts.hourly_rate === 'string' ? parseFloat(ts.hourly_rate) : ts.hourly_rate;
+        if (!rate || Number.isNaN(rate)) {
+          return <span className="text-secondary-400">—</span>;
+        }
+        const amount = (ts.billable_hours || 0) * rate;
+        return (
+          <div>
+            <span className="font-semibold text-secondary-900">
+              {amount.toLocaleString(undefined, { style: 'currency', currency: 'GBP' })}
+            </span>
+            <span className="block text-xs text-secondary-400">@ {rate}/h</span>
+          </div>
+        );
+      },
     },
     {
       key: 'submitted_at',

--- a/opsapi-dashboard/app/dashboard/timesheets/page.tsx
+++ b/opsapi-dashboard/app/dashboard/timesheets/page.tsx
@@ -139,6 +139,15 @@ const CreateTimesheetModal: React.FC<CreateTimesheetModalProps> = ({ isOpen, onC
     };
   }, [isOpen]);
 
+  // Server-side search: the lookups cap at 100 rows, so refetch as the user types
+  // to reach customers/tasks beyond the first page rather than filtering locally.
+  const handleCustomerSearch = useCallback((q: string) => {
+    timesheetsService.lookupCustomers(q).then(setCustomers).catch(() => {});
+  }, []);
+  const handleTaskSearch = useCallback((q: string) => {
+    timesheetsService.lookupTasks(q).then(setTasks).catch(() => {});
+  }, []);
+
   const customerOptions = useMemo(
     () =>
       customers.map((c) => ({
@@ -156,6 +165,13 @@ const CreateTimesheetModal: React.FC<CreateTimesheetModalProps> = ({ isOpen, onC
         hint: t.project_name || undefined,
       })),
     [tasks]
+  );
+
+  // Project derived from the selected task (resolved server-side too, but shown
+  // here so the user sees which project this timesheet will be pinned to).
+  const derivedProjectName = useMemo(
+    () => tasks.find((t) => t.task_uuid === taskUuid)?.project_name || '',
+    [tasks, taskUuid]
   );
 
   const hours = useMemo(() => computeHours(startTime, endTime), [startTime, endTime]);
@@ -226,6 +242,7 @@ const CreateTimesheetModal: React.FC<CreateTimesheetModalProps> = ({ isOpen, onC
             options={customerOptions}
             value={customerUuid}
             onChange={setCustomerUuid}
+            onSearch={handleCustomerSearch}
             placeholder="Select a customer…"
             searchPlaceholder="Search customers…"
             emptyMessage="No customers found"
@@ -240,11 +257,18 @@ const CreateTimesheetModal: React.FC<CreateTimesheetModalProps> = ({ isOpen, onC
             options={taskOptions}
             value={taskUuid}
             onChange={setTaskUuid}
+            onSearch={handleTaskSearch}
             placeholder="Select a task…"
             searchPlaceholder="Search tasks…"
             emptyMessage="No tasks found"
             clearable
           />
+          {/* Derived project — selecting a task pins its parent project on the timesheet. */}
+          {derivedProjectName && (
+            <p className="mt-1 text-xs text-secondary-500">
+              Project: <span className="font-medium text-secondary-700">{derivedProjectName}</span>
+            </p>
+          )}
         </div>
 
         {/* Date + time */}

--- a/opsapi-dashboard/app/login/page.tsx
+++ b/opsapi-dashboard/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { LoginForm } from "@/components/auth";
+import PublicThemeStyles from "@/components/layout/PublicThemeStyles";
 import { useAuthStore } from "@/store/auth.store";
 import { AUTH_TOKEN_KEY } from "@/lib/api-client";
 import { Loader2 } from "lucide-react";
@@ -42,6 +43,8 @@ export default function LoginPage() {
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-linear-to-br from-secondary-900 via-secondary-800 to-primary-900 p-4">
+      {/* Apply the active/default theme so login matches the rest of the site */}
+      <PublicThemeStyles />
       {/* Background Pattern */}
       <div className="absolute inset-0 overflow-hidden">
         <div className="absolute -top-1/2 -right-1/2 w-full h-full bg-primary-500/10 rounded-full blur-3xl" />

--- a/opsapi-dashboard/app/verify-otp/page.tsx
+++ b/opsapi-dashboard/app/verify-otp/page.tsx
@@ -4,6 +4,7 @@ import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { ShieldCheck, AlertCircle, Loader2, ArrowLeft, RotateCw } from 'lucide-react';
 import { Card, Button } from '@/components/ui';
+import PublicThemeStyles from '@/components/layout/PublicThemeStyles';
 import { useAuthStore } from '@/store/auth.store';
 import { authService } from '@/services/auth.service';
 import { AUTH_TOKEN_KEY } from '@/lib/api-client';
@@ -196,6 +197,8 @@ export default function VerifyOtpPage() {
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-secondary-900 via-secondary-800 to-primary-900 p-4">
+      {/* Apply the active/default theme so 2FA matches the rest of the site */}
+      <PublicThemeStyles />
       {/* Background Pattern */}
       <div className="absolute inset-0 overflow-hidden">
         <div className="absolute -top-1/2 -right-1/2 w-full h-full bg-primary-500/10 rounded-full blur-3xl" />

--- a/opsapi-dashboard/components/dashboard/OrdersChart.tsx
+++ b/opsapi-dashboard/components/dashboard/OrdersChart.tsx
@@ -43,11 +43,11 @@ const CustomTooltip = memo(function CustomTooltip({
 // Loading state component
 const ChartLoading = memo(function ChartLoading() {
   return (
-    <Card padding="none" className="h-[400px]">
-      <div className="px-6 py-4 border-b border-secondary-200">
+    <Card padding="none" className="h-full min-h-[400px] flex flex-col shadow-sm">
+      <div className="px-6 py-4 border-b border-secondary-200 flex-shrink-0">
         <h3 className="text-lg font-semibold text-secondary-900">Revenue Overview</h3>
       </div>
-      <div className="flex items-center justify-center h-[320px]">
+      <div className="flex items-center justify-center flex-1 min-h-0">
         <Loader2 className="w-8 h-8 text-primary-500 animate-spin" />
       </div>
     </Card>
@@ -78,10 +78,10 @@ const OrdersChart: React.FC<OrdersChartProps> = memo(function OrdersChart({
   }
 
   return (
-    <Card padding="none" className="h-[400px]">
-      <div className="px-6 py-4 border-b border-secondary-200 flex items-center justify-between">
+    <Card padding="none" className="h-full min-h-[400px] flex flex-col shadow-sm">
+      <div className="px-6 py-4 border-b border-secondary-200 flex items-center justify-between flex-shrink-0">
         <div className="flex items-center gap-3">
-          <div className="w-10 h-10 gradient-primary rounded-lg flex items-center justify-center shadow-md shadow-primary-500/25">
+          <div className="w-10 h-10 gradient-primary rounded-lg flex items-center justify-center shadow-md shadow-primary-500/25 ring-1 ring-white/20">
             <BarChart3 className="w-5 h-5 text-white" />
           </div>
           <div>
@@ -91,7 +91,7 @@ const OrdersChart: React.FC<OrdersChartProps> = memo(function OrdersChart({
         </div>
       </div>
 
-      <div className="p-6 h-[320px]">
+      <div className="p-6 flex-1 min-h-0">
         {data.length === 0 ? (
           <ChartEmpty />
         ) : (

--- a/opsapi-dashboard/components/dashboard/StatsCard.tsx
+++ b/opsapi-dashboard/components/dashboard/StatsCard.tsx
@@ -29,35 +29,44 @@ const StatsCard: React.FC<StatsCardProps> = memo(function StatsCard({
   return (
     <div
       className={cn(
-        'bg-surface rounded-xl border border-secondary-200 p-4 sm:p-6 hover:shadow-lg transition-shadow duration-300',
+        'group relative overflow-hidden bg-surface rounded-2xl border border-secondary-200/70',
+        'p-4 sm:p-6 shadow-sm transition-all duration-300',
+        'hover:shadow-xl hover:shadow-secondary-900/5 hover:-translate-y-0.5 hover:border-primary-200',
         className
       )}
     >
-      <div className="flex items-start justify-between gap-2">
+      {/* Top accent bar — reveals on hover */}
+      <div className="absolute inset-x-0 top-0 h-1 gradient-primary opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+      {/* Soft brand glow in the corner */}
+      <div className="pointer-events-none absolute -top-10 -right-10 w-28 h-28 rounded-full bg-primary-500/5 blur-2xl opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
+
+      <div className="relative flex items-start justify-between gap-3">
         <div className="flex-1 min-w-0">
           <p className="text-xs sm:text-sm font-medium text-secondary-500 truncate">{title}</p>
 
           {isLoading ? (
-            <div className="h-6 sm:h-8 w-16 sm:w-20 bg-secondary-200 rounded animate-pulse mt-1 sm:mt-2" />
+            <div className="h-7 sm:h-9 w-20 sm:w-24 bg-secondary-200 rounded-lg animate-pulse mt-2" />
           ) : (
-            <p className="text-lg sm:text-2xl font-bold text-secondary-900 mt-1 sm:mt-2 truncate">
+            <p className="text-2xl sm:text-3xl font-bold tracking-tight text-secondary-900 mt-1.5 sm:mt-2 truncate">
               {value}
             </p>
           )}
 
           {trend && !isLoading && (
-            <div className="flex items-center gap-1 mt-2 sm:mt-3 flex-wrap">
-              {trend.isPositive ? (
-                <TrendingUp className="w-3 h-3 sm:w-4 sm:h-4 text-success-500 flex-shrink-0" />
-              ) : (
-                <TrendingDown className="w-3 h-3 sm:w-4 sm:h-4 text-error-500 flex-shrink-0" />
-              )}
+            <div className="flex items-center gap-2 mt-3 flex-wrap">
               <span
                 className={cn(
-                  'text-xs sm:text-sm font-medium',
-                  trend.isPositive ? 'text-success-600' : 'text-error-600'
+                  'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold',
+                  trend.isPositive
+                    ? 'bg-success-500/10 text-success-600'
+                    : 'bg-error-500/10 text-error-600'
                 )}
               >
+                {trend.isPositive ? (
+                  <TrendingUp className="w-3.5 h-3.5 flex-shrink-0" />
+                ) : (
+                  <TrendingDown className="w-3.5 h-3.5 flex-shrink-0" />
+                )}
                 {trend.isPositive ? '+' : '-'}
                 {Math.abs(trend.value)}%
               </span>
@@ -68,11 +77,11 @@ const StatsCard: React.FC<StatsCardProps> = memo(function StatsCard({
           )}
 
           {isLoading && (
-            <div className="h-3 sm:h-4 w-20 sm:w-24 bg-secondary-100 rounded animate-pulse mt-2 sm:mt-3" />
+            <div className="h-4 w-24 bg-secondary-100 rounded animate-pulse mt-3" />
           )}
         </div>
 
-        <div className="w-10 h-10 sm:w-12 sm:h-12 gradient-primary rounded-lg sm:rounded-xl flex items-center justify-center text-white shadow-lg shadow-primary-500/25 flex-shrink-0">
+        <div className="w-11 h-11 sm:w-12 sm:h-12 gradient-primary rounded-xl flex items-center justify-center text-white shadow-lg shadow-primary-500/25 ring-1 ring-white/20 flex-shrink-0 transition-transform duration-300 group-hover:scale-105">
           <div className="[&>svg]:w-5 [&>svg]:h-5 sm:[&>svg]:w-6 sm:[&>svg]:h-6">{icon}</div>
         </div>
       </div>

--- a/opsapi-dashboard/components/layout/PublicThemeStyles.tsx
+++ b/opsapi-dashboard/components/layout/PublicThemeStyles.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * PublicThemeStyles — injects the active theme CSS on UNAUTHENTICATED pages
+ * (login, verify-otp) so the whole site is themed, not just the dashboard.
+ *
+ * Unlike <ThemeStyles/>, this does NOT depend on NamespaceContext (which only
+ * exists inside DashboardLayout). It resolves the tenant from an explicit
+ * `?namespace=` query param or the host subdomain; with neither it falls back
+ * to the platform default theme (the pink #ff004e "OpsAPI Bright" preset).
+ *
+ * It targets the same <link id> as ThemeStyles, so once the dashboard mounts
+ * its namespace-aware loader, that takes over seamlessly.
+ */
+const LINK_ID = 'ops-active-theme-css';
+
+function apiBase(): string {
+  return process.env.NEXT_PUBLIC_API_URL || 'http://127.0.0.1:4010';
+}
+
+function resolveSlug(): string | undefined {
+  if (typeof window === 'undefined') return undefined;
+
+  // 1. Explicit query param wins (?namespace=acme)
+  const param = new URLSearchParams(window.location.search).get('namespace');
+  if (param) return param;
+
+  // 2. Host subdomain (acme.opsapi.com -> "acme"), skipping IPs and generic hosts
+  const host = window.location.hostname;
+  const isIp = /^\d{1,3}(\.\d{1,3}){3}$/.test(host);
+  if (!isIp) {
+    const parts = host.split('.');
+    const generic = ['www', 'app', 'dashboard', 'api', 'localhost'];
+    if (parts.length > 2 && parts[0] && !generic.includes(parts[0])) {
+      return parts[0];
+    }
+  }
+
+  // 3. No tenant context -> platform default (pink) theme
+  return undefined;
+}
+
+export default function PublicThemeStyles() {
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+
+    const slug = resolveSlug();
+    const base = `${apiBase()}/api/v2/themes/active/styles.css`;
+    const href = slug ? `${base}?namespace=${encodeURIComponent(slug)}` : base;
+
+    let link = document.getElementById(LINK_ID) as HTMLLinkElement | null;
+    if (!link) {
+      link = document.createElement('link');
+      link.id = LINK_ID;
+      link.rel = 'stylesheet';
+      document.head.appendChild(link);
+    }
+    if (link.href !== href) link.href = href;
+  }, []);
+
+  return null;
+}

--- a/opsapi-dashboard/components/ui/SearchableSelect.tsx
+++ b/opsapi-dashboard/components/ui/SearchableSelect.tsx
@@ -28,6 +28,11 @@ export interface SearchableSelectProps {
   autoFocus?: boolean;
   // Called when the dropdown closes without a selection (e.g. on blur/escape).
   onClose?: () => void;
+  // Optional server-side search. When provided, the typed query is forwarded
+  // (debounced) so the parent can fetch matching options — letting the dropdown
+  // reach records beyond a server-side result cap instead of only filtering the
+  // initial page client-side. Client-side filtering of `options` still applies.
+  onSearch?: (query: string) => void;
 }
 
 const SearchableSelect: React.FC<SearchableSelectProps> = ({
@@ -44,6 +49,7 @@ const SearchableSelect: React.FC<SearchableSelectProps> = ({
   className,
   autoFocus = false,
   onClose,
+  onSearch,
 }) => {
   const [open, setOpen] = useState(autoFocus);
   const [query, setQuery] = useState('');
@@ -65,6 +71,16 @@ const SearchableSelect: React.FC<SearchableSelectProps> = ({
         o.hint?.toLowerCase().includes(q)
     );
   }, [options, query]);
+
+  // Debounced server-side search: forward the typed query to the parent so it
+  // can refetch options. Only active when an onSearch handler is supplied.
+  const onSearchRef = useRef(onSearch);
+  onSearchRef.current = onSearch;
+  useEffect(() => {
+    if (!onSearchRef.current || !open) return;
+    const t = setTimeout(() => onSearchRef.current?.(query.trim()), 250);
+    return () => clearTimeout(t);
+  }, [query, open]);
 
   const close = () => {
     setOpen(false);

--- a/opsapi-dashboard/hooks/useMenu.ts
+++ b/opsapi-dashboard/hooks/useMenu.ts
@@ -50,6 +50,13 @@ async function loadIconMap(): Promise<Record<string, LucideIcon>> {
     Kanban: icons.Kanban,
     Heart: icons.Heart,
     Calculator: icons.Calculator,
+    FileText: icons.FileText,
+    Clock: icons.Clock,
+    BookOpen: icons.BookOpen,
+    Contact: icons.Contact,
+    Landmark: icons.Landmark,
+    FileUp: icons.FileUp,
+    ArrowLeftRight: icons.ArrowLeftRight,
     HelpCircle: icons.HelpCircle,
   };
   return ICON_MAP;

--- a/opsapi-dashboard/lib/invoice-pdf.ts
+++ b/opsapi-dashboard/lib/invoice-pdf.ts
@@ -1,0 +1,308 @@
+import { jsPDF } from 'jspdf';
+import autoTable from 'jspdf-autotable';
+import type { Invoice } from '@/services/invoices.service';
+
+// The "from" party printed at the top of the invoice. Name is required (the
+// namespace name); the rest are optional and omitted from the header when absent.
+export interface InvoiceCompany {
+  name: string;
+  address?: string;
+  email?: string;
+  phone?: string;
+  taxId?: string;
+}
+
+// Optional extra customer detail the Invoice type doesn't formally declare but
+// the backend may carry through (customer_address).
+type InvoiceWithAddress = Invoice & { customer_address?: string | null };
+
+// ---- Palette ----
+const NAVY: [number, number, number] = [15, 23, 42]; // header band
+const ACCENT: [number, number, number] = [37, 99, 235]; // primary-600
+const DARK: [number, number, number] = [30, 41, 59]; // body text
+const MUTED: [number, number, number] = [100, 116, 139]; // secondary-500
+const FAINT: [number, number, number] = [148, 163, 184]; // on-navy subtext
+const LINE: [number, number, number] = [226, 232, 240]; // hairlines
+const SOFT: [number, number, number] = [248, 250, 252]; // zebra / card bg
+const ACCENT_SOFT: [number, number, number] = [219, 234, 254]; // blue-100 highlight
+
+const STATUS_COLORS: Record<string, [number, number, number]> = {
+  draft: [100, 116, 139],
+  sent: [37, 99, 235],
+  paid: [22, 163, 74],
+  partially_paid: [202, 138, 4],
+  overdue: [220, 38, 38],
+  cancelled: [100, 116, 139],
+  void: [100, 116, 139],
+};
+
+function money(amount: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat('en-GB', { style: 'currency', currency: currency || 'GBP' }).format(
+      Number(amount) || 0
+    );
+  } catch {
+    return `${currency} ${(Number(amount) || 0).toFixed(2)}`;
+  }
+}
+
+function initials(name: string): string {
+  const parts = (name || '').trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return 'IN';
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+function invoiceFileName(invoice: InvoiceWithAddress): string {
+  return `Invoice-${invoice.invoice_number || invoice.uuid.slice(0, 8)}.pdf`;
+}
+
+/**
+ * Build the polished, professional invoice PDF document (no I/O).
+ * Pure client-side (jsPDF) — crisp vector text, no server tooling required.
+ * The namespace/company name is featured in a branded header band up top.
+ */
+function buildInvoiceDoc(invoice: InvoiceWithAddress, company: InvoiceCompany): jsPDF {
+  const doc = new jsPDF({ unit: 'pt', format: 'a4' });
+  const pageW = doc.internal.pageSize.getWidth();
+  const pageH = doc.internal.pageSize.getHeight();
+  const margin = 44;
+  const right = pageW - margin;
+  const currency = invoice.currency || 'GBP';
+
+  // ============================================================
+  // Header band (branded) — namespace name + INVOICE
+  // ============================================================
+  const bandH = 120;
+  doc.setFillColor(...NAVY);
+  doc.rect(0, 0, pageW, bandH, 'F');
+  // Accent stripe along the bottom of the band.
+  doc.setFillColor(...ACCENT);
+  doc.rect(0, bandH, pageW, 4, 'F');
+
+  // Monogram badge.
+  const badgeCx = margin + 17;
+  const badgeCy = 50;
+  doc.setFillColor(...ACCENT);
+  doc.circle(badgeCx, badgeCy, 17, 'F');
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(13);
+  doc.setTextColor(255, 255, 255);
+  doc.text(initials(company.name), badgeCx, badgeCy + 4.5, { align: 'center' });
+
+  // Company / namespace name + contact lines.
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(19);
+  doc.setTextColor(255, 255, 255);
+  doc.text(company.name || 'Your Company', margin + 44, 50);
+
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(8.5);
+  doc.setTextColor(...FAINT);
+  let hy = 70;
+  for (const line of [company.address, company.email, company.phone, company.taxId ? `Tax ID: ${company.taxId}` : undefined]) {
+    if (line) {
+      doc.text(String(line), margin + 44, hy);
+      hy += 12;
+    }
+  }
+
+  // INVOICE title + number (right side of the band).
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(30);
+  doc.setTextColor(255, 255, 255);
+  doc.text('INVOICE', right, 50, { align: 'right' });
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(11);
+  doc.setTextColor(...FAINT);
+  doc.text(`# ${invoice.invoice_number || invoice.uuid.slice(0, 8)}`, right, 70, { align: 'right' });
+
+  // Status pill (right, inside band).
+  const statusColor = STATUS_COLORS[invoice.status] || MUTED;
+  const statusLabel = (invoice.status || 'draft').replace('_', ' ').toUpperCase();
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(8.5);
+  const pillW = doc.getTextWidth(statusLabel) + 18;
+  doc.setFillColor(...statusColor);
+  doc.roundedRect(right - pillW, 82, pillW, 17, 8.5, 8.5, 'F');
+  doc.setTextColor(255, 255, 255);
+  doc.text(statusLabel, right - pillW / 2, 93.5, { align: 'center' });
+
+  // ============================================================
+  // Bill-to + meta row
+  // ============================================================
+  const y = bandH + 36;
+
+  // Bill To (left).
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(8.5);
+  doc.setTextColor(...MUTED);
+  doc.text('BILLED TO', margin, y);
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(13);
+  doc.setTextColor(...DARK);
+  doc.text(invoice.customer_name || 'Customer', margin, y + 18);
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(9.5);
+  doc.setTextColor(...MUTED);
+  let by = y + 34;
+  for (const line of [invoice.customer_email, invoice.customer_address]) {
+    if (line) {
+      doc.text(String(line), margin, by);
+      by += 14;
+    }
+  }
+
+  // Meta (right): issue date, due date.
+  const metaLabelX = right - 190;
+  const metaRows: [string, string][] = [
+    ['Issue Date', invoice.issue_date || '—'],
+    ['Due Date', invoice.due_date || '—'],
+  ];
+  let myy = y;
+  for (const [label, value] of metaRows) {
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(9.5);
+    doc.setTextColor(...MUTED);
+    doc.text(label, metaLabelX, myy);
+    doc.setFont('helvetica', 'bold');
+    doc.setTextColor(...DARK);
+    doc.text(String(value), right, myy, { align: 'right' });
+    myy += 17;
+  }
+  // Amount Due call-out (right, emphasized).
+  doc.setFillColor(...ACCENT_SOFT);
+  doc.roundedRect(metaLabelX - 12, myy - 2, right - metaLabelX + 12, 30, 5, 5, 'F');
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(9);
+  doc.setTextColor(...MUTED);
+  doc.text('Amount Due', metaLabelX, myy + 13);
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(13);
+  doc.setTextColor(...ACCENT);
+  doc.text(money(invoice.balance_due, currency), right - 8, myy + 14, { align: 'right' });
+
+  // ============================================================
+  // Line items
+  // ============================================================
+  const items = invoice.items || [];
+  autoTable(doc, {
+    startY: Math.max(by, myy + 44) + 10,
+    margin: { left: margin, right: margin },
+    head: [['#', 'Description', 'Qty', 'Unit Price', 'Tax', 'Amount']],
+    body: items.map((it, i) => [
+      String(i + 1),
+      it.description || '—',
+      (Number(it.quantity) || 0).toString(),
+      money(Number(it.unit_price) || 0, currency),
+      money(Number(it.tax_amount) || 0, currency),
+      money(Number(it.total) || 0, currency),
+    ]),
+    styles: { font: 'helvetica', fontSize: 9.5, cellPadding: 9, textColor: DARK, lineColor: LINE, lineWidth: 0.5 },
+    headStyles: {
+      fillColor: NAVY,
+      textColor: [255, 255, 255],
+      fontStyle: 'bold',
+      fontSize: 8.5,
+      cellPadding: { top: 8, bottom: 8, left: 9, right: 9 },
+    },
+    bodyStyles: { lineColor: LINE, lineWidth: { top: 0, bottom: 0.5, left: 0, right: 0 } },
+    alternateRowStyles: { fillColor: SOFT },
+    columnStyles: {
+      0: { cellWidth: 26, halign: 'center', textColor: MUTED },
+      1: { cellWidth: 'auto' },
+      2: { halign: 'right', cellWidth: 46 },
+      3: { halign: 'right', cellWidth: 78 },
+      4: { halign: 'right', cellWidth: 64 },
+      5: { halign: 'right', cellWidth: 82, fontStyle: 'bold' },
+    },
+  });
+
+  // ============================================================
+  // Totals card (right) + notes (left)
+  // ============================================================
+  const afterTable = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 18;
+  const boxW = 250;
+  const boxX = right - boxW;
+
+  const rows: { label: string; value: string; strong?: boolean }[] = [
+    { label: 'Subtotal', value: money(invoice.subtotal, currency) },
+    { label: 'Tax', value: money(invoice.tax_total, currency) },
+    { label: 'Total', value: money(invoice.total, currency), strong: true },
+    { label: 'Amount Paid', value: money(invoice.amount_paid, currency) },
+  ];
+
+  let ty = afterTable;
+  for (const r of rows) {
+    if (r.strong) {
+      doc.setDrawColor(...LINE);
+      doc.setLineWidth(0.5);
+      doc.line(boxX, ty - 5, right, ty - 5);
+    }
+    doc.setFont('helvetica', r.strong ? 'bold' : 'normal');
+    doc.setFontSize(r.strong ? 11 : 10);
+    doc.setTextColor(...(r.strong ? DARK : MUTED));
+    doc.text(r.label, boxX, ty + 8);
+    doc.setTextColor(...DARK);
+    doc.text(r.value, right, ty + 8, { align: 'right' });
+    ty += r.strong ? 22 : 17;
+  }
+
+  // Balance Due — emphasized accent band.
+  ty += 2;
+  doc.setFillColor(...ACCENT);
+  doc.roundedRect(boxX, ty, boxW, 30, 5, 5, 'F');
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(11);
+  doc.setTextColor(255, 255, 255);
+  doc.text('Balance Due', boxX + 12, ty + 19);
+  doc.setFontSize(13);
+  doc.text(money(invoice.balance_due, currency), right - 12, ty + 19, { align: 'right' });
+
+  // Notes (left, aligned with the totals top).
+  if (invoice.notes) {
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(8.5);
+    doc.setTextColor(...MUTED);
+    doc.text('NOTES', margin, afterTable + 8);
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(9.5);
+    doc.setTextColor(...DARK);
+    const noteLines = doc.splitTextToSize(invoice.notes, boxX - margin - 24);
+    doc.text(noteLines, margin, afterTable + 23);
+  }
+
+  // ============================================================
+  // Footer
+  // ============================================================
+  doc.setDrawColor(...LINE);
+  doc.setLineWidth(0.5);
+  doc.line(margin, pageH - 58, right, pageH - 58);
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(9.5);
+  doc.setTextColor(...DARK);
+  doc.text('Thank you for your business.', margin, pageH - 40);
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(8.5);
+  doc.setTextColor(...MUTED);
+  const terms = invoice.payment_terms_days ? `Payment terms: net ${invoice.payment_terms_days} days` : '';
+  if (terms) doc.text(terms, margin, pageH - 28);
+  doc.text(`${company.name || ''}`, right, pageH - 40, { align: 'right' });
+  doc.text(`Invoice ${invoice.invoice_number || ''}`, right, pageH - 28, { align: 'right' });
+
+  return doc;
+}
+
+/** Build the invoice PDF and trigger a download. */
+export function generateInvoicePdf(invoice: InvoiceWithAddress, company: InvoiceCompany): void {
+  buildInvoiceDoc(invoice, company).save(invoiceFileName(invoice));
+}
+
+/**
+ * Build the invoice PDF and return an object URL for in-app preview (e.g. an
+ * <iframe>). Caller owns the URL and must URL.revokeObjectURL() it when done.
+ */
+export function previewInvoicePdfUrl(invoice: InvoiceWithAddress, company: InvoiceCompany): string {
+  const blob = buildInvoiceDoc(invoice, company).output('blob');
+  return URL.createObjectURL(blob);
+}

--- a/opsapi-dashboard/package-lock.json
+++ b/opsapi-dashboard/package-lock.json
@@ -14,6 +14,8 @@
         "axios": "^1.13.2",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "jspdf": "^4.2.1",
+        "jspdf-autotable": "^5.0.8",
         "lucide-react": "^0.555.0",
         "next": "16.2.3",
         "react": "19.2.0",
@@ -239,6 +241,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1798,6 +1809,19 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
@@ -1829,6 +1853,13 @@
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.10.tgz",
       "integrity": "sha512-TC0dmN0K8YcWEAEfiPi5gJP14eJe30TTGjkvek3iM/1NdHHsdCA/Td6GvNndMOo/iSnIsZ4HuuhrYPDAmbxzww==",
       "dev": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -2833,6 +2864,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -3063,6 +3104,26 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -3255,6 +3316,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -3274,6 +3347,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/csstype": {
@@ -3676,6 +3759,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.9.tgz",
+      "integrity": "sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -4531,6 +4624,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -4548,6 +4652,12 @@
       "dependencies": {
         "pend": "~1.2.0"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/figures": {
       "version": "3.2.0",
@@ -5093,6 +5203,20 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/http-signature": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.4.0.tgz",
@@ -5222,6 +5346,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
@@ -5862,6 +5992,32 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/jspdf-autotable": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-5.0.8.tgz",
+      "integrity": "sha512-Hy05N86yBO7CXBrnSLOge7i1ZYpKH2DjQ94iybaP7vBhSInjvRBgDc99ngKzSbSO8Jc98ZCally8I6n0tj2RJQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jspdf": "^2 || ^3 || ^4"
       }
     },
     "node_modules/jsprim": {
@@ -6854,6 +7010,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6913,7 +7075,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -7099,6 +7261,16 @@
         }
       ]
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
@@ -7229,6 +7401,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -7333,6 +7512,16 @@
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -7742,6 +7931,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/start-server-and-test": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-2.1.3.tgz",
@@ -8059,6 +8258,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.17.tgz",
@@ -8078,6 +8287,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/throttleit": {
@@ -8535,6 +8754,16 @@
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/opsapi-dashboard/package.json
+++ b/opsapi-dashboard/package.json
@@ -22,6 +22,8 @@
     "axios": "^1.13.2",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "jspdf": "^4.2.1",
+    "jspdf-autotable": "^5.0.8",
     "lucide-react": "^0.555.0",
     "next": "16.2.3",
     "react": "19.2.0",

--- a/opsapi-dashboard/services/accounting.service.ts
+++ b/opsapi-dashboard/services/accounting.service.ts
@@ -218,6 +218,13 @@ const BASE = '/api/v2/accounting';
 
 // ── Helper ─────────────────────────────────────────────────────────────────────
 
+// Coerce a value to an array. Empty Lua tables can serialise as `{}` (object)
+// rather than `[]`, so report list fields are guarded before the UI calls .map().
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function asArray<T = any>(v: any): T[] {
+  return Array.isArray(v) ? v : [];
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function buildParams(filters: any): Record<string, string | number> {
   const params: Record<string, string | number> = {};
@@ -253,17 +260,17 @@ export const accountingService = {
 
   async getAccount(uuid: string): Promise<AccountingAccount> {
     const response = await apiClient.get(`${BASE}/accounts/${uuid}`);
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async createAccount(data: Partial<AccountingAccount>): Promise<AccountingAccount> {
     const response = await apiClient.post(`${BASE}/accounts`, toFormData(data as Record<string, unknown>));
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async updateAccount(uuid: string, data: Partial<AccountingAccount>): Promise<AccountingAccount> {
     const response = await apiClient.put(`${BASE}/accounts/${uuid}`, toFormData(data as Record<string, unknown>));
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async deleteAccount(uuid: string): Promise<void> {
@@ -287,17 +294,17 @@ export const accountingService = {
 
   async getJournalEntry(uuid: string): Promise<JournalEntry> {
     const response = await apiClient.get(`${BASE}/journal-entries/${uuid}`);
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async createJournalEntry(data: { entry_date: string; description: string; reference?: string; lines: Omit<JournalLine, 'id'>[] }): Promise<JournalEntry> {
     const response = await apiClient.post(`${BASE}/journal-entries`, toFormData(data as unknown as Record<string, unknown>));
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async voidJournalEntry(uuid: string): Promise<{ message: string }> {
     const response = await apiClient.post(`${BASE}/journal-entries/${uuid}/void`);
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   // ── Bank Transactions ──────────────────────────────────────────────────────
@@ -317,22 +324,22 @@ export const accountingService = {
 
   async getBankTransaction(uuid: string): Promise<BankTransaction> {
     const response = await apiClient.get(`${BASE}/bank-transactions/${uuid}`);
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async updateBankTransaction(uuid: string, data: Partial<BankTransaction>): Promise<BankTransaction> {
     const response = await apiClient.put(`${BASE}/bank-transactions/${uuid}`, toFormData(data as Record<string, unknown>));
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async importBankTransactions(data: { csv_content?: string; transactions?: Partial<BankTransaction>[] }): Promise<{ imported: number; message: string }> {
     const response = await apiClient.post(`${BASE}/bank-transactions/import`, toFormData(data as unknown as Record<string, unknown>));
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async reconcileTransaction(uuid: string, data: { account_id: number }): Promise<BankTransaction> {
     const response = await apiClient.post(`${BASE}/bank-transactions/${uuid}/reconcile`, toFormData(data as Record<string, unknown>));
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   // ── Expenses ───────────────────────────────────────────────────────────────
@@ -352,17 +359,17 @@ export const accountingService = {
 
   async getExpense(uuid: string): Promise<Expense> {
     const response = await apiClient.get(`${BASE}/expenses/${uuid}`);
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async createExpense(data: Partial<Expense>): Promise<Expense> {
     const response = await apiClient.post(`${BASE}/expenses`, toFormData(data as Record<string, unknown>));
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async updateExpense(uuid: string, data: Partial<Expense>): Promise<Expense> {
     const response = await apiClient.put(`${BASE}/expenses/${uuid}`, toFormData(data as Record<string, unknown>));
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async deleteExpense(uuid: string): Promise<void> {
@@ -371,12 +378,12 @@ export const accountingService = {
 
   async approveExpense(uuid: string): Promise<Expense> {
     const response = await apiClient.post(`${BASE}/expenses/${uuid}/approve`);
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async rejectExpense(uuid: string): Promise<Expense> {
     const response = await apiClient.post(`${BASE}/expenses/${uuid}/reject`);
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   // ── VAT Returns ────────────────────────────────────────────────────────────
@@ -388,17 +395,17 @@ export const accountingService = {
 
   async getVatReturn(uuid: string): Promise<VatReturn> {
     const response = await apiClient.get(`${BASE}/vat-returns/${uuid}`);
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async createVatReturn(data: { period_start: string; period_end: string }): Promise<VatReturn> {
     const response = await apiClient.post(`${BASE}/vat-returns`, toFormData(data as Record<string, unknown>));
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async submitVatReturn(uuid: string): Promise<VatReturn> {
     const response = await apiClient.post(`${BASE}/vat-returns/${uuid}/submit`);
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   // ── Reports ────────────────────────────────────────────────────────────────
@@ -406,52 +413,56 @@ export const accountingService = {
   async getTrialBalance(params?: { date_from?: string; date_to?: string }): Promise<TrialBalance> {
     const qs = params ? buildQueryString(params) : '';
     const response = await apiClient.get(`${BASE}/reports/trial-balance${qs}`);
-    return response.data;
+    const d = response.data?.data ?? response.data;
+    return { ...d, accounts: asArray(d?.accounts) };
   },
 
   async getBalanceSheet(params?: { as_of_date?: string }): Promise<BalanceSheet> {
     const qs = params ? buildQueryString(params) : '';
     const response = await apiClient.get(`${BASE}/reports/balance-sheet${qs}`);
-    return response.data;
+    const d = response.data?.data ?? response.data;
+    return { ...d, assets: asArray(d?.assets), liabilities: asArray(d?.liabilities), equity: asArray(d?.equity) };
   },
 
   async getProfitAndLoss(params?: { date_from?: string; date_to?: string }): Promise<ProfitAndLoss> {
     const qs = params ? buildQueryString(params) : '';
     const response = await apiClient.get(`${BASE}/reports/profit-and-loss${qs}`);
-    return response.data;
+    const d = response.data?.data ?? response.data;
+    return { ...d, revenue: asArray(d?.revenue), expenses: asArray(d?.expenses) };
   },
 
   async getExpenseSummary(params?: { date_from?: string; date_to?: string }): Promise<ExpenseSummary> {
     const qs = params ? buildQueryString(params) : '';
     const response = await apiClient.get(`${BASE}/reports/expense-summary${qs}`);
-    return response.data;
+    const d = response.data?.data ?? response.data;
+    return { ...d, categories: asArray(d?.categories) };
   },
 
   async getDashboardStats(): Promise<DashboardStats> {
     const response = await apiClient.get(`${BASE}/reports/dashboard-stats`);
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   // ── AI ─────────────────────────────────────────────────────────────────────
 
   async aiCategorize(data: { description: string; amount: number }): Promise<AiCategorization> {
     const response = await apiClient.post(`${BASE}/ai/categorize`, toFormData(data as Record<string, unknown>));
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async aiSuggestVat(data: { description: string; amount: number; category?: string }): Promise<AiVatSuggestion> {
     const response = await apiClient.post(`${BASE}/ai/suggest-vat`, toFormData(data as Record<string, unknown>));
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async aiQuery(data: { query: string }): Promise<AiQueryResponse> {
     const response = await apiClient.post(`${BASE}/ai/query`, toFormData(data as Record<string, unknown>));
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async aiStatus(): Promise<AiStatusResponse> {
     const response = await apiClient.get(`${BASE}/ai/status`);
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 };
 

--- a/opsapi-dashboard/services/crm.service.ts
+++ b/opsapi-dashboard/services/crm.service.ts
@@ -218,17 +218,17 @@ export const crmService = {
 
   async getAccount(uuid: string): Promise<CrmAccount> {
     const response = await apiClient.get(`/api/v2/crm/accounts/${uuid}`);
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async createAccount(data: Record<string, unknown>): Promise<CrmAccount> {
     const response = await apiClient.post('/api/v2/crm/accounts', toFormData(data));
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async updateAccount(uuid: string, data: Record<string, unknown>): Promise<CrmAccount> {
     const response = await apiClient.put(`/api/v2/crm/accounts/${uuid}`, toFormData(data));
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async deleteAccount(uuid: string): Promise<void> {
@@ -247,17 +247,17 @@ export const crmService = {
 
   async getContact(uuid: string): Promise<CrmContact> {
     const response = await apiClient.get(`/api/v2/crm/contacts/${uuid}`);
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async createContact(data: Record<string, unknown>): Promise<CrmContact> {
     const response = await apiClient.post('/api/v2/crm/contacts', toFormData(data));
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async updateContact(uuid: string, data: Record<string, unknown>): Promise<CrmContact> {
     const response = await apiClient.put(`/api/v2/crm/contacts/${uuid}`, toFormData(data));
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async deleteContact(uuid: string): Promise<void> {
@@ -276,17 +276,17 @@ export const crmService = {
 
   async getDeal(uuid: string): Promise<CrmDeal> {
     const response = await apiClient.get(`/api/v2/crm/deals/${uuid}`);
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async createDeal(data: Record<string, unknown>): Promise<CrmDeal> {
     const response = await apiClient.post('/api/v2/crm/deals', toFormData(data));
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async updateDeal(uuid: string, data: Record<string, unknown>): Promise<CrmDeal> {
     const response = await apiClient.put(`/api/v2/crm/deals/${uuid}`, toFormData(data));
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async deleteDeal(uuid: string): Promise<void> {
@@ -300,7 +300,7 @@ export const crmService = {
 
   async getDashboardStats(): Promise<CrmDashboardStats> {
     const response = await apiClient.get('/api/v2/crm/dashboard/stats');
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   // ----------------------------------------------------------
@@ -314,17 +314,17 @@ export const crmService = {
 
   async getPipeline(uuid: string): Promise<CrmPipeline> {
     const response = await apiClient.get(`/api/v2/crm/pipelines/${uuid}`);
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async createPipeline(data: Record<string, unknown>): Promise<CrmPipeline> {
     const response = await apiClient.post('/api/v2/crm/pipelines', toFormData(data));
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async updatePipeline(uuid: string, data: Record<string, unknown>): Promise<CrmPipeline> {
     const response = await apiClient.put(`/api/v2/crm/pipelines/${uuid}`, toFormData(data));
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async deletePipeline(uuid: string): Promise<void> {
@@ -343,12 +343,12 @@ export const crmService = {
 
   async createActivity(data: Record<string, unknown>): Promise<CrmActivity> {
     const response = await apiClient.post('/api/v2/crm/activities', toFormData(data));
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async updateActivity(uuid: string, data: Record<string, unknown>): Promise<CrmActivity> {
     const response = await apiClient.put(`/api/v2/crm/activities/${uuid}`, toFormData(data));
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async deleteActivity(uuid: string): Promise<void> {
@@ -357,7 +357,7 @@ export const crmService = {
 
   async completeActivity(uuid: string): Promise<CrmActivity> {
     const response = await apiClient.put(`/api/v2/crm/activities/${uuid}/complete`, toFormData({}));
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   // ----------------------------------------------------------
@@ -372,17 +372,17 @@ export const crmService = {
 
   async getLead(uuid: string): Promise<CrmLead> {
     const response = await apiClient.get(`/api/v2/crm/leads/${uuid}`);
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async createLead(data: Record<string, unknown>): Promise<CrmLead> {
     const response = await apiClient.post('/api/v2/crm/leads', toFormData(data));
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async updateLead(uuid: string, data: Record<string, unknown>): Promise<CrmLead> {
     const response = await apiClient.put(`/api/v2/crm/leads/${uuid}`, toFormData(data));
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async deleteLead(uuid: string): Promise<void> {
@@ -393,7 +393,7 @@ export const crmService = {
     const payload: Record<string, unknown> = {};
     if (dealData) payload.deal = dealData;
     const response = await apiClient.post(`/api/v2/crm/leads/${uuid}/convert`, toFormData(payload));
-    return response.data;
+    return response.data?.data ?? response.data;
   },
 
   async getLeadStats(): Promise<CrmLeadStats> {

--- a/opsapi-dashboard/services/invoices.service.ts
+++ b/opsapi-dashboard/services/invoices.service.ts
@@ -123,15 +123,77 @@ export interface PaymentPayload {
   notes?: string;
 }
 
-// Create from timesheet payload
+// Create from timesheet payload. Only the timesheet is required — the backend
+// derives the customer, line items, and rate (per-entry → timesheet → hourly_rate).
 export interface TimesheetInvoicePayload {
   timesheet_uuid: string;
-  customer_name: string;
-  customer_email?: string;
-  hourly_rate: number;
-  due_date: string;
+  hourly_rate?: number;
+  due_date?: string;
   currency?: string;
-  notes?: string;
+}
+
+// One un-invoiced billable entry in a customer-billing preview.
+export interface CustomerBillableEntry {
+  entry_id: number;
+  timesheet_uuid: string;
+  entry_date: string;
+  description?: string;
+  task_reference?: string;
+  project_reference?: string;
+  hours: number;
+  rate: number;
+  amount: number;
+  has_rate: boolean;
+}
+
+// Preview of a customer's un-invoiced work over a period (read-only).
+export interface CustomerBillablePreview {
+  customer: { uuid: string; name?: string | null; email?: string | null };
+  period: { from?: string | null; to?: string | null };
+  currency: string;
+  entries: CustomerBillableEntry[];
+  totals: { count: number; total_hours: number; total_amount: number; missing_rate: boolean };
+}
+
+// Payload to generate one invoice from a customer's approved timesheets.
+export interface CustomerInvoicePayload {
+  customer_uuid: string;
+  period_start?: string;
+  period_end?: string;
+  hourly_rate?: number;
+  due_date?: string;
+  currency?: string;
+}
+
+// Map a backend invoice (total_amount / tax_amount / line_items[].line_total) onto
+// the frontend Invoice shape (total / tax_total / items[].total) the pages expect.
+function normalizeInvoice(raw: Record<string, unknown> | null | undefined): Invoice {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  const num = (v: unknown) => Number(v ?? 0) || 0;
+  const rawItems = Array.isArray(r.line_items)
+    ? (r.line_items as Record<string, unknown>[])
+    : Array.isArray(r.items)
+      ? (r.items as Record<string, unknown>[])
+      : [];
+  return {
+    ...(r as unknown as Invoice),
+    uuid: (r.uuid ?? r.id) as string,
+    subtotal: num(r.subtotal),
+    tax_total: num(r.tax_amount ?? r.tax_total),
+    total: num(r.total_amount ?? r.total),
+    amount_paid: num(r.amount_paid),
+    balance_due: num(r.balance_due),
+    items: rawItems.map((li) => ({
+      ...(li as unknown as InvoiceLineItem),
+      uuid: (li.uuid ?? li.id) as string,
+      quantity: num(li.quantity),
+      unit_price: num(li.unit_price),
+      tax_rate: num(li.tax_rate),
+      tax_amount: num(li.tax_amount),
+      total: num(li.line_total ?? li.total),
+    })),
+    payments: Array.isArray(r.payments) ? (r.payments as InvoicePayment[]) : [],
+  };
 }
 
 export const invoicesService = {
@@ -157,16 +219,22 @@ export const invoicesService = {
 
     const response = await apiClient.get('/api/v2/invoices', { params: queryParams });
 
-    const data = Array.isArray(response.data?.data) ? response.data.data : [];
+    // Backend shape: { success, data: [...], meta: { total, page, perPage, totalPages } }
+    // Pagination lives in `meta`, not at the top level.
+    const body = response.data ?? {};
+    const list = Array.isArray(body.data) ? body.data : [];
+    const meta = body.meta ?? {};
+    const page = meta.page ?? params.page ?? 1;
+    const totalPages = meta.totalPages ?? 0;
 
     return {
-      data,
-      total: response.data?.total || 0,
-      page: response.data?.page || params.page || 1,
-      per_page: response.data?.per_page || params.perPage || 10,
-      total_pages: response.data?.total_pages || 0,
-      has_next: response.data?.has_next || false,
-      has_prev: response.data?.has_prev || false,
+      data: list.map(normalizeInvoice),
+      total: meta.total ?? list.length,
+      page,
+      per_page: meta.perPage ?? params.perPage ?? 10,
+      total_pages: totalPages,
+      has_next: page < totalPages,
+      has_prev: page > 1,
     };
   },
 
@@ -175,7 +243,7 @@ export const invoicesService = {
    */
   async getInvoice(uuid: string): Promise<Invoice> {
     const response = await apiClient.get(`/api/v2/invoices/${uuid}`);
-    return response.data;
+    return normalizeInvoice(response.data?.data ?? response.data);
   },
 
   /**
@@ -183,7 +251,7 @@ export const invoicesService = {
    */
   async createInvoice(data: InvoicePayload): Promise<Invoice> {
     const response = await apiClient.post('/api/v2/invoices', toFormData(data as unknown as Record<string, unknown>));
-    return response.data;
+    return normalizeInvoice(response.data?.data ?? response.data);
   },
 
   /**
@@ -191,7 +259,7 @@ export const invoicesService = {
    */
   async updateInvoice(uuid: string, data: Partial<InvoicePayload>): Promise<Invoice> {
     const response = await apiClient.put(`/api/v2/invoices/${uuid}`, toFormData(data as unknown as Record<string, unknown>));
-    return response.data;
+    return normalizeInvoice(response.data?.data ?? response.data);
   },
 
   /**
@@ -270,7 +338,48 @@ export const invoicesService = {
    */
   async getDashboardStats(): Promise<InvoiceDashboardStats> {
     const response = await apiClient.get('/api/v2/invoices/dashboard/stats');
-    return response.data;
+    const r = (response.data?.data ?? response.data ?? {}) as Record<string, unknown>;
+    const num = (v: unknown) => Number(v ?? 0) || 0;
+    const byStatus = Array.isArray(r.by_status) ? (r.by_status as Record<string, unknown>[]) : [];
+    const count = (s: string) => byStatus.filter((b) => b.status === s).reduce((a, b) => a + num(b.count), 0);
+    return {
+      total_invoiced: num(r.total_invoiced),
+      total_paid: num(r.total_paid),
+      total_outstanding: num(r.total_outstanding),
+      total_overdue: num(r.total_overdue),
+      invoice_count: byStatus.reduce((a, b) => a + num(b.count), 0),
+      paid_count: count('paid'),
+      outstanding_count: count('sent'),
+      overdue_count: num(r.overdue_count),
+    };
+  },
+
+  /**
+   * Preview a customer's un-invoiced billable work over a period (read-only).
+   */
+  async getCustomerBillable(
+    customerUuid: string,
+    from?: string,
+    to?: string,
+    hourlyRate?: number
+  ): Promise<CustomerBillablePreview> {
+    const params: Record<string, string | number> = { customer_uuid: customerUuid };
+    if (from) params.from = from;
+    if (to) params.to = to;
+    if (hourlyRate != null) params.hourly_rate = hourlyRate;
+    const response = await apiClient.get('/api/v2/invoices/customer-billable', { params });
+    return response.data?.data ?? response.data;
+  },
+
+  /**
+   * Generate one invoice from a customer's approved timesheets over a period.
+   */
+  async createFromCustomer(data: CustomerInvoicePayload): Promise<Invoice> {
+    const response = await apiClient.post(
+      '/api/v2/invoices/from-customer',
+      toFormData(data as unknown as Record<string, unknown>)
+    );
+    return normalizeInvoice(response.data?.data ?? response.data);
   },
 
   /**
@@ -289,7 +398,7 @@ export const invoicesService = {
       '/api/v2/invoices/from-timesheet',
       toFormData(data as unknown as Record<string, unknown>)
     );
-    return response.data;
+    return normalizeInvoice(response.data?.data ?? response.data);
   },
 };
 

--- a/opsapi-dashboard/services/timesheets.service.ts
+++ b/opsapi-dashboard/services/timesheets.service.ts
@@ -23,15 +23,55 @@ export interface TimesheetSummaryParams {
 }
 
 export interface CreateTimesheetData {
-  period_start: string;
-  period_end: string;
+  // Either a single work date (preferred) or an explicit period range.
+  work_date?: string;
+  period_start?: string;
+  period_end?: string;
+  // Customer this work was for (ecommerce customers.uuid). Resolved server-side
+  // to customer_id + client_name snapshot.
+  customer_uuid?: string;
+  client_name?: string;
+  // Task the work belongs to (kanban task.uuid). Resolved server-side to the
+  // task title + parent project.
+  task_uuid?: string;
+  task?: string;
+  // Single-session timing — hours are computed server-side from these.
+  start_time?: string;
+  end_time?: string;
+  // Billing.
+  is_billable?: boolean;
+  hourly_rate?: number;
   notes?: string;
 }
 
 export interface UpdateTimesheetData {
+  work_date?: string;
   period_start?: string;
   period_end?: string;
+  customer_uuid?: string;
+  client_name?: string;
+  task_uuid?: string;
+  task?: string;
+  start_time?: string;
+  end_time?: string;
+  is_billable?: boolean;
+  hourly_rate?: number;
   notes?: string;
+}
+
+// Lookup option shapes for the searchable dropdowns (namespace-scoped).
+export interface CustomerOption {
+  uuid: string;
+  first_name?: string;
+  last_name?: string;
+  email?: string;
+}
+
+export interface TaskOption {
+  task_uuid: string;
+  title: string;
+  project_uuid?: string;
+  project_name?: string;
 }
 
 export interface CreateEntryData {
@@ -79,6 +119,19 @@ export interface Timesheet {
   status: TimesheetStatus;
   total_hours: number;
   billable_hours: number;
+  // Client-work fields (enriched timesheet model)
+  customer_id?: number | null;
+  customer_uuid?: string | null;
+  client_name?: string | null;
+  task?: string | null;
+  task_uuid?: string | null;
+  project_uuid?: string | null;
+  project_name?: string | null;
+  work_date?: string | null;
+  start_time?: string | null;
+  end_time?: string | null;
+  hourly_rate?: number | string | null;
+  is_billable?: boolean;
   notes?: string;
   submitted_at?: string;
   approved_at?: string;
@@ -132,17 +185,48 @@ export const timesheetsService = {
     const queryString = buildQueryString(queryParams);
     const response = await apiClient.get(`/api/v2/timesheets${queryString}`);
 
-    const data = Array.isArray(response.data?.data) ? response.data.data : [];
+    // Backend shape: { success, data: { data: [...], meta: { total, page, per_page, total_pages } } }
+    // Unwrap the {success,data} envelope, then read the inner list + meta.
+    const body = response.data?.data ?? response.data;
+    const data: Timesheet[] = Array.isArray(body?.data)
+      ? body.data
+      : Array.isArray(body)
+        ? body
+        : [];
+    const meta = body?.meta ?? {};
+    const page = meta.page ?? params.page ?? 1;
+    const perPage = meta.per_page ?? params.per_page ?? 10;
+    const totalPages = meta.total_pages ?? 0;
 
     return {
       data,
-      total: response.data?.total || 0,
-      page: response.data?.page || params.page || 1,
-      per_page: response.data?.per_page || params.per_page || 10,
-      total_pages: response.data?.total_pages || 0,
-      has_next: response.data?.has_next || false,
-      has_prev: response.data?.has_prev || false,
+      total: meta.total ?? data.length,
+      page,
+      per_page: perPage,
+      total_pages: totalPages,
+      has_next: page < totalPages,
+      has_prev: page > 1,
     };
+  },
+
+  /**
+   * Namespace-scoped customer lookup for the create/edit dropdown.
+   */
+  async lookupCustomers(q?: string): Promise<CustomerOption[]> {
+    const qs = q ? `?q=${encodeURIComponent(q)}` : '';
+    const response = await apiClient.get(`/api/v2/timesheets/lookups/customers${qs}`);
+    const data = response.data?.data ?? response.data;
+    return Array.isArray(data) ? data : [];
+  },
+
+  /**
+   * Namespace-scoped task lookup (kanban tasks + their project).
+   */
+  async lookupTasks(q?: string): Promise<TaskOption[]> {
+    const qs = q ? `?q=${encodeURIComponent(q)}` : '';
+    const response = await apiClient.get(`/api/v2/timesheets/lookups/tasks${qs}`);
+    const data = response.data?.data ?? response.data;
+    return Array.isArray(data) ? data : [];
   },
 
   /**

--- a/opsapi-dashboard/services/timesheets.service.ts
+++ b/opsapi-dashboard/services/timesheets.service.ts
@@ -319,16 +319,28 @@ export const timesheetsService = {
     const queryString = buildQueryString(queryParams);
     const response = await apiClient.get(`/api/v2/timesheets/approval-queue${queryString}`);
 
-    const data = Array.isArray(response.data?.data) ? response.data.data : [];
+    // Backend shape: { success, data: { data: [...], meta: { total, page, per_page, total_pages } } }
+    // Unwrap the {success,data} envelope, then read the inner list + meta — the
+    // meta lives one level deeper than a naive response.data.total read assumes.
+    const body = response.data?.data ?? response.data;
+    const data: Timesheet[] = Array.isArray(body?.data)
+      ? body.data
+      : Array.isArray(body)
+        ? body
+        : [];
+    const meta = body?.meta ?? {};
+    const page = meta.page ?? params.page ?? 1;
+    const perPage = meta.per_page ?? params.per_page ?? 10;
+    const totalPages = meta.total_pages ?? 0;
 
     return {
       data,
-      total: response.data?.total || 0,
-      page: response.data?.page || params.page || 1,
-      per_page: response.data?.per_page || params.per_page || 10,
-      total_pages: response.data?.total_pages || 0,
-      has_next: response.data?.has_next || false,
-      has_prev: response.data?.has_prev || false,
+      total: meta.total ?? data.length,
+      page,
+      per_page: perPage,
+      total_pages: totalPages,
+      has_next: page < totalPages,
+      has_prev: page > 1,
     };
   },
 
@@ -367,7 +379,26 @@ export const timesheetsService = {
   async getSummary(params: TimesheetSummaryParams = {}): Promise<TimesheetSummaryResponse> {
     const queryString = buildQueryString(params as Record<string, unknown>);
     const response = await apiClient.get(`/api/v2/timesheets/summary${queryString}`);
-    return response.data?.data || response.data;
+    // Backend shape: { summary: { total_hours, billable_hours, submitted_count, approved_count, ... },
+    //                  by_project: [{ project_reference, total_hours, billable_hours }],
+    //                  by_category: [{ category, total_hours, billable_hours }] }
+    // Flatten it into the flat TimesheetSummaryResponse the UI expects.
+    const raw = response.data?.data || response.data || {};
+    const s = raw.summary || raw || {};
+    return {
+      total_hours: Number(s.total_hours) || 0,
+      billable_hours: Number(s.billable_hours) || 0,
+      pending_count: Number(s.submitted_count ?? s.pending_count) || 0,
+      approved_count: Number(s.approved_count) || 0,
+      by_project: (raw.by_project || []).map((p: { project_reference?: string; total_hours?: number; hours?: number }) => ({
+        project_reference: p.project_reference || 'No Project',
+        hours: Number(p.total_hours ?? p.hours) || 0,
+      })),
+      by_category: (raw.by_category || []).map((c: { category?: string; total_hours?: number; hours?: number }) => ({
+        category: c.category || 'Uncategorized',
+        hours: Number(c.total_hours ?? c.hours) || 0,
+      })),
+    };
   },
 };
 

--- a/start.sh
+++ b/start.sh
@@ -1217,32 +1217,72 @@ sleep 5
 HOSTNAME="opsapi-dev.local"
 K3S_LB_IP=127.0.0.1
 HOSTS_FILE="/etc/hosts"
+DESIRED_ENTRY="$K3S_LB_IP $HOSTNAME"
 
-echo "[+] Removing lines matching '$HOSTNAME' from $HOSTS_FILE"
+# ------------------------------------------------------------------
+# Map opsapi-dev.local -> 127.0.0.1 in /etc/hosts.
+#
+# This is purely a convenience: the stack is always reachable at
+# http://127.0.0.1:<port> regardless. So editing /etc/hosts must NEVER block
+# startup and must NEVER prompt for a sudo password. We write only when we can do
+# so without prompting; otherwise we print a friendly "add this line yourself"
+# hint and carry on.
+# ------------------------------------------------------------------
 
-# Backup before change
-sudo cp "$HOSTS_FILE" "$HOSTS_FILE.bak"
+# Escape dots so the grep below matches literally (127.0.0.1, opsapi-dev.local).
+_HOST_RE="${HOSTNAME//./\\.}"
+_IP_RE="${K3S_LB_IP//./\\.}"
 
-# Delete lines containing the host entry (cross-platform sed -i)
-if [[ "$(uname)" == "Darwin" ]]; then
-    sudo sed -i '' "/${HOSTNAME//./\\.}/d" "$HOSTS_FILE"
+if grep -qE "^[[:space:]]*${_IP_RE}[[:space:]]+${_HOST_RE}([[:space:]]|\$)" "$HOSTS_FILE" 2>/dev/null; then
+    # Already correct — nothing to do, and crucially no sudo needed. This is the
+    # common case on every run after the first.
+    echo -e "${GREEN}[+] /etc/hosts already maps ${HOSTNAME} -> ${K3S_LB_IP}; nothing to do${NC}"
 else
-    sudo sed -i "/${HOSTNAME//./\\.}/d" "$HOSTS_FILE"
-fi
-
-echo "[+] House keeping Done. Backup saved as $HOSTS_FILE.bak"
-
-# Check if the entry already exists
-if grep -q "$HOSTNAME" $HOSTS_FILE; then
-    echo "[+] Updating existing entry for $HOSTNAME"
-    if [[ "$(uname)" == "Darwin" ]]; then
-        sudo sed -i '' "s/^.*$HOSTNAME\$/$K3S_LB_IP $HOSTNAME/" $HOSTS_FILE
+    # Work out how (or whether) we can write to /etc/hosts WITHOUT ever prompting.
+    # start.sh must never block on a sudo password prompt, so we only use sudo
+    # when it is non-interactive: passwordless sudo, or credentials the user has
+    # already cached this session (e.g. by running `sudo -v` first). Anything
+    # that would prompt is treated as "can't edit" and we fall back to the hint.
+    HOSTS_SUDO=""
+    CAN_EDIT_HOSTS=true
+    if [ "$(id -u)" -eq 0 ] || [ -w "$HOSTS_FILE" ]; then
+        HOSTS_SUDO=""
+    elif command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+        HOSTS_SUDO="sudo -n"   # non-interactive sudo only — never prompts
     else
-        sudo sed -i "s/^.*$HOSTNAME\$/$K3S_LB_IP $HOSTNAME/" $HOSTS_FILE
+        CAN_EDIT_HOSTS=false
     fi
-else
-    echo "[+] Adding new entry: $K3S_LB_IP $HOSTNAME"
-    echo "$K3S_LB_IP $HOSTNAME" | sudo tee -a $HOSTS_FILE > /dev/null
+
+    if [ "$CAN_EDIT_HOSTS" = true ]; then
+        echo "[+] Configuring ${HOSTNAME} -> ${K3S_LB_IP} in $HOSTS_FILE"
+
+        # Best-effort backup; not fatal if it fails.
+        $HOSTS_SUDO cp "$HOSTS_FILE" "$HOSTS_FILE.bak" 2>/dev/null || true
+
+        # Drop any stale entry for the host (cross-platform sed -i), then append
+        # the fresh mapping. If any step fails (e.g. not actually a sudoer), fall
+        # through to the manual hint instead of leaving a half-applied change.
+        if [[ "$(uname)" == "Darwin" ]]; then
+            $HOSTS_SUDO sed -i '' "/${_HOST_RE}/d" "$HOSTS_FILE" 2>/dev/null || CAN_EDIT_HOSTS=false
+        else
+            $HOSTS_SUDO sed -i "/${_HOST_RE}/d" "$HOSTS_FILE" 2>/dev/null || CAN_EDIT_HOSTS=false
+        fi
+
+        if [ "$CAN_EDIT_HOSTS" = true ] && echo "$DESIRED_ENTRY" | $HOSTS_SUDO tee -a "$HOSTS_FILE" >/dev/null 2>&1; then
+            echo -e "${GREEN}[+] Added '${DESIRED_ENTRY}' to ${HOSTS_FILE} (backup: ${HOSTS_FILE}.bak)${NC}"
+        else
+            CAN_EDIT_HOSTS=false
+        fi
+    fi
+
+    if [ "$CAN_EDIT_HOSTS" != true ]; then
+        echo -e "${YELLOW}[!] Skipping the /etc/hosts update — would need a sudo password (not prompting).${NC}"
+        echo -e "${YELLOW}    This step is optional: everything still works at http://127.0.0.1:<port>.${NC}"
+        echo -e "${YELLOW}    To also use http://${HOSTNAME}, add this line to ${HOSTS_FILE} yourself:${NC}"
+        echo -e "${CYAN}        ${DESIRED_ENTRY}${NC}"
+        echo -e "${YELLOW}    e.g.  echo '${DESIRED_ENTRY}' | sudo tee -a ${HOSTS_FILE}${NC}"
+        echo -e "${YELLOW}    Tip: run 'sudo -v' once before start.sh and it'll be applied automatically.${NC}"
+    fi
 fi
 
 sleep 5


### PR DESCRIPTION
## Summary

Builds out timesheet→invoice billing end-to-end, makes the invoice module actually work, and hardens a few latent issues.

### Customer-period invoicing (new)
- Generate **one invoice** aggregating all of a customer's approved, billable, **un-invoiced** hours over a period.
  - `GET /api/v2/invoices/customer-billable` — read-only preview (every entry with hours/rate/amount + totals).
  - `POST /api/v2/invoices/from-customer` — creates the invoice; each line links to its `timesheet_entry_id` so hours can't be billed twice (idempotent).
- **"From Timesheets"** modal on the invoices page: customer search (server-side), period pickers, live work preview, one-click generate.

### Professional invoice PDF (client-side, jsPDF — no server tooling)
- Branded header band featuring the **namespace name** + monogram, BILL TO, line-items table, totals card with emphasised Balance Due, notes, footer.
- **Preview** (in-app iframe modal) and **Download PDF** on the invoice detail page.

### Invoice CRUD fixes (every endpoint was failing in some way)
- Drop non-existent `discount_amount` column from `get()/getLineItems()/updateLineItem()` (caused **GET invoice → 500**, cascading to add-item/payments).
- `recordPayment()`: stop `find({id=nil})` "empty table" error; set NOT-NULL `namespace_id` + `currency`; use real column `reference_number`.
- Dashboard stats: add overdue **amount** (`total_overdue`).
- Frontend `invoices.service`: normalise backend→UI fields (`total_amount→total`, `line_items[].line_total→items[].total`, …), fix list pagination (reads `meta`), unwrap `{success,data}` envelopes.
- Widen `invoice_tax_rates.rate` `DECIMAL(5,4)→DECIMAL(6,2)` — a 20% rate overflowed (`createTaxRate → 500`).

### Timesheet SHOULD-FIX items
- Fix approval-queue pagination nesting; server-side customer/task lookups (reach results past the first 100); show derived project in the create modal; validate NOT-NULL columns in `createEntry` for non-route callers.

### Hardening
- Lapis `model:update()` boolean-return fixes (kanban sprint/task, template, timesheet — return the refreshed row, not the boolean).
- Migration sweep dropping the bogus `namespace_id DEFAULT 0` off every FK column (customers, kanban_projects, …); register the orphaned kanban `[41]` migration.
- `start.sh`: the `/etc/hosts` step never blocks startup and **never prompts for a sudo password**.

## Testing
- Backend: full invoice CRUD + new preview/generate verified end-to-end via API (idempotency confirmed). Lua syntax-checked; migrations applied cleanly (0 remaining `namespace_id DEFAULT 0`).
- Frontend: `tsc --noEmit` clean; eslint clean on edited files. PDF verified by rendering full-fidelity output.
- `start.sh`: scenario-tested (add / idempotent / wrong-IP fix / no-sudo skip) — no prompt, no hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
