### PR TITLE
fix(db): enable pgmoon SSL (POSTGRES_SSL) so k3s Zalando Postgres connects

### DIFF
--- a/devops/helm-charts/diytaxreturn-lapis/templates/deployment.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/templates/deployment.yaml
@@ -70,6 +70,14 @@ spec:
             # deployments get no banner.
             - name: OPSAPI_DEPLOY_ENV
               value: {{ .Values.env | quote }}
+            # The k3s Zalando Postgres enforces TLS (pg_hba: `hostnossl all
+            # all all reject`); config.lua reads POSTGRES_SSL to turn on
+            # pgmoon SSL (ssl_verify=false for the self-signed cert). This
+            # chart only ever deploys to k8s/Zalando environments, so SSL is
+            # always required here. Without it every DB call is rejected with
+            # "no encryption" and the whole API 500s.
+            - name: POSTGRES_SSL
+              value: {{ .Values.postgresSsl | default "true" | quote }}
             # PCRE pattern (matched via ngx.re.match) of recipients
             # whose SMTP delivery must be silently skipped. Used by
             # helper/mail.lua + helper/otp.lua; gated internally on

--- a/lapis/config.lua
+++ b/lapis/config.lua
@@ -26,7 +26,14 @@ config("development", {
     host = os.getenv("POSTGRES_HOST") or "172.72.0.10",
     user = os.getenv("POSTGRES_USER") or "pguser",
     password = os.getenv("POSTGRES_PASSWORD") or "pgpassword",
-    database = os.getenv("POSTGRES_DB") or "opsapi-diytaxreturn"
+    database = os.getenv("POSTGRES_DB") or "opsapi-diytaxreturn",
+    -- Enable TLS when POSTGRES_SSL=true. The k3s Zalando Postgres enforces
+    -- SSL via pg_hba (`hostnossl all all all reject`), so a plaintext
+    -- connection is rejected with "no encryption" and every DB call fails.
+    -- ssl_verify=false because Zalando serves a self-signed cert. Docker /
+    -- test Postgres leaves POSTGRES_SSL unset and keeps connecting plaintext.
+    ssl = os.getenv("POSTGRES_SSL") == "true" or nil,
+    ssl_verify = false
   }
 })
 
@@ -42,7 +49,9 @@ config("production", {
     user = os.getenv("POSTGRES_USER") or "pguser",
     password = os.getenv("POSTGRES_PASSWORD") or "pgpassword",
     database = os.getenv("POSTGRES_DB") or "opsapi",
-    port = tonumber(os.getenv("POSTGRES_PORT") or "5432")
+    port = tonumber(os.getenv("POSTGRES_PORT") or "5432"),
+    ssl = os.getenv("POSTGRES_SSL") == "true" or nil,
+    ssl_verify = false
   }
 })
 
@@ -88,7 +97,9 @@ for _, env_name in ipairs(non_prod_envs) do
       user = os.getenv("POSTGRES_USER") or "pguser",
       password = os.getenv("POSTGRES_PASSWORD") or "pgpassword",
       database = os.getenv("POSTGRES_DB") or "opsapi-diytaxreturn",
-      port = tonumber(os.getenv("POSTGRES_PORT") or "5432")
+      port = tonumber(os.getenv("POSTGRES_PORT") or "5432"),
+      ssl = os.getenv("POSTGRES_SSL") == "true" or nil,
+      ssl_verify = false
     }
   })
 end


### PR DESCRIPTION
## Problem
The k3s Zalando Postgres enforces TLS — `pg_hba.conf` ends with `hostnossl all all all reject`. `config.lua` on `main` has **no SSL config**, so any image built from `main` connects in plaintext and is rejected with `FATAL: pg_hba.conf rejects connection … no encryption`. Every DB-backed request then 500s (login, Google OAuth callback, even the error-catalog lookup → `SYSTEM_500`).

This is what took int down: a fresh `latest` built from `main` had no SSL, so `diytaxreturn-lapis` couldn't reach `diy-tax-db`. (The previously-working image carried SSL config that was never merged to `main`.)

## Fix
- **`lapis/config.lua`**: add `ssl = os.getenv("POSTGRES_SSL") == "true" or nil` + `ssl_verify = false` (Zalando serves a self-signed cert) to **all three** postgres blocks:
  - `development` — selected when `LAPIS_ENVIRONMENT` is unset (the diy-tax-return-uk chart's deploy path),
  - `production` — selected by **this** chart, which hardcodes `LAPIS_ENVIRONMENT=production`,
  - the `int/test/acc/local` loop.
  Docker/test Postgres leaves `POSTGRES_SSL` unset and keeps connecting plaintext.
- **chart `templates/deployment.yaml`**: set `POSTGRES_SSL` (default `"true"`). This chart only deploys to k8s/Zalando envs, which all require SSL.

## Rollout / impact
Merging triggers `deploy-k3s.yml` → rebuilds `bwalia/opsapi:latest` (now with SSL **and** the `resolver local=on` fix from #440) and deploys to dev + int. After that int connects on `latest` and the temporary image-digest pin can be removed. acc picks it up on its next deploy; the diytaxreturn-lapis chart in the diy repo already sets `POSTGRES_SSL=true` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)