### PR TITLE
fix(otp): gate TEST_OTP_CODE bypass on OPSAPI_DEPLOY_ENV, not LAPIS_ENVIRONMENT

### DIFF
--- a/lapis/helper/otp.lua
+++ b/lapis/helper/otp.lua
@@ -188,16 +188,25 @@ function OTP.verify(user_id, code)
     -- Normalize: strip whitespace
     code = code:gsub("%s+", "")
 
-    -- Dev-only bypass: accept TEST_OTP_CODE to skip email OTP during development.
-    -- Guards: (1) only works when LAPIS_ENVIRONMENT is NOT "production",
-    --         (2) code must be at least 6 characters to prevent trivial values,
+    -- Non-prod bypass: accept TEST_OTP_CODE to skip email OTP outside production.
+    -- Guards: (1) only fires when the deploy env is NOT prod/production. The
+    --         label is taken from OPSAPI_DEPLOY_ENV (set by Helm to the env
+    --         suffix: dev / test / int / acc / prod), falling back to
+    --         LAPIS_ENVIRONMENT, then defaulting to "production" (fail-closed
+    --         — matches routes/e2e-otp.lua's deploy_env() so an unconfigured
+    --         pod can never accidentally enable the bypass).
+    --         (2) code must be at least 6 characters to prevent trivial values.
     --         (3) still invalidates DB codes so the bypass is auditable.
-    local env = os.getenv("LAPIS_ENVIRONMENT") or "development"
-    if env ~= "production" then
+    -- LAPIS_ENVIRONMENT alone can't gate this on K8s: it's hardcoded "production"
+    -- there so the ESO-templated config.lua's single config("production") block
+    -- is selected — without OPSAPI_DEPLOY_ENV, every cluster env (int/acc)
+    -- would look like prod and the bypass would never fire.
+    local deploy = os.getenv("OPSAPI_DEPLOY_ENV") or os.getenv("LAPIS_ENVIRONMENT") or "production"
+    if deploy ~= "production" and deploy ~= "prod" then
         local test_code = os.getenv("TEST_OTP_CODE")
         if test_code and #test_code >= 6 and code == test_code then
-            ngx.log(ngx.WARN, "[OTP] Dev bypass used for user_id=", user_id,
-                " env=", env, " ip=", ngx.var.remote_addr or "unknown")
+            ngx.log(ngx.WARN, "[OTP] Test bypass used for user_id=", user_id,
+                " deploy_env=", deploy, " ip=", ngx.var.remote_addr or "unknown")
             invalidate_existing(user_id)
             return true
         end
@@ -256,9 +265,12 @@ function OTP.sendToEmail(user, brand)
     -- When TEST_OTP_CODE is set, the bypass code is accepted by OTP.verify()
     -- but we still create a real OTP and send the email so users receive the code.
     -- This allows developers to bypass with the test code while real users get emails.
-    local env = os.getenv("LAPIS_ENVIRONMENT") or "development"
+    -- Mirrors the deploy-env guard in OTP.verify() above — OPSAPI_DEPLOY_ENV-first
+    -- so cluster envs (int/acc with LAPIS_ENVIRONMENT="production") still log
+    -- the bypass notice correctly. Fail-closed default "production".
+    local deploy = os.getenv("OPSAPI_DEPLOY_ENV") or os.getenv("LAPIS_ENVIRONMENT") or "production"
     local test_code = os.getenv("TEST_OTP_CODE")
-    if env ~= "production" and test_code and #test_code >= 6 then
+    if deploy ~= "production" and deploy ~= "prod" and test_code and #test_code >= 6 then
         ngx.log(ngx.NOTICE, "[OTP] Test bypass enabled — real OTP will also be created and emailed for ", user.email)
     end
 


### PR DESCRIPTION
## Summary

Restores the \`TEST_OTP_CODE\` 2FA bypass on int (and now acc) K8s deployments without weakening prod. Playwright e2e tests in [\`frontend/e2e/lib/otp.ts\`](frontend/e2e/lib/otp.ts) use this path (FALLBACK_OTP=987654) for envs without the broker; broken on int K3s since the docker-compose → K3s migration.

## Why the bypass was broken on int

\`lapis/helper/otp.lua\` gated the bypass on \`LAPIS_ENVIRONMENT != "production"\`. But in every K8s deploy, \`LAPIS_ENVIRONMENT\` has to be \`"production"\` so Lapis loads the right config block from the ESO-rendered \`config.lua\` (which has a single \`config("production", {...})\` block). So the guard couldn't tell apart "production cluster" from "actual prod" and refused the bypass everywhere.

## Fix

Mirror the pattern already used in \`routes/e2e-otp.lua\` — prefer \`OPSAPI_DEPLOY_ENV\` (set by Helm to the env suffix: \`dev\` / \`test\` / \`int\` / \`acc\` / \`prod\`), fall back to \`LAPIS_ENVIRONMENT\`, default \`"production"\` (fail-closed):

\`\`\`diff
-    local env = os.getenv("LAPIS_ENVIRONMENT") or "development"
-    if env ~= "production" then
+    local deploy = os.getenv("OPSAPI_DEPLOY_ENV") or os.getenv("LAPIS_ENVIRONMENT") or "production"
+    if deploy ~= "production" and deploy ~= "prod" then
\`\`\`

Same change in both \`OTP.verify()\` (line 191) and \`OTP.sendToEmail()\` (line 256).

## Defence in depth — prod stays blocked

| layer | prod | int / acc / test / dev |
|---|---|---|
| Helm chart \`env:\` → \`OPSAPI_DEPLOY_ENV\` | \`prod\` (values-prod.yaml) | env suffix |
| New guard (this PR) | trips on \`"prod"\` | passes |
| Vault \`TEST_OTP_CODE\` | not set | \`987654\` for int/acc/test |
| Inner code-length check | n/a — env var missing | \`#test_code >= 6\` ✓ |

So prod requires BOTH the OPSAPI_DEPLOY_ENV guard to be bypassed AND for someone to put TEST_OTP_CODE in prod Vault — neither happens accidentally.

## Test plan

- [x] \`luac -p lapis/helper/otp.lua\` — syntax OK
- [ ] After merge + manual deploy to int (\`workflow_dispatch\` deploy-k3s.yml with TARGET_ENV=int):
  - [ ] Log in to \`int.diytaxreturn.co.uk\` with admin@gmail.com → at OTP screen enter \`987654\` → should pass
  - [ ] \`kubectl -n int logs deploy/diytaxreturn-lapis\` → expect \`[OTP] Test bypass used for user_id=… deploy_env=int\`
- [ ] After deploy to acc:
  - [ ] Same flow on acc.diytaxreturn.co.uk works with \`987654\`
  - [ ] Playwright e2e suite continues to pass on acc (was using broker mode; now also has the fallback path)
- [ ] Negative test on prod (when next promoted):
  - [ ] Login to prod → OTP screen → \`987654\` should be rejected (\`Invalid code\`)
  - [ ] \`kubectl -n prod logs deploy/diytaxreturn-lapis | grep -i bypass\` → no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)