### PR TITLE
ci(deploy-k3s): public-URL health gate + chart sentinel comments

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -331,6 +331,64 @@ jobs:
           echo "Waiting for diytaxreturn-lapis rollout..."
           kubectl rollout status deployment/diytaxreturn-lapis -n "$NS" --timeout=180s || true
 
+      # Why this gate exists:
+      # `kubectl rollout status` only proves the Pod is Ready. It does NOT
+      # prove the public URL actually returns 200 — and on 2026-06-15 we
+      # had a 4-day intermittent outage of int-api where the Pod was healthy
+      # but a stale Ingress in a different namespace was sharing the host
+      # claim, so the wslproxy ingress controller flapped between a working
+      # backend and an orphaned one. Symptom: 9/10 requests succeeded; 1/10
+      # returned the wslproxy ingress controller's stock 404 page. Both
+      # `kubectl get pods` and the rollout step happily reported success.
+      #
+      # The gate below requires 5 CONSECUTIVE fast 200s within 2 minutes
+      # before the deploy is declared green. The consecutive bar is the
+      # important part — it catches the "sometimes works" regression mode
+      # that a single-shot probe would have missed today.
+      - name: Public-URL health gate
+        run: |
+          # Map env -> public URL. dev/int/acc follow the `<env>-api.*`
+          # convention; prod's public URL is bare `api.*`. New envs need
+          # to be added here explicitly rather than left to a default,
+          # so a typo in an env name fails CI instead of silently passing.
+          case "${{ matrix.target_env }}" in
+            prod) URL="https://api.diytaxreturn.co.uk/health" ;;
+            dev|int|acc) URL="https://${{ matrix.target_env }}-api.diytaxreturn.co.uk/health" ;;
+            *)
+              echo "::error::Unknown env '${{ matrix.target_env }}' — extend the case above with its public URL"
+              exit 1
+              ;;
+          esac
+          echo "Health-gating against $URL — need 5 consecutive fast 200s within 2 min"
+          ok_run=0
+          last_code=""
+          last_time=""
+          # ~30 attempts * 4s sleep = ~2 min ceiling. The 8s connect timeout
+          # is intentional: any single probe taking longer than the slow-path
+          # threshold (3s) breaks the streak — that's how we catch the
+          # Ingress-conflict pattern where one backend works and another
+          # times out at ~5s.
+          for i in $(seq 1 30); do
+            t=$(curl -s -o /dev/null -w "%{http_code} %{time_total}" -m 8 "$URL" 2>&1 || true)
+            last_code=$(echo "$t" | awk '{print $1}')
+            last_time=$(echo "$t" | awk '{print $2}')
+            slow=$(echo "$last_time" | awk '{print ($1 >= 3.0) ? 1 : 0}')
+            if [ "$last_code" = "200" ] && [ "$slow" = "0" ]; then
+              ok_run=$((ok_run+1))
+              echo "  attempt $i: code=$last_code time=${last_time}s — streak=$ok_run/5"
+              if [ "$ok_run" -ge 5 ]; then
+                echo "::notice::$URL healthy — 5 consecutive fast 200s"
+                exit 0
+              fi
+            else
+              ok_run=0
+              echo "  attempt $i: code=$last_code time=${last_time}s — streak reset"
+            fi
+            sleep 4
+          done
+          echo "::error::Public health gate failed — $URL did not produce 5 consecutive fast 200s in ~2 min (last: code=$last_code time=${last_time}s)"
+          exit 1
+
       - name: Cleanup Kubeconfig
         if: always()
         run: |

--- a/devops/helm-charts/diytaxreturn-lapis/values-acc.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/values-acc.yaml
@@ -29,6 +29,13 @@ service:
   type: ClusterIP
   port: 80
 
+# INTENTIONALLY DISABLED — see the same block in values-int.yaml for the full
+# story. tl;dr: `acc-api.diytaxreturn.co.uk` is already owned by the
+# `diytaxreturn-fastapi` chart (sibling diy-tax-return-uk repo), which does
+# path-based routing into THIS chart's lapis Service via `/`, `/auth`,
+# `/opsapi`. Enabling the block below creates a second Ingress for the same
+# host and starts an intermittent two-Ingress conflict on the wslproxy
+# ingress controller — exactly the failure mode that bit int on 2026-06-15.
 ingress:
   enabled: false
   className: wslproxy

--- a/devops/helm-charts/diytaxreturn-lapis/values-int.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/values-int.yaml
@@ -27,6 +27,25 @@ service:
   type: ClusterIP
   port: 80
 
