### PR TITLE
feat(version): dynamic APP_VERSION from git — same string in every env

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -81,6 +81,13 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # Need full history + tags so `git describe --tags` resolves to the
+          # nearest annotated tag (e.g. v1.4.0-12-gabc1234) rather than
+          # falling back to the bare commit sha. The Determine build metadata
+          # step below depends on this; without fetch-depth: 0 you get a
+          # shallow clone with no tags and every image reports "dev".
+          fetch-depth: 0
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -91,6 +98,22 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Determine build metadata
+        id: version
+        run: |
+          # Mirrors the diytaxreturn-uk deploy-single-environment.yml step of
+          # the same name so opsapi + fastapi + frontend all report the same
+          # `git describe`-derived string when built from the same commit.
+          # This is the whole point of the "constant across environments"
+          # requirement — the version should reflect the CODE, not the env.
+          APP_VERSION=$(git describe --tags --always 2>/dev/null || echo 'dev')
+          BUILD_NUMBER="${GITHUB_RUN_NUMBER:-local}"
+          BUILD_TIME=$(date -u '+%Y-%m-%d %H:%M UTC')
+          echo "APP_VERSION=$APP_VERSION" >> $GITHUB_OUTPUT
+          echo "BUILD_NUMBER=$BUILD_NUMBER" >> $GITHUB_OUTPUT
+          echo "BUILD_TIME=$BUILD_TIME" >> $GITHUB_OUTPUT
+          echo "Build: v$APP_VERSION #$BUILD_NUMBER at $BUILD_TIME"
+
       - name: Build and push OpsAPI
         uses: docker/build-push-action@v5
         with:
@@ -98,7 +121,15 @@ jobs:
           file: ./lapis/Dockerfile
           push: true
           tags: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-          build-args: TAG=latest
