### PR TITLE
release: income questionnaire seed fixes (migration 723) — verified in int + acc

### DIFF
--- a/lapis/helper/migration-utils.lua
+++ b/lapis/helper/migration-utils.lua
@@ -19,10 +19,19 @@ function MigrationUtils.generateUUID()
     local random = math.random
     local template = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx"
 
-    return string.gsub(template, "[xy]", function(c)
+    -- string.gsub returns TWO values: the result string AND the substitution
+    -- count (31 for this template). Returning it directly leaks that count as a
+    -- second return value, so any caller that inlines generateUUID() among other
+    -- db.query params has every following bind shifted by one — e.g.
+    -- `db.query("... VALUES (?, ?, ?)", generateUUID(), cat_id, key)` binds
+    -- (uuid, 31, cat_id) instead of (uuid, cat_id, key), so category_id=31 and
+    -- the fk_pq_category foreign key fails. Assign to a local so only the string
+    -- is returned.
+    local uuid = string.gsub(template, "[xy]", function(c)
         local v = (c == "x") and random(0, 15) or random(8, 11)
         return string.format("%x", v)
     end)
+    return uuid
 end
 
 -- Get current timestamp in SQL format

--- a/lapis/migrations/dynamic-profile-builder.lua
+++ b/lapis/migrations/dynamic-profile-builder.lua
@@ -2259,17 +2259,21 @@ return {
         local has_key = "has_income_sources"
         local q1 = db.select("id FROM profile_questions WHERE question_key = ?", has_key)
         if q1 and #q1 > 0 then
+            -- NOTE: the label text contains a '?', and db.query counts every
+            -- '?' in the query string as a bind placeholder. Pass the label as
+            -- a parameter (not a literal) so its '?' isn't miscounted, which
+            -- otherwise throws "db.interpolate_query: missing replacement N".
             db.query([[
-                UPDATE profile_questions SET category_id = ?, label = 'Do you have any income sources?',
+                UPDATE profile_questions SET category_id = ?, label = ?,
                     question_type = 'boolean', is_required = true, display_order = 1,
                     is_active = true, is_archived = false, updated_at = NOW()
                 WHERE question_key = ?
-            ]], cat_id, has_key)
+            ]], cat_id, "Do you have any income sources?", has_key)
         else
             db.query([[
                 INSERT INTO profile_questions (uuid, category_id, question_key, label, question_type, is_required, display_order, is_active, version, created_at, updated_at)
-                VALUES (?, ?, ?, 'Do you have any income sources?', 'boolean', true, 1, true, 1, NOW(), NOW())
-            ]], MigrationUtils.generateUUID(), cat_id, has_key)
+                VALUES (?, ?, ?, ?, 'boolean', true, 1, true, 1, NOW(), NOW())
+            ]], MigrationUtils.generateUUID(), cat_id, has_key, "Do you have any income sources?")
         end
 
         -- Q2: multi-select of income types; options sourced from the catalogue
@@ -2277,17 +2281,18 @@ return {
         local cfg = '{"options_source":"income_types"}'
         local q2 = db.select("id FROM profile_questions WHERE question_key = ?", sel_key)
         if q2 and #q2 > 0 then
+            -- Label passed as a parameter (contains a '?') — see note above.
             db.query([[
-                UPDATE profile_questions SET category_id = ?, label = 'Which income types apply to you?',
+                UPDATE profile_questions SET category_id = ?, label = ?,
                     question_type = 'multi_select', is_required = false, is_multi_value = true,
                     display_order = 2, config_json = ?, is_active = true, is_archived = false, updated_at = NOW()
                 WHERE question_key = ?
-            ]], cat_id, cfg, sel_key)
+            ]], cat_id, "Which income types apply to you?", cfg, sel_key)
         else
             db.query([[
                 INSERT INTO profile_questions (uuid, category_id, question_key, label, question_type, is_required, is_multi_value, display_order, config_json, is_active, version, created_at, updated_at)
-                VALUES (?, ?, ?, 'Which income types apply to you?', 'multi_select', false, true, 2, ?, true, 1, NOW(), NOW())
-            ]], MigrationUtils.generateUUID(), cat_id, sel_key, cfg)
+                VALUES (?, ?, ?, ?, 'multi_select', false, true, 2, ?, true, 1, NOW(), NOW())
+            ]], MigrationUtils.generateUUID(), cat_id, sel_key, "Which income types apply to you?", cfg)
         end
 
         -- Visibility rule: show Q2 only when Q1 = true


### PR DESCRIPTION
Promotes the two migration fixes that finally let the income questionnaire seed (and unblock the lapis rollout).

## What's included
- **#452** — `MigrationUtils.generateUUID()` returns a single value (was leaking `string.gsub`'s substitution count, shifting multi-param `db.query` binds).
- **#453** — income-seed question **labels contain a literal `?`** (`'Do you have any income sources?'`, `'Which income types apply to you?'`); `db.query` counted those as bind placeholders → `db.interpolate_query: missing replacement 3` → migration 723 aborted the bootstrap → **rollout failed on every env**. Labels are now passed as bind params.

## Verified (real `lapis migrate`, not a workaround)
| env | result |
|-----|--------|
| **int** | ✅ `723_applied=1`, both questions + visibility rule seeded, pod `1/1 Running`, deploy green |
| **acc** | ✅ `723_applied=1`, seed correct, pod `1/1 Running` (self-healed once it pulled the fixed image) |

Migration 723 is idempotent (upsert by `question_key`), so it applies cleanly on the release/prod rollout the same way. After this merges and deploys, the income questionnaire (`has_income_sources` + catalogue-sourced `selected_income_types`) appears on `/profile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)