### PR TITLE
feat(deploy): enable int K3s via Vault + fix POSTGRES_* placeholders in chart

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -150,6 +150,9 @@ jobs:
     needs: [smoke-test]
     if: always() && (needs.smoke-test.result == 'success' || github.event.inputs.SKIP_SMOKE_TEST == 'true') && (needs.smoke-test.result != 'failure')
     runs-on: [self-hosted, Linux, X64]
+    # Backstop: never let a hung kubectl step hold the (single) self-hosted
+    # runner for GitHub's 6h default — fail fast and free it for the next run.
+    timeout-minutes: 15
     steps:
       - name: Identify Runner
         run: echo "Running on $(hostname)"
@@ -258,9 +261,18 @@ jobs:
         run: |
           export KUBECONFIG=$(pwd)/kubeconfig
           NS=${{ steps.env.outputs.TARGET_ENV }}
-          # Remove failed pods so K3s recreates them with new config
-          kubectl delete pods -n "$NS" --field-selector=status.phase=Failed || true
-          kubectl delete pods -n "$NS" -l app=diytaxreturn-lapis || true
+          # Remove failed pods so K3s recreates them with new config.
+          # --wait=false is REQUIRED: kubectl delete otherwise blocks until
+          # the pods fully terminate, and a pod stuck in Terminating (a
+          # finalizer, a container ignoring SIGTERM, or an unresponsive
+          # kubelet) hangs the whole job for hours — this exact step hung
+          # the acc deploy for 2h+ on 2026-06-11. We only want to *issue*
+          # the deletes; the Deployment recreates pods and the next step
+          # waits on the rollout. --grace-period=30 bounds termination.
+          kubectl delete pods -n "$NS" --field-selector=status.phase=Failed \
+            --wait=false --grace-period=30 || true
+          kubectl delete pods -n "$NS" -l app=diytaxreturn-lapis \
+            --wait=false --grace-period=30 || true
 
       - name: Wait for rollout
         run: |

--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -7,12 +7,13 @@ on:
   workflow_dispatch:
     inputs:
       TARGET_ENV:
-        description: "Environment to deploy (dev, acc, prod)"
+        description: "Environment to deploy (dev, int, acc, prod)"
         required: true
         default: "acc"
         type: choice
         options:
           - dev
+          - int
           - acc
           - prod
       SKIP_BUILD:
@@ -210,8 +211,8 @@ jobs:
           kubectl create namespace ${{ steps.env.outputs.TARGET_ENV }} --dry-run=client -o yaml | kubectl apply -f -
 
       # For dev: Vault ExternalSecrets are disabled, so create secrets manually.
-      # For acc/prod: Vault manages secrets via ExternalSecret — skip manual creation.
-      - name: Create Secrets (dev only — acc/prod use Vault)
+      # For int/acc/prod: Vault manages secrets via ExternalSecret — skip manual creation.
+      - name: Create Secrets (dev only — int/acc/prod use Vault)
         if: steps.env.outputs.TARGET_ENV == 'dev'
         env:
           ENV_CONTENT: ${{ secrets.OPSAPI_ENV_FILE }}

