### PR TITLE
feat(profile-builder): business-profile wizard tree + completion gate

### DIFF
--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -1359,6 +1359,13 @@ local _migrations = {
     ['501_tax_create_user_subscriptions']            = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 80),
     ['502_tax_add_user_subscriptions_indexes']       = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 81),
     ['503_tax_create_processed_apple_notifications'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 82),
+    -- Wizard tree depends on classification_profiles (created at 480), the
+    -- existing rules-pack seed rows (re-parented here), and
+    -- tax_user_profiles.default_profile_key (added at 496, source for the
+    -- one-time backfill into the join table). Registering after 503 puts
+    -- it safely past every direct dependency without splitting the
+    -- numbering convention used by the rest of the tax_copilot block.
+    ['504_profile_business_wizard_tree']             = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, profile_builder_migrations, 37),
 
     -- =========================================================================
     -- CORE AUTH: Password reset tokens

--- a/lapis/migrations/dynamic-profile-builder.lua
+++ b/lapis/migrations/dynamic-profile-builder.lua
@@ -1869,4 +1869,358 @@ return {
 
         print("[Profile] Created profile_question_business_profiles join table")
     end,
+
+    -- =========================================================================
+    -- [37] BUSINESS-PROFILE WIZARD TREE — hierarchy + multi-profile support
+    --
+    -- Lets a user say "I'm a sole-trader electrician AND I rent out a flat"
+    -- via a 3-step wizard (root pick → drill into branches → confirm) instead
+    -- of the current single `default_profile_key` column. Strict backwards
+    -- compat — nothing existing breaks:
+    --
+    --   • The five existing classification_profiles rows
+    --     (amazon_seller, construction_company, health_and_safety,
+    --      it_contractor, landlord) are UPDATEd with the new wizard columns
+    --     ONLY where currently NULL (COALESCE-guarded), so any admin-set
+    --     value is preserved. Their profile_key, display_name, rules_markdown
+    --     and is_active are untouched.
+    --   • The new tax_user_profiles_profiles join table is additive. The
+    --     existing tax_user_profiles.default_profile_key column is kept and
+    --     remains the read-path for /profile until the Phase 6 schema-gate
+    --     change; this migration backfills the join from it so the two
+    --     views agree on day one.
+    --   • New rows are added with ON CONFLICT DO NOTHING — re-running is a
+    --     no-op.
+    --
+    -- Tree shape:
+    --   sole_trader (branch)                     ← root
+    --     ├ sole_trader_tradesperson (branch)
+    --     │   ├ construction_company (EXISTING, re-parented)
+    --     │   ├ electrician, plumber, …
+    --     ├ sole_trader_ecommerce (branch)
+    --     │   ├ amazon_seller (EXISTING, re-parented)
+    --     │   ├ ebay_etsy_seller, …
+    --     ├ sole_trader_professional (branch)
+    --     │   ├ health_and_safety (EXISTING, re-parented)
+    --     │   ├ accountant_bookkeeper, …
+    --     ├ sole_trader_tech (branch)
+    --     │   ├ it_contractor (EXISTING, re-parented)
+    --     │   ├ freelance_developer, …
+    --     ├ … (driver / hair_beauty / hospitality / creative / education / healthcare)
+    --     ├ childminder, property_developer, other_sole_trader (direct leaves)
+    --   ltd_director (leaf)                      ← root
+    --   partner (leaf)                           ← root
+    --   landlord (EXISTING, kept as a leaf root)
+    --   other_income (leaf)                      ← root
+    --
+    -- The wizard treats "CIS subcontractor?" as a *follow-up question* on
+    -- tradesperson leaves, not a separate subtree — see the profile-builder
+    -- question rules (existing infrastructure). Same for "Are you a Ltd Co
+    -- director?" which is layered as an additional pick alongside the trade.
+    -- =========================================================================
+    [37] = function()
+        -- ── 1. classification_profiles — add wizard-tree columns ──────────────
+        local cols = db.query([[
+            SELECT column_name FROM information_schema.columns
+            WHERE table_name = 'classification_profiles'
+              AND column_name IN ('parent_profile_key','wizard_question','wizard_label','display_order','is_leaf')
+        ]])
+        local has_col = {}
+        for _, r in ipairs(cols or {}) do has_col[r.column_name] = true end
+
+        if not has_col.parent_profile_key then
+            db.query("ALTER TABLE classification_profiles ADD COLUMN parent_profile_key VARCHAR(100)")
+        end
+        if not has_col.wizard_question then
+            db.query("ALTER TABLE classification_profiles ADD COLUMN wizard_question TEXT")
+        end
+        if not has_col.wizard_label then
+            db.query("ALTER TABLE classification_profiles ADD COLUMN wizard_label VARCHAR(255)")
+        end
+        if not has_col.display_order then
+            db.query("ALTER TABLE classification_profiles ADD COLUMN display_order INTEGER NOT NULL DEFAULT 0")
+        end
+        if not has_col.is_leaf then
+            db.query("ALTER TABLE classification_profiles ADD COLUMN is_leaf BOOLEAN NOT NULL DEFAULT true")
+        end
+
+        db.query([[
+            CREATE INDEX IF NOT EXISTS idx_classification_profiles_parent
+            ON classification_profiles (parent_profile_key)
+            WHERE parent_profile_key IS NOT NULL
+        ]])
+
+        -- ── 2. tax_user_profiles_profiles — new join table for multi-profile ──
+        local jt = db.query([[
+            SELECT to_regclass('public.tax_user_profiles_profiles') AS reg
+        ]])
+        if not (jt and jt[1] and jt[1].reg) then
+            db.query([[
+                CREATE TABLE tax_user_profiles_profiles (
+                    user_id      INTEGER      NOT NULL,
+                    profile_key  VARCHAR(100) NOT NULL,
+                    namespace_id INTEGER      NOT NULL DEFAULT 0,
+                    is_primary   BOOLEAN      NOT NULL DEFAULT false,
+                    created_at   TIMESTAMP    NOT NULL DEFAULT NOW(),
+                    PRIMARY KEY (user_id, profile_key),
+                    CONSTRAINT fk_tupp_user
+                        FOREIGN KEY (user_id)
+                        REFERENCES users(id)
+                        ON DELETE CASCADE
+                )
+            ]])
+            db.query([[
+                CREATE INDEX idx_tupp_user
+                ON tax_user_profiles_profiles (user_id)
+            ]])
+            -- At most one primary per user (caches default_profile_key).
+            db.query([[
+                CREATE UNIQUE INDEX uq_tupp_user_primary
+                ON tax_user_profiles_profiles (user_id)
+                WHERE is_primary = true
+            ]])
+        end
+
+        -- ── 3. Seed: roots (4 new + 1 existing kept as-is, with wizard_label set) ──
+        -- INSERT … ON CONFLICT DO NOTHING — re-running is a no-op for new keys.
+        db.query([[
+            INSERT INTO classification_profiles
+                (profile_key, display_name, industry, user_profile_type,
+                 parent_profile_key, wizard_question, wizard_label,
+                 display_order, is_leaf, is_active, namespace_id)
+            VALUES
+                ('sole_trader',  'Sole Trader',                'self_employed', 'sole_trader',
+                 NULL, 'What kind of work do you do?',  'I work for myself as a sole trader',
+                 10, false, true, 0),
+                ('ltd_director', 'Limited Company Director',   'limited_company', 'limited_company',
+                 NULL, NULL, 'I''m a director of a Limited Company',
+                 20, true,  true, 0),
+                ('partner',      'Business Partnership',       'partnership',  'partnership',
+                 NULL, NULL, 'I''m in a business partnership',
+                 30, true,  true, 0),
+                ('other_income', 'Other Income',               'other',        'individual',
+                 NULL, NULL, 'I have other income (foreign / trust / investments)',
+                 50, true,  true, 0)
+            ON CONFLICT (profile_key) DO NOTHING
+        ]])
+
+        -- ── 4. Seed: sole-trader sub-branches ─────────────────────────────────
+        db.query([[
+            INSERT INTO classification_profiles
+                (profile_key, display_name, industry, user_profile_type,
+                 parent_profile_key, wizard_question, wizard_label,
+                 display_order, is_leaf, is_active, namespace_id)
+            VALUES
+                ('sole_trader_tradesperson', 'Tradesperson',           'construction',  'sole_trader',
+                 'sole_trader', 'What''s your trade?', 'Tradesperson (electrician, plumber, builder, …)',
+                 10,  false, true, 0),
+                ('sole_trader_driver',       'Driver',                 'transport',     'sole_trader',
+                 'sole_trader', 'What kind of driving work?', 'Driver (taxi, rideshare, delivery, …)',
+                 20,  false, true, 0),
+                ('sole_trader_ecommerce',    'E-commerce / Online',    'ecommerce',     'sole_trader',
+                 'sole_trader', 'Where do you sell?',  'E-commerce / Online seller',
+                 30,  false, true, 0),
+                ('sole_trader_hair_beauty',  'Hair, Beauty & Wellbeing','hair_beauty', 'sole_trader',
+                 'sole_trader', 'What''s your specialty?', 'Hair, beauty or wellbeing',
+                 40,  false, true, 0),
+                ('sole_trader_hospitality',  'Food & Hospitality',     'hospitality',   'sole_trader',
+                 'sole_trader', 'What''s your hospitality work?', 'Food / hospitality',
+                 50,  false, true, 0),
+                ('sole_trader_professional', 'Professional Services',  'professional',  'sole_trader',
+                 'sole_trader', 'What''s your profession?', 'Professional services (accountant, consultant, …)',
+                 60,  false, true, 0),
+                ('sole_trader_tech',         'Tech & IT',              'technology',    'sole_trader',
+                 'sole_trader', 'What kind of tech work?', 'Tech / IT (developer, designer, contractor)',
+                 70,  false, true, 0),
+                ('sole_trader_creative',     'Creative & Content',     'creative',      'sole_trader',
+                 'sole_trader', 'What''s your creative work?', 'Creative / content (photographer, writer, …)',
+                 80,  false, true, 0),
+                ('sole_trader_education',    'Education & Training',   'education',     'sole_trader',
+                 'sole_trader', 'What do you teach or instruct?', 'Education / instruction',
+                 90,  false, true, 0),
+                ('sole_trader_healthcare',   'Healthcare (non-NHS)',   'healthcare',    'sole_trader',
+                 'sole_trader', 'What''s your healthcare specialty?', 'Healthcare (non-NHS)',
+                 100, false, true, 0)
+            ON CONFLICT (profile_key) DO NOTHING
+        ]])
+
+        -- ── 5. Seed: leaves (concrete trade picks) ────────────────────────────
+        -- ~40 new leaves. Existing keys (amazon_seller, construction_company,
+        -- health_and_safety, it_contractor) are re-parented in section 6.
+        db.query([[
+            INSERT INTO classification_profiles
+                (profile_key, display_name, industry, user_profile_type,
+                 parent_profile_key, wizard_label, display_order, is_leaf,
+                 is_active, namespace_id)
+            VALUES
+                -- Tradespeople
+                ('electrician',        'Electrician',         'construction', 'sole_trader',
+                 'sole_trader_tradesperson', 'Electrician',         20, true, true, 0),
+                ('plumber',            'Plumber',             'construction', 'sole_trader',
+                 'sole_trader_tradesperson', 'Plumber',             30, true, true, 0),
+                ('decorator_painter',  'Decorator / Painter', 'construction', 'sole_trader',
+                 'sole_trader_tradesperson', 'Decorator / Painter', 40, true, true, 0),
+                ('carpenter',          'Carpenter',           'construction', 'sole_trader',
+                 'sole_trader_tradesperson', 'Carpenter',           50, true, true, 0),
+                ('gas_engineer',       'Gas Engineer',        'construction', 'sole_trader',
+                 'sole_trader_tradesperson', 'Gas Engineer',        60, true, true, 0),
+                ('roofer',             'Roofer',              'construction', 'sole_trader',
+                 'sole_trader_tradesperson', 'Roofer',              70, true, true, 0),
+                ('handyman',           'Handyman',            'construction', 'sole_trader',
+                 'sole_trader_tradesperson', 'Handyman',            80, true, true, 0),
+                ('mobile_mechanic',    'Mobile Mechanic',     'automotive',   'sole_trader',
+                 'sole_trader_tradesperson', 'Mobile Mechanic',     90, true, true, 0),
+
+                -- Drivers
+                ('taxi_phv',           'Taxi / Private Hire Driver', 'transport', 'sole_trader',
+                 'sole_trader_driver', 'Taxi / Private Hire',  10, true, true, 0),
+                ('rideshare',          'Rideshare Driver',           'transport', 'sole_trader',
+                 'sole_trader_driver', 'Rideshare (Uber, Bolt)', 20, true, true, 0),
+                ('delivery_driver',    'Delivery Driver',            'transport', 'sole_trader',
+                 'sole_trader_driver', 'Delivery (Amazon Flex, Deliveroo, DPD)', 30, true, true, 0),
+                ('hgv_courier',        'HGV Driver / Courier',       'transport', 'sole_trader',
+                 'sole_trader_driver', 'HGV / Courier',        40, true, true, 0),
+
+                -- E-commerce (amazon_seller is existing — re-parented in section 6)
+                ('ebay_etsy_seller',   'eBay / Etsy / Vinted Seller', 'ecommerce', 'sole_trader',
+                 'sole_trader_ecommerce', 'eBay / Etsy / Vinted',           20, true, true, 0),
+                ('shopify_dtc',        'Shopify / Direct-to-Consumer','ecommerce', 'sole_trader',
+                 'sole_trader_ecommerce', 'Shopify / Direct-to-Consumer',   30, true, true, 0),
+                ('online_subscription_creator', 'Subscription Creator',  'creative', 'sole_trader',
+                 'sole_trader_ecommerce', 'Subscription Creator (OnlyFans, Patreon)', 40, true, true, 0),
+
+                -- Hair, beauty & wellbeing
+                ('hairdresser_barber', 'Hairdresser / Barber',       'hair_beauty', 'sole_trader',
+                 'sole_trader_hair_beauty', 'Hairdresser / Barber', 10, true, true, 0),
+                ('beautician_nail',    'Beautician / Nail Tech',     'hair_beauty', 'sole_trader',
+                 'sole_trader_hair_beauty', 'Beautician / Nail Tech', 20, true, true, 0),
+                ('massage_therapist',  'Massage Therapist',          'healthcare',  'sole_trader',
+                 'sole_trader_hair_beauty', 'Massage Therapist',    30, true, true, 0),
+                ('personal_trainer',   'Personal Trainer',           'fitness',     'sole_trader',
+                 'sole_trader_hair_beauty', 'Personal Trainer / Yoga Instructor', 40, true, true, 0),
+
+                -- Hospitality
+                ('caterer',            'Caterer',                    'hospitality', 'sole_trader',
+                 'sole_trader_hospitality', 'Caterer',              10, true, true, 0),
+                ('market_trader',      'Market Trader / Food Vendor','hospitality', 'sole_trader',
+                 'sole_trader_hospitality', 'Market Trader / Food Vendor', 20, true, true, 0),
+                ('baker',              'Baker',                      'hospitality', 'sole_trader',
+                 'sole_trader_hospitality', 'Baker',                30, true, true, 0),
+
+                -- Professional (health_and_safety is existing — re-parented in section 6)
+                ('accountant_bookkeeper', 'Accountant / Bookkeeper', 'professional','sole_trader',
+                 'sole_trader_professional', 'Accountant / Bookkeeper', 10, true, true, 0),
+                ('consultant_general',    'Management Consultant',   'professional','sole_trader',
+                 'sole_trader_professional', 'Management / General Consultant', 20, true, true, 0),
+                ('financial_adviser',     'Financial Adviser',       'professional','sole_trader',
+                 'sole_trader_professional', 'Financial Adviser',    30, true, true, 0),
+
+                -- Tech (it_contractor is existing — re-parented in section 6)
+                ('freelance_developer', 'Freelance Developer',       'technology',  'sole_trader',
+                 'sole_trader_tech', 'Freelance Developer',          20, true, true, 0),
+                ('freelance_designer',  'Freelance Designer',        'creative',    'sole_trader',
+                 'sole_trader_tech', 'Freelance Designer',           30, true, true, 0),
+
+                -- Creative
+                ('photographer_videographer', 'Photographer / Videographer', 'creative', 'sole_trader',
+                 'sole_trader_creative', 'Photographer / Videographer', 10, true, true, 0),
+                ('writer_journalist',         'Writer / Journalist',         'creative', 'sole_trader',
+                 'sole_trader_creative', 'Writer / Journalist',         20, true, true, 0),
+                ('musician_performer',        'Musician / Performer',        'creative', 'sole_trader',
+                 'sole_trader_creative', 'Musician / Performer',        30, true, true, 0),
+                ('content_creator',           'Content Creator',             'creative', 'sole_trader',
+                 'sole_trader_creative', 'Content Creator (YouTube / TikTok)', 40, true, true, 0),
+
+                -- Education
+                ('tutor_teacher',      'Tutor / Teacher',            'education',   'sole_trader',
+                 'sole_trader_education', 'Tutor / Teacher',         10, true, true, 0),
+                ('driving_instructor', 'Driving Instructor',         'education',   'sole_trader',
+                 'sole_trader_education', 'Driving Instructor',      20, true, true, 0),
+                ('music_teacher',      'Music Teacher',              'education',   'sole_trader',
+                 'sole_trader_education', 'Music Teacher',           30, true, true, 0),
+
+                -- Healthcare (non-NHS)
+                ('therapist_counsellor',  'Therapist / Counsellor',  'healthcare',  'sole_trader',
+                 'sole_trader_healthcare', 'Therapist / Counsellor', 10, true, true, 0),
+                ('physiotherapist',       'Physiotherapist',         'healthcare',  'sole_trader',
+                 'sole_trader_healthcare', 'Physiotherapist',        20, true, true, 0),
+                ('osteopath_chiropractor','Osteopath / Chiropractor','healthcare',  'sole_trader',
+                 'sole_trader_healthcare', 'Osteopath / Chiropractor', 30, true, true, 0),
+
+                -- Direct leaves under sole_trader (small populations, no sub-branch)
+                ('childminder',          'Childminder',              'education',   'sole_trader',
+                 'sole_trader', 'Childminder',                       110, true, true, 0),
+                ('property_developer',   'Property Developer',       'property',    'sole_trader',
+                 'sole_trader', 'Property Developer (Flipper)',      120, true, true, 0),
+                ('other_sole_trader',    'Other Sole Trader',        'other',       'sole_trader',
+                 'sole_trader', 'Other / Not listed',                130, true, true, 0)
+            ON CONFLICT (profile_key) DO NOTHING
+        ]])
+
+        -- ── 6. Re-parent the existing 5 rows under the new tree ───────────────
+        -- COALESCE-guarded — only sets values that are currently NULL/0, so an
+        -- admin who has already keyed in a parent or wizard_label by hand keeps
+        -- their value. profile_key, display_name, rules_markdown, is_active are
+        -- untouched.
+        db.query([[
+            UPDATE classification_profiles
+            SET parent_profile_key = COALESCE(parent_profile_key, 'sole_trader_ecommerce'),
+                wizard_label       = COALESCE(wizard_label, 'Amazon Seller (FBA / FBM)'),
+                display_order      = CASE WHEN display_order = 0 THEN 10 ELSE display_order END
+            WHERE profile_key = 'amazon_seller'
+        ]])
+        db.query([[
+            UPDATE classification_profiles
+            SET parent_profile_key = COALESCE(parent_profile_key, 'sole_trader_tradesperson'),
+                wizard_label       = COALESCE(wizard_label, 'Builder / Construction'),
+                display_order      = CASE WHEN display_order = 0 THEN 10 ELSE display_order END
+            WHERE profile_key = 'construction_company'
+        ]])
+        db.query([[
+            UPDATE classification_profiles
+            SET parent_profile_key = COALESCE(parent_profile_key, 'sole_trader_professional'),
+                wizard_label       = COALESCE(wizard_label, 'Health & Safety Consultant'),
+                display_order      = CASE WHEN display_order = 0 THEN 40 ELSE display_order END
+            WHERE profile_key = 'health_and_safety'
+        ]])
+        db.query([[
+            UPDATE classification_profiles
+            SET parent_profile_key = COALESCE(parent_profile_key, 'sole_trader_tech'),
+                wizard_label       = COALESCE(wizard_label, 'IT Contractor'),
+                display_order      = CASE WHEN display_order = 0 THEN 10 ELSE display_order END
+            WHERE profile_key = 'it_contractor'
+        ]])
+        db.query([[
+            UPDATE classification_profiles
+            SET wizard_label  = COALESCE(wizard_label, 'I rent out one or more properties'),
+                display_order = CASE WHEN display_order = 0 THEN 40 ELSE display_order END
+            WHERE profile_key = 'landlord'
+        ]])
+
+        -- ── 7. Backfill: tax_user_profiles.default_profile_key → join table ───
+        -- For every user with a default_profile_key, ensure a matching
+        -- (user_id, profile_key, is_primary=true) row exists. Idempotent.
+        -- Until Phase 6 (schema-gate change) the default_profile_key column
+        -- remains the read-path, so we DON'T null it out — the two stay in
+        -- sync via the API write-paths added in Phase 3.
+        db.query([[
+            INSERT INTO tax_user_profiles_profiles
+                (user_id, profile_key, namespace_id, is_primary)
+            SELECT tup.user_id,
+                   tup.default_profile_key,
+                   COALESCE(tup.namespace_id, 0),
+                   true
+            FROM tax_user_profiles tup
+            WHERE tup.default_profile_key IS NOT NULL
+              AND tup.default_profile_key <> ''
+              AND NOT EXISTS (
+                  SELECT 1 FROM tax_user_profiles_profiles tupp
+                  WHERE tupp.user_id = tup.user_id
+                    AND tupp.profile_key = tup.default_profile_key
+              )
+        ]])
+
+        print("[Profile] Wizard tree migration complete (added " ..
+              "wizard columns + tax_user_profiles_profiles + tree seeds)")
+    end,
 }

