### PR TITLE
feat(migration): add nino_locked_at + utr_locked_at columns for identity lock

### DIFF
--- a/lapis/migrations/tax-copilot-system.lua
+++ b/lapis/migrations/tax-copilot-system.lua
@@ -2986,4 +2986,52 @@ return {
         ]])
         print("[Tax Copilot] Added file_hash column + index to tax_statements")
     end,
+
+    -- 88. Add lock timestamps for NINO and UTR on tax_user_profiles.
+    --
+    -- ─── Business rationale ─────────────────────────────────────────────
+    -- Client anti-fraud policy (2026-07-13): a subscriber must not be able
+    -- to file for multiple identities from a single account. The concrete
+    -- rule is "NINO becomes non-editable once the user saves it the first
+    -- time; UTR becomes non-editable once first successfully written".
+    -- Support can UNLOCK on request via the admin panel (see PR #3/#4 for
+    -- the settings table + unlock endpoint).
+    --
+    -- ─── Column shape rationale ─────────────────────────────────────────
+    -- TIMESTAMP (not BOOLEAN) so we can:
+    --   • distinguish "never locked" (NULL) from "locked at T" (timestamp)
+    --   • report time-since-lock in support UIs / audit exports
+    --   • let the JIT backfill worker do
+    --     `SET nino_locked_at = NOW() WHERE has_nino AND nino_locked_at IS NULL`
+    --     idempotently — subsequent runs see IS NOT NULL and skip.
+    -- Mirrors the existing `nino_consent_at` column added in migration #83.
+    --
+    -- ─── Guard implementation (defers to later PR) ──────────────────────
+    -- This migration is intentionally COLUMNS-ONLY. The write guards in
+    -- routes/tax-profile.lua, routes/tax-hmrc-data.lua, and
+    -- routes/profile-builder.lua (the last is the current back-door: the
+    -- generic /api/v2/profile-builder/answers endpoint accepts
+    -- question_key='nino'|'ni_number'|'utr_number' payloads without any
+    -- field-specific validation) land in a follow-up PR alongside the
+    -- admin unlock endpoint. Shipping this migration first is safe —
+    -- adding NULL-defaulted timestamp columns is behaviour-free.
+    --
+    -- ─── Idempotency ────────────────────────────────────────────────────
+    -- ADD COLUMN IF NOT EXISTS makes re-running a no-op. Safe to include
+    -- in the standard `lapis migrate` sweep at every deploy.
+    --
+    -- ─── Namespace scoping (nothing to do here — informational) ─────────
+    -- tax_user_profiles.namespace_id is already NOT NULL (see the table
+    -- declaration and the guardrail comment in
+    -- backend/app/models/tax_user_profile.py:38-46). Every subsequent
+    -- lock/unlock query MUST scope by namespace_id — that's an
+    -- application-code discipline, not a schema constraint.
+    [88] = function()
+        db.query([[
+            ALTER TABLE tax_user_profiles
+            ADD COLUMN IF NOT EXISTS nino_locked_at TIMESTAMP,
+            ADD COLUMN IF NOT EXISTS utr_locked_at  TIMESTAMP
+        ]])
+        print("[Tax Copilot] Added nino_locked_at + utr_locked_at columns to tax_user_profiles")
+    end,
 }


### PR DESCRIPTION
## What

Migration #88 adds two nullable TIMESTAMP columns to `tax_user_profiles`:

```sql
ALTER TABLE tax_user_profiles
  ADD COLUMN IF NOT EXISTS nino_locked_at TIMESTAMP,
  ADD COLUMN IF NOT EXISTS utr_locked_at  TIMESTAMP;
```

## Why

Groundwork for the client-requested anti-fraud feature (2026-07-13): *"lock NINO/UTR after first save so one subscription can't be used to file for multiple identities."* This is the columns-only foundation — writes, guards, and admin unlock all land in follow-up PRs (see roadmap below).

## Design decisions

- **`TIMESTAMP` not `BOOLEAN`** — mirrors the existing `nino_consent_at` (migration #83). Nullable timestamp distinguishes "never locked" (NULL) from "locked at T", supports time-since-lock reporting, and lets the JIT-backfill worker be trivially idempotent (`SET ... WHERE ... IS NULL`).
- **Columns-only, no write guards yet** — additive-only migration is behaviour-free. It's safe to ship on the standard `lapis migrate` sweep at every deploy without a coordinated rollout. `ADD COLUMN IF NOT EXISTS` makes re-runs a no-op.
- **No unique index in this PR** — after senior-review of the anti-fraud requirement, we settled on **app-code uniqueness with a PostgreSQL advisory transaction lock** (see next PR) rather than a DB-level partial unique index. Reason: current `nino_hash` uses bcrypt with random salt, so DB-level dedupe would require a new deterministic-hash column (a security-sensitive crypto change that deserves its own focused review). App-code uses `nino_last4` as a fast filter with decrypt-on-collision — closes the same fraud vector without touching the hashing scheme.

## Roadmap — what lands in each follow-up PR

| PR | Scope |
|---|---|
| **#3 (next)** | `identity_lock_settings` table + `identity_lock.unlock` permission seed |
| **#4** | Backend guards on all 4 NINO/UTR write paths (`tax-profile.lua`, `tax-hmrc-data.lua`, `profile-builder.lua` back-door, HMRC sandbox provisioner) + admin unlock endpoint + advisory-lock uniqueness check + JIT backfill on read |
| **#5** | Frontend: confirmation modal on first save + locked UI states + support-flow links |
| **#6** | Admin dashboard: `/admin/settings/identity-lock` for grace-period / backfill toggles + unlock button on user detail |
| **#7** | Email + in-app banner announcement service integration |

## Verification

- `luac5.1 -p tax-copilot-system.lua` passes — Lua syntax valid.
- Migration slot **88** — next available after the current max (`[87]`) in `tax-copilot-system.lua`.
- Namespace note: `tax_user_profiles.namespace_id` is already `NOT NULL`; the lock queries in PR#4 MUST scope by it. Application-code discipline, not enforced by this migration.

## Test plan

- [ ] Merge → `lapis migrate` runs #88 on next opsapi deploy
- [ ] Verify columns exist: `\d tax_user_profiles` shows `nino_locked_at | timestamp` and `utr_locked_at | timestamp` (both NULL for every existing row)
- [ ] Re-run migrate → no-op (IF NOT EXISTS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)