+# INTENTIONALLY DISABLED — do not flip to `true` without reading this.
+#
+# `int-api.diytaxreturn.co.uk` is already owned by the `diytaxreturn-fastapi`
+# Helm chart (in the sibling diy-tax-return-uk repo). That chart's Ingress
+# does path-based routing on this host: `/fastapi/*` → fastapi service,
+# `/` `/auth` `/opsapi` → THIS chart's lapis Service.
+#
+# Enabling the block below creates a SECOND Ingress claiming the same host,
+# which puts the wslproxy ingress controller in an ambiguous state: it picks
+# one Ingress per request, so traffic flaps between the right backend and
+# whatever the other Ingress points at. On 2026-06-15 a stale duplicate in
+# the `test` namespace caused exactly this — ~10% of int-api requests
+# returned the controller's stock 404 page, the rest worked, and `kubectl
+# get pods` reported everything healthy. Took 4 days to track down because
+# the failure mode is intermittent.
+#
+# If you ever need this chart to own the host directly, first delete the
+# fastapi chart's Ingress (or migrate its path rules into this chart's
+# template) — never run both simultaneously.
 ingress:
   enabled: false
   className: wslproxy


### PR DESCRIPTION
## Summary

Today (2026-06-15) `int-api.diytaxreturn.co.uk` was intermittently returning a 159-byte `openresty/1.29.2.2` 404 — ~10% of requests, the rest worked. Root cause: **two stale Ingresses in the `test` namespace were sharing the host claim** with the int namespace's real Ingress, so the wslproxy ingress controller picked one per request and the orphaned ones 404'd. **Both `kubectl get pods` and `kubectl rollout status` reported healthy throughout** — the failure was invisible to CI, took 4 days to spot.

This PR adds two safeguards so this class of failure can never silently land again.

## 1. Public-URL health gate in `deploy-k3s.yml`

After `Wait for rollout`, the deploy job now curls the public URL for the matrix's target env and requires **5 consecutive fast (<3s) 200s within ~2 minutes** before exiting green.

```bash
case "${{ matrix.target_env }}" in
  prod) URL="https://api.diytaxreturn.co.uk/health" ;;
  dev|int|acc) URL="https://${{ matrix.target_env }}-api.diytaxreturn.co.uk/health" ;;
  *) echo "::error::Unknown env"; exit 1 ;;  # fail closed on typos
esac
# 30 attempts * 4s = ~2 min ceiling; streak resets on ANY 404, timeout, or slow probe
```

The **"consecutive"** bar is what specifically catches today's regression:
- A 9/10 single-shot probe would have been declared green (today's exact symptom).
- A streak of 5 fast 200s breaks the moment one in ten 404s — so the matrix leg fails red, the deploy stops, and someone sees it.

The 3-second slow threshold also catches the bonus failure mode where a dead upstream backend causes proxy_next_upstream retries (today's stale `:32101` backend in the wslproxy rule was producing exactly 5-second timeouts before falling back).

## 2. Sentinel comments in `values-int.yaml` + `values-acc.yaml`

Both files now explain *why* `ingress.enabled: false` is intentional:

> `*-api.diytaxreturn.co.uk` is already owned by the sibling `diytaxreturn-fastapi` chart, which does path-based routing: `/fastapi/*` → fastapi service, `/`, `/auth`, `/opsapi` → THIS chart's lapis Service. Flipping this to `true` creates a second Ingress for the same host and recreates today's two-Ingress conflict on the wslproxy ingress controller.

So if a future maintainer sees "no Ingress, must be broken" and tries to enable the block, code review has an obvious tripwire.

## What was fixed live (not in this PR)

- Deleted `test/diy-tax-return-backend` + `test/diytaxreturn-fastapi` Ingresses (both pointed at Services that don't exist in `test` namespace)
- `helm uninstall diy-tax-return-backend -n test` (abandoned release, hadn't been touched in 84 days)
- Removed dead `:32101` and duplicate `:32100` backends from the wslproxy rule `c1702579-…` (done on the wslproxy box by @harcharansingh; nginx graceful reload picked it up)

## Verification

After all of the above, 30/30 public probes returned 200, with real-app paths (`/auth/hmrc/initiate`) responding in ~30ms. The only residual flap is on `/health` itself, because the int lapis pod's own MinIO sub-probe times out at ~4.6s when its result cache expires — **unrelated to routing**, doesn't affect users, separate clean-up.

```
$ for i in {1..10}; do curl -s -o /dev/null -w 'code=%{http_code} t=%{time_total}s\n' \
    'https://int-api.diytaxreturn.co.uk/auth/hmrc/initiate?...'; done
code=401 t=0.024s   ← all 10 fast (<1s)
code=401 t=0.025s
... (8 more identical)
```

## Test plan

- [x] YAML parses for all 3 files
- [x] Streak logic verified mentally against today's pattern (9/10 = pass with old gate, fail with new gate)
- [ ] After merge → next push to main → confirm both `dev` and `int` matrix legs pass the gate
- [ ] After merge → push to `release` → confirm `acc` matrix leg passes
- [ ] Optionally trigger workflow_dispatch with `TARGET_ENV=prod` (when prod is ready) — verifies the prod URL branch in the `case`

🤖 Generated with [Claude Code](https://claude.com/claude-code)