### PR TITLE
fix(argocd): ExternalSecret defaulting drift + workflow stale-phase race

### DIFF
--- a/.github/workflows/argocd-sync-int.yml
+++ b/.github/workflows/argocd-sync-int.yml
@@ -123,9 +123,20 @@ jobs:
       # request always executes. That's why we keep autoSync: false in the
       # ApplicationSet: CI drives sync explicitly, no self-heal drift-fights.
       - name: Trigger sync of opsapi-${{ env.TARGET_ENV }}
+        id: trigger
         run: |
           APP="opsapi-${TARGET_ENV}"
           SHA="${{ github.sha }}"
+          # Timestamp captured BEFORE the patch so the poll step can
+          # tell "phase came from OUR new operation" from "phase came
+          # from a previous run's operation whose result is still
+          # cached in operationState". Without this guard the poll
+          # sees a stale Failed and exits before Argo even starts the
+          # new sync — that's the failure signature in run 28518780859.
+          TRIGGER_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo "trigger_at=$TRIGGER_AT" >> "$GITHUB_OUTPUT"
+          echo "Trigger timestamp: $TRIGGER_AT"
+
           kubectl -n argocd patch app "$APP" --type merge -p "$(cat <<EOF
           {
             "operation": {
@@ -146,27 +157,48 @@ jobs:
           echo "Sync operation queued on $APP for commit ${SHA:0:12}"
 
       # Poll every 6s for up to 4 minutes. Success = phase Succeeded AND
-      # sync Synced AND health Healthy. Fail fast on phase Failed/Error.
+      # sync Synced AND health Healthy. Fail fast on phase Failed/Error —
+      # BUT ONLY if the failure belongs to the operation we just triggered.
+      # The `phase` field in .status.operationState reflects the LAST
+      # completed operation until Argo picks up our new one (typically
+      # <10s but occasionally 30s+). Comparing operationState.startedAt
+      # against TRIGGER_AT tells us which operation the phase refers to.
       - name: Wait for sync + health
+        env:
+          TRIGGER_AT: ${{ steps.trigger.outputs.trigger_at }}
         run: |
           APP="opsapi-${TARGET_ENV}"
+          echo "Comparing operationState.startedAt against trigger time: $TRIGGER_AT"
           for i in $(seq 1 40); do
             PHASE=$(kubectl -n argocd get app "$APP" -o jsonpath='{.status.operationState.phase}' 2>/dev/null || echo "Pending")
+            STARTED=$(kubectl -n argocd get app "$APP" -o jsonpath='{.status.operationState.startedAt}' 2>/dev/null || echo "")
             SYNC=$(kubectl -n argocd get app "$APP" -o jsonpath='{.status.sync.status}' 2>/dev/null || echo "?")
             HEALTH=$(kubectl -n argocd get app "$APP" -o jsonpath='{.status.health.status}' 2>/dev/null || echo "?")
-            echo "  attempt $i/40: phase=$PHASE sync=$SYNC health=$HEALTH"
-            if [ "$PHASE" = "Succeeded" ] && [ "$SYNC" = "Synced" ] && [ "$HEALTH" = "Healthy" ]; then
-              echo "::notice::$APP reached Synced+Healthy at ${SYNC}/${HEALTH}"
-              exit 0
+
+            # Is the operationState reflecting OUR operation?
+            # String comparison on ISO-8601 UTC timestamps is order-preserving.
+            FRESH="no"
+            if [ -n "$STARTED" ] && [ "$STARTED" \> "$TRIGGER_AT" ]; then
+              FRESH="yes"
             fi
-            case "$PHASE" in
-              Failed|Error)
-                echo "::error::$APP sync $PHASE"
-                kubectl -n argocd get app "$APP" \
-                  -o jsonpath='{.status.operationState.message}{"\n"}{.status.conditions[*].message}{"\n"}'
-                exit 1
-                ;;
-            esac
+
+            echo "  attempt $i/40: phase=$PHASE fresh=$FRESH sync=$SYNC health=$HEALTH  (started=$STARTED)"
+
+            # Only honor a terminal phase if it belongs to the new op.
+            if [ "$FRESH" = "yes" ]; then
+              if [ "$PHASE" = "Succeeded" ] && [ "$SYNC" = "Synced" ] && [ "$HEALTH" = "Healthy" ]; then
+                echo "::notice::$APP reached Synced+Healthy on our operation"
+                exit 0
+              fi
+              case "$PHASE" in
+                Failed|Error)
+                  echo "::error::$APP sync $PHASE (our operation, startedAt=$STARTED)"
+                  kubectl -n argocd get app "$APP" \
+                    -o jsonpath='{.status.operationState.message}{"\n"}{.status.conditions[*].message}{"\n"}'
+                  exit 1
+                  ;;
+              esac
+            fi
             sleep 6
           done
           echo "::error::Timed out after ~4 min waiting for $APP to reach Synced+Healthy"