--- a/devops/helm-charts/diytaxreturn-lapis/templates/externalsecret.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/templates/externalsecret.yaml
@@ -28,11 +28,11 @@ spec:
             session_name = "opsapi_session",
             secret = "{{`{{ .JWT_SECRET_KEY }}`}}",
             postgres = {
-              host = "{{ .Values.database.host | default "{{`{{ .DB_HOST }}`}}" }}",
-              user = "{{`{{ .DB_USER }}`}}",
-              password = "{{`{{ .DB_PASSWORD }}`}}",
+              host = "{{ .Values.database.host | default "{{`{{ .POSTGRES_HOST }}`}}" }}",
+              user = "{{`{{ .POSTGRES_USER }}`}}",
+              password = "{{`{{ .POSTGRES_PASSWORD }}`}}",
               database = "opsapi",
-              port = {{`{{ .DB_PORT }}`}},
+              port = {{`{{ .POSTGRES_PORT }}`}},
               ssl = true
             },
             google = {

--- a/devops/helm-charts/diytaxreturn-lapis/values-int.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/values-int.yaml
@@ -13,10 +13,6 @@ projectCode: tax_copilot
 # this to bootstrap ``namespaces.allowed_redirect_origins`` on first
 # run; runtime path also falls back to it if any namespace's column
 # is empty. See README.md → Password Reset Flow.
-#
-# Note: int currently runs on a docker-compose host (192.168.1.193),
-# not k3s. This value applies if/when int migrates to k3s. For the
-# docker-compose deployment, FRONTEND_URL is set by start.sh.
 frontendUrl: "https://int.diytaxreturn.co.uk"
 # passwordResetAllowedOrigins: ""
 
@@ -41,8 +37,11 @@ ingress:
 database:
   host: "10.96.129.108"
 
+# int runs on k3s and follows the acc/prod path: secrets come from Vault
+# via ExternalSecret (dataFrom secret/diytaxreturnuk/opsapi/int/config),
+# not a manually-created Kubernetes secret.
 externalSecret:
-  enabled: false
+  enabled: true
 
 setup:
   adminEmail: ""


### PR DESCRIPTION
## Summary

Brings the int environment online on K3s alongside acc, sharing the same Vault → ExternalSecret pattern. Also fixes a placeholder-naming inconsistency in the lapis chart that caused a 16h CrashLoopBackOff on int when the Vault \`DB_PASSWORD\` drifted from the postgres-operator's pguser secret while the canonical \`POSTGRES_PASSWORD\` (used by the rest of the stack) looked fine.

### Commits

- \`ci(deploy): enable int environment on k3s via the Vault/acc path\` — adds \`int\` as a workflow_dispatch choice in deploy-k3s.yml, switches int from manual secret creation to ExternalSecret (matching acc/prod).
- \`ci(deploy): stop Force Refresh Pods from hanging the deploy job\` — \`kubectl delete pods --wait=false --grace-period=30\` so a stuck-Terminating pod can't burn the (single) self-hosted runner for hours (acc deploy hung 2h+ on 2026-06-11 from this).
- \`fix(chart): use POSTGRES_* placeholders instead of DB_* in lapis ExternalSecret\` — template now uses \`{{ .POSTGRES_HOST/USER/PASSWORD/PORT }}\`, matching \`lapis/config.lua\`, \`docker-compose.yml\`, and the backup CronJob.

### Why the chart change matters

Before this PR, the chart rendered \`config.lua\` from Vault keys \`DB_HOST/USER/PASSWORD/PORT\` while every other consumer in the stack reads \`POSTGRES_*\`. Vault kept both naming sets present but the lapis ExternalSecret was the only consumer of the \`DB_*\` set, so a drift between them was invisible until it caused a hard failure.

Post-deploy of this PR + a follow-up Vault cleanup, the \`DB_*\` keys can be removed from \`secret/diytaxreturnuk/opsapi/{int,acc,prod}/config\`. Rolling is safe: Vault currently has both key sets pointing at the live pguser password (synced 2026-06-12 during the int outage fix), so the rendered config.lua is identical whether the chart reads \`DB_*\` or \`POSTGRES_*\`.

## Test plan

- [x] int K3s lapis pod was 1/1 Running after force-syncing ExternalSecret with both key sets pointing at the live pguser password (verified pre-PR while diagnosing the outage).
- [ ] \`helm template -f values-int.yaml\` renders the new placeholders correctly (verified locally).
- [ ] After merge, manually trigger \`deploy-k3s.yml\` with \`TARGET_ENV=int\` (push-to-main still defaults to acc) and confirm rollout succeeds.
- [ ] Re-check acc backup CronJob — should now succeed at \`pg_dump\` (the MinIO upload step has a separate pre-existing bug with \`mc\` binary corruption that's out of scope for this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)