--- a/lapis/routes/profile-builder.lua
+++ b/lapis/routes/profile-builder.lua
@@ -408,13 +408,33 @@ end
 
 -- Evaluate visibility rules for a question against current answers
 local function evaluateVisibility(question_id, answer_map)
+    -- Use ``priority`` for the within-group ordering — that's the
+    -- actual column on profile_question_rules. The original code used
+    -- ``display_order``, which doesn't exist on this table, so the
+    -- pcall would silently swallow the SQL error and the function
+    -- would fall through to the early-return at "no rules" and treat
+    -- the question as always-visible. Net effect: server-side
+    -- visibility rules were a no-op for every conditional question,
+    -- which surfaced as frontend-says-100-backend-says-96 mismatches
+    -- in the completion gate.
     local ok, rules = pcall(db.query, [[
         SELECT rule_type, operator, expected_value, source_question_id, logic_group
         FROM profile_question_rules
         WHERE question_id = ? AND is_active = true AND rule_type = 'visibility'
-        ORDER BY logic_group ASC, display_order ASC
+        ORDER BY logic_group ASC, priority ASC
     ]], question_id)
-    if not ok or not rules or #rules == 0 then
+    if not ok then
+        -- Query failure must be visible — silently defaulting to
+        -- "visible" lies to the completion endpoint and the gate, and
+        -- that's exactly how the display_order typo escaped review.
+        -- Log loudly; default to visible so the user isn't locked out
+        -- of unanswerable questions, but downstream now has a paper
+        -- trail for the next time something rhymes with this.
+        ngx.log(ngx.ERR, "[ProfileBuilder] evaluateVisibility query failed for question_id=",
+            tostring(question_id), ": ", tostring(rules))
+        return true
+    end
+    if not rules or #rules == 0 then
         return true -- No rules = always visible
     end
 
