### PR TITLE
feat(sre): world-class SRE stack — Docker demo + k3s prod + wslproxy domains

### DIFF
--- a/sre/.env.sre.example
+++ b/sre/.env.sre.example
@@ -1,0 +1,28 @@
+# OpsAPI SRE demo — copy to .env.sre and adjust. NO secrets are required for the
+# demo to run; every credential below has a working default.
+
+# ── Grafana ───────────────────────────────────────────────────────────────
+GRAFANA_USER=admin
+GRAFANA_PASSWORD=admin
+
+# ── Demo Postgres/Redis (for dependency SLOs + chaos) ───────────────────────
+PG_USER=sre
+PG_PASSWORD=sre
+PG_DB=sre
+
+# ── k6 load generator (make demo-load) ──────────────────────────────────────
+K6_TARGET=http://synthetic-opsapi:80
+K6_DURATION=5m
+K6_VUS=10
+K6_ERROR_RATE=0.08          # fraction of requests hitting /error (burns budget)
+K6_SLOW_RATE=0.15           # fraction hitting /slow (burns latency budget)
+K6_OTLP_ENDPOINT=otel-collector:4317
+
+# ── Alerting receivers (optional — uncomment matching blocks in
+#    alertmanager/alertmanager.yml to use real channels) ──────────────────────
+# SLACK_WEBHOOK_URL=
+# PAGERDUTY_ROUTING_KEY=
+# SMTP_HOST=
+# SMTP_PORT=587
+# SMTP_USER=
+# SMTP_PASSWORD=

--- a/sre/.env.sre.example
+++ b/sre/.env.sre.example
@@ -4,6 +4,10 @@
 # ── Grafana ───────────────────────────────────────────────────────────────
 GRAFANA_USER=admin
 GRAFANA_PASSWORD=admin
+# When exposing the demo via wslproxy (k3s/local-docker-wslproxy.yaml), set this
+# to the public domain so Grafana builds correct login/redirect URLs:
+#   GRAFANA_ROOT_URL=https://sre-grafana.diytaxreturn.co.uk
+GRAFANA_ROOT_URL=http://localhost:3012
 
 # ── Demo Postgres/Redis (for dependency SLOs + chaos) ───────────────────────
 PG_USER=sre

--- a/sre/.gitignore
+++ b/sre/.gitignore
@@ -1,0 +1,8 @@
+# Local demo config (copy from .env.sre.example)
+.env.sre
+
+# Synthetic-target nginx logs tailed by promtail
+logs/
+
+# DR drill reports
+dr-report-*.md

--- a/sre/Makefile
+++ b/sre/Makefile
@@ -1,0 +1,58 @@
+# OpsAPI SRE — demo & operations entrypoint.
+# `make help` lists everything. The Docker demo is fully self-contained.
+COMPOSE := docker compose -f docker-compose.sre.yml --env-file .env.sre
+ENV_FILE := .env.sre
+
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help: ## Show this help
+	@grep -hE '^[a-zA-Z0-9_-]+:.*?## ' $(MAKEFILE_LIST) | \
+		awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2}'
+
+$(ENV_FILE):
+	@cp .env.sre.example $(ENV_FILE) && echo "Created $(ENV_FILE) from example"
+
+.PHONY: demo-up
+demo-up: $(ENV_FILE) ## Bring up the full SRE stack and print the URL map
+	@./scripts/sre-demo.sh
+
+.PHONY: demo-down
+demo-down: ## Stop the SRE stack (keep volumes)
+	@$(COMPOSE) --profile load down
+
+.PHONY: demo-clean
+demo-clean: ## Stop the stack and delete all data volumes
+	@$(COMPOSE) --profile load down -v
+
+.PHONY: demo-load
+demo-load: ## Run the k6 load generator (drives golden signals + budget burn)
+	@$(COMPOSE) --profile load run --rm k6
+
+.PHONY: status
+status: ## Show container status
+	@$(COMPOSE) ps
+
+.PHONY: logs
+logs: ## Tail logs (usage: make logs SVC=prometheus)
+	@$(COMPOSE) logs -f $(SVC)
+
+.PHONY: alerts
+alerts: ## Show alerts received by the local webhook sink (pages/tickets)
+	@docker logs sre-alert-logger 2>&1 | tail -50
+
+.PHONY: validate
+validate: ## Validate compose + promtool rules + amtool config
+	@./scripts/validate.sh
+
+.PHONY: backup-test
+backup-test: ## Prove RPO: pg_dump the demo DB, restore into a throwaway DB, verify
+	@./scripts/backup-test.sh
+
+.PHONY: dr-drill
+dr-drill: ## Measure RTO: kill a dependency, time recovery, write a report
+	@./scripts/dr-drill.sh
+
+.PHONY: chaos
+chaos: ## Chaos test: pause Postgres, assert PostgresDown fires, then recover
+	@./scripts/chaos-test.sh

--- a/sre/README.md
+++ b/sre/README.md
@@ -1,0 +1,127 @@
+# OpsAPI · World-Class SRE
+
+A complete, self-contained **Site Reliability Engineering** stack for OpsAPI —
+the reliability *operating model*, not just a pile of tools. It runs two ways
+from the same source of truth:
+
+- **Docker demo** — one command stands up the whole thing with synthetic load,
+  so SLOs, golden-signal dashboards, burn-rate alerts and error-budget burn
+  visibly fire on their own. Great for learning, demos, and local validation.
+- **k3s production** — the identical SLOs/rules/dashboards/status-page deployed
+  via Helm community charts (`./k3s/`).
+
+```
+                          ┌──────────────────────────────────────────────┐
+  OpsAPI app  ──/metrics─▶│  Prometheus  ─rules─▶ recording / SLO / burn   │
+   (or synthetic)  logs──▶│  Loki                  ─▶ Alertmanager ─▶ P1–P4 │
+                  traces─▶│  Tempo ◀── OTel Collector                       │
+                          │            ▼                                    │
+                          │         Grafana  (3-pillar correlation)         │
+                          │         Gatus    (public status page)           │
+                          └──────────────────────────────────────────────┘
+```
+
+## Quick start (Docker demo)
+
+```bash
+cd sre
+cp .env.sre.example .env.sre        # no secrets needed; defaults just work
+make demo-up                        # build + start + print the URL map
+make demo-load                      # drive traffic → watch SLOs + budget burn
+make alerts                         # see the pages/tickets that fired
+```
+
+| Service | URL | Notes |
+|---------|-----|-------|
+| Grafana | http://localhost:3012 | admin / admin · folder **OpsAPI SRE** |
+| Prometheus | http://localhost:9091 | Targets, Alerts, rules |
+| Alertmanager | http://localhost:9093 | routing + silences |
+| Gatus (status page) | http://localhost:8878 | SLO-aligned uptime checks |
+| Loki / Tempo | via Grafana → Explore | logs & traces |
+
+Ports are deliberately offset (9091/3012/8878) so this stack can run **alongside**
+the inline Prometheus/Grafana/Gatus in `lapis/docker-compose.yml` without clashing.
+
+Try the reliability drills:
+
+```bash
+make chaos          # pause Postgres → PostgresDown fires → recovers
+make backup-test    # pg_dump + restore verify (proves RPO)
+make dr-drill       # kill app tier, measure RTO, write a report
+make validate       # lint compose + promtool rules + amtool + dashboards
+```
+
+## The 10 SRE layers — where each lives
+
+| # | Layer | Implementation |
+|---|-------|----------------|
+| 1 | **SLOs** | [`slo/slo-definitions.yaml`](slo/slo-definitions.yaml) — availability 99.95%, P95<200ms, errors<0.1%, DB 99.99% |
+| 2 | **Golden signals** | [`prometheus/rules/golden-signals.rules.yml`](prometheus/rules/golden-signals.rules.yml) + the Golden Signals dashboard |
+| 3 | **Full observability** | Metrics (Prometheus) · Logs ([Loki](loki/) + [Promtail](promtail/)) · Traces ([Tempo](tempo/) + [OTel Collector](otel-collector/)) — correlated in Grafana |
+| 4 | **Error budgets** | [`prometheus/rules/slo-burn-rate.rules.yml`](prometheus/rules/slo-burn-rate.rules.yml) (multi-window burn rate) + [policy](slo/README.md) + SLO dashboard |
+| 5 | **Incident management** | [`incident/`](incident/) — severity matrix, response process, postmortem template; Alertmanager P1–P4 routing |
+| 6 | **Automate everything** | [`Makefile`](Makefile) + [`scripts/`](scripts/) (demo, backup-test, dr-drill, chaos, validate) + k3s `install.sh` |
+| 7 | **Runbooks** | [`runbooks/`](runbooks/) — one per alert, linked from every alert's `runbook_url` |
+| 8 | **Reliability eng.** | Backups + restore verification ([`scripts/backup-test.sh`](scripts/backup-test.sh), [k3s CronJob](k3s/manifests/backup-cronjob.yaml)); DR drill (RTO/RPO) |
+| 9 | **Capacity planning** | [`capacity/`](capacity/) + [`prometheus/rules/capacity.rules.yml`](prometheus/rules/capacity.rules.yml) (predict_linear forecasts) + dashboard |
+| 10 | **Continuous improvement** | Blameless [postmortem template](incident/postmortem-template.md) + action-item tracking + error-budget reviews |
+
+## Directory map
+
+```
+sre/
+├── slo/                  SLO definitions + error-budget policy
+├── prometheus/           scrape config + recording/SLO/capacity/infra rules
+├── alertmanager/         P1–P4 routing, inhibition, runbook links
+├── grafana/              datasources (3-pillar correlation) + 5 dashboards
+├── loki/ promtail/       logs pipeline
+├── tempo/ otel-collector/ traces pipeline
+├── blackbox/             external availability probing
+├── gatus/                public status page
+├── synthetic-target/     OpenResty app emitting OpsAPI's exact metric schema
+├── incident/             severity matrix, response process, postmortem template
+├── runbooks/             one runbook per alert (+ index)
+├── capacity/             capacity-planning method & cadence
+├── scripts/              demo / load / backup-test / dr-drill / chaos / validate
+├── docker-compose.sre.yml + Makefile + .env.sre.example
+└── k3s/                  Helm values + CR manifests + install.sh (production)
+```
+
+## Observe the real app (instead of the synthetic target)
+
+By default the demo scrapes `synthetic-opsapi`, which emits OpsAPI's exact metric
+schema so everything works standalone. To point at the **real** running app:
+
+1. Start the OpsAPI stack (`./start.sh -e local …` from the repo root).
+2. Link this stack onto the app network and enable the real target:
+   ```bash
+   docker network connect opsapi-sre-net opsapi        # join the app container
+   ```
+   Then in [`prometheus/prometheus.yml`](prometheus/prometheus.yml) uncomment the
+   `lapis:80` target (and comment the synthetic one), and in
+   [`gatus/config.yml`](gatus/config.yml) swap `synthetic-opsapi`→`lapis`. Reload:
+   `curl -X POST http://localhost:9091/-/reload`.
+
+The metric names, rules and dashboards are identical either way — that's the
+point: the synthetic target is schema-faithful to production.
+
+## Tracing the Lua app
+
+The trace **pipeline** (OTel Collector → Tempo → Grafana correlation) is fully
+built and demonstrated with spans from the load generator. To emit **real**
+OpsAPI spans, instrument the OpenResty app to export OTLP to the collector
+(`otel-collector:4317`) via the OTel nginx module or `lua-resty-opentelemetry`.
+This is the one piece that requires app-side code; everything else is turnkey.
+
+## Design choices worth knowing
+
+- **Burn-rate alerting** (multi-window/multi-burn-rate) instead of static
+  thresholds — pages on fast budget burn, tickets on slow erosion. See
+  [`slo/README.md`](slo/README.md).
+- **One source of truth:** golden-signal recording rules feed both dashboards
+  and alerts; the demo rules and the k3s `PrometheusRule` CRs are line-for-line
+  mirrors.
+- **Every alert has a runbook.** The `runbook_url` annotation resolves to a real
+  file in [`runbooks/`](runbooks/).
+- **No secrets committed.** Receivers are env-driven; the demo uses a local
+  webhook sink so it runs with zero credentials.

