### PR TITLE
fix(profile-builder): completion-status honours business-profile tag filter

### DIFF
--- a/lapis/routes/profile-builder.lua
+++ b/lapis/routes/profile-builder.lua
@@ -911,16 +911,76 @@ return function(app)
             end
         end
 
-        -- Active, non-archived questions in the user's scope. Include
-        -- question_key + label so debug mode can name them; cheap
-        -- columns, no measurable perf impact.
+        -- Resolve the user's business profile (e.g. amazon_seller,
+        -- landlord). The schema endpoint uses this exact pattern to
+        -- gate which questions ever surface in the UI:
+        --
+        --   * a question with NO business-profile tags applies to everyone
+        --   * a question with tags only appears if the user's
+        --     default_profile_key is in that set
+        --
+        -- Without applying the same filter here, completion-status
+        -- inflates ``total`` with questions the user can never see —
+        -- e.g. amazon_seller users were being counted on
+        -- ``is_construction_worker`` (tagged construction_company)
+        -- and the gate said 26/27 = 96% even though the frontend
+        -- showed 100% (because frontend honours the tag filter via
+        -- the schema response).
+        --
+        -- This mirrors lines 615-635 / 645-675 of the schema endpoint
+        -- below; keep them in lock-step. ``default_profile_key`` is
+        -- the singular wizard-primary pick (the wizard mirrors
+        -- is_primary→default_profile_key on save, so this stays the
+        -- right key to consult for non-multi-pick gating).
+        local user_profile_key = nil
+        local ok_up, up_rows = pcall(db.query, [[
+            SELECT default_profile_key FROM tax_user_profiles
+            WHERE user_id = ? LIMIT 1
+        ]], user_id)
+        if ok_up and up_rows and #up_rows > 0 then
+            local k = up_rows[1].default_profile_key
+            if k and k ~= "" and k ~= cjson.null then
+                user_profile_key = k
+            end
+        end
+
+        -- Active, non-archived questions in the user's scope, with the
+        -- business-profile tag filter applied. Include question_key +
+        -- label so ?debug=true can name them; cheap columns, no
+        -- measurable perf impact.
+        local bp_filter
+        local query_params = {}
+        if user_profile_key then
+            bp_filter = [[
+              AND (
+                NOT EXISTS (
+                  SELECT 1 FROM profile_question_business_profiles
+                  WHERE question_id = pq.id
+                )
+                OR EXISTS (
+                  SELECT 1 FROM profile_question_business_profiles
+                  WHERE question_id = pq.id AND profile_key = ?
+                )
+              )]]
+            table.insert(query_params, user_profile_key)
+        else
+            -- No business profile chosen yet: only universal questions
+            -- (with no tag link set) surface. Strictest filter; matches
+            -- schema endpoint's same-branch behaviour.
+            bp_filter = [[
+              AND NOT EXISTS (
+                SELECT 1 FROM profile_question_business_profiles
+                WHERE question_id = pq.id
+              )]]
+        end
+
         local ok_qs, questions = pcall(db.query, [[
             SELECT pq.id, pq.question_key, pq.label, pq.is_required
             FROM profile_questions pq
             JOIN profile_categories pc ON pc.id = pq.category_id
             WHERE pq.is_active = true AND pq.is_archived = false
               AND pc.is_active = true AND pc.is_archived = false
-            ]] .. ns_filter)
+            ]] .. ns_filter .. bp_filter, unpack(query_params))
         if not ok_qs then
             ngx.log(ngx.ERR, "[ProfileBuilder] completion-status questions query failed: ", tostring(questions))
             return { status = 500, json = { error = "Failed to compute completion" } }


### PR DESCRIPTION
## Summary

Closes the **frontend-100-vs-backend-96** gap that QA reproduced on int with an \`amazon_seller\` user (Leilani Henson, user_id=245). The frontend correctly hides questions that are tagged for other business profiles; \`/api/v2/profile-builder/completion-status\` did not, so it inflated \`total\` by counting questions the user can never see.

## Root cause

The schema endpoint gates question visibility through **two** independent mechanisms:

1. **Visibility rules** (\`profile_question_rules\`) — conditional logic like "show if X = yes". The completion-status endpoint already honours these via the shared \`evaluateVisibility()\` helper.
2. **Business-profile tags** (\`profile_question_business_profiles\`) — questions can be tagged with specific business profiles (e.g. \`is_construction_worker\` is tagged \`construction_company\`). A user whose \`default_profile_key\` doesn't match the tags never sees the question. The schema endpoint filters by this at lines 645-675. The completion-status endpoint **didn't**.

Trace of the gap on Leilani's data:

| | Question count |
|---|---|
| Active questions in her namespace | 30 |
| Hidden by \`evaluateVisibility\` (No-parent rules) | 3 |
| → after rules | 27 |
| Hidden by business-profile tag (q69 \`is_construction_worker\` tagged \`construction_company\`, she's \`amazon_seller\`) | 1 |
| → what she actually sees / what she answered | 26 |

Frontend computes 26 / 26 = **100%** → green banner → user clicks Go to dashboard. Backend computed 26 / 27 = **96%** → cookie not set → middleware bounces. The two views disagreed by exactly one tagged question.

## Fix

Copied the **exact same WHERE-clause pattern** the schema endpoint uses (lines 645-675) into the completion-status endpoint. Both endpoints now:

1. Resolve \`default_profile_key\` from \`tax_user_profiles\` (same query)
2. Filter questions by:
   \`\`\`sql
   AND (
     NOT EXISTS (SELECT 1 FROM profile_question_business_profiles WHERE question_id = pq.id)
     OR EXISTS (SELECT 1 FROM profile_question_business_profiles WHERE question_id = pq.id AND profile_key = ?)
   )
   \`\`\`
3. Fall back to "only universal questions" when the user has no profile picked yet (same strict branch the schema uses)

## Why this is the permanent fix (per the asker's spec)

- **Single source of truth**: both endpoints query the same table with the same SQL shape. They can't drift on tag filtering anymore.
- **Same parameter resolution**: both read \`default_profile_key\` from \`tax_user_profiles\` with identical fallback semantics.
- **Future-proof**: admin adds a new question with tags, changes tags, retires a tag — both endpoints react identically without any code change. The "if I change the question the flow should work perfectly" requirement now holds by construction.
- **In-code invariant marker**: the body comment in completion-status references the line numbers in the schema endpoint and instructs the next reviewer to keep them in lock-step. Drift now requires touching two places and ignoring a code-level note.

## Test plan

- [x] \`luac -p\` passes
- [ ] After deploy, hit \`GET /api/v2/profile-builder/completion-status\` as Leilani (user_id=245) → expect \`{"is_complete": true, "overall_percent": 100, "answered": 26, "total": 26}\` (down from \`total: 27\`)
- [ ] \`?debug=true\` on the same endpoint should now omit \`is_construction_worker\` from the per-question array (it's filtered out at the SQL level)
- [ ] Frontend's \`Go to dashboard\` button should successfully navigate to \`/\` (cookie set on the response)
- [ ] Repro the original 27/28 scenario from earlier reports: parent question = No → child question correctly hidden by visibility rule, tagged questions correctly hidden by tag filter, the two should agree

🤖 Generated with [Claude Code](https://claude.com/claude-code)