### PR TITLE
fix(migrations): generateUUID leaks string.gsub count → breaks income questionnaire seed

### DIFF
--- a/lapis/helper/migration-utils.lua
+++ b/lapis/helper/migration-utils.lua
@@ -19,10 +19,19 @@ function MigrationUtils.generateUUID()
     local random = math.random
     local template = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx"
 
-    return string.gsub(template, "[xy]", function(c)
+    -- string.gsub returns TWO values: the result string AND the substitution
+    -- count (31 for this template). Returning it directly leaks that count as a
+    -- second return value, so any caller that inlines generateUUID() among other
+    -- db.query params has every following bind shifted by one — e.g.
+    -- `db.query("... VALUES (?, ?, ?)", generateUUID(), cat_id, key)` binds
+    -- (uuid, 31, cat_id) instead of (uuid, cat_id, key), so category_id=31 and
+    -- the fk_pq_category foreign key fails. Assign to a local so only the string
+    -- is returned.
+    local uuid = string.gsub(template, "[xy]", function(c)
         local v = (c == "x") and random(0, 15) or random(8, 11)
         return string.format("%x", v)
     end)
+    return uuid
 end
 
 -- Get current timestamp in SQL format


### PR DESCRIPTION
## The bug
The income questionnaire (`has_income_sources` + `selected_income_types` Profile Builder questions) never appears, because migration **723** (`dynamic-profile-builder.lua [38]`) creates the **Income Sources category** but **not the questions**, and is never marked applied — in **int and acc** both.

## Root cause
`MigrationUtils.generateUUID()` ended with:
```lua
return string.gsub(template, "[xy]", ...)   -- gsub returns (string, count)
```
`string.gsub` returns **two** values — the string **and** the substitution count (**31** for the UUID template). Returning it directly leaks that 31 as a second return value. So when `[38]` inlines it among other params:
```lua
db.query("... VALUES (?, ?, ?, ...)", MigrationUtils.generateUUID(), cat_id, has_key)
-- binds: (uuid, 31, cat_id)  ← shifted by one
```
`category_id` is bound to **31** → **`fk_pq_category` foreign-key violation** → the question insert throws. The *category* insert has a single `?`, so its stray trailing count is harmless — which is exactly why the category exists but the questions don't.

**Reproduced on acc:**
```
ERROR: insert or update on "profile_questions" violates foreign key "fk_pq_category"
DETAIL: Key (category_id)=(31) is not present in table "profile_categories".
```

## Fix
Assign `string.gsub`'s result to a local before returning, so only the string escapes. Verified with luajit: return count goes **2 → 1**.

This also hardens **every** migration that inlines `generateUUID()` in a multi-param `db.query`.

## After merge + deploy
Migration 723 is idempotent (upsert by `question_key`) and currently unapplied everywhere, so it re-runs and seeds the two questions + visibility rule correctly. **int** self-heals (its manually-inserted rows hit the UPDATE path; 723 finally marks applied); **acc** seeds them fresh. No data cleanup needed — the corrupted insert always failed, so no junk rows were ever written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)