### PR TITLE
fix(income): edge crashes + disabled-type edit

### DIFF
--- a/lapis/queries/IncomeTypeQueries.lua
+++ b/lapis/queries/IncomeTypeQueries.lua
@@ -94,7 +94,10 @@ function IncomeTypeQueries.admin_list(params)
         FROM income_types it ]] .. where .. [[
         ORDER BY it.display_order ASC, it.display_name ASC
     ]])
-    return { data = decode_rows(rows), total = #(rows or {}) }
+    local data = decode_rows(rows)
+    -- Force [] (not {}) when empty so the admin page's `data.filter/.sort`
+    -- doesn't blow up on an all-inactive / empty catalogue.
+    return { data = #data > 0 and data or cjson.empty_array, total = #data }
 end
 
 function IncomeTypeQueries.show(uuid)

--- a/lapis/routes/my-incomes.lua
+++ b/lapis/routes/my-incomes.lua
@@ -108,7 +108,10 @@ return function(app)
         for _, r in ipairs(rows) do
             data[#data + 1] = { key = r.income_type_key, label = r.display_name }
         end
-        return { json = { data = data }, status = 200 }
+        -- Force [] (not {}) when empty so JSON consumers that do
+        -- `(res.data.data ?? []).map(...)` don't blow up on an all-disabled
+        -- or empty catalogue (?? doesn't catch an object).
+        return { json = { data = #data > 0 and data or cjson.empty_array }, status = 200 }
     end))
 
     -- List
@@ -140,6 +143,16 @@ return function(app)
     -- Update
     app:put("/api/v2/tax/my-incomes/:id", AuthMiddleware.requireAuth(function(self)
         merge_params(self)
+        -- Grandfather an unchanged income_type: an admin may have disabled the
+        -- type after this row was created, but the user must still be able to
+        -- edit/correct the row. Only re-validate income_type when it's actually
+        -- being changed to a different value.
+        if self.params.income_type ~= nil then
+            local existing = MyIncomeQueries.show(tostring(self.params.id), self.current_user)
+            if existing and existing.income_type == self.params.income_type then
+                self.params.income_type = nil
+            end
+        end
         local ok, vmsg = validate(self.params, false)
         if not ok then return { json = { error = vmsg }, status = 400 } end
         local row, err = MyIncomeQueries.update(tostring(self.params.id), self.params, self.current_user)


### PR DESCRIPTION
Fixes 2 of the 3 real bugs from the cross-phase income sweep (opsapi side).

- **Disabled-type edit (LOGIC):** the update path re-validated `income_type` against the *active* catalogue, so editing any field of a row whose type was later disabled returned 400. Now an **unchanged** `income_type` is grandfathered on update (only re-validated when actually changed), so users can still edit/correct/delete historical rows.
- **Empty catalogue → {} crash (LOGIC):** `/my-incomes/types` and the admin `income-types` list returned `{"data":{}}` when empty (all types disabled), and the frontend's `(res.data.data ?? []).map(...)` throws on an object. Now they emit `cjson.empty_array` → `[]`.

Pairs with the diy PR (hide Add for disabled types + the FastAPI table guard). Verified: `luajit` loadfile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)