### PR TITLE
fix(migrations): make generateUUID ngx-safe so seed migrations survive lapis migrate

### DIFF
--- a/lapis/helper/global.lua
+++ b/lapis/helper/global.lua
@@ -6,6 +6,14 @@ local saltRounds = 10
 local Global = {}
 
 function Global.generateUUID()
+    -- `ngx` only exists inside an OpenResty request/worker context. When this
+    -- runs from the `lapis migrate` CLI (e.g. the k8s bootstrap postStart hook),
+    -- ngx is nil and `ngx.md5` would throw "attempt to index global 'ngx'",
+    -- crashing seed migrations and crash-looping the pod. Fall back to the
+    -- ngx-free generator at migrate time; request-context behaviour is unchanged.
+    if not ngx or not ngx.md5 then
+        return Global.generateStaticUUID()
+    end
     local random = math.random(1000000000)
     local timestamp = os.time()
     local hash = ngx.md5(tostring(random) .. tostring(timestamp))


### PR DESCRIPTION
## Root cause
`Global.generateUUID()` (`lapis/helper/global.lua`) called `ngx.md5(...)`. `ngx` only exists inside an OpenResty request/worker context. When `lapis migrate` runs from the **CLI** (the k8s bootstrap `postStart` hook), `ngx` is **nil**, so any seed migration that calls `generateUUID` throws:

```
Error: attempt to index global 'ngx' (a nil value)
```

This took down **acc**: migration `719_seed_income_types` (added in #445, income-types catalogue) seeds rows with `generateUUID`, so `lapis migrate` died → bootstrap `exit 1` → `FailedPostStartHook` → SIGKILL (137) → `CrashLoopBackOff`. With no healthy Lapis upstream, the entire `/opsapi` service returned **502**, breaking acc register/login/OAuth and failing the daily acc E2E suite ([run 28147752378](https://github.com/bwalia/diy-tax-return-uk/actions/runs/28147752378)).

## Fix
When `ngx` is unavailable, fall back to the existing ngx-free `generateStaticUUID()`. Request-context behaviour is unchanged. This covers **every** seed migration that calls `generateUUID`, not just income_types.

## Verification
- Reproduced the exact error live, then applied this patch in an isolated debug pod and ran `lapis migrate` → exit 0, `719_seed_income_types` applied, 8 income types seeded.
- Restarted the acc `diytaxreturn-lapis` deployment → new pod `1/1 Running`, `GET /opsapi/` now **200** (was 502); register returns clean app-level validation instead of 502.
- `luac -p` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)