### PR TITLE
fix(tax-copilot): namespace_id NOT NULL + filing workflow + duplicate upload

### DIFF
--- a/lapis/helper/hmrc.lua
+++ b/lapis/helper/hmrc.lua
@@ -4,6 +4,7 @@
 
 local cjson = require("cjson")
 local db = require("lapis.db")
+local NamespaceResolver = require("helper.namespace-resolver")
 
 local HMRC = {}
 
@@ -191,17 +192,20 @@ function HMRC.refresh_token(user_uuid, refresh_token)
         return nil, "Invalid refresh response"
     end
 
-    -- Store new tokens
+    -- Store new tokens — hmrc_tokens.namespace_id is NOT NULL with no DB
+    -- default, so we must set it explicitly. See HMRCTokenQueries.upsert
+    -- for the same fix applied to the initial-auth path.
+    local namespace_id = NamespaceResolver.getByUuid(user_uuid)
     local expires_at = db.raw("NOW() + INTERVAL '" .. (data.expires_in or 14400) .. " seconds'")
     db.query([[
-        INSERT INTO hmrc_tokens (user_uuid, access_token, refresh_token, scope, expires_at, created_at)
-        VALUES (?, ?, ?, ?, ?, NOW())
+        INSERT INTO hmrc_tokens (user_uuid, namespace_id, access_token, refresh_token, scope, expires_at, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, NOW())
         ON CONFLICT (user_uuid) DO UPDATE SET
             access_token = EXCLUDED.access_token,
             refresh_token = EXCLUDED.refresh_token,
             scope = EXCLUDED.scope,
             expires_at = EXCLUDED.expires_at
-    ]], user_uuid, data.access_token, data.refresh_token or refresh_token, data.scope or "", expires_at)
+    ]], user_uuid, namespace_id, data.access_token, data.refresh_token or refresh_token, data.scope or "", expires_at)
 
     return data.access_token, nil
 end

--- a/lapis/helper/namespace-resolver.lua
+++ b/lapis/helper/namespace-resolver.lua
@@ -19,6 +19,43 @@ local Global = require("helper.global")
 
 local _M = {}
 
