### PR TITLE
feat(income): expose required_documents + allows_manual_entry on /types (Phase 5)

### DIFF
--- a/lapis/routes/my-incomes.lua
+++ b/lapis/routes/my-incomes.lua
@@ -106,7 +106,16 @@ return function(app)
         local rows = IncomeTypeQueries.list_active()
         local data = {}
         for _, r in ipairs(rows) do
-            data[#data + 1] = { key = r.income_type_key, label = r.display_name }
+            -- required_documents may decode to an empty table for types with no
+            -- docs; coerce to [] so JSON consumers can .map it safely.
+            local docs = r.required_documents
+            if type(docs) ~= "table" or #docs == 0 then docs = cjson.empty_array end
+            data[#data + 1] = {
+                key = r.income_type_key,
+                label = r.display_name,
+                required_documents = docs,
+                allows_manual_entry = r.allows_manual_entry,
+            }
         end
         -- Force [] (not {}) when empty so JSON consumers that do
         -- `(res.data.data ?? []).map(...)` don't blow up on an all-disabled


### PR DESCRIPTION
Phase 5 (opsapi side). The per-type My Income page needs each type's document requirements + manual-entry flag.

- `GET /api/v2/tax/my-incomes/types` now returns `required_documents` (coerced to `[]` when empty so the frontend can `.map` safely) and `allows_manual_entry` per type, in addition to `{key,label}`.

Pairs with the diy PR (document upload + AI extraction + the supporting-docs UI). Verified: `luajit` loadfile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)