### PR TITLE
fix(lapis): use resolver local=on so cluster DNS works in k8s

### DIFF
--- a/lapis/nginx.conf
+++ b/lapis/nginx.conf
@@ -311,23 +311,25 @@ http {
     }
 
     # DNS resolver for lua-resty-http (cosocket) outbound calls — used by
-    # the HMRC OAuth token-exchange flow + any other server-to-server
-    # HTTPS calls from Lua.
+    # the HMRC + Google OAuth token-exchange flows + any other
+    # server-to-server HTTPS calls from Lua.
     #
-    # Why a list: Docker Desktop for Mac's NAT can intermittently drop
-    # UDP packets to external DNS (8.8.8.8), causing 30-second timeouts
-    # on the HMRC token-exchange callback. Using Docker's built-in
-    # resolver (127.0.0.11) as PRIMARY avoids the NAT hop entirely —
-    # it resolves locally via Docker Engine's embedded DNS.
+    # ``local=on`` reads the nameservers from /etc/resolv.conf at startup,
+    # so the resolver is correct in every deployment WITHOUT hardcoding an
+    # IP that only works in one of them:
+    #   - Docker / docker-compose → 127.0.0.11 (Docker's embedded DNS)
+    #   - Kubernetes (k3s) pod     → 10.96.0.10 (CoreDNS, resolves both
+    #                                cluster-internal and external names)
     #
-    # On Kubernetes this also works: 127.0.0.11 isn't reachable in a
-    # pod, so nginx silently falls through to 8.8.8.8 / 8.8.4.4. In
-    # bare-metal production the same fallback applies. Same config,
-    # works in every container deployment we'd run.
+    # Why this matters: a hardcoded ``resolver 127.0.0.11 8.8.8.8 8.8.4.4``
+    # round-robins across the list, so in a k8s pod ~1/3 of lookups hit the
+    # unreachable 127.0.0.11 and fail with "Connection refused", breaking
+    # the Google/HMRC token exchange intermittently (SYSTEM_500). nginx does
+    # NOT silently fall through to the next address on a refused resolver.
     #
     # ``valid=30s`` caches DNS responses to avoid hammering the
     # resolver on every API call.
-    resolver 127.0.0.11 8.8.8.8 8.8.4.4 ipv6=off valid=30s;
+    resolver local=on ipv6=off valid=30s;
 
     # Trust the system CA bundle so lua-resty-http can verify TLS certificates
     # (ssl_verify=true) on outbound HTTPS — required for HMRC production calls, which
@@ -342,7 +344,7 @@ http {
         # Repeat the resolver inside the server block — some OpenResty
         # builds don't inherit the http-level resolver into cosocket
         # contexts used by lua-resty-http's request_uri().
-        resolver 127.0.0.11 8.8.8.8 8.8.4.4 ipv6=off valid=30s;
+        resolver local=on ipv6=off valid=30s;
 
         # Simple location block - authentication is handled by Lapis
         location / {


### PR DESCRIPTION
## Problem
`lapis/nginx.conf` hardcodes `resolver 127.0.0.11 8.8.8.8 8.8.4.4`. In k3s/k8s:
- `127.0.0.11` is Docker's embedded DNS and is **connection-refused** (nginx does not silently fall through to the next address on a refused resolver), and
- `8.8.8.8/8.8.4.4` are public resolvers that **cannot resolve cluster-internal names** (`*.svc.cluster.local`).

So any cosocket DNS lookup for an in-cluster hostname fails (`could not be resolved (3: Host not found)`). This contributed to the int outage where `diytaxreturn-lapis` could not reach `diy-tax-db.int.svc.cluster.local` and every DB-backed request returned `SYSTEM_500`.

## Fix
Use `resolver local=on ipv6=off valid=30s;` (both http and server scope), which reads the pod's `/etc/resolv.conf` (kube-dns, e.g. `10.96.0.10`). kube-dns resolves both cluster-internal **and** public names, so OAuth/MinIO/Stripe outbound calls keep working while in-cluster service DNS starts working too. In plain Docker, `local=on` reads Docker's resolver — correct there as well, with no hardcoding.

Single-file change to `lapis/nginx.conf` (`lapis server` regenerates `nginx.conf.compiled` from it at startup; the compiled file is gitignored).

## Impact / rollout
`bwalia/opsapi:latest` is built via manual `workflow_dispatch`. After merge, rebuild + push `latest`, then the next pod restart on int/acc picks up the correct resolver. Lets the diytaxreturn-lapis chart drop the int `POSTGRES_HOST` ClusterIP workaround once shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)