### PR TITLE
fix(migrations): income seed labels contain '?' → breaks 723 & blocks rollout

### DIFF
--- a/lapis/migrations/dynamic-profile-builder.lua
+++ b/lapis/migrations/dynamic-profile-builder.lua
@@ -2259,17 +2259,21 @@ return {
         local has_key = "has_income_sources"
         local q1 = db.select("id FROM profile_questions WHERE question_key = ?", has_key)
         if q1 and #q1 > 0 then
+            -- NOTE: the label text contains a '?', and db.query counts every
+            -- '?' in the query string as a bind placeholder. Pass the label as
+            -- a parameter (not a literal) so its '?' isn't miscounted, which
+            -- otherwise throws "db.interpolate_query: missing replacement N".
             db.query([[
-                UPDATE profile_questions SET category_id = ?, label = 'Do you have any income sources?',
+                UPDATE profile_questions SET category_id = ?, label = ?,
                     question_type = 'boolean', is_required = true, display_order = 1,
                     is_active = true, is_archived = false, updated_at = NOW()
                 WHERE question_key = ?
-            ]], cat_id, has_key)
+            ]], cat_id, "Do you have any income sources?", has_key)
         else
             db.query([[
                 INSERT INTO profile_questions (uuid, category_id, question_key, label, question_type, is_required, display_order, is_active, version, created_at, updated_at)
-                VALUES (?, ?, ?, 'Do you have any income sources?', 'boolean', true, 1, true, 1, NOW(), NOW())
-            ]], MigrationUtils.generateUUID(), cat_id, has_key)
+                VALUES (?, ?, ?, ?, 'boolean', true, 1, true, 1, NOW(), NOW())
+            ]], MigrationUtils.generateUUID(), cat_id, has_key, "Do you have any income sources?")
         end
 
         -- Q2: multi-select of income types; options sourced from the catalogue
@@ -2277,17 +2281,18 @@ return {
         local cfg = '{"options_source":"income_types"}'
         local q2 = db.select("id FROM profile_questions WHERE question_key = ?", sel_key)
         if q2 and #q2 > 0 then
+            -- Label passed as a parameter (contains a '?') — see note above.
             db.query([[
-                UPDATE profile_questions SET category_id = ?, label = 'Which income types apply to you?',
+                UPDATE profile_questions SET category_id = ?, label = ?,
                     question_type = 'multi_select', is_required = false, is_multi_value = true,
                     display_order = 2, config_json = ?, is_active = true, is_archived = false, updated_at = NOW()
                 WHERE question_key = ?
-            ]], cat_id, cfg, sel_key)
+            ]], cat_id, "Which income types apply to you?", cfg, sel_key)
         else
             db.query([[
                 INSERT INTO profile_questions (uuid, category_id, question_key, label, question_type, is_required, is_multi_value, display_order, config_json, is_active, version, created_at, updated_at)
-                VALUES (?, ?, ?, 'Which income types apply to you?', 'multi_select', false, true, 2, ?, true, 1, NOW(), NOW())
-            ]], MigrationUtils.generateUUID(), cat_id, sel_key, cfg)
+                VALUES (?, ?, ?, ?, 'multi_select', false, true, 2, ?, true, 1, NOW(), NOW())
+            ]], MigrationUtils.generateUUID(), cat_id, sel_key, "Which income types apply to you?", cfg)
         end
 
         -- Visibility rule: show Q2 only when Q1 = true


### PR DESCRIPTION
## Impact
The opsapi **rollout fails** — the lapis pod's bootstrap aborts running migration **723** and crash-loops, so `kubectl rollout status` times out and the deploy job fails (int/dev/acc).

## Root cause (from the failing pod's bootstrap log)
```
Migrating: 723_profile_seed_income_questions
SELECT id FROM profile_categories WHERE slug = 'income-sources'        ✓ category
SELECT id FROM profile_questions WHERE question_key = 'has_income_sources'
Error: db.interpolate_query: missing replacement 3
... Migrations failed after 5 attempts. Aborting bootstrap. exit 1
```
The question **labels contain a literal `?`** — `'Do you have any income sources?'` and `'Which income types apply to you?'`. Lapis's `db.query` counts **every `?` in the query string** as a bind placeholder, so the label's `?` was treated as an extra placeholder with no value → `missing replacement 3`. The category text has no `?`, which is precisely why every environment ended up with the **category created but the questions missing** and **723 never applied**.

## Fix
Pass the two labels as **bind parameters** instead of embedding them as string literals, so the `?` lives inside an escaped value and isn't re-counted. (Pairs with #452 — `generateUUID` single-return — which the INSERT path also needs.)

Verified: `luajit` loadfile clean; placeholder/param counts now match (Q1 3↔3 / 4↔4, Q2 4↔4 / 5↔5).

## After merge + deploy
723 is idempotent (upsert by `question_key`). It now completes: seeds `has_income_sources` + `selected_income_types` + the visibility rule, marks 723 applied, the bootstrap succeeds, the pod becomes Ready, and the **rollout passes**. int self-heals (UPDATE path over the manual rows); acc/dev seed fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)