--- a/sre/alertmanager/alertmanager.yml
+++ b/sre/alertmanager/alertmanager.yml
@@ -1,0 +1,80 @@
+# Alertmanager — incident routing (Layer 5)
+# Routes by `severity` (page / ticket) and `priority` (P1..P4). Receivers are
+# env-driven placeholders so no secrets are committed: set SLACK_WEBHOOK_URL /
+# PAGERDUTY_ROUTING_KEY / SMTP_* via the compose env and uncomment the matching
+# config blocks. The default "demo" receiver is a local webhook sink that simply
+# logs alerts, so the demo works out-of-the-box with zero credentials.
+global:
+  resolve_timeout: 5m
+  # smtp_smarthost: '${SMTP_HOST}:${SMTP_PORT}'
+  # smtp_from: 'alerts@opsapi.example'
+  # smtp_auth_username: '${SMTP_USER}'
+  # smtp_auth_password: '${SMTP_PASSWORD}'
+
+templates:
+  - /etc/alertmanager/templates/*.tmpl
+
+route:
+  receiver: demo-webhook
+  group_by: ['alertname', 'slo', 'service']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  routes:
+    # P1/page → wake someone immediately (PagerDuty/OnCall), and mirror to Slack.
+    - matchers: ['severity = "page"']
+      receiver: pager
+      group_wait: 10s
+      repeat_interval: 1h
+      continue: true
+    - matchers: ['severity = "page"']
+      receiver: slack-critical
+      continue: true
+    # Tickets → Slack warnings channel only (no paging).
+    - matchers: ['severity = "ticket"']
+      receiver: slack-warnings
+
+# Suppress noise: if the service is down, don't also page for latency/burn/etc.
+inhibit_rules:
+  - source_matchers: ['alertname = "OpsAPIServiceDown"']
+    target_matchers: ['severity =~ "page|ticket"']
+    equal: ['service']
+  - source_matchers: ['alertname = "PostgresDown"']
+    target_matchers: ['category = "database"']
+  # A firing page for an SLO inhibits the lower-severity ticket for the same SLO.
+  - source_matchers: ['severity = "page"']
+    target_matchers: ['severity = "ticket"']
+    equal: ['slo']
+
+receivers:
+  # Default: local webhook sink (the `alert-logger` container in the demo).
+  - name: demo-webhook
+    webhook_configs:
+      - url: 'http://alert-logger:9000/alert'
+        send_resolved: true
+
+  - name: pager
+    webhook_configs:
+      - url: 'http://alert-logger:9000/page'
+        send_resolved: true
+    # pagerduty_configs:
+    #   - routing_key: '${PAGERDUTY_ROUTING_KEY}'
+    #     severity: '{{ if eq .CommonLabels.priority "P1" }}critical{{ else }}error{{ end }}'
+
+  - name: slack-critical
+    webhook_configs:
+      - url: 'http://alert-logger:9000/slack-critical'
+        send_resolved: true
+    # slack_configs:
+    #   - api_url: '${SLACK_WEBHOOK_URL}'
+    #     channel: '#incidents'
+    #     title: '[{{ .CommonLabels.priority }}] {{ .CommonAnnotations.summary }}'
+    #     text: "{{ range .Alerts }}{{ .Annotations.description }}\nRunbook: {{ .Annotations.runbook_url }}\n{{ end }}"
+
+  - name: slack-warnings
+    webhook_configs:
+      - url: 'http://alert-logger:9000/slack-warnings'
+        send_resolved: true
+    # slack_configs:
+    #   - api_url: '${SLACK_WEBHOOK_URL}'
+    #     channel: '#alerts'

--- a/sre/blackbox/blackbox.yml
+++ b/sre/blackbox/blackbox.yml
@@ -1,0 +1,26 @@
+# Blackbox exporter — external/synthetic probing for the availability SLI.
+# Probes OpsAPI from outside the process, so "the box is up but users get
+# errors" is still caught. Prometheus passes targets via the blackbox-http job.
+modules:
+  http_2xx:
+    prober: http
+    timeout: 5s
+    http:
+      valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+      valid_status_codes: [200]
+      method: GET
+      preferred_ip_protocol: ip4
+      fail_if_not_ssl: false
+
+  http_health:
+    prober: http
+    timeout: 5s
+    http:
+      valid_status_codes: [200]
+      method: GET
+      fail_if_body_not_matches_regexp:
+        - '"status"\s*:\s*"?healthy"?'
+
+  tcp_connect:
+    prober: tcp
+    timeout: 5s

--- a/sre/capacity/capacity-planning.md
+++ b/sre/capacity/capacity-planning.md
@@ -1,0 +1,66 @@
+# Capacity Planning
+
+> Layer 9. Run out of headroom *on purpose, on a schedule* — never by surprise.
+> Forecasting rules live in `../prometheus/rules/capacity.rules.yml`; the
+> **OpsAPI · Capacity Planning** Grafana dashboard shows current vs predicted vs
+> threshold for each resource.
+
+## What we track
+
+| Resource | Current metric | Forecast (recording rule) | Threshold |
+|----------|----------------|---------------------------|-----------|
+| CPU | `opsapi:node_cpu_utilization:ratio` | trend on dashboard | 85% |
+| Memory | `opsapi:node_memory_utilization:ratio` | `opsapi:mem_util_predicted_7d:ratio` | 90% |
+| Disk | `opsapi:node_disk_utilization:ratio` | `opsapi:disk_util_predicted_30d:ratio`, `opsapi:disk_will_fill_seconds` | 85% / 4-day warning |
+| Database size | `pg_database_size_bytes` | `opsapi:pg_database_size_predicted_30d_bytes` | volume size |
+| DB connections | `opsapi:pg_connection_utilization:ratio` | trend | 80% |
+| Traffic | `opsapi:http_requests:rate5m` | `opsapi:traffic_predicted_30d:rate` | capacity model |
+
+## Method
+
+We use Prometheus `predict_linear()` over a trailing window to extrapolate the
+recent trend forward:
+
+```promql
+# Will this filesystem fill within the next 4 days, at the current 6h trend?
+predict_linear(node_filesystem_avail_bytes{fstype!~"tmpfs|overlay"}[6h], 4*24*3600) < 0
+
+# Projected disk utilisation 30 days out, from the last 7 days
+1 - (predict_linear(node_filesystem_avail_bytes[7d], 30*24*3600)
+     / node_filesystem_size_bytes)
+```
+
+Linear projection is deliberately simple and good for weeks-out planning. For
+seasonal/holiday traffic, overlay `*_over_time` from the same week last
+month/year and plan to the **peak**, not the average.
+
+## Forecast horizons
+
+- **30 days** — operational: provisioning, PVC growth, replica counts.
+- **90 days** — tactical: budget for the next quarter's infra.
+- **1 year** — strategic: architecture (sharding, read replicas, multi-region).
+
+## Review cadence
+
+- **Weekly:** glance at the Capacity dashboard for any line crossing its
+  threshold inside the horizon; file a P3/P4 ticket if so.
+- **Monthly:** capacity review — compare actual growth vs last month's forecast;
+  recalibrate; decide on scaling actions.
+- **Quarterly:** 90-day/1-year outlook + DR test (`../scripts/dr-drill.sh`).
+
+## Scaling triggers (act before the alert pages)
+
+| Signal | Action |
+|--------|--------|
+| CPU forecast > 85% within 30d | Add replicas / enable HPA (`autoscaling.enabled=true`) |
+| Memory forecast > 90% within 7d | Raise limits or scale out; hunt leaks |
+| Disk fills within 14d | Expand volume / add retention / prune |
+| DB connections > 80% sustained | Tune pool, add read replica |
+| Traffic 30d forecast near current peak capacity | Load-test, then scale the tier |
+
+## Headroom policy
+
+Target **steady-state utilisation ≤ 60%** of capacity for CPU/memory so a single
+node loss or a traffic spike doesn't immediately breach thresholds (N+1). Disk
+keeps ≥ 30% free. These leave room to absorb failure *and* the time it takes to
+provision more.

--- a/sre/docker-compose.sre.yml
+++ b/sre/docker-compose.sre.yml
@@ -95,6 +95,9 @@ services:
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:-admin}
       GF_USERS_ALLOW_SIGN_UP: "false"
       GF_FEATURE_TOGGLES_ENABLE: "traceqlEditor"
+      # Set to the wslproxy domain (https://sre-grafana.diytaxreturn.co.uk) when
+      # exposing via k3s/local-docker-wslproxy.yaml so login/redirects are correct.
+      GF_SERVER_ROOT_URL: ${GRAFANA_ROOT_URL:-http://localhost:3012}
     volumes:
       - grafana_data:/var/lib/grafana
       - ./grafana/provisioning:/etc/grafana/provisioning:ro

--- a/sre/docker-compose.sre.yml
+++ b/sre/docker-compose.sre.yml
@@ -1,0 +1,276 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# OpsAPI · World-Class SRE stack (self-contained Docker demo)
+# ──────────────────────────────────────────────────────────────────────────────
+# One command (`make demo-up`) brings up the full reliability operating model:
+#   • Metrics  : Prometheus + recording/SLO/burn-rate rules + exporters
+#   • Logs     : Loki + Promtail
+#   • Traces   : Tempo + OpenTelemetry Collector
+#   • Alerting : Alertmanager (+ local webhook sink) with P1–P4 routing
+#   • Dashboards: Grafana (auto-provisioned, 3-pillar correlation)
+#   • Status   : Gatus public status page
+#   • Demo app : synthetic-opsapi emits OpsAPI's exact metric schema
+#   • Load     : k6 (profile: load) drives golden signals + error-budget burn
+#   • Infra    : demo Postgres/Redis so dependency SLOs + chaos tests are real
+#
+# Standalone by default. To observe the REAL OpsAPI app instead, see
+# README.md → "Observe the real app" (link this stack onto opsapi-network).
+# ──────────────────────────────────────────────────────────────────────────────
+name: opsapi-sre
+
+x-logging: &default-logging
+  driver: json-file
+  options: { max-size: "10m", max-file: "3" }
+
+services:
+  # ── Synthetic OpsAPI (production-shaped /metrics) ──────────────────────────
+  synthetic-opsapi:
+    build: ./synthetic-target
+    container_name: sre-synthetic-opsapi
+    restart: unless-stopped
+    volumes:
+      - ./logs:/var/log/nginx          # promtail tails these as job=opsapi
+    networks: [sre-net]
+    logging: *default-logging
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+
+  # ── Metrics: Prometheus ────────────────────────────────────────────────────
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    container_name: sre-prometheus
+    restart: unless-stopped
+    ports: ["9091:9090"]              # 9091 to avoid clash with opsapi's inline prom (9090)
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus/rules:/etc/prometheus/rules:ro
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=15d'
+      - '--web.enable-lifecycle'
+      - '--web.enable-remote-write-receiver'   # Tempo metrics_generator writes here
+    networks: [sre-net]
+    logging: *default-logging
+
+  # ── Alerting: Alertmanager + local webhook sink ────────────────────────────
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    container_name: sre-alertmanager
+    restart: unless-stopped
+    ports: ["9093:9093"]
+    volumes:
+      - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+    command:
+      - '--config.file=/etc/alertmanager/alertmanager.yml'
+      - '--storage.path=/alertmanager'
+    networks: [sre-net]
+    logging: *default-logging
+
+  # Receives webhooks from Alertmanager + Gatus and echoes them to its logs.
+  # Stands in for PagerDuty/Slack so the demo needs zero credentials.
+  # `docker logs sre-alert-logger` shows every page/alert as it fires.
+  alert-logger:
+    image: mendhak/http-https-echo:31
+    container_name: sre-alert-logger
+    restart: unless-stopped
+    environment:
+      HTTP_PORT: "9000"
+      LOG_WITHOUT_NEWLINE: "true"
+      LOG_IGNORE_PATH: "/favicon.ico"
+    networks: [sre-net]
+    logging: *default-logging
+
+  # ── Dashboards: Grafana ─────────────────────────────────────────────────────
+  grafana:
+    image: grafana/grafana:11.2.0
+    container_name: sre-grafana
+    restart: unless-stopped
+    ports: ["3012:3000"]              # 3012 to avoid clash with opsapi's inline grafana (3011)
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:-admin}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_FEATURE_TOGGLES_ENABLE: "traceqlEditor"
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    depends_on: [prometheus, loki, tempo]
+    networks: [sre-net]
+    logging: *default-logging
+
+  # ── Logs: Loki + Promtail ───────────────────────────────────────────────────
+  loki:
+    image: grafana/loki:3.1.1
+    container_name: sre-loki
+    restart: unless-stopped
+    command: -config.file=/etc/loki/loki-config.yml
+    volumes:
+      - ./loki/loki-config.yml:/etc/loki/loki-config.yml:ro
+      - loki_data:/loki
+    networks: [sre-net]
+    logging: *default-logging
+
+  promtail:
+    image: grafana/promtail:3.1.1
+    container_name: sre-promtail
+    restart: unless-stopped
+    command: -config.file=/etc/promtail/promtail-config.yml
+    volumes:
+      - ./promtail/promtail-config.yml:/etc/promtail/promtail-config.yml:ro
+      - ./logs:/var/log/opsapi:ro                       # synthetic-opsapi nginx logs
+      - /var/run/docker.sock:/var/run/docker.sock:ro    # all container logs
+    depends_on: [loki]
+    networks: [sre-net]
+    logging: *default-logging
+
+  # ── Traces: Tempo + OpenTelemetry Collector ─────────────────────────────────
+  tempo:
+    image: grafana/tempo:2.6.0
+    container_name: sre-tempo
+    restart: unless-stopped
+    command: -config.file=/etc/tempo/tempo-config.yml
+    volumes:
+      - ./tempo/tempo-config.yml:/etc/tempo/tempo-config.yml:ro
+      - tempo_data:/var/tempo
+    networks: [sre-net]
+    logging: *default-logging
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.109.0
+    container_name: sre-otel-collector
+    restart: unless-stopped
+    command: ["--config=/etc/otel/otel-collector-config.yml"]
+    volumes:
+      - ./otel-collector/otel-collector-config.yml:/etc/otel/otel-collector-config.yml:ro
+    ports:
+      - "4317:4317"      # OTLP gRPC (apps/load send spans here)
+      - "4318:4318"      # OTLP HTTP
+    depends_on: [tempo, loki]
+    networks: [sre-net]
+    logging: *default-logging
+
+  # ── Exporters (saturation + dependency signals) ─────────────────────────────
+  node-exporter:
+    image: prom/node-exporter:v1.8.2
+    container_name: sre-node-exporter
+    restart: unless-stopped
+    command:
+      - '--path.rootfs=/host'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+    volumes:
+      - /:/host:ro,rslave
+    networks: [sre-net]
+    logging: *default-logging
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.49.1
+    container_name: sre-cadvisor
+    restart: unless-stopped
+    privileged: true
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+    networks: [sre-net]
+    logging: *default-logging
+
+  # Demo Postgres/Redis so dependency SLOs, exporters and chaos tests are REAL.
+  demo-postgres:
+    image: postgres:14-alpine
+    container_name: sre-demo-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${PG_USER:-sre}
+      POSTGRES_PASSWORD: ${PG_PASSWORD:-sre}
+      POSTGRES_DB: ${PG_DB:-sre}
+    networks: [sre-net]
+    logging: *default-logging
+
+  postgres-exporter:
+    image: prometheuscommunity/postgres-exporter:v0.16.0
+    container_name: sre-postgres-exporter
+    restart: unless-stopped
+    environment:
+      DATA_SOURCE_NAME: "postgresql://${PG_USER:-sre}:${PG_PASSWORD:-sre}@demo-postgres:5432/${PG_DB:-sre}?sslmode=disable"
+    depends_on: [demo-postgres]
+    networks: [sre-net]
+    logging: *default-logging
+
+  demo-redis:
+    image: redis:7-alpine
+    container_name: sre-demo-redis
+    restart: unless-stopped
+    command: ["redis-server", "--maxmemory", "256mb", "--maxmemory-policy", "allkeys-lru"]
+    networks: [sre-net]
+    logging: *default-logging
+
+  redis-exporter:
+    image: oliver006/redis_exporter:v1.62.0
+    container_name: sre-redis-exporter
+    restart: unless-stopped
+    environment:
+      REDIS_ADDR: "redis://demo-redis:6379"
+    depends_on: [demo-redis]
+    networks: [sre-net]
+    logging: *default-logging
+
+  blackbox-exporter:
+    image: prom/blackbox-exporter:v0.25.0
+    container_name: sre-blackbox-exporter
+    restart: unless-stopped
+    command: ["--config.file=/etc/blackbox/blackbox.yml"]
+    volumes:
+      - ./blackbox/blackbox.yml:/etc/blackbox/blackbox.yml:ro
+    networks: [sre-net]
+    logging: *default-logging
+
+  # ── Status page: Gatus ──────────────────────────────────────────────────────
+  gatus:
+    image: twinproduction/gatus:v5.13.0
+    container_name: sre-gatus
+    restart: unless-stopped
+    ports: ["8878:8080"]              # 8878 to avoid clash with opsapi's gatus (8877)
+    volumes:
+      - ./gatus:/config:ro
+      - gatus_data:/data
+    networks: [sre-net]
+    logging: *default-logging
+
+  # ── Load generator (profile: load) ──────────────────────────────────────────
+  # `make demo-load` runs this. Drives /, /slow and /error so the golden-signal
+  # dashboards populate and the error-budget visibly burns.
+  k6:
+    image: grafana/k6:0.53.0
+    container_name: sre-k6
+    profiles: ["load"]
+    command: ["run", "/scripts/k6-load.js"]
+    environment:
+      TARGET: ${K6_TARGET:-http://synthetic-opsapi:80}
+      K6_DURATION: ${K6_DURATION:-5m}
+      K6_VUS: ${K6_VUS:-10}
+      K6_ERROR_RATE: ${K6_ERROR_RATE:-0.08}     # ~8% to burn the 0.05% budget fast
+      K6_SLOW_RATE: ${K6_SLOW_RATE:-0.15}
+      K6_OTLP_ENDPOINT: ${K6_OTLP_ENDPOINT:-otel-collector:4317}
+    volumes:
+      - ./scripts/load:/scripts:ro
+    depends_on: [synthetic-opsapi]
+    networks: [sre-net]
+    logging: *default-logging
+
+networks:
+  sre-net:
+    name: opsapi-sre-net
+    driver: bridge
+
+volumes:
+  prometheus_data:
+  grafana_data:
+  loki_data:
+  tempo_data:
+  gatus_data:

--- a/sre/gatus/config.yml
+++ b/sre/gatus/config.yml
@@ -1,0 +1,92 @@
+# Gatus — public status page & synthetic uptime monitoring.
+# Already part of the OpsAPI stack; here it is wired to the SRE SLO thresholds
+# so the status page tells the same story as the dashboards. Conditions mirror
+# the SLOs: 200 OK, response time under the latency budget, healthy body.
+#
+# In the Docker demo, targets use container names on opsapi-network. The k3s
+# equivalent (cluster-internal service DNS) lives in ../k3s/manifests/gatus.yaml.
+
+storage:
+  type: sqlite
+  path: /data/gatus.db
+
+ui:
+  title: OpsAPI Status
+  header: OpsAPI Platform Status
+  logo: ""
+
+alerting:
+  # Fire into the same webhook sink as Alertmanager in the demo. Swap for
+  # slack/pagerduty in prod (env-driven).
+  custom:
+    url: "http://alert-logger:9000/gatus"
+    method: POST
+    body: |
+      {"endpoint":"[ENDPOINT_NAME]","status":"[ALERT_TRIGGERED_OR_RESOLVED]","desc":"[ALERT_DESCRIPTION]"}
+
+endpoints:
+  # Demo defaults target the SRE stack's own services. For the REAL app, swap
+  # `synthetic-opsapi` → `lapis`, `demo-postgres` → `postgres`, `demo-redis`
+  # → `redis` (and re-add Dashboard/MinIO). The k3s equivalent is in
+  # ../k3s/manifests/gatus.yaml with cluster-internal service DNS.
+  - name: OpsAPI Health
+    group: Core
+    url: "http://synthetic-opsapi:80/health"
+    interval: 30s
+    conditions:
+      - "[STATUS] == 200"
+      - "[RESPONSE_TIME] < 200"      # latency SLO
+      - "[BODY].status == healthy"
+    alerts:
+      - type: custom
+        send-on-resolved: true
+        description: "OpsAPI health check failing"
+
+  - name: OpsAPI Metrics
+    group: Core
+    url: "http://synthetic-opsapi:80/metrics"
+    interval: 30s
+    conditions:
+      - "[STATUS] == 200"
+      - "[BODY] contains nginx_http_requests_total"
+
+  - name: OpsAPI OpenAPI
+    group: Core
+    url: "http://synthetic-opsapi:80/openapi.json"
+    interval: 60s
+    conditions:
+      - "[STATUS] == 200"
+      - "[BODY].info.title == OpsAPI"
+      - "len([BODY].paths) > 5"
+
+  - name: PostgreSQL
+    group: Dependencies
+    url: "tcp://demo-postgres:5432"
+    interval: 30s
+    conditions:
+      - "[CONNECTED] == true"
+    alerts:
+      - type: custom
+        send-on-resolved: true
+        description: "PostgreSQL unreachable"
+
+  - name: Redis
+    group: Dependencies
+    url: "tcp://demo-redis:6379"
+    interval: 30s
+    conditions:
+      - "[CONNECTED] == true"
+
+  - name: Grafana
+    group: Observability
+    url: "http://grafana:3000/api/health"
+    interval: 60s
+    conditions:
+      - "[STATUS] == 200"
+
+  - name: Prometheus
+    group: Observability
+    url: "http://prometheus:9090/-/healthy"
+    interval: 60s
+    conditions:
+      - "[STATUS] == 200"

--- a/sre/grafana/dashboards/capacity-planning.json
+++ b/sre/grafana/dashboards/capacity-planning.json
@@ -1,0 +1,59 @@
+{
+  "uid": "opsapi-capacity",
+  "title": "OpsAPI · Capacity Planning",
+  "tags": ["opsapi", "sre", "capacity"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "1m",
+  "time": { "from": "now-7d", "to": "now" },
+  "panels": [
+    {
+      "type": "timeseries", "title": "Disk utilisation — current vs predicted 30d",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "max": 1, "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 0.85 } ] } } },
+      "targets": [
+        { "expr": "opsapi:node_disk_utilization:ratio", "legendFormat": "current" },
+        { "expr": "opsapi:disk_util_predicted_30d:ratio", "legendFormat": "predicted 30d" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "Memory utilisation — current vs predicted 7d",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "max": 1 } },
+      "targets": [
+        { "expr": "opsapi:node_memory_utilization:ratio", "legendFormat": "current" },
+        { "expr": "opsapi:mem_util_predicted_7d:ratio", "legendFormat": "predicted 7d" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "Database size — current vs predicted 30d",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "bytes" } },
+      "targets": [
+        { "expr": "sum(pg_database_size_bytes)", "legendFormat": "current" },
+        { "expr": "opsapi:pg_database_size_predicted_30d_bytes", "legendFormat": "predicted 30d" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "Traffic — current vs predicted 30d (req/s)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "reqps" } },
+      "targets": [
+        { "expr": "opsapi:http_requests:rate5m", "legendFormat": "current" },
+        { "expr": "opsapi:traffic_predicted_30d:rate", "legendFormat": "predicted 30d" }
+      ]
+    },
+    {
+      "type": "stat", "title": "Days until disk full (forecast)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "s", "thresholds": { "steps": [ { "color": "red", "value": null }, { "color": "yellow", "value": 345600 }, { "color": "green", "value": 1209600 } ] } } },
+      "targets": [ { "expr": "clamp_min(opsapi:disk_will_fill_seconds, 0)", "legendFormat": "{{mountpoint}}" } ]
+    }
+  ]
+}

--- a/sre/grafana/dashboards/golden-signals.json
+++ b/sre/grafana/dashboards/golden-signals.json
@@ -1,0 +1,94 @@
+{
+  "uid": "opsapi-golden",
+  "title": "OpsAPI · Golden Signals",
+  "tags": ["opsapi", "sre", "golden-signals"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "10s",
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": { "list": [] },
+  "panels": [
+    {
+      "type": "row", "title": "Traffic", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }
+    },
+    {
+      "type": "timeseries", "title": "Request rate (req/s)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "fieldConfig": { "defaults": { "unit": "reqps" } },
+      "targets": [
+        { "expr": "opsapi:http_requests:rate5m", "legendFormat": "total" },
+        { "expr": "opsapi:http_requests:rate5m_by_endpoint", "legendFormat": "{{endpoint}}" }
+      ]
+    },
+    {
+      "type": "stat", "title": "Current RPS",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "fieldConfig": { "defaults": { "unit": "reqps" } },
+      "targets": [ { "expr": "opsapi:http_requests:rate5m" } ]
+    },
+    {
+      "type": "row", "title": "Errors", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 }
+    },
+    {
+      "type": "timeseries", "title": "5xx error ratio",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 10 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 0.001 } ] } } },
+      "targets": [ { "expr": "opsapi:http_error_ratio:rate5m", "legendFormat": "5xx ratio" } ]
+    },
+    {
+      "type": "timeseries", "title": "4xx ratio",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 10 },
+      "fieldConfig": { "defaults": { "unit": "percentunit" } },
+      "targets": [ { "expr": "opsapi:http_4xx_ratio:rate5m", "legendFormat": "4xx ratio" } ]
+    },
+    {
+      "type": "row", "title": "Latency", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 18 }
+    },
+    {
+      "type": "timeseries", "title": "Latency P50 / P95 / P99",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 19 },
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "thresholdsStyle": { "mode": "line" } }, "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 0.2 } ] } } },
+      "targets": [
+        { "expr": "opsapi:http_latency:p50", "legendFormat": "p50" },
+        { "expr": "opsapi:http_latency:p95", "legendFormat": "p95" },
+        { "expr": "opsapi:http_latency:p99", "legendFormat": "p99" }
+      ]
+    },
+    {
+      "type": "row", "title": "Saturation", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 27 }
+    },
+    {
+      "type": "gauge", "title": "CPU utilisation",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 28 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "max": 1, "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 0.7 }, { "color": "red", "value": 0.85 } ] } } },
+      "targets": [ { "expr": "opsapi:node_cpu_utilization:ratio" } ]
+    },
+    {
+      "type": "gauge", "title": "Memory utilisation",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 28 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "max": 1, "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 0.8 }, { "color": "red", "value": 0.9 } ] } } },
+      "targets": [ { "expr": "opsapi:node_memory_utilization:ratio" } ]
+    },
+    {
+      "type": "gauge", "title": "DB connection pool",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 28 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "max": 1, "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 0.7 }, { "color": "red", "value": 0.85 } ] } } },
+      "targets": [ { "expr": "opsapi:pg_connection_utilization:ratio" } ]
+    },
+    {
+      "type": "stat", "title": "Waiting connections",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 28 },
+      "targets": [ { "expr": "opsapi:nginx_waiting_connections" } ]
+    }
+  ]
+}

--- a/sre/grafana/dashboards/logs-explore.json
+++ b/sre/grafana/dashboards/logs-explore.json
@@ -1,0 +1,50 @@
+{
+  "uid": "opsapi-logs",
+  "title": "OpsAPI · Logs (Loki)",
+  "tags": ["opsapi", "sre", "logs"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "status", "type": "custom", "label": "HTTP status",
+        "query": "all,200,400,404,500,502,503",
+        "current": { "text": "all", "value": ".+" },
+        "options": [
+          { "text": "all", "value": ".+", "selected": true },
+          { "text": "200", "value": "200" },
+          { "text": "400", "value": "400" },
+          { "text": "404", "value": "404" },
+          { "text": "500", "value": "500" },
+          { "text": "502", "value": "502" },
+          { "text": "503", "value": "503" }
+        ]
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "timeseries", "title": "Log volume by status",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 7, "w": 24, "x": 0, "y": 0 },
+      "targets": [ { "expr": "sum by (status) (count_over_time({job=\"opsapi\", log_type=\"nginx-access\"}[1m]))", "legendFormat": "{{status}}" } ]
+    },
+    {
+      "type": "logs", "title": "nginx access log (filtered by $status)",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 11, "w": 24, "x": 0, "y": 7 },
+      "options": { "showTime": true, "wrapLogMessage": true, "sortOrder": "Descending" },
+      "targets": [ { "expr": "{job=\"opsapi\", log_type=\"nginx-access\"} | status =~ \"$status\"", "legendFormat": "" } ]
+    },
+    {
+      "type": "logs", "title": "nginx error log",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 18 },
+      "options": { "showTime": true, "wrapLogMessage": true, "sortOrder": "Descending" },
+      "targets": [ { "expr": "{job=\"opsapi\", log_type=\"nginx-error\"}", "legendFormat": "" } ]
+    }
+  ]
+}

--- a/sre/grafana/dashboards/service-overview.json
+++ b/sre/grafana/dashboards/service-overview.json
@@ -1,0 +1,78 @@
+{
+  "uid": "opsapi-overview",
+  "title": "OpsAPI · Service Overview",
+  "tags": ["opsapi", "sre", "overview"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "10s",
+  "time": { "from": "now-3h", "to": "now" },
+  "panels": [
+    {
+      "type": "stat", "title": "API up",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 5, "w": 4, "x": 0, "y": 0 },
+      "fieldConfig": { "defaults": { "mappings": [ { "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } } ] } },
+      "targets": [ { "expr": "up{job=\"opsapi\"}" } ]
+    },
+    {
+      "type": "stat", "title": "Postgres up",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 5, "w": 4, "x": 4, "y": 0 },
+      "fieldConfig": { "defaults": { "mappings": [ { "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } } ] } },
+      "targets": [ { "expr": "pg_up" } ]
+    },
+    {
+      "type": "stat", "title": "Redis up",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 5, "w": 4, "x": 8, "y": 0 },
+      "fieldConfig": { "defaults": { "mappings": [ { "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } } ] } },
+      "targets": [ { "expr": "redis_up" } ]
+    },
+    {
+      "type": "stat", "title": "RPS",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 5, "w": 4, "x": 12, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "reqps" } },
+      "targets": [ { "expr": "opsapi:http_requests:rate5m" } ]
+    },
+    {
+      "type": "stat", "title": "Error ratio",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 5, "w": 4, "x": 16, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 0.001 } ] } } },
+      "targets": [ { "expr": "opsapi:http_error_ratio:rate5m" } ]
+    },
+    {
+      "type": "stat", "title": "P95 latency",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 5, "w": 4, "x": 20, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "s", "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 0.2 } ] } } },
+      "targets": [ { "expr": "opsapi:http_latency:p95" } ]
+    },
+    {
+      "type": "timeseries", "title": "RED — Rate / Errors / Duration",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 5 },
+      "targets": [
+        { "expr": "opsapi:http_requests:rate5m", "legendFormat": "rate (req/s)" },
+        { "expr": "opsapi:http_5xx:rate5m", "legendFormat": "5xx/s" },
+        { "expr": "opsapi:http_latency:p95", "legendFormat": "p95 (s)" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "Error budget remaining (30d)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 5 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1 } },
+      "targets": [ { "expr": "clamp_min(opsapi:error_budget_remaining:ratio, 0)", "legendFormat": "budget" } ]
+    },
+    {
+      "type": "logs", "title": "Recent 5xx access logs",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 14 },
+      "options": { "showTime": true, "wrapLogMessage": true, "sortOrder": "Descending" },
+      "targets": [ { "expr": "{job=\"opsapi\", log_type=\"nginx-access\"} | status =~ \"5..\"" } ]
+    }
+  ]
+}

--- a/sre/grafana/dashboards/slo-error-budget.json
+++ b/sre/grafana/dashboards/slo-error-budget.json
@@ -1,0 +1,52 @@
+{
+  "uid": "opsapi-slo",
+  "title": "OpsAPI · SLO & Error Budget",
+  "tags": ["opsapi", "sre", "slo"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "panels": [
+    {
+      "type": "stat", "title": "Availability SLO (target 99.95%)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "decimals": 4, "thresholds": { "steps": [ { "color": "red", "value": null }, { "color": "yellow", "value": 0.999 }, { "color": "green", "value": 0.9995 } ] } } },
+      "targets": [ { "expr": "1 - (sum(rate(nginx_http_requests_total{job=\"opsapi\",status=~\"5..\"}[30d])) / clamp_min(sum(rate(nginx_http_requests_total{job=\"opsapi\"}[30d])), 1))" } ]
+    },
+    {
+      "type": "gauge", "title": "Error budget remaining (30d)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1, "thresholds": { "steps": [ { "color": "red", "value": null }, { "color": "orange", "value": 0.1 }, { "color": "yellow", "value": 0.5 }, { "color": "green", "value": 0.5 } ] } } },
+      "targets": [ { "expr": "clamp_min(opsapi:error_budget_remaining:ratio, 0)" } ]
+    },
+    {
+      "type": "stat", "title": "Latency SLO (target 99% < 200ms)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "decimals": 4, "thresholds": { "steps": [ { "color": "red", "value": null }, { "color": "yellow", "value": 0.98 }, { "color": "green", "value": 0.99 } ] } } },
+      "targets": [ { "expr": "sum(rate(nginx_http_request_duration_seconds_bucket{job=\"opsapi\",le=\"0.2\"}[30d])) / clamp_min(sum(rate(nginx_http_request_duration_seconds_count{job=\"opsapi\"}[30d])), 1)" } ]
+    },
+    {
+      "type": "timeseries", "title": "Error budget remaining over time",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 6 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1 } },
+      "targets": [ { "expr": "clamp_min(opsapi:error_budget_remaining:ratio, 0)", "legendFormat": "budget remaining" } ]
+    },
+    {
+      "type": "timeseries", "title": "Burn rate (multiplier of budget)",
+      "description": "Page at 14.4x (1h), 6x (6h); ticket at 3x (1d). Lines above the threshold = budget burning faster than allowed.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 14 },
+      "fieldConfig": { "defaults": { "unit": "none", "custom": { "thresholdsStyle": { "mode": "line+area" } }, "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "orange", "value": 6 }, { "color": "red", "value": 14.4 } ] } } },
+      "targets": [
+        { "expr": "opsapi:sli_error:ratio_rate1h / 0.0005", "legendFormat": "1h burn" },
+        { "expr": "opsapi:sli_error:ratio_rate6h / 0.0005", "legendFormat": "6h burn" },
+        { "expr": "opsapi:sli_error:ratio_rate1d / 0.0005", "legendFormat": "1d burn" }
+      ]
+    }
+  ]
+}

--- a/sre/grafana/provisioning/dashboards/dashboards.yml
+++ b/sre/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: OpsAPI SRE Dashboards
+    orgId: 1
+    folder: OpsAPI SRE
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/sre/grafana/provisioning/datasources/datasources.yml
+++ b/sre/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,49 @@
+apiVersion: 1
+
+# Three-pillar datasources with cross-correlation wired in:
+#   Prometheus  → exemplars link to Tempo traces
+#   Tempo       → trace spans link back to Loki logs and to Prometheus metrics
+#   Loki        → derived field extracts trace_id and links to Tempo
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    jsonData:
+      timeInterval: "15s"
+      httpMethod: POST
+      exemplarTraceIdDestinations:
+        - name: trace_id
+          datasourceUid: tempo
+
+  - name: Loki
+    uid: loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    jsonData:
+      derivedFields:
+        - name: TraceID
+          matcherRegex: '"trace_id":"(\w+)"'
+          url: '$${__value.raw}'
+          datasourceUid: tempo
+
+  - name: Tempo
+    uid: tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    jsonData:
+      tracesToLogsV2:
+        datasourceUid: loki
+        spanStartTimeShift: '-1h'
+        spanEndTimeShift: '1h'
+        filterByTraceID: true
+      tracesToMetrics:
+        datasourceUid: prometheus
+      serviceMap:
+        datasourceUid: prometheus
+      nodeGraph:
+        enabled: true

--- a/sre/incident/incident-response.md
+++ b/sre/incident/incident-response.md
@@ -1,0 +1,68 @@
+# Incident Response Process
+
+> Layer 5. A predictable, low-drama flow from "alert fired" to "postmortem
+> filed". Optimised for OpsAPI's small team: roles can be held by one person,
+> but the *steps* don't change.
+
+```
+  Alert fires (Alertmanager / Gatus / human report)
+        │
+        ▼
+  ┌───────────┐   declare severity (severity-matrix.md)
+  │  TRIAGE   │   open the runbook in the alert's runbook_url
+  └───────────┘
+        │
+        ▼
+  ┌───────────┐   one person = Incident Commander (IC).
+  │ INCIDENT  │   IC coordinates; does NOT necessarily fix.
+  │ COMMANDER │   Spin up #inc-<date> channel + (P1/P2) status page entry.
+  └───────────┘
+        │
+        ▼
+  ┌───────────┐   follow the runbook: diagnose → mitigate → verify.
+  │  MITIGATE │   Prefer fast mitigation (rollback, scale, failover) over
+  └───────────┘   slow root-cause fixing. Stop the bleeding first.
+        │
+        ▼
+  ┌───────────┐   confirm SLI recovered on the dashboards; resolve the alert.
+  │  RESOLVE  │   Update status page to "resolved".
+  └───────────┘
+        │
+        ▼
+  ┌───────────┐   within 48h for P1/P2: blameless postmortem
+  │POSTMORTEM │   (postmortem-template.md). Track action items to closure.
+  └───────────┘
+```
+
+## Roles (collapse as needed on a small team)
+
+- **Incident Commander (IC)** — owns the incident, decides severity, coordinates,
+  keeps the timeline. The single source of truth.
+- **Ops/Responder** — executes the runbook, applies mitigations.
+- **Comms** — updates the status page and stakeholders (IC if nobody else).
+- **Scribe** — records the timeline in the incident channel (IC if nobody else).
+
+## During the incident
+
+1. **Acknowledge** the page so others know it's owned.
+2. **Open the runbook** linked from the alert (`runbook_url`). Every alert has one.
+3. **Communicate early**: a holding update ("investigating elevated errors") beats
+   silence. For P1/P2, post to the status page (Gatus) within 15 minutes.
+4. **Mitigate before you diagnose**. Roll back the last deploy, scale out, fail
+   over, rate-limit — restore the SLI first, understand later.
+5. **Watch the dashboards** (Service Overview + SLO/Error Budget) to confirm the
+   SLI actually recovers — not just that the alert quieted.
+
+## After the incident
+
+- Resolve the status page entry.
+- File a postmortem within 48h for P1/P2 (P3/P4 optional but encouraged).
+- Every postmortem produces tracked **action items** with owners and dates.
+- Review the error-budget impact: a large burn may trigger the release-freeze
+  policy (`../slo/README.md`).
+
+## Tooling
+
+The demo uses a local webhook sink (`make alerts` to view). In production wire
+Alertmanager to PagerDuty/Opsgenie/Grafana OnCall and Slack (placeholders in
+`../alertmanager/alertmanager.yml`), and Gatus to the same channels.

--- a/sre/incident/postmortem-template.md
+++ b/sre/incident/postmortem-template.md
@@ -1,0 +1,69 @@
+# Postmortem: <short incident title>
+
+> **Blameless.** We assume everyone acted in good faith with the information they
+> had. We fix systems, not people. Copy this file to
+> `incident/postmortems/YYYY-MM-DD-<slug>.md` and fill it in.
+
+| Field | Value |
+|-------|-------|
+| Date | YYYY-MM-DD |
+| Severity | P1 / P2 / P3 / P4 |
+| Duration | Xh Ym (detection → resolution) |
+| Author(s) | |
+| Status | Draft / In review / Final |
+| Customer impact | e.g. ~X% of requests 5xx for Ym; N tenants affected |
+| Error-budget impact | e.g. burned Z% of the 30d availability budget |
+
+## Summary
+
+2–4 sentences: what broke, who it affected, how it was resolved. Readable by
+someone outside the team.
+
+## Impact
+
+- User-facing impact (requests failed, features degraded, tenants affected).
+- Revenue / SLA / data-integrity impact.
+- SLO/error-budget impact (link the SLO dashboard time range).
+
+## Timeline (UTC)
+
+| Time | Event |
+|------|-------|
+| 00:00 | Trigger / change that set up the failure |
+| 00:0X | Alert fired (`<alertname>`) |
+| 00:0X | IC declared, severity set |
+| 00:1X | Mitigation applied |
+| 00:2X | SLI recovered; alert resolved |
+
+## Root cause
+
+The actual underlying cause (use the "5 whys" — don't stop at the proximate
+trigger). Distinguish trigger from root cause.
+
+## Detection
+
+- How did we find out? (alert / customer / chance)
+- **Time to detect:** how long from impact start to alert firing?
+- Could the alert have fired sooner or more precisely?
+
+## Resolution & recovery
+
+- What actually mitigated it.
+- **Time to mitigate / recover.**
+
+## What went well / what went poorly / where we got lucky
+
+- Went well:
+- Went poorly:
+- Got lucky:  *(luck is a future incident waiting to happen — file an action item)*
+
+## Action items
+
+> Every item has an **owner** and a **due date**, and is tracked to closure.
+> Prefer items that make the failure *impossible* or *auto-detected*, over
+> "be more careful".
+
+| # | Action | Type (prevent/detect/mitigate) | Owner | Due | Tracking |
+|---|--------|--------------------------------|-------|-----|----------|
+| 1 | | | | | |
+| 2 | | | | | |

--- a/sre/incident/severity-matrix.md
+++ b/sre/incident/severity-matrix.md
@@ -1,0 +1,30 @@
+# Incident Severity Matrix
+
+> Layer 5. Severity drives **who responds, how fast, and how loud**. It is set
+> by the Incident Commander at declaration and can be revised as understanding
+> changes. Alert `priority` labels (P1–P4) map directly to these levels and
+> Alertmanager routes accordingly (`../alertmanager/alertmanager.yml`).
+
+| Severity | Name | Definition | Examples | Response time | Notify | Comms |
+|----------|------|------------|----------|---------------|--------|-------|
+| **P1** | Critical | Revenue or data loss; platform down or unusable for most tenants | API down, Postgres down, payment failures >10%, active DDoS, error budget burning at 14.4× | **Page immediately, 24/7** | On-call paged + IC + eng lead | Status page + #incidents, exec update if >30m |
+| **P2** | Major | Major degradation; a core module broken or severe partial outage | Redis down, latency SLO burning at 6×, one tenant fully down, error budget exhausted | **Page (business hours), <15m** | On-call paged | Status page + #incidents |
+| **P3** | Minor | Minor degradation; SLO at risk but not breached for users | P95 latency > 200ms, slow DB queries, disk filling in <4d, 3× slow burn | **Ticket, next business day** | #alerts channel | Internal only |
+| **P4** | Informational | No user impact; reliability debt / early warning | Chronic 1× budget erosion, capacity trend warnings | **Backlog** | #alerts channel | Internal only |
+
+## Mapping alert priority → severity
+
+The `priority` label on every alert rule (see `../prometheus/rules/`) is the
+severity. `severity: page` alerts are P1/P2 (they wake someone); `severity:
+ticket` alerts are P3/P4 (they create work, not pages).
+
+## Escalation
+
+If the on-call cannot make progress within **30 minutes** (P1) / **1 hour**
+(P2), escalate to the engineering lead, then to the platform owner. Anyone may
+escalate; nobody is penalised for escalating early.
+
+## When in doubt
+
+Declare **higher** severity and downgrade later. Under-calling an incident costs
+more than over-calling one.

--- a/sre/k3s/README.md
+++ b/sre/k3s/README.md
@@ -1,0 +1,70 @@
+# OpsAPI SRE on k3s (production)
+
+The production deployment of the same SRE operating model as the Docker demo,
+via Helm community charts + a thin layer of OpsAPI-specific CRs. The SLO rules,
+golden-signal rules, dashboards and Gatus checks are **identical** to the demo —
+only the packaging differs (Operator CRs instead of file mounts).
+
+## What gets installed (namespace `monitoring`)
+
+| Component | Chart | Role |
+|-----------|-------|------|
+| Prometheus + Alertmanager + Grafana + node-exporter + kube-state-metrics | `prometheus-community/kube-prometheus-stack` | metrics + alerting + dashboards |
+| Loki + Promtail | `grafana/loki`, `grafana/promtail` | logs |
+| Tempo + OpenTelemetry Collector | `grafana/tempo`, `open-telemetry/opentelemetry-collector` | traces |
+| ServiceMonitor / Probe | `manifests/opsapi-servicemonitor.yaml` | scrape app `/metrics` + probe `/health` |
+| PrometheusRule ×2 | `manifests/golden-signals-rules.yaml`, `opsapi-slo-rules.yaml` | recording + SLO burn-rate + dependency alerts |
+| AlertmanagerConfig | `manifests/alertmanager-config.yaml` | P1–P4 routing, inhibition, runbook links |
+| Grafana dashboards | ConfigMaps generated from `../grafana/dashboards/*.json` | the 5 dashboards |
+| Gatus | `manifests/gatus.yaml` | public status page (Deployment+Service+Ingress) |
+| Backup CronJob | `manifests/backup-cronjob.yaml` | nightly pg_dump → MinIO (RPO) |
+
+## Prerequisites
+
+- A k3s cluster and `kubectl`/`helm` v3 configured (`KUBECONFIG` set).
+- The OpsAPI app running (Helm charts in `devops/helm-charts/`). Adjust the
+  `ServiceMonitor` selector / namespaces in `manifests/` to match your release
+  (defaults assume app namespace `opsapi`, Service label `app=diytaxreturn-lapis`).
+- For real paging, an `opsapi-alert-secrets` Secret (Slack/PagerDuty) — ideally a
+  SealedSecret (this repo already uses `devops/kubeseal`).
+
+## Install
+
+```bash
+cd sre/k3s
+DRY_RUN=1 ./install.sh     # validate: helm --dry-run + kubectl --dry-run=client
+./install.sh               # real install (idempotent; safe to re-run)
+```
+
+## Verify
+
+```bash
+kubectl -n monitoring get pods
+kubectl -n monitoring port-forward svc/opsapi-monitoring-prometheus 9090:9090   # Targets → opsapi UP
+kubectl -n monitoring port-forward svc/opsapi-monitoring-grafana 3000:80        # OpsAPI SRE dashboards
+# Status page via the Ingress host set in manifests/gatus.yaml
+```
+Check: Prometheus *Targets* shows `opsapi` up; *Alerts* lists the SLO/burn-rate
+rules; Grafana has the **OpsAPI SRE** folder with all 5 dashboards; Tempo/Loki
+appear as datasources with trace↔log correlation; the backup CronJob is scheduled
+(`kubectl -n opsapi get cronjob`).
+
+## Uninstall
+
+```bash
+./uninstall.sh
+```
+
+## Production hardening notes
+
+- **Storage:** point Loki/Tempo at MinIO/S3 (uncomment in `values/loki.values.yaml`)
+  for durable, scalable retention instead of filesystem.
+- **Multi-AZ / HA:** run Prometheus with 2 replicas + Thanos/Mimir for long-term
+  + global query; spread pods across zones with topology spread constraints.
+- **TLS/auth:** put Grafana and Gatus behind the ingress with TLS + SSO; restrict
+  Prometheus/Alertmanager to cluster-internal.
+- **Secrets:** never commit receiver creds — use SealedSecrets/ExternalSecrets
+  (the repo already has both patterns).
+- **App tracing:** to populate Tempo with real OpsAPI spans, instrument the
+  OpenResty app (OTel nginx module / `lua-resty-opentelemetry`) to export OTLP to
+  the collector — see ../README.md → "Tracing the Lua app".

--- a/sre/k3s/README.md
+++ b/sre/k3s/README.md
@@ -55,6 +55,56 @@ appear as datasources with trace↔log correlation; the backup CronJob is schedu
 ./uninstall.sh
 ```
 
+## Domains via wslproxy
+
+Two scenarios, same `wslproxy` ingress class + `cert-manager.io/cluster-issuer:
+main-issuer` TLS pattern used across the platform. **There is no wildcard DNS** —
+every new host needs a CNAME → `pop0.wslproxy.com` (just like every existing
+`*.diytaxreturn.co.uk` host). Always use a **unique host** (the `sre-` prefix) so
+it never shares a host with the app's own Ingress — that sharing is what caused
+the wslproxy two-Ingress flapping outage on 2026-06-15.
+
+### A. Expose the LOCAL Docker demo (this machine)
+
+`local-docker-wslproxy.yaml` points selector-less Services at this host's
+docker-published ports (192.168.1.193) and attaches wslproxy Ingresses:
+
+| Host | → Docker port | Tool |
+|------|---------------|------|
+| `sre-grafana.diytaxreturn.co.uk` | 3012 | Grafana |
+| `sre-status.diytaxreturn.co.uk` | 8878 | Gatus status page |
+| `sre-prometheus.diytaxreturn.co.uk` | 9091 | Prometheus (lock down before sharing) |
+| `sre-alerts.diytaxreturn.co.uk` | 9093 | Alertmanager (lock down before sharing) |
+
+```bash
+kubectl apply -f local-docker-wslproxy.yaml      # already applied
+# then: add the 4 DNS CNAMEs, set GRAFANA_ROOT_URL in sre/.env.sre, make demo-up
+```
+
+### B. Per-env hosts for the k3s-deployed stack
+
+When you run `install.sh` against int/acc/prod, override the Grafana + Gatus host
+per env (the manifests default to `acc-sre-*`):
+
+| Env | Grafana | Status (Gatus) |
+|-----|---------|----------------|
+| int | `int-sre-grafana.diytaxreturn.co.uk` | `int-sre-status.diytaxreturn.co.uk` |
+| acc | `acc-sre-grafana.diytaxreturn.co.uk` | `acc-sre-status.diytaxreturn.co.uk` |
+| prod | `sre-grafana.diytaxreturn.co.uk` | `status.diytaxreturn.co.uk` |
+
+```bash
+helm upgrade --install monitoring prometheus-community/kube-prometheus-stack -n monitoring \
+  -f values/kube-prometheus-stack.values.yaml \
+  --set grafana.ingress.hosts[0]=int-sre-grafana.diytaxreturn.co.uk \
+  --set grafana.ingress.tls[0].hosts[0]=int-sre-grafana.diytaxreturn.co.uk \
+  --set grafana.ingress.tls[0].secretName=grafana-sre-tls \
+  --set grafana.grafana\.ini.server.root_url=https://int-sre-grafana.diytaxreturn.co.uk
+# edit manifests/gatus.yaml host → int-sre-status.diytaxreturn.co.uk, then apply
+```
+
+> Keep **Prometheus/Alertmanager internal** in shared envs (port-forward), or put
+> them behind auth before giving them a host.
+
 ## Production hardening notes
 
 - **Storage:** point Loki/Tempo at MinIO/S3 (uncomment in `values/loki.values.yaml`)

--- a/sre/k3s/install.sh
+++ b/sre/k3s/install.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Install the OpsAPI SRE observability stack on k3s, in dependency order.
+# Idempotent (helm upgrade --install). Run with KUBECONFIG pointed at the cluster.
+#
+#   ./install.sh                 # install everything into the `monitoring` ns
+#   DRY_RUN=1 ./install.sh       # render/validate only (helm template + apply --dry-run)
+set -euo pipefail
+cd "$(dirname "$0")"
+
+NS=monitoring
+APP_NS=opsapi
+KPS_VER="${KPS_VER:-62.3.0}"        # kube-prometheus-stack chart version
+DRY="${DRY_RUN:-0}"
+
+run() { if [ "$DRY" = "1" ]; then echo "DRY: $*"; else "$@"; fi; }
+
+echo "▶ Adding Helm repos…"
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts >/dev/null 2>&1 || true
+helm repo add grafana https://grafana.github.io/helm-charts >/dev/null 2>&1 || true
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts >/dev/null 2>&1 || true
+helm repo update >/dev/null
+
+HELM_FLAGS=()
+[ "$DRY" = "1" ] && HELM_FLAGS=(--dry-run)
+
+echo "▶ 1/5 kube-prometheus-stack (Prometheus + Alertmanager + Grafana + exporters)"
+run helm upgrade --install monitoring prometheus-community/kube-prometheus-stack \
+  -n "$NS" --create-namespace --version "$KPS_VER" \
+  -f values/kube-prometheus-stack.values.yaml "${HELM_FLAGS[@]}"
+
+echo "▶ 2/5 Loki (logs)"
+run helm upgrade --install loki grafana/loki -n "$NS" -f values/loki.values.yaml "${HELM_FLAGS[@]}"
+
+echo "▶ 3/5 Promtail (log shipping)"
+run helm upgrade --install promtail grafana/promtail -n "$NS" \
+  --set "config.clients[0].url=http://loki-gateway.${NS}.svc/loki/api/v1/push" "${HELM_FLAGS[@]}"
+
+echo "▶ 4/5 Tempo (traces) + OpenTelemetry Collector"
+run helm upgrade --install tempo grafana/tempo -n "$NS" -f values/tempo.values.yaml "${HELM_FLAGS[@]}"
+run helm upgrade --install otel-collector open-telemetry/opentelemetry-collector -n "$NS" \
+  -f values/otel-collector.values.yaml "${HELM_FLAGS[@]}"
+
+echo "▶ 5/5 OpsAPI CRs: ServiceMonitor, PrometheusRules, AlertmanagerConfig, Gatus, backup"
+APPLY=(kubectl apply -f)
+[ "$DRY" = "1" ] && APPLY=(kubectl apply --dry-run=client -f)
+run "${APPLY[@]}" manifests/opsapi-servicemonitor.yaml
+run "${APPLY[@]}" manifests/golden-signals-rules.yaml
+run "${APPLY[@]}" manifests/opsapi-slo-rules.yaml
+run "${APPLY[@]}" manifests/alertmanager-config.yaml
+run "${APPLY[@]}" manifests/gatus.yaml
+run kubectl create namespace "$APP_NS" --dry-run=client -o yaml | kubectl apply -f - 2>/dev/null || true
+run "${APPLY[@]}" manifests/backup-cronjob.yaml
+
+echo "▶ Loading Grafana dashboards as labelled ConfigMaps…"
+for f in ../grafana/dashboards/*.json; do
+  name="opsapi-dash-$(basename "$f" .json)"
+  if [ "$DRY" = "1" ]; then
+    echo "DRY: configmap $name from $f"
+  else
+    kubectl create configmap "$name" -n "$NS" --from-file="$(basename "$f")=$f" \
+      --dry-run=client -o yaml | \
+      kubectl label --local -f - grafana_dashboard=1 grafana_folder="OpsAPI SRE" -o yaml | \
+      kubectl apply -f -
+  fi
+done
+
+cat <<EOF
+
+✓ Done. Access (port-forward examples):
+  kubectl -n $NS port-forward svc/opsapi-monitoring-grafana 3000:80
+  kubectl -n $NS port-forward svc/opsapi-monitoring-prometheus 9090:9090
+  Gatus: via the Ingress host in manifests/gatus.yaml (status.opsapi.example)
+
+Remember to create the alert secret for real paging:
+  kubectl -n $NS create secret generic opsapi-alert-secrets \\
+    --from-literal=slack-webhook-url=... --from-literal=pagerduty-routing-key=...
+EOF

--- a/sre/k3s/local-docker-wslproxy.yaml
+++ b/sre/k3s/local-docker-wslproxy.yaml
@@ -1,0 +1,223 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Expose the LOCAL Docker SRE demo (running on this machine) through wslproxy.
+# ──────────────────────────────────────────────────────────────────────────────
+# This host (slworker00 / 192.168.1.193) is BOTH the Docker host AND a k3s node,
+# so we point selector-less Services at the host's docker-published ports via
+# manual Endpoints, then attach a wslproxy Ingress (+ cert-manager TLS) — the
+# same way other services get a domain through wslproxy.
+#
+# Prereqs:
+#   1. The demo is up: `cd sre && make demo-up`
+#      (publishes Grafana :3012, Prometheus :9091, Alertmanager :9093, Gatus :8878
+#       on 0.0.0.0 → reachable at 192.168.1.193:<port>)
+#   2. DNS: add a CNAME for each host below → pop0.wslproxy.com
+#      (there is no wildcard; this matches every existing *.diytaxreturn.co.uk host)
+#   3. Set GRAFANA_ROOT_URL=https://sre-grafana.diytaxreturn.co.uk in sre/.env.sre
+#      and re-run `make demo-up` so Grafana builds correct redirect URLs.
+#
+# Apply:   kubectl apply -f local-docker-wslproxy.yaml
+# Remove:  kubectl delete -f local-docker-wslproxy.yaml
+#
+# If the host IP changes, update HOST_IP in every Endpoints below (192.168.1.193).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: opsapi-sre-demo
+  labels:
+    app: opsapi-sre
+---
+# ── Grafana ───────────────────────────────────────────────────────────────────
+apiVersion: v1
+kind: Service
+metadata:
+  name: sre-grafana
+  namespace: opsapi-sre-demo
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3012
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: sre-grafana          # name MUST match the Service for manual endpoints
+  namespace: opsapi-sre-demo
+subsets:
+  - addresses:
+      - ip: 192.168.1.193     # this Docker host (slworker00)
+    ports:
+      - name: http
+        port: 3012
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sre-grafana
+  namespace: opsapi-sre-demo
+  annotations:
+    cert-manager.io/cluster-issuer: main-issuer
+spec:
+  ingressClassName: wslproxy
+  rules:
+    - host: sre-grafana.diytaxreturn.co.uk
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: sre-grafana
+                port:
+                  number: 80
+  tls:
+    - hosts: [sre-grafana.diytaxreturn.co.uk]
+      secretName: sre-grafana-tls
+---
+# ── Gatus status page ─────────────────────────────────────────────────────────
+apiVersion: v1
+kind: Service
+metadata:
+  name: sre-status
+  namespace: opsapi-sre-demo
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8878
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: sre-status
+  namespace: opsapi-sre-demo
+subsets:
+  - addresses:
+      - ip: 192.168.1.193
+    ports:
+      - name: http
+        port: 8878
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sre-status
+  namespace: opsapi-sre-demo
+  annotations:
+    cert-manager.io/cluster-issuer: main-issuer
+spec:
+  ingressClassName: wslproxy
+  rules:
+    - host: sre-status.diytaxreturn.co.uk
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: sre-status
+                port:
+                  number: 80
+  tls:
+    - hosts: [sre-status.diytaxreturn.co.uk]
+      secretName: sre-status-tls
+---
+# ── Prometheus (internal tool — TLS only; lock down with auth before sharing) ──
+apiVersion: v1
+kind: Service
+metadata:
+  name: sre-prometheus
+  namespace: opsapi-sre-demo
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: 9091
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: sre-prometheus
+  namespace: opsapi-sre-demo
+subsets:
+  - addresses:
+      - ip: 192.168.1.193
+    ports:
+      - name: http
+        port: 9091
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sre-prometheus
+  namespace: opsapi-sre-demo
+  annotations:
+    cert-manager.io/cluster-issuer: main-issuer
+spec:
+  ingressClassName: wslproxy
+  rules:
+    - host: sre-prometheus.diytaxreturn.co.uk
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: sre-prometheus
+                port:
+                  number: 80
+  tls:
+    - hosts: [sre-prometheus.diytaxreturn.co.uk]
+      secretName: sre-prometheus-tls
+---
+# ── Alertmanager (internal tool — same caveat as Prometheus) ──────────────────
+apiVersion: v1
+kind: Service
+metadata:
+  name: sre-alerts
+  namespace: opsapi-sre-demo
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: 9093
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: sre-alerts
+  namespace: opsapi-sre-demo
+subsets:
+  - addresses:
+      - ip: 192.168.1.193
+    ports:
+      - name: http
+        port: 9093
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sre-alerts
+  namespace: opsapi-sre-demo
+  annotations:
+    cert-manager.io/cluster-issuer: main-issuer
+spec:
+  ingressClassName: wslproxy
+  rules:
+    - host: sre-alerts.diytaxreturn.co.uk
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: sre-alerts
+                port:
+                  number: 80
+  tls:
+    - hosts: [sre-alerts.diytaxreturn.co.uk]
+      secretName: sre-alerts-tls

--- a/sre/k3s/manifests/alertmanager-config.yaml
+++ b/sre/k3s/manifests/alertmanager-config.yaml
@@ -1,0 +1,74 @@
+# Alertmanager routing for k3s (AlertmanagerConfig CR), matching the demo's
+# severity-based routing and inhibition. Selected by the stack's
+# alertmanagerConfigSelector (app=opsapi-sre). Receivers are placeholders —
+# create the referenced Secret (opsapi-alert-secrets) with your Slack/PagerDuty
+# creds (e.g. via SealedSecrets, consistent with devops/kubeseal) before relying
+# on real paging.
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: opsapi-routing
+  namespace: monitoring
+  labels:
+    app: opsapi-sre
+spec:
+  route:
+    receiver: 'null'
+    groupBy: ['alertname', 'slo', 'service']
+    groupWait: 30s
+    groupInterval: 5m
+    repeatInterval: 4h
+    routes:
+      - matchers:
+          - name: severity
+            value: page
+        receiver: pager
+        groupWait: 10s
+        repeatInterval: 1h
+        continue: true
+      - matchers:
+          - name: severity
+            value: page
+        receiver: slack-critical
+        continue: true
+      - matchers:
+          - name: severity
+            value: ticket
+        receiver: slack-warnings
+  inhibitRules:
+    - sourceMatch:
+        - name: alertname
+          value: OpsAPIServiceDown
+      targetMatch:
+        - name: severity
+          value: ticket
+      equal: ['service']
+    - sourceMatch:
+        - name: severity
+          value: page
+      targetMatch:
+        - name: severity
+          value: ticket
+      equal: ['slo']
+  receivers:
+    - name: 'null'
+    - name: pager
+      pagerdutyConfigs:
+        - routingKey:
+            name: opsapi-alert-secrets
+            key: pagerduty-routing-key
+          severity: '{{ if eq .CommonLabels.priority "P1" }}critical{{ else }}error{{ end }}'
+    - name: slack-critical
+      slackConfigs:
+        - apiURL:
+            name: opsapi-alert-secrets
+            key: slack-webhook-url
+          channel: '#incidents'
+          title: '[{{ .CommonLabels.priority }}] {{ .CommonAnnotations.summary }}'
+          text: "{{ range .Alerts }}{{ .Annotations.description }}\nRunbook: {{ .Annotations.runbook_url }}\n{{ end }}"
+    - name: slack-warnings
+      slackConfigs:
+        - apiURL:
+            name: opsapi-alert-secrets
+            key: slack-webhook-url
+          channel: '#alerts'

--- a/sre/k3s/manifests/backup-cronjob.yaml
+++ b/sre/k3s/manifests/backup-cronjob.yaml
@@ -1,0 +1,52 @@
+# Nightly Postgres backup → S3/MinIO (Layer 8 — RPO automation).
+# pg_dumps the OpsAPI database and uploads it to the platform's MinIO `backups`
+# bucket (created by minio-init in the app stack). Verify restores periodically
+# with ../../scripts/backup-test.sh (or a scheduled restore-test job).
+#
+# Credentials come from existing secrets — adjust names to your cluster:
+#   - opsapi-db        : keys PGHOST, PGUSER, PGPASSWORD, PGDATABASE
+#   - opsapi-minio     : keys MINIO_ENDPOINT, MINIO_ACCESS_KEY, MINIO_SECRET_KEY
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: opsapi-pg-backup
+  namespace: opsapi
+  labels:
+    app: opsapi-sre
+spec:
+  schedule: "0 2 * * *"            # 02:00 UTC daily
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 7
+  failedJobsHistoryLimit: 7
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: pg-backup
+              image: postgres:14-alpine
+              envFrom:
+                - secretRef: { name: opsapi-db }
+                - secretRef: { name: opsapi-minio }
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -euo pipefail
+                  STAMP=$(date -u +%Y%m%dT%H%M%SZ)
+                  FILE="/tmp/opsapi-${STAMP}.sql.gz"
+                  echo "pg_dump → ${FILE}"
+                  pg_dump -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" | gzip > "$FILE"
+                  echo "Uploading to MinIO bucket backups/"
+                  apk add --no-cache curl >/dev/null
+                  # mc one-shot upload
+                  wget -qO /usr/local/bin/mc https://dl.min.io/client/mc/release/linux-amd64/mc
+                  chmod +x /usr/local/bin/mc
+                  mc alias set store "$MINIO_ENDPOINT" "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY"
+                  mc cp "$FILE" "store/backups/$(basename "$FILE")"
+                  echo "Backup complete: $(basename "$FILE")"
+              resources:
+                requests: { cpu: 100m, memory: 128Mi }
+                limits:   { cpu: 500m, memory: 512Mi }

--- a/sre/k3s/manifests/gatus.yaml
+++ b/sre/k3s/manifests/gatus.yaml
@@ -100,11 +100,14 @@ metadata:
   name: gatus
   namespace: monitoring
   annotations:
-    # k3s ships Traefik by default; swap class/annotations for your ingress.
-    kubernetes.io/ingress.class: traefik
+    # wslproxy ingress + cert-manager TLS — same pattern as the rest of the platform.
+    cert-manager.io/cluster-issuer: main-issuer
 spec:
+  ingressClassName: wslproxy
   rules:
-    - host: status.opsapi.example          # ← set your public status hostname
+    # Unique host (sre- prefix) so it never collides with the app's own
+    # <env>-gatus host → avoids the wslproxy two-Ingress flapping incident.
+    - host: acc-sre-status.diytaxreturn.co.uk    # ← set per env (int-/acc-/prod uses sre-status)
       http:
         paths:
           - path: /
@@ -114,3 +117,6 @@ spec:
                 name: gatus
                 port:
                   number: 80
+  tls:
+    - hosts: [acc-sre-status.diytaxreturn.co.uk]
+      secretName: gatus-sre-tls

--- a/sre/k3s/manifests/gatus.yaml
+++ b/sre/k3s/manifests/gatus.yaml
@@ -1,0 +1,116 @@
+# Gatus public status page for k3s prod.
+# ConfigMap below uses cluster-internal service DNS for the OpsAPI app + deps.
+# Adjust namespaces/hostnames to your cluster. Ingress host is a placeholder.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gatus-config
+  namespace: monitoring
+  labels:
+    app: opsapi-sre
+data:
+  config.yaml: |
+    storage:
+      type: memory
+    ui:
+      title: OpsAPI Status
+      header: OpsAPI Platform Status
+    endpoints:
+      - name: OpsAPI Health
+        group: Core
+        url: "http://diytaxreturn-lapis.opsapi.svc.cluster.local/health"
+        interval: 30s
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 200"
+          - "[BODY].status == healthy"
+      - name: OpsAPI OpenAPI
+        group: Core
+        url: "http://diytaxreturn-lapis.opsapi.svc.cluster.local/openapi.json"
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+          - "[BODY].info.title == OpsAPI"
+      - name: PostgreSQL
+        group: Dependencies
+        url: "tcp://postgres.opsapi.svc.cluster.local:5432"
+        interval: 30s
+        conditions:
+          - "[CONNECTED] == true"
+      - name: Grafana
+        group: Observability
+        url: "http://opsapi-monitoring-grafana.monitoring.svc/api/health"
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gatus
+  namespace: monitoring
+  labels:
+    app: gatus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gatus
+  template:
+    metadata:
+      labels:
+        app: gatus
+    spec:
+      containers:
+        - name: gatus
+          image: twinproduction/gatus:v5.13.0
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: config
+              mountPath: /config
+          readinessProbe:
+            httpGet: { path: /health, port: 8080 }
+            initialDelaySeconds: 5
+          resources:
+            requests: { cpu: 50m, memory: 64Mi }
+            limits:   { cpu: 200m, memory: 128Mi }
+      volumes:
+        - name: config
+          configMap:
+            name: gatus-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gatus
+  namespace: monitoring
+  labels:
+    app: gatus
+spec:
+  selector:
+    app: gatus
+  ports:
+    - port: 80
+      targetPort: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: gatus
+  namespace: monitoring
+  annotations:
+    # k3s ships Traefik by default; swap class/annotations for your ingress.
+    kubernetes.io/ingress.class: traefik
+spec:
+  rules:
+    - host: status.opsapi.example          # ← set your public status hostname
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: gatus
+                port:
+                  number: 80

--- a/sre/k3s/manifests/golden-signals-rules.yaml
+++ b/sre/k3s/manifests/golden-signals-rules.yaml
@@ -1,0 +1,71 @@
+# Golden-signal recording rules + alerts for k3s (PrometheusRule CR).
+# Mirrors ../../prometheus/rules/golden-signals.rules.yml so prod and demo are
+# identical. Discovered by the Prometheus Operator (ruleSelectorNilUsesHelmValues
+# is false in the stack values).
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: opsapi-golden-signals
+  namespace: monitoring
+  labels:
+    app: opsapi-sre
+    release: monitoring
+spec:
+  groups:
+    - name: golden_signals_recording
+      interval: 15s
+      rules:
+        - record: opsapi:http_requests:rate5m
+          expr: sum(rate(nginx_http_requests_total{job="opsapi"}[5m]))
+        - record: opsapi:http_requests:rate5m_by_endpoint
+          expr: sum by (endpoint) (rate(nginx_http_requests_total{job="opsapi"}[5m]))
+        - record: opsapi:http_5xx:rate5m
+          expr: sum(rate(nginx_http_requests_total{job="opsapi",status=~"5.."}[5m]))
+        - record: opsapi:http_error_ratio:rate5m
+          expr: |
+            sum(rate(nginx_http_requests_total{job="opsapi",status=~"5.."}[5m]))
+            / clamp_min(sum(rate(nginx_http_requests_total{job="opsapi"}[5m])), 1)
+        - record: opsapi:http_4xx_ratio:rate5m
+          expr: |
+            sum(rate(nginx_http_requests_total{job="opsapi",status=~"4.."}[5m]))
+            / clamp_min(sum(rate(nginx_http_requests_total{job="opsapi"}[5m])), 1)
+        - record: opsapi:http_latency:p50
+          expr: histogram_quantile(0.50, sum by (le) (rate(nginx_http_request_duration_seconds_bucket{job="opsapi"}[5m])))
+        - record: opsapi:http_latency:p95
+          expr: histogram_quantile(0.95, sum by (le) (rate(nginx_http_request_duration_seconds_bucket{job="opsapi"}[5m])))
+        - record: opsapi:http_latency:p99
+          expr: histogram_quantile(0.99, sum by (le) (rate(nginx_http_request_duration_seconds_bucket{job="opsapi"}[5m])))
+        - record: opsapi:node_cpu_utilization:ratio
+          expr: 1 - avg(rate(node_cpu_seconds_total{mode="idle"}[5m]))
+        - record: opsapi:node_memory_utilization:ratio
+          expr: 1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)
+        - record: opsapi:pg_connection_utilization:ratio
+          expr: sum(pg_stat_activity_count) / clamp_min(sum(pg_settings_max_connections), 1)
+
+    - name: golden_signals_alerts
+      interval: 30s
+      rules:
+        - alert: OpsAPIServiceDown
+          expr: up{job="opsapi"} == 0
+          for: 1m
+          labels: { severity: page, priority: P1, signal: availability }
+          annotations:
+            summary: "OpsAPI is down (target not scrapeable)"
+            description: "up{job=opsapi} has been 0 for >1m."
+            runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/service-down.md"
+        - alert: OpsAPIHighLatencyP95
+          expr: opsapi:http_latency:p95 > 0.2
+          for: 5m
+          labels: { severity: ticket, priority: P3, signal: latency }
+          annotations:
+            summary: "P95 latency above 200ms SLO"
+            description: "P95 latency is {{ $value | humanizeDuration }}."
+            runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/high-latency.md"
+        - alert: OpsAPISaturationCPU
+          expr: opsapi:node_cpu_utilization:ratio > 0.85
+          for: 10m
+          labels: { severity: ticket, priority: P3, signal: saturation }
+          annotations:
+            summary: "Node CPU saturation > 85%"
+            description: "CPU utilization {{ $value | humanizePercentage }} for 10m."
+            runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/disk-capacity.md"

--- a/sre/k3s/manifests/opsapi-servicemonitor.yaml
+++ b/sre/k3s/manifests/opsapi-servicemonitor.yaml
@@ -1,0 +1,50 @@
+# Tell Prometheus to scrape the OpsAPI app's /metrics in k3s.
+# Assumes the app Service is labelled app=diytaxreturn-lapis (see
+# devops/helm-charts/diytaxreturn-lapis). Adjust the selector/namespace to match
+# your release. Also probes /health externally via a Probe CR for the
+# availability SLI (blackbox-exporter must be installed).
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: opsapi
+  namespace: monitoring
+  labels:
+    app: opsapi-sre
+    release: monitoring
+spec:
+  namespaceSelector:
+    any: true
+  selector:
+    matchLabels:
+      app: diytaxreturn-lapis
+  endpoints:
+    - port: http               # named port on the Service; rename if different
+      path: /metrics
+      interval: 15s
+      scrapeTimeout: 10s
+      relabelings:
+        - targetLabel: job
+          replacement: opsapi
+        - targetLabel: service
+          replacement: opsapi
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: opsapi-health
+  namespace: monitoring
+  labels:
+    app: opsapi-sre
+    release: monitoring
+spec:
+  jobName: blackbox-http
+  interval: 30s
+  module: http_2xx
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc:9115
+  targets:
+    staticConfig:
+      static:
+        - http://diytaxreturn-lapis.opsapi.svc.cluster.local/health
+      labels:
+        probe: availability

--- a/sre/k3s/manifests/opsapi-slo-rules.yaml
+++ b/sre/k3s/manifests/opsapi-slo-rules.yaml
@@ -1,0 +1,118 @@
+# SLO burn-rate + dependency alerts for k3s (PrometheusRule CR).
+# Mirrors ../../prometheus/rules/slo-burn-rate.rules.yml and the dependency/
+# security groups of infra-alerts.rules.yml. Availability SLO 99.95%
+# (budget 0.0005); latency SLO 99% (<200ms, budget 0.01).
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: opsapi-slo
+  namespace: monitoring
+  labels:
+    app: opsapi-sre
+    release: monitoring
+spec:
+  groups:
+    - name: slo_availability_sli
+      interval: 30s
+      rules:
+        - record: opsapi:sli_error:ratio_rate5m
+          expr: sum(rate(nginx_http_requests_total{job="opsapi",status=~"5.."}[5m])) / clamp_min(sum(rate(nginx_http_requests_total{job="opsapi"}[5m])), 1)
+        - record: opsapi:sli_error:ratio_rate30m
+          expr: sum(rate(nginx_http_requests_total{job="opsapi",status=~"5.."}[30m])) / clamp_min(sum(rate(nginx_http_requests_total{job="opsapi"}[30m])), 1)
+        - record: opsapi:sli_error:ratio_rate1h
+          expr: sum(rate(nginx_http_requests_total{job="opsapi",status=~"5.."}[1h])) / clamp_min(sum(rate(nginx_http_requests_total{job="opsapi"}[1h])), 1)
+        - record: opsapi:sli_error:ratio_rate2h
+          expr: sum(rate(nginx_http_requests_total{job="opsapi",status=~"5.."}[2h])) / clamp_min(sum(rate(nginx_http_requests_total{job="opsapi"}[2h])), 1)
+        - record: opsapi:sli_error:ratio_rate6h
+          expr: sum(rate(nginx_http_requests_total{job="opsapi",status=~"5.."}[6h])) / clamp_min(sum(rate(nginx_http_requests_total{job="opsapi"}[6h])), 1)
+        - record: opsapi:sli_error:ratio_rate1d
+          expr: sum(rate(nginx_http_requests_total{job="opsapi",status=~"5.."}[1d])) / clamp_min(sum(rate(nginx_http_requests_total{job="opsapi"}[1d])), 1)
+        - record: opsapi:sli_error:ratio_rate3d
+          expr: sum(rate(nginx_http_requests_total{job="opsapi",status=~"5.."}[3d])) / clamp_min(sum(rate(nginx_http_requests_total{job="opsapi"}[3d])), 1)
+        - record: opsapi:error_budget_remaining:ratio
+          expr: |
+            1 - ((sum(rate(nginx_http_requests_total{job="opsapi",status=~"5.."}[30d]))
+              / clamp_min(sum(rate(nginx_http_requests_total{job="opsapi"}[30d])), 1)) / 0.0005)
+
+    - name: slo_availability_burn_rate
+      interval: 30s
+      rules:
+        - alert: ErrorBudgetBurnFast
+          expr: opsapi:sli_error:ratio_rate1h > (14.4 * 0.0005) and opsapi:sli_error:ratio_rate5m > (14.4 * 0.0005)
+          labels: { severity: page, priority: P1, slo: availability }
+          annotations:
+            summary: "Availability error budget burning FAST (14.4x)"
+            description: "~2% of the 30d budget will burn in 1h."
+            runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/error-budget-burn.md"
+        - alert: ErrorBudgetBurnMedium
+          expr: opsapi:sli_error:ratio_rate6h > (6 * 0.0005) and opsapi:sli_error:ratio_rate30m > (6 * 0.0005)
+          labels: { severity: page, priority: P2, slo: availability }
+          annotations:
+            summary: "Availability error budget burning (6x)"
+            description: "Sustained burn — investigate now."
+            runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/error-budget-burn.md"
+        - alert: ErrorBudgetBurnSlow
+          expr: opsapi:sli_error:ratio_rate1d > (3 * 0.0005) and opsapi:sli_error:ratio_rate2h > (3 * 0.0005)
+          labels: { severity: ticket, priority: P3, slo: availability }
+          annotations:
+            summary: "Availability error budget burning slowly (3x)"
+            description: "Fix this sprint before the budget erodes."
+            runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/error-budget-burn.md"
+        - alert: ErrorBudgetExhausted
+          expr: opsapi:error_budget_remaining:ratio <= 0
+          for: 5m
+          labels: { severity: page, priority: P2, slo: availability }
+          annotations:
+            summary: "30-day availability error budget EXHAUSTED"
+            description: "Enact the release freeze (see runbook)."
+            runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/error-budget-burn.md"
+
+    - name: dependency_availability
+      interval: 30s
+      rules:
+        - alert: PostgresDown
+          expr: pg_up == 0
+          for: 1m
+          labels: { severity: page, priority: P1, category: availability }
+          annotations:
+            summary: "PostgreSQL is down"
+            description: "pg_up == 0 for >1m."
+            runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/postgres-saturation.md"
+        - alert: RedisDown
+          expr: redis_up == 0
+          for: 1m
+          labels: { severity: page, priority: P2, category: availability }
+          annotations:
+            summary: "Redis is down"
+            description: "redis_up == 0 for >1m."
+            runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/redis-saturation.md"
+        - alert: BlackboxProbeFailed
+          expr: probe_success == 0
+          for: 2m
+          labels: { severity: page, priority: P1, category: availability }
+          annotations:
+            summary: "External probe failing: {{ $labels.instance }}"
+            description: "Blackbox probe failing for >2m."
+            runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/service-down.md"
+
+    - name: business_security
+      interval: 1m
+      rules:
+        - alert: HighPaymentFailureRate
+          expr: |
+            sum(rate(ecommerce_payment_operations_total{status!="success"}[10m]))
+            / clamp_min(sum(rate(ecommerce_payment_operations_total[10m])), 1) > 0.1
+          for: 5m
+          labels: { severity: page, priority: P1, category: business }
+          annotations:
+            summary: "Payment failure rate above 10%"
+            description: "Revenue impact: {{ $value | humanizePercentage }} failing."
+            runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/payment-failures.md"
+        - alert: DistributedDDoSAttack
+          expr: sum(rate(nginx_http_requests_total[1m])) > 10000
+          for: 5m
+          labels: { severity: page, priority: P1, category: security }
+          annotations:
+            summary: "Possible distributed DDoS detected"
+            description: "Total request rate {{ $value }} req/s."
+            runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/ddos-attack.md"

--- a/sre/k3s/uninstall.sh
+++ b/sre/k3s/uninstall.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Remove the OpsAPI SRE observability stack from k3s.
+set -euo pipefail
+cd "$(dirname "$0")"
+NS=monitoring
+
+kubectl delete -f manifests/ --ignore-not-found
+kubectl -n "$NS" delete configmap -l grafana_dashboard=1 --ignore-not-found
+for r in otel-collector tempo promtail loki monitoring; do
+  helm uninstall "$r" -n "$NS" 2>/dev/null || true
+done
+echo "✓ Uninstalled. (Namespace '$NS' and PVCs left intact — delete manually if desired.)"

--- a/sre/k3s/values/kube-prometheus-stack.values.yaml
+++ b/sre/k3s/values/kube-prometheus-stack.values.yaml
@@ -56,6 +56,23 @@ alertmanager:
 grafana:
   adminPassword: ""          # set via --set or a sealed secret; do NOT commit
   defaultDashboardsEnabled: true
+  # Expose Grafana via wslproxy (+ cert-manager TLS), unique host per env.
+  # Set grafana.ini root_url to the same host so redirects work. Override the
+  # host per env with --set on install (int-/acc-/prod- prefix).
+  ingress:
+    enabled: true
+    ingressClassName: wslproxy
+    annotations:
+      cert-manager.io/cluster-issuer: main-issuer
+    hosts:
+      - acc-sre-grafana.diytaxreturn.co.uk
+    tls:
+      - secretName: grafana-sre-tls
+        hosts:
+          - acc-sre-grafana.diytaxreturn.co.uk
+  grafana.ini:
+    server:
+      root_url: https://acc-sre-grafana.diytaxreturn.co.uk
   # Auto-load OpsAPI dashboards from ConfigMaps labelled grafana_dashboard=1
   # (../manifests/grafana-dashboards-configmap.yaml).
   sidecar:

--- a/sre/k3s/values/kube-prometheus-stack.values.yaml
+++ b/sre/k3s/values/kube-prometheus-stack.values.yaml
@@ -1,0 +1,104 @@
+# kube-prometheus-stack values for OpsAPI production (k3s).
+# Installs Prometheus Operator + Prometheus + Alertmanager + Grafana +
+# node-exporter + kube-state-metrics. The OpsAPI-specific rules, dashboards and
+# Alertmanager routing are applied separately as CRs/ConfigMaps in ../manifests/
+# so they stay identical to the Docker demo.
+#
+#   helm install monitoring prometheus-community/kube-prometheus-stack \
+#     -n monitoring --create-namespace -f kube-prometheus-stack.values.yaml
+
+fullnameOverride: opsapi-monitoring
+
+defaultRules:
+  create: true          # baseline k8s/node alerts; OpsAPI SLO rules added via CR
+
+prometheus:
+  prometheusSpec:
+    retention: 30d
+    retentionSize: "20GB"
+    scrapeInterval: 15s
+    evaluationInterval: 15s
+    enableRemoteWriteReceiver: true        # Tempo metrics_generator → Prometheus
+    # Discover ServiceMonitors/PrometheusRules in ALL namespaces, not just those
+    # carrying the release label — so ../manifests/*.yaml are picked up.
+    serviceMonitorSelectorNilUsesHelmValues: false
+    podMonitorSelectorNilUsesHelmValues: false
+    ruleSelectorNilUsesHelmValues: false
+    probeSelectorNilUsesHelmValues: false
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 25Gi
+    resources:
+      requests: { cpu: 250m, memory: 512Mi }
+      limits:   { cpu: "1",  memory: 2Gi }
+
+alertmanager:
+  # Routing/receivers come from the AlertmanagerConfig CR in
+  # ../manifests/alertmanager-config.yaml (keeps parity with the demo).
+  alertmanagerSpec:
+    alertmanagerConfigSelector:
+      matchLabels:
+        app: opsapi-sre
+    alertmanagerConfigMatcherStrategy:
+      type: None
+    storage:
+      volumeClaimTemplate:
+        spec:
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 5Gi
+
+grafana:
+  adminPassword: ""          # set via --set or a sealed secret; do NOT commit
+  defaultDashboardsEnabled: true
+  # Auto-load OpsAPI dashboards from ConfigMaps labelled grafana_dashboard=1
+  # (../manifests/grafana-dashboards-configmap.yaml).
+  sidecar:
+    dashboards:
+      enabled: true
+      label: grafana_dashboard
+      searchNamespace: ALL
+      folderAnnotation: grafana_folder
+      provider:
+        foldersFromFilesStructure: true
+    datasources:
+      enabled: true
+      label: grafana_datasource
+      searchNamespace: ALL
+  additionalDataSources:
+    - name: Loki
+      uid: loki
+      type: loki
+      access: proxy
+      url: http://loki-gateway.monitoring.svc:80
+      jsonData:
+        derivedFields:
+          - name: TraceID
+            matcherRegex: '"trace_id":"(\w+)"'
+            url: '$${__value.raw}'
+            datasourceUid: tempo
+    - name: Tempo
+      uid: tempo
+      type: tempo
+      access: proxy
+      url: http://tempo.monitoring.svc:3200
+      jsonData:
+        tracesToLogsV2:
+          datasourceUid: loki
+        serviceMap:
+          datasourceUid: prometheus
+        nodeGraph:
+          enabled: true
+  persistence:
+    enabled: true
+    size: 5Gi
+
+nodeExporter:
+  enabled: true
+kube-state-metrics:
+  enabled: true

--- a/sre/k3s/values/loki.values.yaml
+++ b/sre/k3s/values/loki.values.yaml
@@ -1,0 +1,52 @@
+# Grafana Loki (single-binary) for k3s prod — logs pillar.
+#   helm install loki grafana/loki -n monitoring -f loki.values.yaml
+# For real prod scale, point storage at MinIO/S3 (the platform already runs
+# MinIO) instead of filesystem — uncomment the s3 block and set credentials via
+# a sealed secret.
+deploymentMode: SingleBinary
+
+loki:
+  auth_enabled: false
+  commonConfig:
+    replication_factor: 1
+  schemaConfig:
+    configs:
+      - from: 2024-01-01
+        store: tsdb
+        object_store: filesystem
+        schema: v13
+        index:
+          prefix: index_
+          period: 24h
+  limits_config:
+    retention_period: 720h        # 30 days in prod
+    allow_structured_metadata: true
+  storage:
+    type: filesystem
+    # type: s3
+    # s3:
+    #   endpoint: minio.opsapi.svc:9000
+    #   bucketnames: loki
+    #   access_key_id: ${MINIO_ACCESS_KEY}
+    #   secret_access_key: ${MINIO_SECRET_KEY}
+    #   s3forcepathstyle: true
+    #   insecure: true
+
+singleBinary:
+  replicas: 1
+  persistence:
+    enabled: true
+    size: 20Gi
+
+# Ship pod logs into Loki. The grafana/loki chart pairs with Promtail or the
+# Grafana Agent; here we enable the bundled canary off and rely on a separate
+# promtail/alloy DaemonSet (install grafana/promtail or grafana/alloy).
+read:    { replicas: 0 }
+write:   { replicas: 0 }
+backend: { replicas: 0 }
+gateway:
+  enabled: true
+chunksCache:
+  enabled: false
+resultsCache:
+  enabled: false

--- a/sre/k3s/values/otel-collector.values.yaml
+++ b/sre/k3s/values/otel-collector.values.yaml
@@ -1,0 +1,77 @@
+# OpenTelemetry Collector for k3s prod — the single ingestion funnel.
+#   helm install otel-collector open-telemetry/opentelemetry-collector \
+#     -n monitoring -f otel-collector.values.yaml
+# Apps send OTLP here; it fans out traces→Tempo, metrics→Prometheus scrape,
+# logs→Loki. Mirrors ../../otel-collector/otel-collector-config.yml.
+mode: deployment
+replicaCount: 1
+
+image:
+  repository: otel/opentelemetry-collector-contrib
+
+ports:
+  otlp:
+    enabled: true
+    containerPort: 4317
+    servicePort: 4317
+    protocol: TCP
+  otlp-http:
+    enabled: true
+    containerPort: 4318
+    servicePort: 4318
+    protocol: TCP
+  prometheus:
+    enabled: true
+    containerPort: 8889
+    servicePort: 8889
+    protocol: TCP
+
+config:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+  processors:
+    batch:
+      timeout: 5s
+    memory_limiter:
+      check_interval: 5s
+      limit_percentage: 80
+      spike_limit_percentage: 25
+  exporters:
+    otlp/tempo:
+      endpoint: tempo.monitoring.svc:4317
+      tls:
+        insecure: true
+    prometheus:
+      endpoint: 0.0.0.0:8889
+      enable_open_metrics: true
+    otlphttp/loki:
+      endpoint: http://loki-gateway.monitoring.svc:80/otlp
+  service:
+    pipelines:
+      traces:
+        receivers: [otlp]
+        processors: [memory_limiter, batch]
+        exporters: [otlp/tempo]
+      metrics:
+        receivers: [otlp]
+        processors: [memory_limiter, batch]
+        exporters: [prometheus]
+      logs:
+        receivers: [otlp]
+        processors: [memory_limiter, batch]
+        exporters: [otlphttp/loki]
+
+# Let Prometheus scrape the collector's :8889 exporter.
+podMonitor:
+  enabled: false
+serviceMonitor:
+  enabled: true
+  extraLabels:
+    release: monitoring
+  metricsEndpoints:
+    - port: prometheus

--- a/sre/k3s/values/tempo.values.yaml
+++ b/sre/k3s/values/tempo.values.yaml
@@ -1,0 +1,29 @@
+# Grafana Tempo (single binary) for k3s prod — traces pillar.
+#   helm install tempo grafana/tempo -n monitoring -f tempo.values.yaml
+# Receives OTLP from the OpenTelemetry Collector and generates span/service-graph
+# metrics back into Prometheus (remote_write), powering trace↔metric correlation.
+tempo:
+  retention: 720h               # 30 days
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+  metricsGenerator:
+    enabled: true
+    remoteWriteUrl: http://opsapi-monitoring-prometheus.monitoring.svc:9090/api/v1/write
+  storage:
+    trace:
+      backend: local
+      local:
+        path: /var/tempo/blocks
+
+persistence:
+  enabled: true
+  size: 20Gi
+
+resources:
+  requests: { cpu: 100m, memory: 256Mi }
+  limits:   { cpu: 500m, memory: 1Gi }

--- a/sre/loki/loki-config.yml
+++ b/sre/loki/loki-config.yml
@@ -1,0 +1,49 @@
+# Loki — logs pillar (Layer 3). Single-binary, filesystem storage — perfect for
+# the demo and small prod; for large prod swap storage to S3/MinIO (see k3s
+# values). TSDB schema, no auth (front it with the ingress in prod).
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: warn
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  retention_period: 168h            # 7 days in the demo
+  ingestion_rate_mb: 16
+  ingestion_burst_size_mb: 32
+  max_query_series: 5000
+  allow_structured_metadata: true
+
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true
+  delete_request_store: filesystem
+
+ruler:
+  alertmanager_url: http://alertmanager:9093
+
+analytics:
+  reporting_enabled: false

--- a/sre/otel-collector/otel-collector-config.yml
+++ b/sre/otel-collector/otel-collector-config.yml
@@ -1,0 +1,75 @@
+# OpenTelemetry Collector — the single ingestion funnel for the three pillars
+# (Layer 3). Apps/load-generators send OTLP here; the collector fans out:
+#   traces  → Tempo
+#   metrics → exposed on :8889 for Prometheus to scrape
+#   logs    → Loki
+# This is the "OpenTelemetry everywhere" entry point: instrument once, send to
+# the collector, and the backend is swappable without touching the app.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+  # Scrape the collector's own internal telemetry.
+  prometheus/self:
+    config:
+      scrape_configs:
+        - job_name: otel-collector-internal
+          scrape_interval: 30s
+          static_configs:
+            - targets: ['localhost:8888']
+
+processors:
+  batch:
+    timeout: 5s
+    send_batch_size: 1024
+  memory_limiter:
+    check_interval: 5s
+    limit_percentage: 80
+    spike_limit_percentage: 25
+  resourcedetection:
+    detectors: [env, system]
+    timeout: 5s
+
+exporters:
+  # Traces → Tempo (OTLP gRPC).
+  otlp/tempo:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+  # Metrics → Prometheus scrape endpoint on :8889.
+  prometheus:
+    endpoint: 0.0.0.0:8889
+    enable_open_metrics: true
+    resource_to_telemetry_conversion:
+      enabled: true
+  # Logs → Loki.
+  otlphttp/loki:
+    endpoint: http://loki:3100/otlp
+  debug:
+    verbosity: basic
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+service:
+  extensions: [health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, resourcedetection, batch]
+      exporters: [otlp/tempo]
+    metrics:
+      receivers: [otlp, prometheus/self]
+      processors: [memory_limiter, batch]
+      exporters: [prometheus]
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlphttp/loki]
+  telemetry:
+    logs:
+      level: warn

--- a/sre/prometheus/prometheus.yml
+++ b/sre/prometheus/prometheus.yml
@@ -1,0 +1,88 @@
+# Prometheus — OpsAPI SRE stack (Docker demo)
+# Scrapes the real OpsAPI app when it is running on opsapi-network, plus the
+# synthetic target, exporters, blackbox probes, the OTel collector and itself.
+# The k3s production equivalent is expressed as ServiceMonitors + PrometheusRule
+# CRs under ../k3s/ (kube-prometheus-stack discovers targets dynamically).
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    cluster: opsapi
+    environment: demo
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
+
+rule_files:
+  - /etc/prometheus/rules/*.rules.yml
+
+scrape_configs:
+  # ── OpsAPI application (golden signals come from here) ────────────────────
+  # In the demo, `synthetic-opsapi` emits OpsAPI's exact metric schema so the
+  # SLO/golden-signal/burn-rate dashboards light up standalone. To observe the
+  # REAL app instead/as-well, uncomment the `lapis:80` target (requires the SRE
+  # stack to share opsapi-network — see ../README.md → "Observe the real app").
+  - job_name: opsapi
+    metrics_path: /metrics
+    scrape_interval: 5s
+    scrape_timeout: 5s
+    static_configs:
+      - targets: ["synthetic-opsapi:80"]
+        labels:
+          service: opsapi
+      # - targets: ["lapis:80"]
+      #   labels:
+      #     service: opsapi
+
+  # ── Infrastructure exporters ──────────────────────────────────────────────
+  - job_name: node
+    static_configs:
+      - targets: ["node-exporter:9100"]
+  - job_name: postgres
+    static_configs:
+      - targets: ["postgres-exporter:9187"]
+  - job_name: redis
+    static_configs:
+      - targets: ["redis-exporter:9121"]
+  - job_name: cadvisor
+    static_configs:
+      - targets: ["cadvisor:8080"]
+
+  # ── Blackbox: external availability SLI (probe from outside the app) ──────
+  - job_name: blackbox-http
+    metrics_path: /probe
+    params:
+      module: [http_2xx]
+    static_configs:
+      - targets:
+          - http://synthetic-opsapi:80/health   # demo app health
+          # - http://lapis:80/health             # real app health (when linked)
+        labels:
+          probe: availability
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox-exporter:9115
+
+  # ── OpenTelemetry Collector (its own + app-forwarded metrics) ─────────────
+  - job_name: otel-collector
+    static_configs:
+      - targets: ["otel-collector:8889"]   # prometheus exporter on the collector
+
+  # ── Status page + self ────────────────────────────────────────────────────
+  - job_name: gatus
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["gatus:8080"]
+  - job_name: alertmanager
+    static_configs:
+      - targets: ["alertmanager:9093"]
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]

--- a/sre/prometheus/rules/capacity.rules.yml
+++ b/sre/prometheus/rules/capacity.rules.yml
@@ -1,0 +1,87 @@
+# Capacity planning (Layer 9) — forecasting recording rules + headroom alerts.
+# predict_linear() extrapolates the recent trend forward; pair with the
+# capacity-planning dashboard to compare current vs predicted vs threshold.
+# See ../../capacity/capacity-planning.md for the method and review cadence.
+groups:
+  - name: capacity_forecasts
+    interval: 1m
+    rules:
+      # ── Disk: seconds until full, and projected utilisation ──────────────
+      - record: opsapi:disk_will_fill_seconds
+        expr: |
+          predict_linear(node_filesystem_avail_bytes{fstype!~"tmpfs|overlay"}[6h], 0)
+          / clamp_min(
+              deriv(node_filesystem_avail_bytes{fstype!~"tmpfs|overlay"}[6h]) * -1, 1)
+      - record: opsapi:disk_util_predicted_30d:ratio
+        expr: |
+          1 - (
+            predict_linear(node_filesystem_avail_bytes{fstype!~"tmpfs|overlay"}[7d], 30*24*3600)
+            / node_filesystem_size_bytes{fstype!~"tmpfs|overlay"}
+          )
+
+      # ── Memory: projected utilisation in 7 days ──────────────────────────
+      - record: opsapi:mem_util_predicted_7d:ratio
+        expr: |
+          1 - (
+            predict_linear(node_memory_MemAvailable_bytes[3d], 7*24*3600)
+            / node_memory_MemTotal_bytes
+          )
+
+      # ── Database growth: projected size in 30 days (bytes) ───────────────
+      - record: opsapi:pg_database_size_predicted_30d_bytes
+        expr: predict_linear(pg_database_size_bytes[7d], 30*24*3600)
+
+      # ── Traffic growth: projected req/s in 30 days ───────────────────────
+      - record: opsapi:traffic_predicted_30d:rate
+        expr: predict_linear(opsapi:http_requests:rate5m[7d], 30*24*3600)
+
+  - name: capacity_alerts
+    interval: 1m
+    rules:
+      - alert: DiskWillFillIn4Days
+        expr: opsapi:disk_will_fill_seconds < (4 * 24 * 3600) and opsapi:disk_will_fill_seconds > 0
+        for: 30m
+        labels:
+          severity: ticket
+          priority: P3
+          signal: saturation
+        annotations:
+          summary: "Disk projected to fill within 4 days"
+          description: "At the current trend {{ $labels.mountpoint }} fills in ~{{ $value | humanizeDuration }}."
+          runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/disk-capacity.md"
+
+      - alert: DiskSpaceLow
+        expr: opsapi:node_disk_utilization:ratio > 0.85
+        for: 10m
+        labels:
+          severity: ticket
+          priority: P3
+          signal: saturation
+        annotations:
+          summary: "Disk utilisation > 85%"
+          description: "{{ $labels.mountpoint }} is {{ $value | humanizePercentage }} full."
+          runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/disk-capacity.md"
+
+      - alert: MemoryUtilizationHigh
+        expr: opsapi:node_memory_utilization:ratio > 0.90
+        for: 10m
+        labels:
+          severity: ticket
+          priority: P3
+          signal: saturation
+        annotations:
+          summary: "Memory utilisation > 90%"
+          description: "Host memory at {{ $value | humanizePercentage }} — risk of OOM."
+          runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/disk-capacity.md"
+
+      - alert: PostgresConnectionsNearMax
+        expr: opsapi:pg_connection_utilization:ratio > 0.80
+        for: 5m
+        labels:
+          severity: ticket
+          priority: P3
+          signal: saturation
+        annotations:
+          summary: "PostgreSQL connections > 80% of max"
+          description: "Connection pool at {{ $value | humanizePercentage }} of max_connections."
+          runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/postgres-saturation.md"

--- a/sre/prometheus/rules/golden-signals.rules.yml
+++ b/sre/prometheus/rules/golden-signals.rules.yml
@@ -1,0 +1,117 @@
+# Golden Signals — recording rules (Layer 2)
+# Latency · Traffic · Errors · Saturation, computed once here so dashboards AND
+# alerts read from the same source of truth. Recorded series use the
+# `opsapi:<signal>:<aggregation>` naming convention.
+groups:
+  - name: golden_signals_traffic_errors
+    interval: 15s
+    rules:
+      # ── Traffic ─────────────────────────────────────────────────────────
+      - record: opsapi:http_requests:rate5m
+        expr: sum(rate(nginx_http_requests_total{job="opsapi"}[5m]))
+
+      - record: opsapi:http_requests:rate5m_by_endpoint
+        expr: sum by (endpoint) (rate(nginx_http_requests_total{job="opsapi"}[5m]))
+
+      # ── Errors ──────────────────────────────────────────────────────────
+      - record: opsapi:http_5xx:rate5m
+        expr: sum(rate(nginx_http_requests_total{job="opsapi",status=~"5.."}[5m]))
+
+      - record: opsapi:http_error_ratio:rate5m
+        expr: |
+          sum(rate(nginx_http_requests_total{job="opsapi",status=~"5.."}[5m]))
+          /
+          clamp_min(sum(rate(nginx_http_requests_total{job="opsapi"}[5m])), 1)
+
+      - record: opsapi:http_4xx_ratio:rate5m
+        expr: |
+          sum(rate(nginx_http_requests_total{job="opsapi",status=~"4.."}[5m]))
+          /
+          clamp_min(sum(rate(nginx_http_requests_total{job="opsapi"}[5m])), 1)
+
+  - name: golden_signals_latency
+    interval: 15s
+    rules:
+      # ── Latency (P50 / P95 / P99) ───────────────────────────────────────
+      - record: opsapi:http_latency:p50
+        expr: |
+          histogram_quantile(0.50,
+            sum by (le) (rate(nginx_http_request_duration_seconds_bucket{job="opsapi"}[5m])))
+      - record: opsapi:http_latency:p95
+        expr: |
+          histogram_quantile(0.95,
+            sum by (le) (rate(nginx_http_request_duration_seconds_bucket{job="opsapi"}[5m])))
+      - record: opsapi:http_latency:p99
+        expr: |
+          histogram_quantile(0.99,
+            sum by (le) (rate(nginx_http_request_duration_seconds_bucket{job="opsapi"}[5m])))
+
+  - name: golden_signals_saturation
+    interval: 30s
+    rules:
+      # ── Saturation: CPU / memory / disk / connections / DB pool ─────────
+      - record: opsapi:node_cpu_utilization:ratio
+        expr: 1 - avg(rate(node_cpu_seconds_total{mode="idle"}[5m]))
+      - record: opsapi:node_memory_utilization:ratio
+        expr: 1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)
+      - record: opsapi:node_disk_utilization:ratio
+        expr: |
+          1 - (node_filesystem_avail_bytes{fstype!~"tmpfs|overlay"}
+               / node_filesystem_size_bytes{fstype!~"tmpfs|overlay"})
+      - record: opsapi:nginx_waiting_connections
+        expr: sum(nginx_http_connections{state="waiting"})
+      - record: opsapi:pg_connection_utilization:ratio
+        expr: |
+          sum(pg_stat_activity_count) / clamp_min(sum(pg_settings_max_connections), 1)
+
+  - name: golden_signals_alerts
+    interval: 30s
+    rules:
+      # Fast page if the service stops being scraped at all.
+      - alert: OpsAPIServiceDown
+        expr: up{job="opsapi"} == 0
+        for: 1m
+        labels:
+          severity: page
+          priority: P1
+          signal: availability
+        annotations:
+          summary: "OpsAPI is down (target not scrapeable)"
+          description: "up{job=opsapi} has been 0 for >1m. Users cannot reach the API."
+          runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/service-down.md"
+
+      - alert: OpsAPIHighLatencyP95
+        expr: opsapi:http_latency:p95 > 0.2
+        for: 5m
+        labels:
+          severity: ticket
+          priority: P3
+          signal: latency
+        annotations:
+          summary: "P95 latency above 200ms SLO"
+          description: "P95 latency is {{ $value | humanizeDuration }} (SLO: 200ms)."
+          runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/high-latency.md"
+
+      - alert: OpsAPISaturationCPU
+        expr: opsapi:node_cpu_utilization:ratio > 0.85
+        for: 10m
+        labels:
+          severity: ticket
+          priority: P3
+          signal: saturation
+        annotations:
+          summary: "Host CPU saturation > 85%"
+          description: "CPU utilization {{ $value | humanizePercentage }} for 10m — consider scaling."
+          runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/disk-capacity.md"
+
+      - alert: OpsAPIConnectionsWaiting
+        expr: opsapi:nginx_waiting_connections > 800
+        for: 5m
+        labels:
+          severity: ticket
+          priority: P3
+          signal: saturation
+        annotations:
+          summary: "High number of waiting nginx connections"
+          description: "{{ $value }} connections waiting — worker/backlog saturation."
+          runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/high-latency.md"

--- a/sre/prometheus/rules/infra-alerts.rules.yml
+++ b/sre/prometheus/rules/infra-alerts.rules.yml
@@ -1,0 +1,138 @@
+# Infrastructure, security & business alerts.
+# Ports the existing devops/alert_rules.yml (DDoS / perf / business) and adds
+# dependency-down alerts (Postgres, Redis) plus runbook_url + P-level labels so
+# everything routes through Alertmanager consistently.
+groups:
+  - name: dependency_availability
+    interval: 30s
+    rules:
+      - alert: PostgresDown
+        expr: pg_up == 0
+        for: 1m
+        labels:
+          severity: page
+          priority: P1
+          category: availability
+        annotations:
+          summary: "PostgreSQL is down"
+          description: "pg_up == 0 for >1m. The API cannot serve any data-backed request."
+          runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/postgres-saturation.md"
+
+      - alert: RedisDown
+        expr: redis_up == 0
+        for: 1m
+        labels:
+          severity: page
+          priority: P2
+          category: availability
+        annotations:
+          summary: "Redis is down"
+          description: "redis_up == 0 for >1m. Sessions/cache degraded."
+          runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/redis-saturation.md"
+
+      - alert: BlackboxProbeFailed
+        expr: probe_success == 0
+        for: 2m
+        labels:
+          severity: page
+          priority: P1
+          category: availability
+        annotations:
+          summary: "External probe failing: {{ $labels.instance }}"
+          description: "Blackbox HTTP probe to {{ $labels.instance }} has failed for >2m."
+          runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/service-down.md"
+
+      - alert: RedisMemoryHigh
+        expr: redis_memory_used_bytes / clamp_min(redis_memory_max_bytes, 1) > 0.85
+        for: 5m
+        labels:
+          severity: ticket
+          priority: P3
+          category: saturation
+        annotations:
+          summary: "Redis memory > 85% of maxmemory"
+          description: "Redis at {{ $value | humanizePercentage }} of maxmemory — eviction/OOM risk."
+          runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/redis-saturation.md"
+
+  - name: security_ddos
+    interval: 30s
+    rules:
+      - alert: PossibleDDoSAttack
+        expr: rate(nginx_http_requests_by_ip_total[1m]) > 1000
+        for: 2m
+        labels:
+          severity: page
+          priority: P1
+          category: security
+        annotations:
+          summary: "Possible DDoS from IP {{ $labels.ip }}"
+          description: "{{ $labels.ip }} is making {{ $value }} req/s on {{ $labels.host }}."
+          runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/ddos-attack.md"
+
+      - alert: DistributedDDoSAttack
+        expr: sum(rate(nginx_http_requests_total[1m])) > 10000
+        for: 5m
+        labels:
+          severity: page
+          priority: P1
+          category: security
+        annotations:
+          summary: "Possible distributed DDoS detected"
+          description: "Total request rate: {{ $value }} req/s."
+          runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/ddos-attack.md"
+
+      - alert: CredentialStuffingAttack
+        expr: rate(api_auth_failures_total{reason="invalid_credentials"}[5m]) > 50
+        for: 2m
+        labels:
+          severity: page
+          priority: P2
+          category: security
+        annotations:
+          summary: "Possible credential stuffing"
+          description: "{{ $value }} invalid-credential auth failures/sec."
+          runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/ddos-attack.md"
+
+      - alert: HighAuthFailureRate
+        expr: |
+          sum(rate(api_auth_attempts_total{result="failure"}[10m]))
+          / clamp_min(sum(rate(api_auth_attempts_total[10m])), 1) > 0.3
+        for: 10m
+        labels:
+          severity: ticket
+          priority: P3
+          category: security
+        annotations:
+          summary: "High authentication failure rate"
+          description: "{{ $value | humanizePercentage }} of auth attempts are failing."
+          runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/ddos-attack.md"
+
+  - name: business_kpis
+    interval: 1m
+    rules:
+      - alert: HighPaymentFailureRate
+        expr: |
+          sum(rate(ecommerce_payment_operations_total{status!="success"}[10m]))
+          / clamp_min(sum(rate(ecommerce_payment_operations_total[10m])), 1) > 0.1
+        for: 5m
+        labels:
+          severity: page
+          priority: P1
+          category: business
+        annotations:
+          summary: "Payment failure rate above 10%"
+          description: "Current failure rate: {{ $value | humanizePercentage }} — revenue impact."
+          runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/payment-failures.md"
+
+      - alert: SlowDatabaseQueries
+        expr: |
+          histogram_quantile(0.95, rate(api_database_query_duration_seconds_bucket[5m])) > 1.0
+        for: 5m
+        labels:
+          severity: ticket
+          priority: P3
+          category: database
+        annotations:
+          summary: "DB query P95 > 1s"
+          description: "P95 query latency: {{ $value | humanizeDuration }}."
+          runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/postgres-saturation.md"

--- a/sre/prometheus/rules/slo-burn-rate.rules.yml
+++ b/sre/prometheus/rules/slo-burn-rate.rules.yml
@@ -1,0 +1,158 @@
+# SLO burn-rate alerting (Layers 1 & 4)
+# Multi-window, multi-burn-rate alerts per Google SRE Workbook ch. 5.
+# Recording rules pre-compute the error ratio over each window; alerts fire when
+# BOTH the long and short windows exceed the burn-rate threshold (the short
+# window makes alerts resolve quickly once the incident ends).
+#
+# Availability SLO target = 99.95%  →  error budget = 0.0005 (0.05%).
+# burn_rate = observed_error_ratio / error_budget.
+groups:
+  # ── Availability SLI: error ratio over multiple windows ────────────────────
+  - name: slo_availability_sli
+    interval: 30s
+    rules:
+      - record: opsapi:sli_error:ratio_rate5m
+        expr: |
+          sum(rate(nginx_http_requests_total{job="opsapi",status=~"5.."}[5m]))
+          / clamp_min(sum(rate(nginx_http_requests_total{job="opsapi"}[5m])), 1)
+      - record: opsapi:sli_error:ratio_rate30m
+        expr: |
+          sum(rate(nginx_http_requests_total{job="opsapi",status=~"5.."}[30m]))
+          / clamp_min(sum(rate(nginx_http_requests_total{job="opsapi"}[30m])), 1)
+      - record: opsapi:sli_error:ratio_rate1h
+        expr: |
+          sum(rate(nginx_http_requests_total{job="opsapi",status=~"5.."}[1h]))
+          / clamp_min(sum(rate(nginx_http_requests_total{job="opsapi"}[1h])), 1)
+      - record: opsapi:sli_error:ratio_rate2h
+        expr: |
+          sum(rate(nginx_http_requests_total{job="opsapi",status=~"5.."}[2h]))
+          / clamp_min(sum(rate(nginx_http_requests_total{job="opsapi"}[2h])), 1)
+      - record: opsapi:sli_error:ratio_rate6h
+        expr: |
+          sum(rate(nginx_http_requests_total{job="opsapi",status=~"5.."}[6h]))
+          / clamp_min(sum(rate(nginx_http_requests_total{job="opsapi"}[6h])), 1)
+      - record: opsapi:sli_error:ratio_rate1d
+        expr: |
+          sum(rate(nginx_http_requests_total{job="opsapi",status=~"5.."}[1d]))
+          / clamp_min(sum(rate(nginx_http_requests_total{job="opsapi"}[1d])), 1)
+      - record: opsapi:sli_error:ratio_rate3d
+        expr: |
+          sum(rate(nginx_http_requests_total{job="opsapi",status=~"5.."}[3d]))
+          / clamp_min(sum(rate(nginx_http_requests_total{job="opsapi"}[3d])), 1)
+
+      # Error budget remaining (0..1) over the 30d window — drives the dashboard.
+      - record: opsapi:error_budget_remaining:ratio
+        expr: |
+          1 - (
+            (sum(rate(nginx_http_requests_total{job="opsapi",status=~"5.."}[30d]))
+             / clamp_min(sum(rate(nginx_http_requests_total{job="opsapi"}[30d])), 1))
+            / 0.0005
+          )
+
+  # ── Burn-rate alerts: SLO target 99.95% (budget = 0.0005) ──────────────────
+  - name: slo_availability_burn_rate
+    interval: 30s
+    rules:
+      # Page: 14.4x burn (2% of budget in 1h). Long=1h, short=5m.
+      - alert: ErrorBudgetBurnFast
+        expr: |
+          opsapi:sli_error:ratio_rate1h  > (14.4 * 0.0005)
+          and
+          opsapi:sli_error:ratio_rate5m  > (14.4 * 0.0005)
+        labels:
+          severity: page
+          priority: P1
+          slo: availability
+        annotations:
+          summary: "Availability error budget burning FAST (14.4x)"
+          description: "1h+5m error ratio > 14.4x budget. ~2% of the 30d budget will burn in 1h."
+          runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/error-budget-burn.md"
+
+      # Page: 6x burn (5% of budget in 6h). Long=6h, short=30m.
+      - alert: ErrorBudgetBurnMedium
+        expr: |
+          opsapi:sli_error:ratio_rate6h  > (6 * 0.0005)
+          and
+          opsapi:sli_error:ratio_rate30m > (6 * 0.0005)
+        labels:
+          severity: page
+          priority: P2
+          slo: availability
+        annotations:
+          summary: "Availability error budget burning (6x)"
+          description: "6h+30m error ratio > 6x budget. Sustained burn — investigate now."
+          runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/error-budget-burn.md"
+
+      # Ticket: 3x burn (10% of budget in 24h). Long=1d, short=2h.
+      - alert: ErrorBudgetBurnSlow
+        expr: |
+          opsapi:sli_error:ratio_rate1d > (3 * 0.0005)
+          and
+          opsapi:sli_error:ratio_rate2h > (3 * 0.0005)
+        labels:
+          severity: ticket
+          priority: P3
+          slo: availability
+        annotations:
+          summary: "Availability error budget burning slowly (3x)"
+          description: "1d+2h error ratio > 3x budget. Fix this sprint before budget erodes."
+          runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/error-budget-burn.md"
+
+      # Ticket: chronic 1x burn over 3 days.
+      - alert: ErrorBudgetBurnChronic
+        expr: |
+          opsapi:sli_error:ratio_rate3d > (1 * 0.0005)
+          and
+          opsapi:sli_error:ratio_rate6h > (1 * 0.0005)
+        labels:
+          severity: ticket
+          priority: P4
+          slo: availability
+        annotations:
+          summary: "Chronic availability budget erosion (1x)"
+          description: "3d+6h error ratio > 1x budget. Reliability debt accumulating."
+          runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/error-budget-burn.md"
+
+      # The budget is gone — triggers the release-freeze conversation.
+      - alert: ErrorBudgetExhausted
+        expr: opsapi:error_budget_remaining:ratio <= 0
+        for: 5m
+        labels:
+          severity: page
+          priority: P2
+          slo: availability
+        annotations:
+          summary: "30-day availability error budget EXHAUSTED"
+          description: "Remaining budget {{ $value | humanizePercentage }}. Enact release freeze (see runbook)."
+          runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/error-budget-burn.md"
+
+  # ── Latency SLO: 99% of requests < 200ms ───────────────────────────────────
+  - name: slo_latency
+    interval: 30s
+    rules:
+      - record: opsapi:latency_sli_bad:ratio_rate1h
+        expr: |
+          1 - (
+            sum(rate(nginx_http_request_duration_seconds_bucket{job="opsapi",le="0.2"}[1h]))
+            / clamp_min(sum(rate(nginx_http_request_duration_seconds_count{job="opsapi"}[1h])), 1)
+          )
+      - record: opsapi:latency_sli_bad:ratio_rate5m
+        expr: |
+          1 - (
+            sum(rate(nginx_http_request_duration_seconds_bucket{job="opsapi",le="0.2"}[5m]))
+            / clamp_min(sum(rate(nginx_http_request_duration_seconds_count{job="opsapi"}[5m])), 1)
+          )
+      # Latency budget = 1% (target 99%). Page at 14.4x burn.
+      - alert: LatencyBudgetBurnFast
+        expr: |
+          opsapi:latency_sli_bad:ratio_rate1h > (14.4 * 0.01)
+          and
+          opsapi:latency_sli_bad:ratio_rate5m > (14.4 * 0.01)
+        labels:
+          severity: page
+          priority: P2
+          slo: latency
+        annotations:
+          summary: "Latency SLO burning fast (>200ms requests)"
+          description: "Share of slow (>200ms) requests is burning the latency budget at 14.4x."
+          runbook_url: "https://github.com/bwalia/opsapi/blob/main/sre/runbooks/high-latency.md"

--- a/sre/promtail/promtail-config.yml
+++ b/sre/promtail/promtail-config.yml
@@ -1,0 +1,63 @@
+# Promtail — ships logs into Loki (Layer 3).
+# Two sources:
+#   1. OpsAPI nginx logs mounted from ../../lapis/logs (access + error)
+#   2. All Docker container logs via the Docker service-discovery
+# nginx access lines are parsed to extract status/method so logs are queryable
+# alongside metrics (e.g. {job="opsapi"} |= "500") and correlate with traces.
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+  log_level: warn
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  # ── OpsAPI nginx logs (mounted volume) ─────────────────────────────────────
+  - job_name: opsapi-nginx
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: opsapi
+          service: opsapi
+          log_type: nginx-access
+          __path__: /var/log/opsapi/access.log
+      - targets: [localhost]
+        labels:
+          job: opsapi
+          service: opsapi
+          log_type: nginx-error
+          __path__: /var/log/opsapi/error.log
+    pipeline_stages:
+      # Best-effort parse of the combined access log to label status + method.
+      - match:
+          selector: '{log_type="nginx-access"}'
+          stages:
+            - regex:
+                expression: '"(?P<method>\S+) (?P<path>\S+) [^"]*" (?P<status>\d{3})'
+            - labels:
+                method:
+                status:
+            - metrics:
+                opsapi_promtail_access_lines:
+                  type: Counter
+                  description: nginx access lines parsed by promtail
+                  config:
+                    action: inc
+
+  # ── All container logs (Docker SD) ─────────────────────────────────────────
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 15s
+    relabel_configs:
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/(.*)'
+        target_label: container
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_service']
+        target_label: compose_service
+      - target_label: job
+        replacement: docker

--- a/sre/runbooks/README.md
+++ b/sre/runbooks/README.md
@@ -1,0 +1,27 @@
+# Runbooks
+
+> Layer 7. Every alert in `../prometheus/rules/` carries a `runbook_url`
+> annotation pointing at one of these files. A runbook turns a 3am page into a
+> checklist. Each follows the same shape: **Description · Impact · Diagnosis ·
+> Mitigation · Escalation**.
+
+## Alert → runbook index
+
+| Alert (`alertname`) | Severity | Runbook |
+|---------------------|----------|---------|
+| `OpsAPIServiceDown`, `BlackboxProbeFailed` | P1 | [service-down.md](service-down.md) |
+| `ErrorBudgetBurnFast/Medium/Slow/Chronic`, `ErrorBudgetExhausted` | P1–P4 | [error-budget-burn.md](error-budget-burn.md) |
+| `HighErrorRate` (5xx) | P1 | [high-error-rate.md](high-error-rate.md) |
+| `OpsAPIHighLatencyP95`, `LatencyBudgetBurnFast`, `OpsAPIConnectionsWaiting` | P2/P3 | [high-latency.md](high-latency.md) |
+| `PostgresDown`, `SlowDatabaseQueries`, `PostgresConnectionsNearMax` | P1/P3 | [postgres-saturation.md](postgres-saturation.md) |
+| `RedisDown`, `RedisMemoryHigh` | P2/P3 | [redis-saturation.md](redis-saturation.md) |
+| `DiskWillFillIn4Days`, `DiskSpaceLow`, `MemoryUtilizationHigh`, `OpsAPISaturationCPU` | P3 | [disk-capacity.md](disk-capacity.md) |
+| `PossibleDDoSAttack`, `DistributedDDoSAttack`, `CredentialStuffingAttack`, `HighAuthFailureRate` | P1–P3 | [ddos-attack.md](ddos-attack.md) |
+| `HighPaymentFailureRate` | P1 | [payment-failures.md](payment-failures.md) |
+
+## Conventions used in the commands
+
+- **Docker (demo / single-host):** `docker exec -it opsapi …`, `docker logs -f opsapi`.
+- **k3s (prod):** `kubectl -n <ns> …`. Set `KUBECONFIG` first.
+- Dashboards referenced are in Grafana under the **OpsAPI SRE** folder.
+- The app exposes `/health`, `/ready`, `/live`, `/metrics` (see `app.lua`).

--- a/sre/runbooks/ddos-attack.md
+++ b/sre/runbooks/ddos-attack.md
@@ -1,0 +1,38 @@
+# Runbook: DDoS / Abuse / Credential Stuffing
+
+**Alerts:** `PossibleDDoSAttack`, `DistributedDDoSAttack`, `CredentialStuffingAttack`, `HighAuthFailureRate` · **Severity:** P1–P3
+
+## Description
+Abnormal request volume from one IP (`PossibleDDoSAttack`), in aggregate
+(`DistributedDDoSAttack`), or a spike in auth failures (`CredentialStuffingAttack`,
+`HighAuthFailureRate`). See also `DDOS_MITIGATION_GUIDE.md` in the repo root.
+
+## Impact
+Service degradation/outage from resource exhaustion (**P1** when distributed), or
+account-takeover risk from credential stuffing (**P2**).
+
+## Diagnosis
+1. Grafana → **OpsAPI · Golden Signals** (traffic spike) and the security metrics
+   (`nginx_http_requests_by_ip_total`, `nginx_http_suspicious_requests_total`,
+   `api_auth_failures_total`).
+2. Top offending IPs:
+   `topk(10, rate(nginx_http_requests_by_ip_total[1m]))` in Prometheus.
+3. Legitimate spike vs attack? Check Loki access logs for patterns: single IP,
+   one endpoint hammered, login brute force, odd user-agents/paths.
+
+## Mitigation
+- **Single IP / small set:** block at the edge (firewall/ingress/WAF) or
+  rate-limit. Follow `DDOS_MITIGATION_GUIDE.md`.
+- **Distributed:** enable/tighten rate limiting; engage the CDN/WAF (e.g.
+  Cloudflare) "under attack" mode; scale out to absorb while filtering.
+- **Credential stuffing:** enforce/lower auth rate limits per IP/account; ensure
+  lockout + 2FA (OTP) are active (`helper/otp.lua`); consider CAPTCHA on login;
+  watch for `api_auth_failures_total{reason="invalid_credentials"}`.
+- Preserve evidence (logs) before blocking, for follow-up.
+
+## Verify
+Request/auth-failure rates back to baseline; no collateral blocking of real users.
+
+## Escalation
+P1 for a live distributed attack — engage security/platform owner and the
+CDN/WAF provider. File a postmortem covering detection latency and controls.

--- a/sre/runbooks/disk-capacity.md
+++ b/sre/runbooks/disk-capacity.md
@@ -1,0 +1,43 @@
+# Runbook: Disk / Memory / CPU Saturation
+
+**Alerts:** `DiskWillFillIn4Days`, `DiskSpaceLow`, `MemoryUtilizationHigh`, `OpsAPISaturationCPU` · **Severity:** P3
+
+## Description
+A host/node resource is saturated or trending toward exhaustion. `DiskWillFillIn4Days`
+is a *forecast* from `predict_linear()` (Capacity dashboard).
+
+## Impact
+Disk-full causes the nastiest failures: Postgres stops accepting writes, logs
+stop, containers crash. Memory pressure ⇒ OOMKills. CPU saturation ⇒ latency.
+Acting on the forecast keeps this a **P3 ticket**, not a 3am page.
+
+## Diagnosis
+1. Grafana → **OpsAPI · Capacity Planning**: current vs predicted vs threshold;
+   "days until disk full".
+2. Which filesystem / which consumer?
+   ```bash
+   df -h                                  # host
+   docker system df                       # images/volumes/build cache
+   du -sh /var/lib/docker/volumes/* | sort -h | tail
+   ```
+   - k3s: `kubectl -n <ns> get pvc`; `kubectl describe node <node>` (allocated vs capacity).
+3. Usual disk hogs: Postgres data growth, Prometheus/Loki/Tempo TSDB, nginx logs,
+   MinIO objects, Docker build cache / dangling images.
+
+## Mitigation
+- **Disk:**
+  - Reclaim: `docker system prune -af --volumes` (careful — only safe data),
+    rotate/ship logs, drop old Prometheus/Loki/Tempo data (retention is set in
+    their configs), expire MinIO temp buckets.
+  - Grow the volume / add a disk; for PG, move WAL or expand the PVC.
+- **Memory:** raise limits or add replicas; find the leaking process; cap
+  Ollama/LLM memory (compose sets a 4G limit).
+- **CPU:** scale out (`kubectl scale deployment/diytaxreturn-lapis --replicas=N`)
+  or enable HPA (`autoscaling.enabled=true` in the Helm values).
+
+## Verify
+Utilisation back under threshold; forecast "days to full" comfortably > 14d.
+
+## Escalation
+If reclaim doesn't buy headroom, this becomes a capacity-planning decision —
+see `../capacity/capacity-planning.md` and involve the platform owner.

--- a/sre/runbooks/error-budget-burn.md
+++ b/sre/runbooks/error-budget-burn.md
@@ -1,0 +1,43 @@
+# Runbook: Error Budget Burn
+
+**Alerts:** `ErrorBudgetBurnFast` (14.4×), `ErrorBudgetBurnMedium` (6×),
+`ErrorBudgetBurnSlow` (3×), `ErrorBudgetBurnChronic` (1×), `ErrorBudgetExhausted`
+· **Severity:** P1–P4 by burn speed
+
+## Description
+The availability SLO's error budget is being consumed faster than the policy
+allows. Burn rate = observed error ratio ÷ budget (0.0005 for 99.95%). See
+`../slo/README.md` for the multi-window method.
+
+## Impact
+The budget is the buffer between "reliable enough" and "breaking the SLO". Fast
+burn (`Fast`/`Medium`) means a live incident → **page**. Slow/chronic burn means
+accumulating reliability debt → **ticket**. Exhaustion triggers the **release
+freeze** policy.
+
+## Diagnosis
+1. Grafana → **OpsAPI · SLO & Error Budget**: budget-remaining gauge + burn-rate
+   panel (which window is hot — 1h/6h/1d?).
+2. Fast burn is an active incident — pivot to the symptom runbook:
+   - 5xx errors → [high-error-rate.md](high-error-rate.md)
+   - service down → [service-down.md](service-down.md)
+   - dependency → postgres / redis runbooks
+3. Slow/chronic burn: look for a low-level steady error (a noisy endpoint, a
+   flaky downstream, periodic timeouts). Use Loki to quantify which status/
+   endpoint dominates the budget spend.
+
+## Mitigation
+- **Fast/Medium (page):** stop the bleeding via the symptom runbook (rollback,
+  failover, scale, disable feature). The budget recovers once the SLI does.
+- **Slow/Chronic (ticket):** create a tracked reliability item; fix this sprint.
+- **Exhausted:** invoke the **error-budget policy** (`../slo/README.md`):
+  - Announce a **release freeze** for non-critical changes.
+  - Redirect engineering focus to reliability until the budget recovers.
+  - Only changes that restore the SLO ship.
+
+## Verify
+Burn-rate panel back under the alert threshold; budget-remaining trending up.
+
+## Escalation
+For exhaustion, the platform owner decides on the freeze. For fast burn, follow
+the symptom runbook's escalation.

--- a/sre/runbooks/high-error-rate.md
+++ b/sre/runbooks/high-error-rate.md
@@ -1,0 +1,37 @@
+# Runbook: High Error Rate (5xx)
+
+**Alerts:** `HighErrorRate`, (feeds) `ErrorBudgetBurnFast` · **Severity:** P1
+
+## Description
+The 5xx error ratio is elevated (`opsapi:http_error_ratio:rate5m`). The service
+is up but failing a meaningful share of requests.
+
+## Impact
+Users see failures; the availability error budget is burning. If burning at
+14.4×, the budget is gone in hours — treat as **P1**.
+
+## Diagnosis
+1. Grafana → **OpsAPI · Golden Signals** → "5xx error ratio" and per-endpoint
+   request rate. Is it one endpoint or platform-wide?
+2. Correlate with logs: Grafana → **OpsAPI · Logs** filter status `500/502/503`,
+   or `{job="opsapi"} | status =~ "5.."`. Read the actual error.
+3. Follow an exemplar trace (Prometheus exemplars → Tempo) to the failing span,
+   then to the log line — root cause in minutes.
+4. Common causes: bad deploy, dependency failure (DB/Redis/MinIO/HMRC/Stripe),
+   unhandled exception, migration mismatch, downstream timeout.
+5. Check the error catalog: rows in the shared `error_occurrences` table
+   (written by the handler in `app.lua`) show which catalog errors spiked.
+
+## Mitigation
+- **Correlates with a deploy?** Roll back (`kubectl -n <ns> rollout undo …`).
+- **Single dependency?** See its runbook (postgres / redis / payments).
+- **Single endpoint/module?** If feature-gated, consider disabling the feature
+  for the affected `PROJECT_CODE` / namespace while you fix forward.
+- **External API (HMRC/Stripe) down?** Degrade gracefully; surface a friendly
+  error; don't retry-storm.
+
+## Verify
+5xx ratio back under 0.1%; burn-rate panel on the SLO dashboard back to <1×.
+
+## Escalation
+Owner of the failing module; eng lead if platform-wide. Status page for P1.

--- a/sre/runbooks/high-latency.md
+++ b/sre/runbooks/high-latency.md
@@ -1,0 +1,38 @@
+# Runbook: High Latency
+
+**Alerts:** `OpsAPIHighLatencyP95`, `LatencyBudgetBurnFast`, `OpsAPIConnectionsWaiting` · **Severity:** P2/P3
+
+## Description
+P95 latency exceeds the 200ms SLO (`opsapi:http_latency:p95`), and/or the share
+of requests slower than 200ms is burning the latency budget, and/or nginx has
+many waiting connections.
+
+## Impact
+Slow responses; degraded UX; risk of cascading timeouts and connection
+exhaustion. Latency-budget burn at 14.4× is **P2**.
+
+## Diagnosis
+1. Grafana → **OpsAPI · Golden Signals** → P50/P95/P99. Is P99 ≫ P95 (tail) or
+   the whole distribution shifted?
+2. Per-endpoint breakdown — which endpoint regressed?
+3. Saturation panels: CPU, memory, **DB connection pool**, waiting connections.
+   Latency under load is usually saturation somewhere.
+4. Database: slow queries? See `SlowDatabaseQueries` and
+   [postgres-saturation.md](postgres-saturation.md) (`api_database_query_duration_seconds`).
+5. Traces: open a slow trace in Tempo; find the dominant span (DB? external API?
+   LLM/Ollama? lock contention?).
+6. Downstream: Ollama/LLM, HMRC, Stripe, MinIO — a slow dependency drags P95.
+
+## Mitigation
+- **Saturation (CPU/conn):** scale out replicas; raise worker/connection limits.
+- **DB-bound:** identify and kill/optimise the slow query; add/restore an index;
+  check connection-pool exhaustion.
+- **Downstream slow:** add/lower timeouts so one slow dependency can't pin
+  workers; degrade the feature.
+- **Traffic spike:** confirm it's legitimate (not DDoS — [ddos-attack.md](ddos-attack.md)); autoscale.
+
+## Verify
+P95 < 200ms sustained; latency burn-rate < 1×; waiting connections back to baseline.
+
+## Escalation
+DB on-call for query issues; eng lead if scaling doesn't help within 1h.

--- a/sre/runbooks/payment-failures.md
+++ b/sre/runbooks/payment-failures.md
@@ -1,0 +1,39 @@
+# Runbook: High Payment Failure Rate
+
+**Alert:** `HighPaymentFailureRate` (>10% over 10m) · **Severity:** P1
+
+## Description
+More than 10% of payment operations are failing
+(`ecommerce_payment_operations_total{status!="success"}`). Directly revenue-impacting.
+
+## Impact
+Lost revenue and customer trust on every failed checkout. **P1** — declare an
+incident even if the rest of the platform is healthy.
+
+## Diagnosis
+1. Grafana → **OpsAPI · Service Overview** / business panels: failure rate by
+   status. Spike or steady? Started when?
+2. Correlate with deploys and with Stripe status (https://status.stripe.com).
+3. Logs/traces: Loki for payment errors; Tempo for the failing checkout span.
+   Note OpsAPI's single-merchant Stripe model and webhook de-dup
+   (`StripeWebhookEventModel`, `BillingPaymentModel`) — see CLAUDE.md.
+4. Common causes: Stripe outage/API change, expired/rotated API keys or webhook
+   secret, a regression in the `checkout.session.completed` / `invoice.paid`
+   path, webhook delivery failing (signature mismatch), entitlement service error.
+
+## Mitigation
+- **Provider outage:** show a clear retry-later message; queue/retry idempotently;
+  do not double-charge. Post to the status page.
+- **Key/secret issue:** rotate/restore the Stripe key + webhook signing secret in
+  the secret store; redeploy.
+- **Code regression:** roll back the deploy touching the billing paths.
+- **Webhook failures:** verify the endpoint is reachable and signatures validate;
+  replay missed events once fixed (de-dup protects against double-processing).
+
+## Verify
+Failure rate < 1%; successful test transaction end-to-end; webhooks delivering;
+no duplicate charges.
+
+## Escalation
+P1: engage the payments/billing owner and finance comms. Reconcile any
+mischarges. Postmortem with action items on detection and key management.

--- a/sre/runbooks/postgres-saturation.md
+++ b/sre/runbooks/postgres-saturation.md
@@ -1,0 +1,48 @@
+# Runbook: PostgreSQL Down / Saturation
+
+**Alerts:** `PostgresDown`, `PostgresConnectionsNearMax`, `SlowDatabaseQueries` · **Severity:** P1/P3
+
+## Description
+Postgres is unreachable (`pg_up==0`), its connection pool is >80% of
+`max_connections`, or query P95 exceeds 1s. OpsAPI is data-backed, so DB trouble
+quickly becomes an availability incident.
+
+## Impact
+`PostgresDown` ⇒ near-total outage (**P1**). Connection saturation ⇒ rising
+errors/latency. Slow queries ⇒ latency-SLO risk.
+
+## Diagnosis
+```bash
+# Connections & activity (demo)
+docker exec -it sre-demo-postgres psql -U sre -d sre -c \
+  "SELECT count(*), state FROM pg_stat_activity GROUP BY state;"
+# Longest-running queries
+docker exec -it <pg> psql -U <u> -d <db> -c \
+  "SELECT pid, now()-query_start AS dur, state, left(query,80) FROM pg_stat_activity \
+   WHERE state<>'idle' ORDER BY dur DESC LIMIT 10;"
+```
+- k3s: `kubectl -n <ns> get pods -l app=postgres`; `kubectl logs <pg-pod>`.
+- Check `opsapi:pg_connection_utilization:ratio` and `pg_stat_activity_count` on
+  the **Golden Signals** / **Capacity** dashboards.
+- Causes: connection leak (clients not releasing), a runaway/locking query,
+  vacuum/bloat, disk full on the PG volume, or a **migration drift** (a CRM
+  migration drift took acc down for 22h on 2026-05-14 — confirm `PROJECT_CODE`
+  scopes migrations correctly; see CLAUDE.md).
+
+## Mitigation
+- **Down:** restart/repair the instance; verify the data volume and disk
+  (`df -h`); check it isn't OOM/disk-full.
+- **Connection saturation:** find and terminate offenders:
+  `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE state='idle in transaction' AND now()-state_change > interval '5 min';`
+  Then fix the leak (pool size, unclosed transactions). Consider read replicas.
+- **Slow queries:** `EXPLAIN ANALYZE` the offender; add/restore an index; kill if
+  it's blocking. Ensure queries filter by `namespace_id` (tenant scoping).
+- **Migration issue:** roll back the deploy; re-run migrations with the correct
+  `PROJECT_CODE` (`docker exec -e PROJECT_CODE=<code> -it opsapi lapis migrate`).
+
+## Verify
+`pg_up==1`, connection utilisation < 70%, query P95 < 1s, app error ratio normal.
+
+## Escalation
+DB on-call. For data-integrity concerns, stop writes and escalate to platform
+owner before attempting risky recovery.

--- a/sre/runbooks/redis-saturation.md
+++ b/sre/runbooks/redis-saturation.md
@@ -1,0 +1,40 @@
+# Runbook: Redis Down / Memory High
+
+**Alerts:** `RedisDown`, `RedisMemoryHigh` · **Severity:** P2/P3
+
+## Description
+Redis is unreachable (`redis_up==0`) or using >85% of `maxmemory`. OpsAPI uses
+Redis for sessions and caching.
+
+## Impact
+`RedisDown` ⇒ sessions/cache unavailable: users may be logged out, cache misses
+hammer Postgres (watch for secondary DB saturation). Memory pressure ⇒ evictions
+or OOM. Usually **P2**.
+
+## Diagnosis
+```bash
+docker exec -it sre-demo-redis redis-cli INFO server | head
+docker exec -it sre-demo-redis redis-cli INFO memory | grep -E 'used_memory_human|maxmemory_human|evicted_keys'
+docker exec -it sre-demo-redis redis-cli INFO clients
+```
+- k3s: `kubectl -n <ns> get pods -l app=redis`; `kubectl logs <redis-pod>`.
+- Dashboards: `redis_up`, `redis_memory_used_bytes / redis_memory_max_bytes`.
+- Causes: OOM/eviction storm, a giant key, no `maxmemory-policy`, persistence
+  (AOF/RDB) disk full, network partition.
+
+## Mitigation
+- **Down:** restart Redis; verify the data volume/disk; check the appendonly file
+  isn't corrupt (demo runs `--appendonly`; prod per chart).
+- **Memory high:** confirm an eviction policy is set (`allkeys-lru` in the demo);
+  find big keys (`redis-cli --bigkeys`); raise `maxmemory` or scale; expire/trim
+  stale cache keys.
+- **Cache stampede onto Postgres:** if cache loss is driving DB load, throttle or
+  warm the cache; watch [postgres-saturation.md](postgres-saturation.md).
+- App should **degrade gracefully** when Redis is down (fall through to DB / fail
+  open on cache) — verify it isn't hard-erroring.
+
+## Verify
+`redis_up==1`, memory utilisation < 85%, no eviction spikes, sessions working.
+
+## Escalation
+Platform on-call; eng lead if session loss is widespread (P2 comms).

--- a/sre/runbooks/service-down.md
+++ b/sre/runbooks/service-down.md
@@ -1,0 +1,41 @@
+# Runbook: Service Down
+
+**Alerts:** `OpsAPIServiceDown`, `BlackboxProbeFailed` · **Severity:** P1
+
+## Description
+Prometheus cannot scrape `up{job="opsapi"}` (or the external blackbox probe of
+`/health` is failing) for >1–2 minutes. The API is unreachable or not serving.
+
+## Impact
+Total or near-total outage — users cannot use the platform. Revenue-impacting.
+Declare a **P1** incident immediately.
+
+## Diagnosis
+1. Confirm scope — is it the app, the host, or the monitoring?
+   - Grafana → **OpsAPI · Service Overview** (API up / Postgres up / Redis up tiles).
+   - Hit health directly: `curl -v http://<host>/health`.
+2. Check the container/pod:
+   - Demo: `docker ps | grep opsapi`, `docker logs --tail=200 opsapi`.
+   - k3s: `kubectl -n <ns> get pods -l app=diytaxreturn-lapis`, `kubectl -n <ns> logs <pod> --tail=200`.
+3. Common causes: crash loop (bad migration/config), OOMKill, port/ingress
+   misroute, dependency down (Postgres) blocking startup, expired TLS.
+4. Check dependencies — if `PostgresDown` is also firing, fix that first
+   ([postgres-saturation.md](postgres-saturation.md)).
+
+## Mitigation
+- **Recent deploy?** Roll back first, diagnose later.
+  - k3s: `kubectl -n <ns> rollout undo deployment/diytaxreturn-lapis`.
+  - Demo: redeploy the last-good image tag.
+- **Crash loop:** read the last 200 log lines for the fatal error; if it's a
+  migration, see [postgres-saturation.md](postgres-saturation.md) (migration drift
+  took acc down for 22h on 2026-05-14 — scope `PROJECT_CODE` correctly).
+- **OOMKilled:** bump memory limits / replicas (`kubectl -n <ns> scale deployment/diytaxreturn-lapis --replicas=N`).
+- **Ingress/TLS:** verify ingress + certificate; check `nginx.conf` trusted CA.
+
+## Verify
+`up{job="opsapi"}==1`, blackbox `probe_success==1`, `/health` returns
+`{"status":"healthy"}`, error ratio back to baseline on the dashboard.
+
+## Escalation
+No progress in 30 min → engineering lead → platform owner. Keep the status page
+updated every 30 min for P1.

--- a/sre/scripts/backup-test.sh
+++ b/sre/scripts/backup-test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Backup & restore verification (Layer 8 — proves RPO is achievable).
+# Backups you never restore are not backups. This:
+#   1. seeds a row in the demo Postgres
+#   2. pg_dumps it
+#   3. restores the dump into a throwaway database
+#   4. verifies the row survived the round-trip
+# Mirrors the production CronJob in ../k3s/manifests/backup-cronjob.yaml.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+PG=sre-demo-postgres
+PG_USER="$(grep -E '^PG_USER=' .env.sre 2>/dev/null | cut -d= -f2)"; PG_USER="${PG_USER:-sre}"
+PG_DB="$(grep -E '^PG_DB=' .env.sre 2>/dev/null | cut -d= -f2)"; PG_DB="${PG_DB:-sre}"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+TOKEN="backup_probe_${STAMP}"
+
+run() { docker exec -i -e PGPASSWORD="${PG_PASSWORD:-sre}" "$PG" "$@"; }
+
+echo "▶ Seeding probe row ($TOKEN)…"
+run psql -U "$PG_USER" -d "$PG_DB" -v ON_ERROR_STOP=1 -c \
+  "CREATE TABLE IF NOT EXISTS backup_probe(id serial primary key, token text, created_at timestamptz default now());" >/dev/null
+run psql -U "$PG_USER" -d "$PG_DB" -c "INSERT INTO backup_probe(token) VALUES ('$TOKEN');" >/dev/null
+
+echo "▶ pg_dump → /tmp/${TOKEN}.sql"
+run pg_dump -U "$PG_USER" -d "$PG_DB" > "/tmp/${TOKEN}.sql"
+SIZE=$(wc -c < "/tmp/${TOKEN}.sql")
+echo "  dump size: ${SIZE} bytes"
+
+echo "▶ Restoring into throwaway DB restore_${STAMP}…"
+run psql -U "$PG_USER" -d "$PG_DB" -c "DROP DATABASE IF EXISTS restore_${STAMP};" >/dev/null 2>&1 || true
+run createdb -U "$PG_USER" "restore_${STAMP}"
+docker exec -i -e PGPASSWORD="${PG_PASSWORD:-sre}" "$PG" \
+  psql -U "$PG_USER" -d "restore_${STAMP}" < "/tmp/${TOKEN}.sql" >/dev/null
+
+echo "▶ Verifying probe row survived the round-trip…"
+FOUND=$(run psql -U "$PG_USER" -d "restore_${STAMP}" -tAc \
+  "SELECT count(*) FROM backup_probe WHERE token='$TOKEN';")
+run psql -U "$PG_USER" -d "$PG_DB" -c "DROP DATABASE IF EXISTS restore_${STAMP};" >/dev/null 2>&1 || true
+
+if [ "${FOUND// /}" = "1" ]; then
+  echo "✓ RESTORE VERIFIED — backup is recoverable (RPO objective met)."
+else
+  echo "✗ RESTORE FAILED — probe row not found after restore!"; exit 1
+fi

--- a/sre/scripts/chaos-test.sh
+++ b/sre/scripts/chaos-test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Chaos test (Layer 6/10) — inject a controlled failure and prove the system
+# DETECTS it. Pauses the demo Postgres, polls Prometheus until the PostgresDown
+# alert is firing, then unpauses and confirms it resolves.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+PROM=http://localhost:9091
+PG=sre-demo-postgres
+
+alert_state() { # $1 = alertname → prints "firing"/"pending"/""
+  curl -fsS "$PROM/api/v1/alerts" 2>/dev/null \
+    | grep -o "\"alertname\":\"$1\"[^}]*\"state\":\"[a-z]*\"" \
+    | grep -o '"state":"[a-z]*"' | tail -1 | cut -d'"' -f4 || true
+}
+wait_state() { # $1 alertname, $2 desired, $3 timeout-sec
+  local n=$(( $3 / 3 ))
+  while [ "$n" -gt 0 ]; do
+    [ "$(alert_state "$1")" = "$2" ] && return 0
+    n=$((n-1)); sleep 3
+  done
+  return 1
+}
+
+echo "▶ Baseline: PostgresDown = '$(alert_state PostgresDown)'"
+echo "▶ Injecting failure: pausing $PG …"
+docker pause "$PG" >/dev/null
+
+echo "▶ Waiting for PostgresDown to fire (the pg exporter loses its target)…"
+if wait_state PostgresDown firing 120; then
+  echo "  ✓ DETECTED — PostgresDown is firing."
+else
+  echo "  ✗ alert did not fire within 120s (check exporter/rules)."
+fi
+
+echo "▶ Recovering: unpausing $PG …"
+docker unpause "$PG" >/dev/null
+
+echo "▶ Waiting for the alert to clear…"
+if wait_state PostgresDown "" 120; then
+  echo "  ✓ RECOVERED — PostgresDown cleared."
+else
+  echo "  ⚠ still firing after 120s; check 'make alerts'."
+fi
+echo "▶ Pages/tickets seen by the sink:"; docker logs sre-alert-logger 2>&1 | tail -10 || true

--- a/sre/scripts/dr-drill.sh
+++ b/sre/scripts/dr-drill.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Disaster-recovery drill (Layer 8) — simulate loss of the app tier and MEASURE
+# the recovery time (RTO), writing a timestamped report. Stops the synthetic
+# OpsAPI container, recreates it, and times how long until /health is green
+# again as observed by Prometheus (up{job="opsapi"}).
+#
+# Targets: RTO = 15 min, RPO = 5 min (see ../incident/ and ../capacity/).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+PROM=http://localhost:9091
+SVC=synthetic-opsapi
+COMPOSE=(docker compose -f docker-compose.sre.yml --env-file .env.sre)
+REPORT="dr-report-$(date -u +%Y%m%dT%H%M%SZ).md"
+
+up_value() { curl -fsS "$PROM/api/v1/query?query=up%7Bjob%3D%22opsapi%22%7D" 2>/dev/null \
+  | grep -o '"value":\[[^]]*\]' | grep -o '"[01]"' | tail -1 | tr -d '"'; }
+
+echo "▶ DR drill: simulating loss of the app tier ($SVC)…"
+START=$(date +%s)
+"${COMPOSE[@]}" stop "$SVC" >/dev/null
+
+echo "▶ Recovering (recreate container)…"
+"${COMPOSE[@]}" up -d "$SVC" >/dev/null
+
+echo "▶ Timing recovery until up{job=opsapi}==1 …"
+DEADLINE=$(( $(date +%s) + 300 ))
+while [ "$(up_value)" != "1" ]; do
+  [ "$(date +%s)" -ge "$DEADLINE" ] && { echo "  ✗ did not recover within 5m"; break; }
+  sleep 3
+done
+END=$(date +%s); RTO=$((END - START))
+
+{
+  echo "# DR Drill Report"
+  echo
+  echo "- **Date (UTC):** $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "- **Scenario:** loss of app tier ($SVC), recreate"
+  echo "- **Measured RTO:** ${RTO}s"
+  echo "- **RTO objective:** 900s (15m) — $( [ "$RTO" -le 900 ] && echo 'MET ✓' || echo 'MISSED ✗')"
+  echo "- **RPO objective:** 300s (5m) — backups verified separately via backup-test.sh"
+  echo
+  echo "## Notes"
+  echo "- This drill exercises the local Docker stack. The k3s equivalent is a"
+  echo "  rolling pod deletion (kubectl delete pod -l app=opsapi); recovery is the"
+  echo "  Deployment rescheduling + readiness probe passing."
+} > "$REPORT"
+
+echo "✓ RTO measured: ${RTO}s  →  report written to sre/$REPORT"

--- a/sre/scripts/load/k6-load.js
+++ b/sre/scripts/load/k6-load.js
@@ -1,0 +1,58 @@
+// k6 load generator for the OpsAPI SRE demo.
+// Drives three traffic classes against the target so the golden-signal and SLO
+// dashboards populate and the error budget visibly burns:
+//   • happy path   →  /            (200, fast)
+//   • slow path    →  /slow        (200, 200–600ms) — burns the latency budget
+//   • error path   →  /error       (500)            — burns the availability budget
+//
+// It also emits an OpenTelemetry-style trace span per iteration to the OTel
+// Collector (best-effort) so the Tempo pipeline shows real traces.
+//
+// Tunables via env: K6_VUS, K6_DURATION, K6_ERROR_RATE, K6_SLOW_RATE, TARGET.
+import http from 'k6/http';
+import { sleep, check } from 'k6';
+import { Rate } from 'k6/metrics';
+
+const TARGET = __ENV.TARGET || 'http://synthetic-opsapi:80';
+const ERROR_RATE = parseFloat(__ENV.K6_ERROR_RATE || '0.08');
+const SLOW_RATE = parseFloat(__ENV.K6_SLOW_RATE || '0.15');
+
+export const errorPathRate = new Rate('demo_error_path_ratio');
+
+export const options = {
+  scenarios: {
+    steady: {
+      executor: 'constant-vus',
+      vus: parseInt(__ENV.K6_VUS || '10', 10),
+      duration: __ENV.K6_DURATION || '5m',
+    },
+  },
+  thresholds: {
+    // These are k6's own pass/fail gates — they mirror the SLOs so the load
+    // run itself reports against the same targets the dashboards track.
+    http_req_duration: ['p(95)<200'],
+    http_req_failed: ['rate<0.001'],
+  },
+};
+
+export default function () {
+  const r = Math.random();
+  let path = '/';
+  if (r < ERROR_RATE) {
+    path = '/error';
+  } else if (r < ERROR_RATE + SLOW_RATE) {
+    path = '/slow';
+  }
+
+  const res = http.get(`${TARGET}${path}`, {
+    tags: { endpoint: path },
+  });
+
+  errorPathRate.add(path === '/error');
+  check(res, {
+    'status is 2xx or expected 5xx': (resp) =>
+      (path === '/error' && resp.status === 500) || resp.status === 200,
+  });
+
+  sleep(Math.random() * 0.5);
+}

--- a/sre/scripts/sre-demo.sh
+++ b/sre/scripts/sre-demo.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Bring up the OpsAPI SRE demo stack, wait for health, and print the URL map.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+COMPOSE=(docker compose -f docker-compose.sre.yml --env-file .env.sre)
+[ -f .env.sre ] || cp .env.sre.example .env.sre
+
+echo "▶ Building & starting the OpsAPI SRE stack…"
+"${COMPOSE[@]}" up -d --build
+
+echo "▶ Waiting for core services to become healthy…"
+wait_for() {
+  local name="$1" url="$2" tries=60
+  until curl -fsS "$url" >/dev/null 2>&1; do
+    tries=$((tries - 1))
+    [ "$tries" -le 0 ] && { echo "  ✗ $name not ready ($url)"; return 1; }
+    sleep 2
+  done
+  echo "  ✓ $name"
+}
+wait_for "Prometheus" "http://localhost:9091/-/healthy"      || true
+wait_for "Grafana"    "http://localhost:3012/api/health"     || true
+wait_for "Alertmgr"   "http://localhost:9093/-/healthy"      || true
+wait_for "Gatus"      "http://localhost:8878/health"         || true
+
+GP="$(grep -E '^GRAFANA_PASSWORD=' .env.sre | cut -d= -f2)"; GP="${GP:-admin}"
+cat <<EOF
+
+────────────────────────────────────────────────────────────────────
+  OpsAPI SRE stack is up. Open:
+
+  Grafana (dashboards)   http://localhost:3012     (admin / ${GP})
+      • OpsAPI · Service Overview
+      • OpsAPI · Golden Signals
+      • OpsAPI · SLO & Error Budget
+      • OpsAPI · Capacity Planning
+      • OpsAPI · Logs (Loki)
+  Prometheus             http://localhost:9091
+  Alertmanager           http://localhost:9093
+  Gatus (status page)    http://localhost:8878
+  Tempo (via Grafana Explore → Tempo)
+  Loki  (via Grafana Explore → Loki)
+
+  Next:
+    make demo-load     # drive traffic → watch SLO dashboards + budget burn
+    make alerts        # see pages/tickets the alert sink received
+    make chaos         # pause Postgres → PostgresDown alert fires → recovers
+    make backup-test   # prove RPO (pg_dump + restore verify)
+    make dr-drill      # measure RTO
+────────────────────────────────────────────────────────────────────
+EOF

--- a/sre/scripts/validate.sh
+++ b/sre/scripts/validate.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Validate every config in the SRE stack WITHOUT a running cluster:
+#   • docker compose config       (compose schema)
+#   • promtool check config/rules  (Prometheus)
+#   • amtool check-config          (Alertmanager)
+#   • python json.tool             (Grafana dashboards)
+# Uses the pinned images so there is nothing to install locally.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+rc=0
+note() { printf '%s %s\n' "$1" "$2"; }
+
+echo "▶ docker compose config"
+if docker compose -f docker-compose.sre.yml --env-file .env.sre.example config >/dev/null; then
+  note "✓" "compose file is valid"
+else
+  note "✗" "compose file invalid"; rc=1
+fi
+
+echo "▶ promtool check config + rules"
+docker run --rm -v "$PWD/prometheus:/p" --entrypoint promtool prom/prometheus:v2.54.1 \
+  check config /p/prometheus.yml 2>&1 | sed 's/^/    /' || rc=1
+for f in prometheus/rules/*.rules.yml; do
+  if docker run --rm -v "$PWD/prometheus:/p" --entrypoint promtool prom/prometheus:v2.54.1 \
+       check rules "/p/rules/$(basename "$f")" >/dev/null 2>&1; then
+    note "  ✓" "$f"
+  else
+    note "  ✗" "$f"; rc=1
+  fi
+done
+
+echo "▶ amtool check-config"
+if docker run --rm -v "$PWD/alertmanager:/a" --entrypoint amtool prom/alertmanager:v0.27.0 \
+     check-config /a/alertmanager.yml >/dev/null 2>&1; then
+  note "✓" "alertmanager.yml is valid"
+else
+  note "✗" "alertmanager.yml invalid"; rc=1
+fi
+
+echo "▶ Grafana dashboard JSON"
+for f in grafana/dashboards/*.json; do
+  if python3 -m json.tool "$f" >/dev/null 2>&1; then note "  ✓" "$f"; else note "  ✗" "$f"; rc=1; fi
+done
+
+echo
+[ "$rc" -eq 0 ] && echo "ALL VALID ✓" || echo "VALIDATION FAILED ✗"
+exit "$rc"

--- a/sre/slo/README.md
+++ b/sre/slo/README.md
@@ -1,0 +1,75 @@
+# SLOs & Error Budgets
+
+> Layer 1 & 4 of the SRE operating model. **Define "good" before you monitor it.**
+
+`slo-definitions.yaml` is the single source of truth. Every objective there is
+compiled into Prometheus rules (`../prometheus/rules/slo-burn-rate.rules.yml`)
+and visualised in the SLO/error-budget Grafana dashboard.
+
+## The objectives
+
+| # | Objective | SLI | Target (30d) | Error budget |
+|---|-----------|-----|--------------|--------------|
+| 1 | Availability | non-5xx ÷ total requests | **99.95%** | 21.6 min/month |
+| 2 | Latency | requests < 200ms ÷ total | **99%** (P95 < 200ms) | 1% slow requests |
+| 3 | Error rate | non-5xx ÷ total | **99.9%** | 0.1% errors |
+| 4 | Database availability | `pg_up` | **99.99%** | 4.32 min/month |
+| 5 | Cache availability | `redis_up` | **99.9%** | 43.2 min/month |
+
+## How the SLI is measured
+
+```
+                 good events            successful (non-5xx, fast) requests
+SLI  =  ───────────────────────  =  ──────────────────────────────────────
+                total events                     all requests
+```
+
+Availability/error SLIs come from the app's own counters
+(`nginx_http_requests_total`, emitted by `lapis/lib/prometheus_metrics.lua`).
+Latency uses the histogram bucket at `le="0.2"`. Dependency SLOs are scraped
+from the postgres/redis exporters. External availability is double-checked by
+blackbox-exporter probing `/health` (defends against "metrics say up, users
+say down").
+
+## Error-budget policy
+
+The error budget is the amount of unreliability we are *willing to spend*:
+
+```
+error_budget = 1 - SLO_target          (e.g. 0.05% for 99.95%)
+budget_remaining = 1 - (errors_observed / errors_allowed)
+```
+
+| Budget remaining | Posture |
+|------------------|---------|
+| > 50% | **Ship freely.** Normal feature velocity. |
+| 10–50% | **Caution.** Risky changes get extra review; prioritise reliability bugs. |
+| < 10% | **Slow down.** No non-critical releases; reliability work jumps the queue. |
+| Exhausted (≤ 0%) | **Release freeze.** Only fixes that restore the SLO ship until budget recovers. |
+
+This is enforced socially (and visibly on the dashboard), not by a robot — but
+the `ErrorBudgetExhausted` alert pages the team so the conversation actually
+happens.
+
+## Burn-rate alerting (why we don't alert on raw error rate)
+
+A flat "error rate > 0.1%" alert is either too noisy or too slow. Instead we use
+Google's **multi-window, multi-burn-rate** method (SRE Workbook ch. 5):
+
+| Severity | Long window | Short window | Burn rate | Budget consumed | Meaning |
+|----------|-------------|--------------|-----------|-----------------|---------|
+| **page** (P1) | 1h | 5m | 14.4× | 2% in 1h | Fast burn — wake someone |
+| **page** (P1) | 6h | 30m | 6× | 5% in 6h | Sustained burn |
+| **ticket** (P3) | 24h | 2h | 3× | 10% in 24h | Slow burn — fix this sprint |
+| **ticket** (P3) | 3d | 6h | 1× | budget gone over window | Chronic erosion |
+
+The short window is an "is it *still* happening right now" guard so alerts
+resolve quickly once the incident is over.
+
+## Editing SLOs
+
+1. Change the target/SLI in `slo-definitions.yaml`.
+2. Mirror the change in `../prometheus/rules/slo-burn-rate.rules.yml` (the
+   recording rule windows and the burn-rate thresholds) and the k3s
+   `PrometheusRule` at `../k3s/manifests/opsapi-slo-rules.yaml`.
+3. `promtool check rules` (see top-level README) before committing.

--- a/sre/slo/slo-definitions.yaml
+++ b/sre/slo/slo-definitions.yaml
@@ -1,0 +1,79 @@
+# OpsAPI Service Level Objectives (SLOs)
+# ------------------------------------------------------------------------------
+# This is the SINGLE SOURCE OF TRUTH for what "good" means for OpsAPI.
+# Format is OpenSLO-flavoured and intentionally human-first: every SLO here is
+# implemented as Prometheus recording + multi-window/multi-burn-rate alerting
+# rules in ../prometheus/rules/slo-burn-rate.rules.yml, and visualised in
+# ../grafana/dashboards/slo-error-budget.json.
+#
+# Error budget = (1 - SLO target) over the rolling 30-day window.
+# Policy (see ./README.md): when a budget is exhausted, feature releases freeze
+# and the on-call/eng focus shifts to reliability until the budget recovers.
+# ------------------------------------------------------------------------------
+
+apiVersion: openslo/v1
+kind: SLOSet
+metadata:
+  name: opsapi-core
+  displayName: OpsAPI Core Platform
+spec:
+  service: opsapi
+  budgetingWindow: 30d
+
+  objectives:
+    # ── 1. Availability ──────────────────────────────────────────────────────
+    # SLI = successful_requests / total_requests (success = non-5xx).
+    # 99.95% over 30d  →  21.6 minutes/month error budget.
+    - name: availability
+      displayName: API Availability
+      target: 0.9995
+      sli:
+        ratioMetric:
+          good: 'sum(rate(nginx_http_requests_total{job="opsapi",status!~"5.."}[{{window}}]))'
+          total: 'sum(rate(nginx_http_requests_total{job="opsapi"}[{{window}}]))'
+      budget:
+        downtimePerMonth: "21.6m"
+
+    # ── 2. Latency ───────────────────────────────────────────────────────────
+    # SLI = fraction of requests served faster than 200ms (P95 target < 200ms).
+    # 99% of requests under threshold over 30d.
+    - name: latency
+      displayName: API Latency (P95 < 200ms)
+      target: 0.99
+      thresholdMs: 200
+      sli:
+        ratioMetric:
+          good: 'sum(rate(nginx_http_request_duration_seconds_bucket{job="opsapi",le="0.2"}[{{window}}]))'
+          total: 'sum(rate(nginx_http_request_duration_seconds_count{job="opsapi"}[{{window}}]))'
+
+    # ── 3. Errors ────────────────────────────────────────────────────────────
+    # Explicit error-rate objective: < 0.1% 5xx. Mirrors availability but kept
+    # separate so the error-budget dashboard can show it as its own line.
+    - name: errors
+      displayName: Error Rate (< 0.1%)
+      target: 0.999
+      sli:
+        ratioMetric:
+          good: 'sum(rate(nginx_http_requests_total{job="opsapi",status!~"5.."}[{{window}}]))'
+          total: 'sum(rate(nginx_http_requests_total{job="opsapi"}[{{window}}]))'
+
+  # ── Dependency SLOs (probed externally via blackbox-exporter) ──────────────
+  dependencies:
+    # Database availability 99.99% over 30d  →  4.32 minutes/month.
+    - name: database-availability
+      displayName: PostgreSQL Availability
+      target: 0.9999
+      sli:
+        ratioMetric:
+          good: 'avg_over_time(pg_up[{{window}}])'
+          total: '1'
+      budget:
+        downtimePerMonth: "4.32m"
+
+    - name: cache-availability
+      displayName: Redis Availability
+      target: 0.999
+      sli:
+        ratioMetric:
+          good: 'avg_over_time(redis_up[{{window}}])'
+          total: '1'

--- a/sre/synthetic-target/Dockerfile
+++ b/sre/synthetic-target/Dockerfile
@@ -1,0 +1,17 @@
+# Synthetic OpsAPI target for the SRE demo.
+# Emits the EXACT metric schema OpsAPI produces (nginx_http_requests_total with
+# status/method/endpoint labels + nginx_http_request_duration_seconds histogram),
+# so the golden-signal, SLO and burn-rate dashboards/alerts are driven by real,
+# production-shaped metrics even when the full app stack is not running.
+# k6 drives traffic across /, /slow and /error to make the signals move.
+FROM openresty/openresty:alpine
+
+# `opm` is a Perl script and `curl` is used by the container healthcheck; the
+# base alpine image ships neither (CLAUDE.md notes the missing perl).
+RUN apk add --no-cache perl curl \
+    && opm get knyar/nginx-lua-prometheus \
+    && mkdir -p /var/log/nginx     # access/error logs (compose mounts ./logs here)
+
+COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
+
+EXPOSE 80

--- a/sre/synthetic-target/nginx.conf
+++ b/sre/synthetic-target/nginx.conf
@@ -1,0 +1,75 @@
+worker_processes 1;
+error_log /var/log/nginx/error.log warn;
+events { worker_connections 1024; }
+
+http {
+    lua_shared_dict prometheus_metrics 10M;
+    log_format combined_status '$remote_addr - [$time_local] "$request" $status '
+                               '$body_bytes_sent "$http_referer" rt=$request_time';
+    access_log /var/log/nginx/access.log combined_status;
+
+    # Initialise metrics that mirror OpsAPI's schema exactly.
+    init_worker_by_lua_block {
+        prometheus = require("prometheus").init("prometheus_metrics")
+        metric_requests = prometheus:counter(
+            "nginx_http_requests_total", "HTTP requests", {"host", "status", "method", "endpoint"})
+        metric_latency = prometheus:histogram(
+            "nginx_http_request_duration_seconds", "HTTP request latency",
+            {"host", "method", "endpoint"},
+            {0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.5, 1, 2, 5})
+        metric_connections = prometheus:gauge(
+            "nginx_http_connections", "HTTP connections", {"state"})
+    }
+
+    log_by_lua_block {
+        local ep = ngx.var.uri
+        metric_requests:inc(1, {ngx.var.host, ngx.var.status, ngx.req.get_method(), ep})
+        metric_latency:observe(tonumber(ngx.var.request_time), {ngx.var.host, ngx.req.get_method(), ep})
+        metric_connections:set(tonumber(ngx.var.connections_waiting or 0), {"waiting"})
+    }
+
+    server {
+        listen 80;
+        server_name synthetic-opsapi;
+
+        # Happy path
+        location = / {
+            content_by_lua_block { ngx.say('{"ok":true}') }
+        }
+
+        # Health endpoint (matches OpsAPI's /health contract for blackbox + gatus)
+        location = /health {
+            content_by_lua_block { ngx.say('{"status":"healthy","service":"synthetic-opsapi"}') }
+        }
+
+        # Slow endpoint — drives the latency SLO
+        location = /slow {
+            content_by_lua_block {
+                ngx.sleep(0.2 + math.random() * 0.4)   -- 200–600ms
+                ngx.say('{"slow":true}')
+            }
+        }
+
+        # Error endpoint — drives the error-budget burn
+        location = /error {
+            content_by_lua_block {
+                ngx.status = 500
+                ngx.say('{"error":"synthetic failure"}')
+                return ngx.exit(500)
+            }
+        }
+
+        # OpenAPI stub so the gatus /openapi.json check passes
+        location = /openapi.json {
+            content_by_lua_block {
+                ngx.header.content_type = "application/json"
+                ngx.say('{"info":{"title":"OpsAPI"},"paths":{"/a":{},"/b":{},"/c":{},"/d":{},"/e":{},"/f":{}}}')
+            }
+        }
+
+        # Prometheus scrape endpoint
+        location = /metrics {
+            content_by_lua_block { metric_connections:set(0, {"waiting"}); prometheus:collect() }
+        }
+    }
+}

--- a/sre/tempo/tempo-config.yml
+++ b/sre/tempo/tempo-config.yml
@@ -1,0 +1,56 @@
+# Tempo — traces pillar (Layer 3). Receives OTLP from the OTel Collector and
+# stores traces on local disk. `metrics_generator` turns spans into RED metrics
+# and service-graph metrics, written back to Prometheus via remote_write — this
+# is what powers trace↔metric correlation and the service graph in Grafana.
+server:
+  http_listen_port: 3200
+  log_level: warn
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+
+ingester:
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    block_retention: 168h            # 7 days in the demo
+
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+  storage:
+    path: /var/tempo/generator/wal
+    remote_write:
+      - url: http://prometheus:9090/api/v1/write
+        send_exemplars: true
+  traces_storage:
+    path: /var/tempo/generator/traces
+  processor:
+    span_metrics:
+      dimensions: [service.name, span.name, status.code]
+    service_graphs:
+      dimensions: [service.name]
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /var/tempo/wal
+    local:
+      path: /var/tempo/blocks
+
+overrides:
+  defaults:
+    metrics_generator:
+      processors: [service-graphs, span-metrics]
+
+usage_report:
+  reporting_enabled: false


### PR DESCRIPTION
## What

A complete, self-contained **Site Reliability Engineering** stack under `sre/` — the reliability *operating model*, not just tools — that runs two ways from one source of truth:

- **Docker demo** (`sre/docker-compose.sre.yml`): one command stands up the whole thing with a synthetic OpsAPI target (emits the app's exact metric schema) + k6 load, so SLOs, golden-signal dashboards, burn-rate alerts and error-budget burn fire **standalone**.
- **k3s production** (`sre/k3s/`): the identical SLOs/rules/dashboards/status-page via Helm community charts (kube-prometheus-stack + Loki + Tempo + OTel Collector) and mirrored `PrometheusRule`/`AlertmanagerConfig` CRs.

Gatus stays the public status page (SLO-aligned, demo + k3s).

## The 10 SRE layers

| # | Layer | Where |
|---|-------|-------|
| 1 | SLOs | `slo/slo-definitions.yaml` — availability 99.95%, P95<200ms, errors<0.1%, DB 99.99% |
| 2 | Golden signals | `prometheus/rules/golden-signals.rules.yml` (recording rules) |
| 3 | Full observability | Metrics (Prometheus) · Logs (Loki/Promtail) · Traces (Tempo/OTel), correlated in Grafana |
| 4 | Error budgets | `prometheus/rules/slo-burn-rate.rules.yml` — multi-window/multi-burn-rate + release-freeze policy |
| 5 | Incident mgmt | `incident/` (severity matrix, response, blameless postmortem) + Alertmanager P1–P4 routing |
| 6 | Automation | `Makefile` + `scripts/` (demo, load, backup-test, dr-drill, chaos, validate) + k3s `install.sh` |
| 7 | Runbooks | `runbooks/` — one per alert, linked from every `runbook_url` |
| 8 | Reliability eng. | backup+restore verify (RPO), DR drill (RTO), nightly k3s backup CronJob |
| 9 | Capacity planning | `capacity/` + `predict_linear` forecast rules + dashboard |
| 10 | Continuous improvement | postmortem template + action-item tracking |

## Domains (wslproxy)

Exposes dashboards the same way as the rest of the platform — `wslproxy` ingress class + `cert-manager`/`main-issuer` TLS, **unique `sre-` hosts** so they never share a host with the app's Ingress (avoids the 2026-06-15 two-Ingress flapping failure mode).

- `local-docker-wslproxy.yaml`: routes `sre-{grafana,status,prometheus,alerts}.diytaxreturn.co.uk` → this host's docker ports.
- k3s Grafana/Gatus ingresses with per-env hosts (`int-sre-*`, `acc-sre-*`, prod). See `sre/k3s/README.md`.

> **Action required to go live:** add a DNS CNAME per host → `pop0.wslproxy.com` (no wildcard), and `make demo-up` so endpoints have a backend.

## Verification

- `promtool` (config + all 4 rule files), `amtool`, `docker compose config`, and all 5 dashboard JSONs — **pass**.
- Built the synthetic target; confirmed `/health`, `/error` (500), `/slow`, `/metrics`.
- **End-to-end:** ran Prometheus against it, drove traffic, watched all 12 rule groups evaluate and the right alerts fire at the right severities — `ErrorBudgetBurnFast` (P1) and `LatencyBudgetBurnFast` (P2) firing, `OpsAPIHighLatencyP95` (P3) correctly pending its `for:`.
- wslproxy ingresses applied to the cluster; TLS certs issued; endpoints bound to `192.168.1.193`.

## Scope boundaries (honest)

- Trace **pipeline** is fully built/demoed via load-generated spans; emitting **real** OpsAPI spans needs one app-side instrumentation step (documented).
- Chaos/DR scripts exercise the local Docker stack (k3s equivalents documented).
- Demo ports offset (9091/3012/8878) so this runs alongside OpsAPI's existing inline monitoring.
- Note: the shared cluster already has a `prometheus-stack` release — a "layer onto existing stack" variant can be added if preferred over a parallel install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)