+          # `TAG=latest` retained for existing consumers. New APP_VERSION /
+          # BUILD_NUMBER / BUILD_TIME args are what app.lua reads via
+          # os.getenv() so `/`, `/health`, `/metrics` surface the same
+          # version string in every environment.
+          build-args: |
+            TAG=latest
+            APP_VERSION=${{ steps.version.outputs.APP_VERSION }}
+            BUILD_NUMBER=${{ steps.version.outputs.BUILD_NUMBER }}
+            BUILD_TIME=${{ steps.version.outputs.BUILD_TIME }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/lapis/Dockerfile
+++ b/lapis/Dockerfile
@@ -3,6 +3,26 @@ FROM openresty/openresty:alpine
 ARG TARGET_NGINX_CONF=nginx.conf
 ARG TAG=latest
 
+# Build metadata — injected by CI (build-push-docker-image.yml) from
+# `git describe --tags --always` + GITHUB_RUN_NUMBER + `date -u`. Baked
+# in as container ENVs so app.lua's os.getenv() calls resolve at request
+# time (nginx.conf `env APP_VERSION;` etc. also required — declared there).
+#
+# Every environment (int/test/acc/prod) pulls the same
+# docker.io/bwalia/opsapi:latest tag, so once a new build has propagated
+# they all report the same version — which is what the "constant across
+# environments" requirement in the diytaxreturn-uk platform expects.
+ARG APP_VERSION=dev
+ARG BUILD_NUMBER=local
+ARG BUILD_TIME=""
+ENV APP_VERSION=${APP_VERSION} \
+    BUILD_NUMBER=${BUILD_NUMBER} \
+    BUILD_TIME=${BUILD_TIME}
+LABEL org.opencontainers.image.version="${APP_VERSION}" \
+      org.opencontainers.image.revision="${APP_VERSION}" \
+      org.opencontainers.image.created="${BUILD_TIME}" \
+      opsapi.build.number="${BUILD_NUMBER}"
+
 RUN apk add --no-cache wget make gcc libc-dev \
     && wget https://luarocks.github.io/luarocks/releases/luarocks-3.12.0.tar.gz \
     && tar zxpf luarocks-3.12.0.tar.gz \

--- a/lapis/app.lua
+++ b/lapis/app.lua
@@ -4,6 +4,20 @@ local CorsMiddleware = require("middleware.cors")
 local GlobalRateLimit = require("middleware.global-rate-limit")
 local Errors = require("lib.errors")
 
+-- Build metadata baked into the image at `docker build` time — the CI
+-- workflow passes `--build-arg APP_VERSION=$(git describe --tags --always)`
+-- + BUILD_NUMBER + BUILD_TIME, and the Dockerfile turns them into container
+-- ENVs. Every environment (int/test/acc/prod) pulls the same
+-- docker.io/bwalia/opsapi:latest tag, so they all report the same version
+-- once a new build has propagated — which is the point.
+--
+-- Captured once at module-load rather than re-read per request because it
+-- can't change without a pod restart anyway. Fallbacks match what the
+-- Dockerfile ARG defaults are so a locally-run opsapi (no CI) still boots.
+local APP_VERSION = os.getenv("APP_VERSION") or "dev"
+local BUILD_NUMBER = os.getenv("BUILD_NUMBER") or "local"
+local BUILD_TIME = os.getenv("BUILD_TIME") or ""
+
 -- Enable CORS
 CorsMiddleware.enable(app)
 
@@ -30,7 +44,12 @@ app:get("/", function(self)
     return {
         json = {
             message = "OpsAPI is running",
-            version = "1.0.0",
+            -- All three fields baked in at `docker build` time (see the
+            -- module-level constants above). Same across every environment
+            -- pulling the same :latest tag.
+            version = APP_VERSION,
+            build_number = BUILD_NUMBER,
+            build_time = BUILD_TIME,
             endpoints = {
                 documentation = "/swagger",
                 docs = "/docs",
@@ -143,7 +162,12 @@ app:get("/api/v2/system/info", function(self)
             parsed_codes = info_or_err.project_codes,
             enabled_features = info_or_err.enabled_features,
             environment = os.getenv("LAPIS_ENVIRONMENT") or "development",
-            version = "1.0.0",
+            -- Same git-derived version everything else reports (see module-
+            -- level APP_VERSION). Keeps this endpoint in sync with `/`
+            -- and the /metrics gauge so all three agree.
+            version = APP_VERSION,
+            build_number = BUILD_NUMBER,
+            build_time = BUILD_TIME,
             timestamp = ngx.time(),
         }
     }
@@ -201,7 +225,7 @@ opsapi_up 1
 
 # HELP opsapi_info API information
 # TYPE opsapi_info gauge
-opsapi_info{version="1.0.0"} 1
+opsapi_info{version="]] .. APP_VERSION .. [["} 1
 
 # HELP opsapi_memory_usage_bytes Memory usage in bytes
 # TYPE opsapi_memory_usage_bytes gauge

--- a/lapis/nginx.conf
+++ b/lapis/nginx.conf
@@ -96,6 +96,16 @@ env OLLAMA_MODEL;
 # the chat/completion default). Read at request time by the AI layer.
 env OLLAMA_EMBED_MODEL;
 env PROJECT_CODE;
+# CI build metadata — baked into the image at `docker build` time via
+# --build-arg APP_VERSION=$(git describe --tags --always). Surfaced in the
+# `/`, `/health`, and `/metrics` responses so `curl` alone reveals which
+# opsapi commit is actually running in any environment (int/test/acc/prod
+# all pull the same :latest image, so the version they show should match).
+# openresty strips process env by default; these `env` directives whitelist
+# them so os.getenv() in Lua actually returns something at request time.
+env APP_VERSION;
+env BUILD_NUMBER;
+env BUILD_TIME;
 env ADMIN_EMAIL;
 env ADMIN_PASSWORD;
 env NAMESPACE_NAME;


### PR DESCRIPTION
## Why

Every env (int/test/acc/prod) pulls `docker.io/bwalia/opsapi:latest`. All of them reported the same literal `\"1.0.0\"` in three places:

- `GET /` → `{ \"version\": \"1.0.0\", ... }`
- `GET /api/v2/system/info` → `{ \"version\": \"1.0.0\", ... }`
- `GET /metrics` → `opsapi_info{version=\"1.0.0\"} 1`

No way to `curl` any of them and answer \"which commit is actually deployed here?\" Downstream services in the [diytaxreturn-uk platform](https://github.com/bwalia/diy-tax-return-uk) — fastapi's `/health`, the frontend footer — mirrored the same lie because they read opsapi's `/` response.

## What this PR does

Threads a single git-derived version string end-to-end.

### `lapis/app.lua`
Module-level constants read `APP_VERSION` / `BUILD_NUMBER` / `BUILD_TIME` from `os.getenv()` at boot with safe fallbacks (`\"dev\"` / `\"local\"` / `\"\"`). All three hardcoded sites now use the constants.

### `lapis/nginx.conf`
Declares `env APP_VERSION;` / `env BUILD_NUMBER;` / `env BUILD_TIME;`. OpenResty strips process env by default — without these directives, `os.getenv()` in worker Lua returns nil no matter what the container ENV says.

### `lapis/Dockerfile`
Accepts `ARG APP_VERSION` / `BUILD_NUMBER` / `BUILD_TIME`, promotes to container `ENV`, stamps as OCI image labels (`org.opencontainers.image.version` etc.) so `docker inspect` reveals the version without booting the pod.

### `.github/workflows/deploy-k3s.yml`
- Adds `fetch-depth: 0` to the checkout so `git describe --tags --always` sees tags (a shallow clone would fall back to `\"dev\"`).
- Adds a \"Determine build metadata\" step mirroring the pattern already in the diytaxreturn-uk `deploy-single-environment.yml`.
- Passes the three build-args through to the docker build step.

## Paired PR

**[bwalia/diy-tax-return-uk#670](https://github.com/bwalia/diy-tax-return-uk/pull/670)** does the same on the diytaxreturn-uk side — fastapi's `config.py` reads `APP_VERSION` via Pydantic BaseSettings alias, backend Dockerfile accepts the same three build-args, both CI workflows pass them.

Both PRs should merge in either order; each side falls back to literals until its own build catches up.

## After both merge

```
$ curl https://int-api.diytaxreturn.co.uk/opsapi/
{ \"version\": \"v1.4.0-3-gabc1234\", \"build_number\": \"29123\", \"build_time\": \"2026-07-10 14:22 UTC\", ... }

$ curl https://int-api.diytaxreturn.co.uk/health | jq '.services.opsapi.version'
\"v1.4.0-3-gabc1234\"

$ curl -s https://int-api.diytaxreturn.co.uk/opsapi/metrics | grep opsapi_info
opsapi_info{version=\"v1.4.0-3-gabc1234\"} 1
```

Same commit → same version in every env. Different envs on different commits → different versions, and the difference is instantly visible.

## Test plan

- [ ] Merge → wait for the deploy-k3s.yml workflow to build a fresh `bwalia/opsapi:latest` with new APP_VERSION
- [ ] Once pods roll on int: `curl https://int-api.diytaxreturn.co.uk/opsapi/` returns a git-derived version, not `\"1.0.0\"`
- [ ] `docker inspect bwalia/opsapi:latest --format='{{.Config.Labels}}'` shows `org.opencontainers.image.version=v...` (bonus)
- [ ] `curl -s .../opsapi/metrics | grep opsapi_info` shows the same version in the Prometheus label

## Local dev

Nothing to configure. `lapis server` without APP_VERSION set falls through to `\"dev\"` / `\"local\"` / `\"\"` — same behaviour as today just with different literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)