--- a/devops/helm-charts/diytaxreturn-lapis/templates/externalsecret.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/templates/externalsecret.yaml
@@ -50,4 +50,17 @@ spec:
   dataFrom:
   - extract:
       key: secret/diytaxreturnuk/opsapi/{{ .Values.env }}/config
+      # These three fields are DEFAULTED by ESO's admission webhook the
+      # moment the resource is applied. Declaring them here so what's in
+      # git matches what k8s stores after mutating admission — otherwise
+      # ArgoCD reports the ExternalSecret as OutOfSync forever with a
+      # cosmetic-only diff, blocking the Application from ever going
+      # green. Values MUST match what ESO's webhook writes; the current
+      # defaults for external-secrets v0.9+ are `Default`, `None`, `None`.
+      # If you ever bump ESO's version and the app starts flapping
+      # OutOfSync, check `kubectl explain externalsecret.spec.dataFrom.extract`
+      # for what the new defaults are.
+      conversionStrategy: Default
+      decodingStrategy: None
+      metadataPolicy: None
 {{- end }}


### PR DESCRIPTION
## Summary

Two small independent fixes that together take `argocd-sync-int` from red to green on a healthy int deploy. Together with the [in-cluster patch I applied at 12:52 UTC to strip stale `tcpSocket` handlers](https://github.com/bwalia/opsapi/actions/runs/28518780859) from int's Deployment, this closes out the current failure signature.

## Problem A — ExternalSecret stays OutOfSync even after sync succeeds

ESO's admission webhook mutates every ExternalSecret on apply, adding three defaulted fields under `dataFrom[0].extract` that aren't in the chart's template:

```yaml
conversionStrategy: Default
decodingStrategy: None
metadataPolicy: None
```

ArgoCD's next diff sees these fields in the live resource but not in the rendered manifest, so it reports OutOfSync — forever, on every reconcile. The sync operation itself **succeeds** (Argo's syncResult reports the ExternalSecret as `"configured"`); the overall Application just never reaches `Synced`.

That was the failure signature at 12:57 UTC after the tcpSocket blocker was cleared:

```
phase   = Succeeded            ← sync op ran fine
health  = Healthy              ← pod is running the desired code
sync    = OutOfSync            ← ← ← workflow bails on this
6 of 7 resources Synced
1 of 7 OutOfSync: ExternalSecret
```

**Fix**: declare the three defaulted fields explicitly in `templates/externalsecret.yaml`. Zero behaviour change — the values ARE what ESO's webhook writes — but the diff goes away and the Application can reach fully Synced.

## Problem B — workflow bails on a stale phase before Argo picks up the new operation

`Wait for sync + health` polls `.status.operationState.phase` immediately after triggering. But that field reflects the **last completed operation** until Argo picks up the new one (typically <10s, occasionally 30s+). Attempt 1/40 sees `phase=Failed` from the previous run's blocked attempt, hits the `Failed|Error) exit 1` branch, gives up before the new operation even starts.

That's the failure signature in run [28518780859](https://github.com/bwalia/opsapi/actions/runs/28518780859) — the workflow "failed" ~1 second after triggering, with the SAME error message the previous run had.

**Fix**: capture a timestamp before the patch (`TRIGGER_AT`), compare against `operationState.startedAt` in the poll loop, only honor terminal phases when `startedAt > TRIGGER_AT`. ISO-8601 UTC string comparison is order-preserving so no `jq`/`date` parsing needed.

```bash
# Trigger step (new)
TRIGGER_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
echo "trigger_at=$TRIGGER_AT" >> "$GITHUB_OUTPUT"
# ... existing kubectl patch to trigger sync ...

# Wait step (new logic)
STARTED=$(kubectl ... jsonpath='{.status.operationState.startedAt}')
FRESH="no"
if [ -n "$STARTED" ] && [ "$STARTED" \> "$TRIGGER_AT" ]; then
  FRESH="yes"
fi
if [ "$FRESH" = "yes" ]; then
  # only NOW honor Succeeded / Failed
fi
```

The poll continues sleeping (up to 4 min ceiling) while `FRESH=no`, so we don't confuse pre-existing state with our new operation's outcome.

## Verification

Local sync attempt against the live cluster after applying Fix A: sync operation reaches `Succeeded + Synced + Healthy` (6/7 → 7/7). The last remaining OutOfSync resource clears once the chart matches ESO's post-mutation state.

## Test plan

- [x] YAML parses for both files
- [x] `helm template ... -f values-int.yaml` renders the ExternalSecret cleanly with the three new fields
- [ ] After merge — first workflow_dispatch run should reach Succeeded+Synced+Healthy on all 7 resources
- [ ] The Wait step should log `fresh=no` for the first few attempts (proves race guard is firing), then `fresh=yes` once Argo picks up the new op

🤖 Generated with [Claude Code](https://claude.com/claude-code)