@@ -430,6 +450,27 @@ local function evaluateVisibility(question_id, answer_map)
     local and_result = true
     local or_result = false
     local has_or = false
+
+    -- Boolean-aware equality. Rules authored against Yes/No questions
+    -- store expected_value = "yes" / "no" (admin UI default), but the
+    -- stored answer comes through as a boolean -> tostring("true").
+    -- Naive ``actual == expected`` would never match "true" against
+    -- "yes", so this helper normalises common yes/no/true/false/1/0
+    -- spellings to a canonical bool on both sides before comparing.
+    -- Falls back to lowercase string compare for non-boolean rules.
+    local function parseBoolish(s)
+        if s == nil then return nil end
+        local lower = tostring(s):lower():gsub("^%s+", ""):gsub("%s+$", "")
+        if lower == "true" or lower == "yes" or lower == "1" or lower == "y" then return true end
+        if lower == "false" or lower == "no" or lower == "0" or lower == "n" then return false end
+        return nil
+    end
+    local function looseEquals(a, b)
+        local ab, bb = parseBoolish(a), parseBoolish(b)
+        if ab ~= nil and bb ~= nil then return ab == bb end
+        return tostring(a or ""):lower():gsub("^%s+", ""):gsub("%s+$", "")
+            == tostring(b or ""):lower():gsub("^%s+", ""):gsub("%s+$", "")
+    end
 
     for group_name, group_rules in pairs(groups) do
         for _, rule in ipairs(group_rules) do