+--- Look up a user's namespace_id by their UUID — read-only, no side effects.
+-- Use this in INSERT paths where the row needs a NOT-NULL namespace_id but
+-- the calling context only has the user UUID (e.g. HMRC OAuth callback,
+-- queries module functions that take user_uuid).
+--
+-- Unlike _M.resolve() this does NOT assign a default namespace if missing —
+-- it just returns 0, matching the legacy column default for grandfathered
+-- rows. That keeps INSERTs safe even for edge users who somehow lack a
+-- namespace_members or user_namespace_settings row.
+--
+-- @param user_uuid string The user UUID
+-- @return number The namespace_id, or 0 if not found
+function _M.getByUuid(user_uuid)
+    if not user_uuid or user_uuid == "" then return 0 end
+    -- Preferred source: user_namespace_settings.default_namespace_id (the
+    -- "currently active" namespace the user picked in the UI).
+    local row = db.select(
+        "default_namespace_id FROM user_namespace_settings " ..
+        "WHERE user_id = (SELECT id FROM users WHERE uuid = ? LIMIT 1) LIMIT 1",
+        user_uuid
+    )
+    if row and #row > 0 and row[1].default_namespace_id and row[1].default_namespace_id > 0 then
+        return tonumber(row[1].default_namespace_id) or 0
+    end
+    -- Fallback source: namespace_members (covers users whose settings row
+    -- hasn't been written yet but who are a member of at least one ns).
+    row = db.select(
+        "namespace_id FROM namespace_members " ..
+        "WHERE user_id = (SELECT id FROM users WHERE uuid = ? LIMIT 1) LIMIT 1",
+        user_uuid
+    )
+    if row and #row > 0 and row[1].namespace_id and row[1].namespace_id > 0 then
+        return tonumber(row[1].namespace_id) or 0
+    end
+    return 0
+end
+
 --- Resolve and attach namespace_id to the current user context.
 -- Idempotent: safe to call on every request.
 -- @param user table The authenticated user (ngx.ctx.user)

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -1771,6 +1771,9 @@ local _migrations = {
     ['708_billing_drop_payment_accounts'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, billing_system_migrations, 9),
     ['709_billing_payments_invoice_unique'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, billing_system_migrations, 10),
     ['710_tax_profile_guidance'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_profile_guidance_migrations, 1),
+    ['711_tax_statements_workflow_step_filed_backfill'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 84),
+    ['713_tax_statements_file_hash'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 86),
+    ['714_seed_upload_duplicate_filed_message'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 87),
 
     -- Theme system foundation (Phase 0): drop obsolete scaffold.
     -- Replaced by new tables in Phase 1 migration 621_create_theme_system.

--- a/lapis/migrations/tax-copilot-system.lua
+++ b/lapis/migrations/tax-copilot-system.lua
@@ -2892,4 +2892,98 @@ return {
         db.query("ALTER TABLE tax_user_profiles ADD COLUMN IF NOT EXISTS nino_consent_at TIMESTAMP")
         print("[Tax Copilot] Added nino_consent_at column to tax_user_profiles")
     end,
+
+    -- 84. Backfill workflow_step='FILED' for statements that are filed but
+    --     stuck at TAX_CALCULATED.
+    --
+    -- Backwards-compat fix: the Python final-declaration filing path in
+    -- backend/app/api/hmrc.py used to UPDATE tax_statements to set
+    -- is_filed / filed_at / hmrc_submission_id but FORGOT to advance
+    -- workflow_step. So statements ended up in an inconsistent state:
+    --     is_filed = TRUE  AND  workflow_step = 'TAX_CALCULATED'
+    -- The dashboard's "Recent Activity" and "Statements by period" cards
+    -- both render the badge from workflow_step, so users saw a confusing
+    -- "Calculated" badge on statements they'd already submitted to HMRC.
+    --
+    -- Going-forward fix is in the Python endpoint (the UPDATE now includes
+    -- workflow_step='FILED'); this migration heals the inconsistency on
+    -- existing rows. Idempotent — re-running is a no-op once everything
+    -- is in sync.
+    [84] = function()
+        local result = db.query([[
+            UPDATE tax_statements
+            SET workflow_step = 'FILED',
+                updated_at = NOW()
+            WHERE is_filed = TRUE
+              AND workflow_step IS DISTINCT FROM 'FILED'
+        ]])
+        local n = (result and result.affected_rows) or 0
+        print(string.format(
+            "[Tax Copilot] Backfilled workflow_step='FILED' on %d already-filed " ..
+            "tax_statements row(s)", n
+        ))
+    end,
+
+    -- 87. Seed UPLOAD_DUPLICATE_FILED row in message_catalog so the new
+    --     409 error surfaces through the standard envelope (carrying
+    --     http_status=409 + title/user_message looked up from the
+    --     translations layer) instead of falling back to the generic
+    --     "Something went wrong" code.
+    --
+    --     Matches the newer convention from step 52: catalog row only.
+    --     Translations live in backend/app/errors/translations/*.json
+    --     (already added in en.json) and are loaded by FastAPI on
+    --     startup — seeding message_translations here would duplicate
+    --     the source of truth and risk drift.
+    --
+    --     Idempotent via ON CONFLICT (code) DO NOTHING.
+    [87] = function()
+        db.query([[
+            INSERT INTO message_catalog (code, category, severity, http_status, developer_note)
+            VALUES (
+                'UPLOAD_DUPLICATE_FILED',
+                'error',
+                'warn',
+                409,
+                'User attempted to re-upload a file whose SHA-256 matches a prior is_filed=TRUE tax_statements row for the same user_id. Blocked at backend/app/api/upload.py before the MinIO write.'
+            )
+            ON CONFLICT (code) DO NOTHING
+        ]])
+        print("[Tax Copilot] Seeded UPLOAD_DUPLICATE_FILED in message_catalog")
+    end,
+
+    -- 86. Per-user duplicate-upload guard via content hash.
+    --
+    -- Today /api/upload has zero duplicate detection — the user could
+    -- re-upload the same april_2026.pdf an unlimited number of times for
+    -- the same user, even after that statement had already been filed to
+    -- HMRC. The /file/{id}/check-duplicate endpoint exists but only keys
+    -- on tax_year / period_start / period_end (all NULL at upload time)
+    -- and has zero frontend callers anyway. The cleanest realistic guard
+    -- is a content hash: same hash + same user + already filed → block;
+    -- everything else still flows.
+    --
+    -- We deliberately do NOT add a global UNIQUE on (user_id, file_hash):
+    -- the user may legitimately re-upload a draft they later replace, or
+    -- re-upload an unfiled statement after deleting a half-broken
+    -- extract. The hard guard is application-level and only fires when
+    -- the prior row has is_filed=TRUE.
+    --
+    -- The column is nullable on purpose — pre-existing rows have no
+    -- hash and we don't want to break them. New uploads stamp the hash.
+    [86] = function()
+        db.query([[
+            ALTER TABLE tax_statements
+            ADD COLUMN IF NOT EXISTS file_hash VARCHAR(64)
+        ]])
+        -- Partial index — only rows that have a hash (i.e. new uploads
+        -- post-this-migration). Keeps the index small while still
+        -- supporting the duplicate-lookup query at upload time.
+        db.query([[
+            CREATE INDEX IF NOT EXISTS idx_tax_statements_user_file_hash
+            ON tax_statements (user_id, file_hash)
+            WHERE file_hash IS NOT NULL
+        ]])
+        print("[Tax Copilot] Added file_hash column + index to tax_statements")
+    end,
 }

--- a/lapis/queries/HMRCBusinessQueries.lua
+++ b/lapis/queries/HMRCBusinessQueries.lua
@@ -7,19 +7,24 @@
 
 local db = require("lapis.db")
 local cjson = require("cjson")
+local NamespaceResolver = require("helper.namespace-resolver")
 
 local HMRCBusinessQueries = {}
 
 -- Upsert a business (insert or update on user_uuid + business_id conflict)
 function HMRCBusinessQueries.upsert(data)
+    -- hmrc_businesses.namespace_id is NOT NULL with no DB default —
+    -- resolve from the user's namespace settings so the row is correctly
+    -- tenant-scoped. Returns 0 (legacy default) for users with no settings.
+    local namespace_id = NamespaceResolver.getByUuid(data.user_uuid)
     db.query([[
         INSERT INTO hmrc_businesses (
-            uuid, user_uuid, business_id, type_of_business,
+            uuid, user_uuid, namespace_id, business_id, type_of_business,
             trading_name, accounting_type,
             first_accounting_period_start, first_accounting_period_end,
             raw_response, fetched_at, created_at, updated_at
         ) VALUES (
-            gen_random_uuid()::text, ?, ?, ?,
+            gen_random_uuid()::text, ?, ?, ?, ?,
             ?, ?,
             ?, ?,
             ?, NOW(), NOW(), NOW()
@@ -35,6 +40,7 @@ function HMRCBusinessQueries.upsert(data)
             updated_at = NOW()
     ]],
         data.user_uuid,
+        namespace_id,
         data.business_id,
         data.type_of_business or "self-employment",
         data.trading_name,

--- a/lapis/queries/HMRCObligationQueries.lua
+++ b/lapis/queries/HMRCObligationQueries.lua
@@ -6,19 +6,23 @@
 ]]
 
 local db = require("lapis.db")
+local NamespaceResolver = require("helper.namespace-resolver")
 
 local HMRCObligationQueries = {}
 
 -- Upsert an obligation (insert or update on user_uuid + business_id + period conflict)
 function HMRCObligationQueries.upsert(data)
+    -- hmrc_obligations.namespace_id is NOT NULL with no DB default —
+    -- resolve from the user's namespace settings.
+    local namespace_id = NamespaceResolver.getByUuid(data.user_uuid)
     db.query([[
         INSERT INTO hmrc_obligations (
-            uuid, user_uuid, business_id, tax_year,
+            uuid, user_uuid, namespace_id, business_id, tax_year,
             period_start, period_end, due_date, status,
             received_date, period_key,
             fetched_at, created_at, updated_at
         ) VALUES (
-            gen_random_uuid()::text, ?, ?, ?,
+            gen_random_uuid()::text, ?, ?, ?, ?,
             ?, ?, ?, ?,
             ?, ?,
             NOW(), NOW(), NOW()
@@ -33,6 +37,7 @@ function HMRCObligationQueries.upsert(data)
             updated_at = NOW()
     ]],
         data.user_uuid,
+        namespace_id,
         data.business_id,
         data.tax_year,
         data.period_start,

--- a/lapis/queries/HMRCTokenQueries.lua
+++ b/lapis/queries/HMRCTokenQueries.lua
@@ -15,6 +15,7 @@
 ]]
 
 local db = require("lapis.db")
+local NamespaceResolver = require("helper.namespace-resolver")
 
 local HMRCTokenQueries = {}
 
@@ -42,18 +43,24 @@ end
 -- @param scope         string or nil
 -- @param expires_in    number  Seconds until expiry
 function HMRCTokenQueries.upsert(user_uuid, access_token, refresh_token, scope, expires_in)
+    -- hmrc_tokens.namespace_id is NOT NULL with no DB default. Resolve from
+    -- the user's namespace settings so the row is correctly tenant-scoped.
+    -- Returns 0 (the legacy default) if the user has no settings yet — safe
+    -- for downstream tenant-scoped queries because every existing row
+    -- pre-dating the NOT-NULL constraint already had namespace_id=0 too.
+    local namespace_id = NamespaceResolver.getByUuid(user_uuid)
     local expires_at_sql = string.format("NOW() + INTERVAL '%d seconds'", expires_in or 14400)
 
     db.query([[
-        INSERT INTO hmrc_tokens (user_uuid, access_token, refresh_token, scope, expires_at, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ]] .. expires_at_sql .. [[, NOW(), NOW())
+        INSERT INTO hmrc_tokens (user_uuid, namespace_id, access_token, refresh_token, scope, expires_at, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ]] .. expires_at_sql .. [[, NOW(), NOW())
         ON CONFLICT (user_uuid) DO UPDATE SET
             access_token  = EXCLUDED.access_token,
             refresh_token = EXCLUDED.refresh_token,
             scope         = EXCLUDED.scope,
             expires_at    = EXCLUDED.expires_at,
             updated_at    = NOW()
-    ]], user_uuid, access_token, refresh_token or ngx.null, scope or ngx.null)
+    ]], user_uuid, namespace_id, access_token, refresh_token or ngx.null, scope or ngx.null)
 end
 
 -- Get a valid (non-expired) token for a user.

--- a/lapis/queries/TaxUserProfileQueries.lua
+++ b/lapis/queries/TaxUserProfileQueries.lua
@@ -9,6 +9,7 @@
 local db = require("lapis.db")
 local bcrypt = require("bcrypt")
 local Global = require("helper.global")
+local NamespaceResolver = require("helper.namespace-resolver")
 
 local TaxUserProfileQueries = {}
 
@@ -33,12 +34,16 @@ function TaxUserProfileQueries.getOrCreate(user_uuid, user_id)
         user_id = user_record[1].id
     end
 
-    -- Create empty profile
+    -- Create empty profile. tax_user_profiles.namespace_id is NOT NULL
+    -- with no DB default — must be set on the INSERT. NOT NULL is checked
+    -- BEFORE the ON CONFLICT path fires, so it can't be skipped just
+    -- because a row already exists.
+    local namespace_id = NamespaceResolver.getByUuid(user_uuid)
     db.query([[
-        INSERT INTO tax_user_profiles (uuid, user_id, user_uuid, created_at, updated_at)
-        VALUES (gen_random_uuid()::text, ?, ?, NOW(), NOW())
+        INSERT INTO tax_user_profiles (uuid, user_id, user_uuid, namespace_id, created_at, updated_at)
+        VALUES (gen_random_uuid()::text, ?, ?, ?, NOW(), NOW())
         ON CONFLICT (user_uuid) DO NOTHING
-    ]], user_id, user_uuid)
+    ]], user_id, user_uuid, namespace_id)
 
     -- Re-fetch to get generated fields
     rows = db.query(

--- a/lapis/routes/register.lua
+++ b/lapis/routes/register.lua
@@ -6,6 +6,7 @@ local Global = require("helper.global")
 local db = require("lapis.db")
 local Errors = require("lib.errors")
 local NamespaceAssignment = require("helper.namespace_assignment")
+local NamespaceResolver = require("helper.namespace-resolver")
 
 --- Validate that a business profile key is acceptable.
 -- @param profile_key string|nil The candidate key (e.g. "amazon_seller")
@@ -70,13 +71,17 @@ end
 local function save_default_profile_key(user_id, user_uuid, profile_key)
     if not profile_key or profile_key == "" then return end
     local ok, err = pcall(function()
+        -- tax_user_profiles.namespace_id is NOT NULL with no DB default —
+        -- and NOT NULL is checked before ON CONFLICT, so we must set it
+        -- here even if a row already exists for this user.
+        local namespace_id = NamespaceResolver.getByUuid(user_uuid)
         db.query([[
-            INSERT INTO tax_user_profiles (user_id, user_uuid, default_profile_key, created_at, updated_at)
-            VALUES (?, ?, ?, NOW(), NOW())
+            INSERT INTO tax_user_profiles (user_id, user_uuid, namespace_id, default_profile_key, created_at, updated_at)
+            VALUES (?, ?, ?, ?, NOW(), NOW())
             ON CONFLICT (user_uuid) DO UPDATE
             SET default_profile_key = EXCLUDED.default_profile_key,
                 updated_at = NOW()
-        ]], user_id, user_uuid, profile_key)
+        ]], user_id, user_uuid, namespace_id, profile_key)
     end)
     if not ok then
         ngx.log(ngx.ERR, "[Register] Failed to save default_profile_key: ", tostring(err))

--- a/lapis/routes/tax-hmrc-data.lua
+++ b/lapis/routes/tax-hmrc-data.lua
@@ -15,6 +15,7 @@ local db = require("lapis.db")
 local cjson = require("cjson")
 local AuthMiddleware = require("middleware.auth")
 local Global = require("helper.global")
+local NamespaceResolver = require("helper.namespace-resolver")
 local respond_to = require("lapis.application").respond_to
 
 -- Resolve the numeric user id (tax_user_profiles is keyed on it) from the JWT uuid.
@@ -137,16 +138,18 @@ return function(app)
             -- The MTD list response nests under listOfBusinesses; older shapes vary.
             local businesses = data.listOfBusinesses or data.businesses
                 or data.businessDetails or data.selfEmployment or {}
+            -- hmrc_businesses.namespace_id is NOT NULL — resolve once per request.
+            local namespace_id = NamespaceResolver.getByUuid(user_uuid)
             for _, biz in ipairs(businesses) do
                 db.query([[
-                    INSERT INTO hmrc_businesses (user_uuid, business_id, type_of_business, trading_name, raw_response, fetched_at)
-                    VALUES (?, ?, ?, ?, ?, NOW())
+                    INSERT INTO hmrc_businesses (user_uuid, namespace_id, business_id, type_of_business, trading_name, raw_response, fetched_at)
+                    VALUES (?, ?, ?, ?, ?, ?, NOW())
                     ON CONFLICT (user_uuid, business_id) DO UPDATE SET
                         type_of_business = EXCLUDED.type_of_business,
                         trading_name = EXCLUDED.trading_name,
                         raw_response = EXCLUDED.raw_response,
                         fetched_at = NOW()
-                ]], user_uuid, biz.businessId or biz.id, biz.typeOfBusiness or "",
+                ]], user_uuid, namespace_id, biz.businessId or biz.id, biz.typeOfBusiness or "",
                     biz.tradingName or "", cjson.encode(biz))
             end
 
@@ -239,20 +242,22 @@ return function(app)
                         or (ob.businessId or business_id)
                     ob.businessId = ob_business
                     table.insert(returned, ob)
+                    -- hmrc_obligations.namespace_id is NOT NULL — resolve per ob batch.
+                    local ob_namespace_id = NamespaceResolver.getByUuid(user_uuid)
                     for _, period in ipairs(ob.obligationDetails or {}) do
                         -- Conflict target is the UNIQUE INDEX idx_hmrc_obligations_period
                         -- (user_uuid, business_id, period_start, period_end) — there is no
                         -- named constraint, so use the column-list form.
                         db.query([[
-                            INSERT INTO hmrc_obligations (user_uuid, business_id, period_start, period_end, due_date, status, period_key, tax_year, fetched_at)
-                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, NOW())
+                            INSERT INTO hmrc_obligations (user_uuid, namespace_id, business_id, period_start, period_end, due_date, status, period_key, tax_year, fetched_at)
+                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
                             ON CONFLICT (user_uuid, business_id, period_start, period_end)
                             DO UPDATE SET
                                 status = EXCLUDED.status,
                                 due_date = EXCLUDED.due_date,
                                 tax_year = EXCLUDED.tax_year,
                                 fetched_at = NOW()
-                        ]], user_uuid, ob_business or "",
+                        ]], user_uuid, ob_namespace_id, ob_business or "",
                             period.periodStartDate, period.periodEndDate,
                             period.dueDate, period.status or "Open",
                             period.periodKey or "", tax_year_of(period.periodStartDate))


### PR DESCRIPTION
## Summary

Eight INSERT sites silently broke after migration \`438_tax_namespace_backfill\` enforced \`namespace_id NOT NULL\` without updating the corresponding writers. The user-visible symptom was the post-signup HMRC OAuth flow returning to \`/settings?hmrc_error=token_store_failed\` even though HMRC had accepted the auth. Same pattern was latent in 7 other places.

## namespace_id NOT NULL fixes

New helper \`NamespaceResolver.getByUuid(user_uuid)\` — read-only, no side effects, looks up \`user_namespace_settings → namespace_members → 0\`. Use at any INSERT site where namespace_id is needed but the caller only has a uuid.

Wired into:
- \`queries/HMRCTokenQueries.upsert\` ← the bug the user reported
- \`helper/hmrc.lua\` refresh-token UPSERT
- \`queries/HMRCBusinessQueries.upsert\` + \`routes/tax-hmrc-data.lua\` inline INSERT (business sync)
- \`queries/HMRCObligationQueries.upsert\` + \`routes/tax-hmrc-data.lua\` inline INSERT (obligation sync)
- \`queries/TaxUserProfileQueries.getOrCreate\`
- \`routes/register.lua\` \`save_default_profile_key\`

## Statement workflow_step backfill (migration 711)

Filed statements were stuck at \`workflow_step='TAX_CALCULATED'\` because the Python final-declaration filing path (companion PR) used to set \`is_filed/filed_at/hmrc_submission_id\` but forgot \`workflow_step\`. The dashboard reads \`workflow_step\` for its badge, so users saw a confusing "Calculated" badge on already-filed statements and were tempted to re-file (HMRC rejected on the second attempt with HMRC_SUBMIT_001).

Migration is idempotent — re-running is a no-op once everything is in sync.

## Duplicate-upload guard schema (migrations 713 + 714)

- **713**: adds \`tax_statements.file_hash VARCHAR(64)\` + partial index on \`(user_id, file_hash) WHERE file_hash IS NOT NULL\`.
- **714**: seeds the \`UPLOAD_DUPLICATE_FILED\` row in \`message_catalog\` (http_status=409). Translations live in the FastAPI \`en.json\` per the newer convention from step 52.

The FastAPI side (companion PR) computes SHA-256 at upload, looks up an \`is_filed=TRUE\` row for the same user, and 409s if there's a match. Legacy NULL-hash rows are caught via name+size narrowing + lazy MinIO download.

## Test plan

- [ ] Run \`lapis migrate\` on a fresh schema — confirm 711, 713, 714 apply cleanly
- [ ] Run on an existing schema — confirm idempotent (no-op on second run)
- [ ] Connect to HMRC OAuth on a brand new user → should not 500 with token_store_failed
- [ ] Fetch businesses + obligations → rows persisted with correct namespace_id
- [ ] Register a new user with a default_profile_key → tax_user_profiles row created with namespace_id

## Companion PR

bwalia/diy-tax-return-uk fix branch — matching FastAPI-side fixes for the same namespace_id violations plus the Python filing endpoint update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)