### PR TITLE
fix(academy): validate checkout currency + take course price in major units

### DIFF
--- a/lapis/routes/academy-billing.lua
+++ b/lapis/routes/academy-billing.lua
@@ -40,6 +40,24 @@ local function learner_base()
     return (b:gsub("/+$", ""))
 end
 
+-- Stripe expects lowercase ISO-4217 codes. Guard against bad admin-entered
+-- values (e.g. "GBR") so checkout fails with a clear message, not a cryptic
+-- Stripe 502. Extend this set if you start selling in more currencies.
+local SUPPORTED_CURRENCIES = {
+    usd = true, gbp = true, eur = true, inr = true, aud = true,
+    cad = true, sgd = true, aed = true, jpy = true, nzd = true,
+}
+
+-- Returns (code, nil) for a valid currency or (nil, message) otherwise.
+local function normalize_currency(raw)
+    local c = tostring(raw or ""):lower():gsub("%s+", "")
+    if c == "" then c = "usd" end
+    if not SUPPORTED_CURRENCIES[c] then
+        return nil, "Unsupported currency '" .. tostring(raw) .. "'"
+    end
+    return c, nil
+end
+
 local BANK_OUT_FIELDS = {
     "account_holder_name", "bank_name", "account_number", "routing_number",
     "sort_code", "iban", "swift_bic", "bank_country", "payout_email",
@@ -158,7 +176,8 @@ return function(app)
                 return api_response(400, nil, "amount (in minor units, e.g. 999 = $9.99) is required")
             end
             local interval = (body.interval == "year") and "year" or "month"
-            local currency = body.currency or "usd"
+            local currency, cur_err = normalize_currency(body.currency)
+            if not currency then return api_response(400, nil, cur_err) end
 
             local stripe = Stripe.new()
             local product, perr = stripe:create_product({
@@ -204,6 +223,9 @@ return function(app)
         local amount = math.floor(tonumber(course.price) or 0)
         if amount <= 0 then return api_response(400, nil, "Invalid course price") end
 
+        local currency, cur_err = normalize_currency(course.currency)
+        if not currency then return api_response(400, nil, cur_err) end
+
         local base = learner_base()
         local stripe = Stripe.new()
         local session, err = stripe:create_checkout_session({
@@ -214,7 +236,7 @@ return function(app)
             line_items = { {
                 quantity = 1,
                 price_data = {
-                    currency = course.currency or "usd",
+                    currency = currency,
                     unit_amount = amount,
                     product_data = { name = course.title },
                 },

--- a/opsapi-dashboard/app/dashboard/academy/page.tsx
+++ b/opsapi-dashboard/app/dashboard/academy/page.tsx
@@ -75,7 +75,8 @@ const CourseModal: React.FC<CourseModalProps> = ({ isOpen, course, onClose, onSu
         category: course.category ?? 'general',
         level: course.level,
         is_free: course.is_free,
-        price: course.price,
+        // Stored in minor units (pence/cents); edit in major units.
+        price: (course.price ?? 0) / 100,
         currency: course.currency,
         status: course.status,
       });
@@ -100,7 +101,8 @@ const CourseModal: React.FC<CourseModalProps> = ({ isOpen, course, onClose, onSu
     try {
       const payload: CourseInput = {
         ...form,
-        price: form.is_free ? 0 : Number(form.price) || 0,
+        // Convert major units (what the user typed) back to minor units for the API.
+        price: form.is_free ? 0 : Math.round((Number(form.price) || 0) * 100),
       };
       if (course) {
         await academyService.updateCourse(course.uuid, payload);
@@ -167,11 +169,16 @@ const CourseModal: React.FC<CourseModalProps> = ({ isOpen, course, onClose, onSu
             <>
               <div>
                 <label className="block text-sm font-medium text-secondary-700 mb-1">Price</label>
-                <input className={inputClass} type="number" min={0} value={form.price} onChange={(e) => set('price', Number(e.target.value))} />
+                <input className={inputClass} type="number" min={0} step={0.01} value={form.price} onChange={(e) => set('price', Number(e.target.value))} placeholder="e.g. 9.99" />
+                <p className="mt-1 text-xs text-secondary-500">Amount charged to the learner, e.g. 9.99 for {form.currency} 9.99.</p>
               </div>
               <div>
                 <label className="block text-sm font-medium text-secondary-700 mb-1">Currency</label>
-                <input className={inputClass} value={form.currency} onChange={(e) => set('currency', e.target.value)} placeholder="USD" />
+                <select className={inputClass} value={form.currency} onChange={(e) => set('currency', e.target.value)}>
+                  {['USD', 'GBP', 'EUR', 'INR', 'AUD', 'CAD', 'SGD', 'AED', 'JPY', 'NZD'].map((c) => (
+                    <option key={c} value={c}>{c}</option>
+                  ))}
+                </select>
               </div>
             </>
           )}


### PR DESCRIPTION
## What

Two footguns in the academy course **payment path**, both surfaced while testing a real Stripe checkout.

1. **Invalid currency broke checkout.** The course `currency` was passed to Stripe verbatim, so an admin-entered value like `GBR` (not a real ISO code — should be `GBP`) produced a cryptic Stripe 502 at checkout time. Added `normalize_currency()` — lowercases, validates against a supported set, and returns a clear `400 Unsupported currency` instead. Applied to both course checkout and the community-subscription price.

2. **Price was entered in the wrong units.** Course price is stored in **minor units** (pence/cents), but the dashboard form took a raw number — so `10` meant **£0.10**, not £10. The form now edits in **major units** (`step 0.01`), converts to/from minor units on load/save, and the currency is a **dropdown** of supported currencies instead of free text.

## Scope / safety

- opsapi changes are limited to the academy billing route + the academy dashboard course form.
- No schema changes; no impact on other `PROJECT_CODE`s (e.g. tax_copilot). The currency helper only affects academy checkout/price creation.

## Test

- Non-owner student checkout on a `GBP` course now returns a live Stripe Checkout URL.
- An unsupported currency now returns `400 Unsupported currency '<x>'` rather than a Stripe 502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)