@@ -451,9 +492,9 @@ local function evaluateVisibility(question_id, answer_map)
             local num_expected = tonumber(expected) or 0
 
             if rule.operator == "equals" then
-                match = actual == expected
+                match = looseEquals(actual, expected)
             elseif rule.operator == "not_equals" then
-                match = actual ~= expected
+                match = not looseEquals(actual, expected)
             elseif rule.operator == "greater_than" then
                 match = num_actual > num_expected
             elseif rule.operator == "less_than" then
@@ -469,12 +510,12 @@ local function evaluateVisibility(question_id, answer_map)
                 if #parts >= 2 then match = num_actual >= parts[1] and num_actual <= parts[2] end
             elseif rule.operator == "in_list" then
                 for item in expected:gmatch("[^,]+") do
-                    if actual == item:match("^%s*(.-)%s*$") then match = true; break end
+                    if looseEquals(actual, item:match("^%s*(.-)%s*$")) then match = true; break end
                 end
             elseif rule.operator == "not_in_list" then
                 match = true
                 for item in expected:gmatch("[^,]+") do
-                    if actual == item:match("^%s*(.-)%s*$") then match = false; break end
+                    if looseEquals(actual, item:match("^%s*(.-)%s*$")) then match = false; break end
                 end
             elseif rule.operator == "contains" then
                 match = actual:lower():find(expected:lower(), 1, true) ~= nil
@@ -797,6 +838,217 @@ return function(app)
     end)
 
     -- =====================================================================
+    -- 1b. GET /completion-status — Lightweight authoritative completion check
+    --
+    -- Single source of truth for "has this user finished the profile?".
+    -- The /schema endpoint is heavy (full question tree, options, rules,
+    -- per-category state) and was the wrong shape for "is this user
+    -- done?" calls fired from the gate / Go-to-dashboard button.
+    --
+    -- This endpoint:
+    --   1. Reads the user's answers + every active question in their
+    --      namespace (global + per-tenant).
+    --   2. Evaluates visibility per question using the same rules engine
+    --      that the schema endpoint uses (after the boolean-aware
+    --      ``looseEquals`` fix). Conditionally-hidden questions don't
+    --      count in numerator OR denominator.
+    --   3. Counts answered (non-null answer column) over visible total.
+    --   4. Sets the ``profile_complete=true`` cookie (or clears it) so
+    --      the Next.js middleware can hard-gate routes WITHOUT calling
+    --      back into opsapi on every request.
+    --   5. Returns ``{ is_complete, overall_percent, total, answered }``
+    --      so the frontend can show a coherent state to the user.
+    --
+    -- Cookie is set with ``Path=/; SameSite=Lax`` and NO ``HttpOnly`` —
+    -- the cookie is UX (a gating hint), not credentials. The actual
+    -- authority remains this endpoint plus the same server-side
+    -- per-route checks any feature-flag would have. Cookie expiry is
+    -- session-only so a logout flushes the verdict naturally.
+    -- =====================================================================
+    app:get(PREFIX .. "/completion-status", function(self)
+        local user = requireAuth(self)
+        if not user then
+            return { status = 401, json = { error = "Authentication required" } }
+        end
+        local user_uuid = user.uuid or user.id
+        local user_id = getUserIdByUuid(user_uuid)
+        if not user_id then
+            return { status = 401, json = { error = "User not found" } }
+        end
+        local namespace_id = getNamespaceId(self)
+
+        -- Build the same namespace filter the schema endpoint uses so
+        -- visibility is computed against EXACTLY the questions the user
+        -- can see. Empty filter = the lapis global default scope.
+        local ns_filter = ""
+        if namespace_id and namespace_id > 0 then
+            ns_filter = " AND (pq.namespace_id = " .. db.escape_literal(namespace_id) .. " OR pq.namespace_id = 0)"
+        end
+
+        -- Single answer_map used for BOTH visibility rule evaluation
+        -- AND the answered count. Drafts are treated as real answers
+        -- here on purpose: the frontend's isAnswered only checks for a
+        -- non-empty value (not is_draft), and the user's perception is
+        -- "I typed something in that box, it's answered". The is_draft
+        -- flag is orthogonal — it tracks "the text field's value may
+        -- still change as the user keeps typing", not "this isn't a
+        -- real answer". The existing recalculateCompletion() helper
+        -- filters drafts for a different signal ("officially committed
+        -- answers used by tag rules"), but the gate cookie must match
+        -- what the user sees on the /profile UI — otherwise text-only
+        -- categories sit at 0% on the server while showing 100% to
+        -- the user, exactly the trap we just hit.
+        local answer_map = {}
+        local ok_ans, ans_rows = pcall(db.query, [[
+            SELECT question_id, answer_text, answer_number, answer_boolean,
+                   answer_date, answer_json
+            FROM user_profile_answers
+            WHERE user_id = ?
+        ]], user_id)
+        if ok_ans and ans_rows then
+            for _, a in ipairs(ans_rows) do
+                answer_map[a.question_id] = a
+            end
+        end
+
+        -- Active, non-archived questions in the user's scope. Include
+        -- question_key + label so debug mode can name them; cheap
+        -- columns, no measurable perf impact.
+        local ok_qs, questions = pcall(db.query, [[
+            SELECT pq.id, pq.question_key, pq.label, pq.is_required
+            FROM profile_questions pq
+            JOIN profile_categories pc ON pc.id = pq.category_id
+            WHERE pq.is_active = true AND pq.is_archived = false
+              AND pc.is_active = true AND pc.is_archived = false
+            ]] .. ns_filter)
+        if not ok_qs then
+            ngx.log(ngx.ERR, "[ProfileBuilder] completion-status questions query failed: ", tostring(questions))
+            return { status = 500, json = { error = "Failed to compute completion" } }
+        end
+
+        -- ?debug=true returns a per-question breakdown alongside the
+        -- summary so the next-vs-backend gap can be pinpointed without
+        -- adding instrumentation each time something rhymes with this.
+        -- Cheap to emit; not gated by admin role because the user only
+        -- ever sees their OWN answers.
+        local debug_mode = self.params.debug == "true" or self.params.debug == "1"
+        local debug_rows = debug_mode and {} or nil
+
+        local total_visible = 0
+        local answered = 0
+        for _, q in ipairs(questions or {}) do
+            local is_visible = evaluateVisibility(q.id, answer_map)
+            local a = answer_map[q.id]   -- drafts INCLUDED — see note above answer_map
+            local has_answer = false
+            if a then
+                has_answer = (a.answer_text ~= nil and a.answer_text ~= "")
+                    or a.answer_number ~= nil
+                    or a.answer_boolean ~= nil
+                    or a.answer_date ~= nil
+                    or (a.answer_json ~= nil and a.answer_json ~= "" and a.answer_json ~= "null" and a.answer_json ~= "[]")
+            end
+            if is_visible then
+                total_visible = total_visible + 1
+                if has_answer then
+                    answered = answered + 1
+                end
+            end
+            if debug_mode then
+                -- Stringify each answer column so the response is
+                -- safe to JSON-encode regardless of underlying type
+                -- (booleans / numbers / pgmoon's NULL sentinel).
+                local function show(v)
+                    if v == nil then return nil end
+                    if type(v) == "boolean" then return tostring(v) end
+                    if type(v) == "number" then return v end
+                    return tostring(v)
+                end
+                table.insert(debug_rows, {
+                    question_id = q.id,
+                    question_key = q.question_key,
+                    label = q.label,
+                    is_required = q.is_required,
+                    is_visible = is_visible,
+                    has_answer = has_answer,
+                    counted_in_total = is_visible,
+                    counted_in_answered = is_visible and has_answer,
+                    answer = a and {
+                        answer_text = show(a.answer_text),
+                        answer_number = show(a.answer_number),
+                        answer_boolean = show(a.answer_boolean),
+                        answer_date = show(a.answer_date),
+                        answer_json = show(a.answer_json),
+                    } or nil,
+                })
+            end
+        end
+
+        local pct
+        if total_visible == 0 then
+            pct = 100 -- vacuously complete: nothing to fill in
+        else
+            pct = math.floor((answered / total_visible) * 100)
+        end
+        local is_complete = pct >= 100
+
+        -- Single cookie set via the Set-Cookie header. The Next.js
+        -- middleware reads this verbatim — no client-side js needed.
+        -- Clearing uses Max-Age=0 so the browser drops the cookie
+        -- immediately rather than waiting for session end.
+        --
+        -- Domain resolution mirrors helper/auth-cookies.lua for the
+        -- refresh-token cookie: AUTH_COOKIE_TRUSTED_DOMAINS gives us a
+        -- comma-separated allowlist of apex domains; we longest-suffix
+        -- match it against the Origin and emit ``Domain=.<apex>`` so
+        -- the cookie crosses the api-vs-app subdomain boundary in
+        -- production. No match → omit Domain (host-scoped, correct
+        -- for local dev). Secure default-on; AUTH_COOKIE_INSECURE=true
+        -- opts out for localhost HTTP. Reusing the existing env vars
+        -- keeps operators from having to configure a second allowlist
+        -- (per [[reference_secret_distribution]] / per [[auth_refresh_cookie]]).
+        local cookie_parts = is_complete
+            and { "profile_complete=true", "Path=/", "SameSite=Lax" }
+            or  { "profile_complete=",     "Path=/", "Max-Age=0", "SameSite=Lax" }
+        do
+            local override = os.getenv("AUTH_COOKIE_DOMAIN")
+            local domain = nil
+            if override and override ~= "" then
+                domain = override
+            else
+                local raw = os.getenv("AUTH_COOKIE_TRUSTED_DOMAINS") or ""
+                local allowed_list = {}
+                for item in raw:gmatch("[^,%s]+") do table.insert(allowed_list, item:lower()) end
+                local origin = (self.req and self.req.headers and
+                    (self.req.headers["Origin"] or self.req.headers["origin"])) or nil
+                if origin and #allowed_list > 0 then
+                    local host = origin:gsub("^https?://", ""):gsub(":%d+$", ""):gsub("/.*$", ""):lower()
+                    local best
+                    for _, allowed in ipairs(allowed_list) do
+                        local matches = host == allowed
+                            or host:sub(-(#allowed + 1)) == "." .. allowed
+                        if matches and (not best or #allowed > #best) then best = allowed end
+                    end
+                    if best then domain = "." .. best end
+                end
+            end
+            if domain then table.insert(cookie_parts, "Domain=" .. domain) end
+            if os.getenv("AUTH_COOKIE_INSECURE") ~= "true" then
+                table.insert(cookie_parts, "Secure")
+            end
+        end
+        ngx.header["Set-Cookie"] = table.concat(cookie_parts, "; ")
+
+        local body = {
+            is_complete = is_complete,
+            overall_percent = pct,
+            total = total_visible,
+            answered = answered,
+        }
+        if debug_mode then body.questions = debug_rows end
+        return { status = 200, json = body }
+    end)
+
+    -- =====================================================================
     -- 2. GET /schema/preview — Admin: preview schema as a specific user
     -- =====================================================================
     app:get(PREFIX .. "/schema/preview", function(self)
@@ -915,6 +1167,114 @@ return function(app)
         end
 
         return { status = 200, json = { schema = result, preview_user_uuid = target_uuid } }
+    end)
+
+    -- =====================================================================
+    -- 2b. GET /business-wizard — tree of pickable business profiles
+    --
+    -- User-facing endpoint that powers the post-signup business-profile
+    -- picker. Returns a nested tree of all classification_profiles rows
+    -- that have ``wizard_label`` set, grouped by parent_profile_key:
+    --
+    --   tree: [
+    --     { profile_key: "sole_trader", is_leaf: false,
+    --       wizard_question: "What kind of work do you do?",
+    --       wizard_label: "I work for myself as a sole trader",
+    --       children: [
+    --         { profile_key: "sole_trader_tradesperson", is_leaf: false,
+    --           children: [
+    --             { profile_key: "electrician", is_leaf: true, children: [] },
+    --             …
+    --           ] },
+    --         …
+    --       ] },
+    --     { profile_key: "ltd_director", is_leaf: true, children: [] },
+    --     { profile_key: "landlord",     is_leaf: true, children: [] },
+    --     …
+    --   ]
+    --
+    -- The FE walks this once and renders a 3-step wizard (root multi-select
+    -- → drill into ticked branches → confirm). Leaves with children = [] are
+    -- terminal picks; branches require a follow-up question.
+    --
+    -- ``wizard_label`` is the discriminator that lets us exclude DB rows
+    -- that are catalog-only (rules-pack carriers) rather than wizard-visible.
+    -- After migration 450_profile_business_wizard_tree, every active row
+    -- has a wizard_label set, so the filter is currently a no-op — but
+    -- it keeps the contract future-proof when admins add rule-only rows
+    -- via the admin UI without exposing them in onboarding.
+    --
+    -- Returns the GLOBAL catalogue (namespace_id = 0). Per-tenant overrides
+    -- are a future extension once a customer actually needs custom packs.
+    -- =====================================================================
+    app:get(PREFIX .. "/business-wizard", function(self)
+        local user = requireAuth(self)
+        if not user then
+            return { status = 401, json = { error = "Authentication required" } }
+        end
+
+        -- COALESCE parent_profile_key to '' so we don't have to fight
+        -- pgmoon's NULL representation in Lua (ngx.null vs nil vs cjson.null
+        -- depending on driver build) — empty-string is unambiguous.
+        local ok, rows = pcall(db.query, [[
+            SELECT profile_key,
+                   display_name,
+                   industry,
+                   user_profile_type,
+                   COALESCE(parent_profile_key, '') AS parent_profile_key,
+                   wizard_question,
+                   wizard_label,
+                   display_order,
+                   is_leaf
+            FROM classification_profiles
+            WHERE is_active = true
+              AND wizard_label IS NOT NULL
+              AND wizard_label <> ''
+            ORDER BY display_order ASC, profile_key ASC
+        ]])
+        if not ok then
+            ngx.log(ngx.ERR, "[ProfileBuilder] business-wizard query failed: ", tostring(rows))
+            return { status = 500, json = { error = "Failed to load business profile wizard" } }
+        end
+
+        -- Single-pass build: map profile_key -> node, then a second pass to
+        -- attach children to parents. O(n) and order-independent.
+        local nodes_by_key = {}
+        for _, r in ipairs(rows or {}) do
+            nodes_by_key[r.profile_key] = {
+                profile_key       = r.profile_key,
+                display_name      = r.display_name,
+                industry          = r.industry or "",
+                user_profile_type = r.user_profile_type or "",
+                wizard_question   = r.wizard_question,   -- may be nil for leaves
+                wizard_label      = r.wizard_label,
+                is_leaf           = (r.is_leaf == true) or (r.is_leaf == "t"),
+                display_order     = tonumber(r.display_order) or 0,
+                children          = {},
+            }
+        end
+
+        local roots = {}
+        for _, r in ipairs(rows or {}) do
+            local node = nodes_by_key[r.profile_key]
+            local parent_key = r.parent_profile_key
+            if not parent_key or parent_key == "" then
+                table.insert(roots, node)
+            elseif nodes_by_key[parent_key] then
+                table.insert(nodes_by_key[parent_key].children, node)
+            else
+                -- Parent referenced but parent row not in the visible set
+                -- (e.g. parent has wizard_label NULL or is_active false).
+                -- Surface as a root so the data isn't lost; log so the
+                -- admin notices the inconsistency.
+                ngx.log(ngx.WARN, "[ProfileBuilder] orphan wizard node: ",
+                        r.profile_key, " (parent ", parent_key,
+                        " not in visible set)")
+                table.insert(roots, node)
+            end
+        end
+
+        return { status = 200, json = { tree = roots } }
     end)
 
     -- =====================================================================

--- a/lapis/routes/tax-admin-profiles.lua
+++ b/lapis/routes/tax-admin-profiles.lua
@@ -311,16 +311,32 @@ return function(app)
                 return { status = 409, json = { error = "Profile key already exists" } }
             end
 
+            -- Wizard-tree fields: branches/leaves authored via the admin
+            -- business-types dashboard set these. Existing callers that only
+            -- create rules-pack rows (no wizard surface) leave them NULL/default,
+            -- which keeps the row out of the wizard tree (helper/profile_loader
+            -- already filters legacy rows by ``wizard_label IS NULL``).
+            -- is_leaf defaults to TRUE so a brand-new row is selectable in the
+            -- wizard unless the caller explicitly marks it a branch.
+            local is_leaf
+            if body.is_leaf == nil then
+                is_leaf = true
+            else
+                is_leaf = body.is_leaf and true or false
+            end
+
             local uuid = require("helper.global").generateStaticUUID()
             db.query([[
                 INSERT INTO classification_profiles
                     (uuid, profile_key, display_name, industry, user_profile_type,
                      category_affinity, personal_indicators, excluded_categories,
                      rules_markdown, keyword_rules, category_mappings,
+                     parent_profile_key, wizard_question, wizard_label, display_order, is_leaf,
                      is_active, namespace_id, created_at, updated_at)
                 VALUES (?, ?, ?, ?, ?,
                         ?::jsonb, ?::jsonb, ?::jsonb,
                         ?, ?::jsonb, ?::jsonb,
+                        ?, ?, ?, ?, ?,
                         true, 0, NOW(), NOW())
             ]],
                 uuid,
@@ -333,7 +349,12 @@ return function(app)
                 cjson.encode(body.excluded_categories or {}),
                 body.rules_markdown or db.NULL,
                 cjson.encode(body.keyword_rules or {}),
-                cjson.encode(body.category_mappings or {})
+                cjson.encode(body.category_mappings or {}),
+                body.parent_profile_key or db.NULL,
+                body.wizard_question or db.NULL,
+                body.wizard_label or db.NULL,
+                body.display_order or 100,
+                is_leaf
             )
 
             local created = db.query("SELECT * FROM classification_profiles WHERE uuid = ?", uuid)
@@ -377,6 +398,16 @@ return function(app)
             add("rules_markdown", body.rules_markdown)
             add("keyword_rules", body.keyword_rules, true)
             add("category_mappings", body.category_mappings, true)
+            -- Wizard-tree fields. is_leaf is handled specially because Lua's
+            -- truthiness coerces the JSON ``false`` to nil through pcall paths;
+            -- check for the explicit key so admins can toggle a branch ↔ leaf.
+            add("parent_profile_key", body.parent_profile_key)
+            add("wizard_question", body.wizard_question)
+            add("wizard_label", body.wizard_label)
+            add("display_order", body.display_order)
+            if body.is_leaf ~= nil then
+                table.insert(sets, "is_leaf = " .. db.interpolate_query("?", body.is_leaf and true or false))
+            end
             table.insert(sets, "updated_at = NOW()")
 
             if #sets > 0 then
@@ -402,11 +433,76 @@ return function(app)
             if not existing or #existing == 0 then
                 return { status = 404, json = { error = "Profile not found" } }
             end
+            local pk = existing[1].profile_key
+
+            -- Wizard-tree safety. Refuse delete if the node is referenced — a
+            -- soft-delete would orphan child nodes (the wizard tree breaks)
+            -- and abandon user picks (the user's saved business type silently
+            -- vanishes). Force the admin to re-parent / migrate users first.
+            local children = db.query(
+                "SELECT COUNT(*)::int AS n FROM classification_profiles WHERE parent_profile_key = ? AND is_active = true",
+                pk
+            )
+            if children and children[1] and children[1].n > 0 then
+                return { status = 409, json = {
+                    error = "Profile has " .. children[1].n .. " active child node(s) — re-parent them first",
+                    children_count = children[1].n,
+                } }
+            end
+
+            local user_picks = db.query(
+                "SELECT COUNT(*)::int AS n FROM tax_user_profiles_profiles WHERE profile_key = ?",
+                pk
+            )
+            if user_picks and user_picks[1] and user_picks[1].n > 0 then
+                return { status = 409, json = {
+                    error = "Profile is picked by " .. user_picks[1].n .. " user(s) — re-assign them first",
+                    user_picks_count = user_picks[1].n,
+                } }
+            end
 
             db.query("UPDATE classification_profiles SET is_active = false, updated_at = NOW() WHERE uuid = ?",
                 self.params.uuid)
 
             return { status = 200, json = { message = "Profile deactivated" } }
+        end)
+    )
+
+    -- ========================================
+    -- Usage counts — used by the admin tree dashboard to decide
+    -- whether the Delete button should be enabled. Cheap two-count
+    -- query so the UI can show "5 users / 2 children" inline without
+    -- racing the DELETE 409 response.
+    -- ========================================
+    app:get("/api/v2/tax/admin/profiles/:uuid/usage",
+        AuthMiddleware.requireAuth(function(self)
+            if not isAdmin(self.current_user) then
+                return { status = 403, json = { error = "Admin access required" } }
+            end
+
+            local row = db.query(
+                "SELECT profile_key FROM classification_profiles WHERE uuid = ? AND is_active = true LIMIT 1",
+                self.params.uuid
+            )
+            if not row or #row == 0 then
+                return { status = 404, json = { error = "Profile not found" } }
+            end
+            local pk = row[1].profile_key
+
+            local kids = db.query(
+                "SELECT COUNT(*)::int AS n FROM classification_profiles WHERE parent_profile_key = ? AND is_active = true",
+                pk
+            )
+            local picks = db.query(
+                "SELECT COUNT(*)::int AS n FROM tax_user_profiles_profiles WHERE profile_key = ?",
+                pk
+            )
+
+            return { status = 200, json = {
+                profile_key = pk,
+                children_count = (kids and kids[1] and kids[1].n) or 0,
+                user_picks_count = (picks and picks[1] and picks[1].n) or 0,
+            } }
         end)
     )
 


### PR DESCRIPTION
## Summary

Adds the dynamic business-profile wizard tree (UK self-assessment-aligned), the server-side completion-status endpoint that drives the new frontend profile gate, and admin CRUD for managing the wizard tree.

Also fixes a long-latent bug in \`evaluateVisibility\` that made every conditional question always-visible (wrong ORDER BY column name → SQL throws → pcall swallows → function returns true).

## Endpoints added

| Method | Path | Purpose |
|---|---|---|
| GET | \`/api/v2/profile-builder/business-wizard\` | Nested wizard tree for the onboarding UI (auth-gated, filtered by \`wizard_label IS NOT NULL\`) |
| GET | \`/api/v2/profile-builder/completion-status\` | Single source of truth for "is this user's profile complete?" — sets the \`profile_complete\` cookie via Set-Cookie with Origin-aware Domain. Supports \`?debug=true\` for per-question breakdown. |
| GET | \`/api/v2/tax/admin/profiles/:uuid/usage\` | Children count + user-picks count, for the admin tree dashboard's delete-safety pre-check |

## Schema change

Migration \`504_profile_business_wizard_tree\` (in \`dynamic-profile-builder.lua\` step \`[37]\`):
- 5 new columns on \`classification_profiles\`: \`parent_profile_key\`, \`wizard_question\`, \`wizard_label\`, \`display_order\`, \`is_leaf\`
- New join table \`tax_user_profiles_profiles\` (composite PK, CASCADE FK, partial unique on \`is_primary\`, \`namespace_id\` for tenancy)
- Seeds 54 wizard tree rows (5 roots + 10 sole_trader sub-branches + 39 leaves)
- Re-parents 5 existing rules-pack rows; backfills the join from \`default_profile_key\`

Numbered \`504\` (NOT \`450\`) so it runs AFTER migration \`480\` which creates \`classification_profiles\`.

## Bugs fixed

1. **\`evaluateVisibility\` ORDER BY \`display_order\`** — \`profile_question_rules\` has no \`display_order\` column; the actual column is \`priority\` (used correctly everywhere else in the file). The query threw silently → \`pcall\` returned \`ok=false\` → function fell through to "no rules" early-return → every conditional question was treated as always-visible. Symptom was the 27-vs-28 completion mismatch we tracked down today.
2. **Boolean-string comparison in evaluateVisibility** — \`tostring(true) == "yes"\` is \`false\`, so a Yes-radio answer never matched a rule expecting \`yes\`. Added a \`looseEquals\` helper that parses common boolean spellings (\`true\`/\`yes\`/\`1\`/\`y\` ↔ \`true\`; \`false\`/\`no\`/\`0\`/\`n\` ↔ \`false\`) and compares normalised. Mirrors the same helper in the client-side rules engine.
3. **Silent fail on rules-query error** — added \`ngx.log(ngx.ERR, ...)\` so any future regression doesn't escape review the same way.

## Admin CRUD (tax-admin-profiles.lua)

- POST/PUT now accept the 5 new wizard columns
- DELETE refuses with 409 when the profile has active children OR user picks
- New \`/usage\` endpoint for the admin dashboard's pre-delete check

## Test plan

- [x] \`luac -p\` passes on all 4 files
- [ ] Run migration 504 fresh — confirm 54 wizard rows seeded, 5 existing re-parented, join table populated
- [ ] \`GET /completion-status\` for a freshly-registered user returns \`{is_complete: false, total: N, answered: 0}\` and clears the cookie
- [ ] Same endpoint after answering all visible questions returns \`{is_complete: true, ...}\` and sets the cookie with \`Domain=.diytaxreturn.co.uk\` (in int / acc / prod via \`AUTH_COOKIE_TRUSTED_DOMAINS\`)
- [ ] Answer parent question = "No" → backend correctly hides the dependent question (no longer counts in \`total\`)
- [ ] \`POST /api/v2/tax/admin/profiles\` with wizard fields creates a wizard-tree node; DELETE on a branch with children returns 409 with \`children_count\`

## Pairs with

[diy-tax-return-uk PR — frontend wizard + gate + admin dashboard](https://github.com/bwalia/diy-tax-return-uk/pull/new/feat/business-profile-wizard-tree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)