### PR TITLE
feat(academy): learner lesson-progress tracking + feature-gated migration fix

### DIFF
--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -140,6 +140,7 @@ local academy_migrations = load_if_enabled(ProjectConfig.FEATURES.ACADEMY, "migr
 local academy_menu_migrations = load_if_enabled(ProjectConfig.FEATURES.ACADEMY, "migrations.academy-menu-items") or {}
 local academy_enrollment_migrations = load_if_enabled(ProjectConfig.FEATURES.ACADEMY, "migrations.academy-enrollments") or {}
 local academy_payment_migrations = load_if_enabled(ProjectConfig.FEATURES.ACADEMY, "migrations.academy-payments") or {}
+local academy_progress_migrations = load_if_enabled(ProjectConfig.FEATURES.ACADEMY, "migrations.academy-progress") or {}
 
 -- Core enhancements (always load for namespace/rbac)
 local rbac_enhancements_migrations = require("migrations.rbac-enhancements")
@@ -1864,6 +1865,10 @@ local _migrations = {
     ['815_create_academy_settings'] = conditional_array(ProjectConfig.FEATURES.ACADEMY, academy_payment_migrations, 6),
     ['816_create_creator_payouts'] = conditional_array(ProjectConfig.FEATURES.ACADEMY, academy_payment_migrations, 7),
     ['817_academy_per_instructor_payouts'] = conditional_array(ProjectConfig.FEATURES.ACADEMY, academy_payment_migrations, 8),
+
+    -- Academy learner progress (completed lessons -> dashboard progress bars)
+    ['819_create_academy_lesson_progress'] = conditional_array(ProjectConfig.FEATURES.ACADEMY, academy_progress_migrations, 1),
+    ['820_academy_lesson_progress_indexes'] = conditional_array(ProjectConfig.FEATURES.ACADEMY, academy_progress_migrations, 2),
 
     -- Theme system foundation (Phase 0): drop obsolete scaffold.
     -- Replaced by new tables in Phase 1 migration 621_create_theme_system.

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -212,6 +212,23 @@ end
 -- migration runs if the active PROJECT_CODE enables ANY of them. This lets a
 -- single table be shared across project codes, e.g.
 --   conditional({ProjectConfig.FEATURES.ECOMMERCE, ProjectConfig.FEATURES.TAX_COPILOT}, fn)
+-- A disabled feature's migration must NOT be registered at all.
+--
+-- Returning a no-op function here would let lapis run it and then write the key
+-- into `lapis_migrations`. The feature's tables would never be created, and
+-- because the key is recorded as "applied", turning the feature on later would
+-- silently skip it forever — you'd get routes that 500 with
+-- "relation ... does not exist". Returning nil omits the key from the migrations
+-- table, so lapis neither runs nor records it, and the migration is still
+-- pending the day the feature is enabled.
+--
+-- The skip is recorded here (registry-build time, after MigrationTracker.init)
+-- so the run summary still reports it.
+local function skip_unregistered(name, label)
+    MigrationTracker.recordSkipped(name, label)
+    return nil
+end
+
 local function conditional(feature, migration_func)
     local label = feature_label(feature)
     if ProjectConfig.isAnyFeatureEnabled(feature) and migration_func then
@@ -220,10 +237,10 @@ local function conditional(feature, migration_func)
             return migration_func(...)
         end
     end
-    return skip_migration(label, label)
+    return skip_unregistered(label, label)
 end
 
--- Returns the migration from an array or a skip function (with tracking).
+-- Returns the migration from an array, or nil when the feature is off (see above).
 -- `feature` may be a single feature string or a list (OR semantics) — see conditional().
 local function conditional_array(feature, migrations_array, index)
     local label = feature_label(feature)
@@ -234,7 +251,7 @@ local function conditional_array(feature, migrations_array, index)
             return migrations_array[index](...)
         end
     end
-    return skip_migration(name, label)
+    return skip_unregistered(name, label)
 end
 
 -- Dry-run: preview what would run/skip without touching the DB.

--- a/lapis/migrations/academy-progress.lua
+++ b/lapis/migrations/academy-progress.lua
@@ -1,0 +1,101 @@
+--[[
+    Academy Lesson Progress Migration
+    =================================
+
+    Tracks which lessons a learner has completed, keyed by the learner's JWT
+    user uuid. Namespace-scoped.
+
+    A row means "this lesson is completed". Un-completing a lesson deletes the
+    row, so the table only ever holds completions — `updated_at` doubles as the
+    learner's last activity on the course.
+]]
+
+local schema = require("lapis.db.schema")
+local types = schema.types
+local db = require("lapis.db")
+
+local function table_exists(table_name)
+    local result = db.query([[
+        SELECT EXISTS (
+            SELECT FROM information_schema.tables WHERE table_name = ?
+        ) as exists
+    ]], table_name)
+    return result[1] and result[1].exists
+end
+
+local function index_exists(index_name)
+    local result = db.query([[
+        SELECT EXISTS (SELECT FROM pg_indexes WHERE indexname = ?) as exists
+    ]], index_name)
+    return result[1] and result[1].exists
+end
+
+return {
+    -- ========================================================================
+    -- [1] Create academy_lesson_progress
+    -- ========================================================================
+    [1] = function()
+        if table_exists("academy_lesson_progress") then return end
+
+        schema.create_table("academy_lesson_progress", {
+            { "id", types.serial },
+            { "uuid", types.varchar({ unique = true }) },
+            { "namespace_id", types.integer },
+            { "course_id", types.integer },
+            { "lesson_id", types.integer },
+            { "user_uuid", types.varchar },
+            { "completed_at", types.time({ default = db.raw("NOW()") }) },
+            { "created_at", types.time({ default = db.raw("NOW()") }) },
+            { "updated_at", types.time({ default = db.raw("NOW()") }) },
+            "PRIMARY KEY (id)"
+        })
+
+        pcall(function()
+            db.query([[
+                ALTER TABLE academy_lesson_progress
+                ADD CONSTRAINT academy_lesson_progress_namespace_fk
+                FOREIGN KEY (namespace_id) REFERENCES namespaces(id) ON DELETE CASCADE
+            ]])
+        end)
+
+        pcall(function()
+            db.query([[
+                ALTER TABLE academy_lesson_progress
+                ADD CONSTRAINT academy_lesson_progress_course_fk
+                FOREIGN KEY (course_id) REFERENCES academy_courses(id) ON DELETE CASCADE
+            ]])
+        end)
+
+        pcall(function()
+            db.query([[
+                ALTER TABLE academy_lesson_progress
+                ADD CONSTRAINT academy_lesson_progress_lesson_fk
+                FOREIGN KEY (lesson_id) REFERENCES academy_lessons(id) ON DELETE CASCADE
+            ]])
+        end)
+
+        -- One completion row per (lesson, learner).
+        pcall(function()
+            db.query([[
+                CREATE UNIQUE INDEX academy_lesson_progress_lesson_user_unique
+                ON academy_lesson_progress (lesson_id, user_uuid)
+            ]])
+        end)
+    end,
+
+    -- ========================================================================
+    -- [2] academy_lesson_progress indexes
+    -- ========================================================================
+    [2] = function()
+        if not index_exists("idx_academy_lesson_progress_uuid") then
+            db.query("CREATE UNIQUE INDEX idx_academy_lesson_progress_uuid ON academy_lesson_progress (uuid)")
+        end
+        -- Dashboard reads progress per learner, grouped by course.
+        if not index_exists("idx_academy_lesson_progress_user_course") then
+            db.query([[
+                CREATE INDEX idx_academy_lesson_progress_user_course
+                ON academy_lesson_progress (user_uuid, namespace_id, course_id)
+            ]])
+        end
+    end,
+}

--- a/lapis/queries/ProgressQueries.lua
+++ b/lapis/queries/ProgressQueries.lua
@@ -1,0 +1,108 @@
+--[[
+    Academy Lesson Progress Queries
+    ===============================
+    Which lessons a learner has completed, keyed by the learner's JWT user uuid.
+
+    A row in academy_lesson_progress means "completed". Un-completing deletes the
+    row, so counting rows is the progress count and MAX(updated_at) is the
+    learner's last activity on a course.
+]]
+
+local Global = require "helper.global"
+local db = require("lapis.db")
+
+local ProgressQueries = {}
+
+--- Mark a lesson complete (idempotent). Returns true.
+function ProgressQueries.complete(namespace_id, course_id, lesson_id, user_uuid)
+    if not user_uuid then return false end
+    db.query([[
+        INSERT INTO academy_lesson_progress
+            (uuid, namespace_id, course_id, lesson_id, user_uuid, completed_at, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, NOW(), NOW(), NOW())
+        ON CONFLICT (lesson_id, user_uuid)
+        DO UPDATE SET updated_at = NOW()
+    ]], Global.generateUUID(), namespace_id, course_id, lesson_id, user_uuid)
+    return true
+end
+
+--- Un-mark a lesson (idempotent). Returns true.
+function ProgressQueries.uncomplete(lesson_id, user_uuid)
+    if not user_uuid then return false end
+    db.query("DELETE FROM academy_lesson_progress WHERE lesson_id = ? AND user_uuid = ?",
+        lesson_id, user_uuid)
+    return true
+end
+
+--- Completed lesson ids for one course, as a lookup set keyed by lesson id.
+function ProgressQueries.completedLessonIds(course_id, user_uuid)
+    if not user_uuid then return {} end
+    local rows = db.query(
+        "SELECT lesson_id FROM academy_lesson_progress WHERE course_id = ? AND user_uuid = ?",
+        course_id, user_uuid)
+    local set = {}
+    for _, r in ipairs(rows or {}) do set[r.lesson_id] = true end
+    return set
+end
+
+--- Per-course progress for a learner: completed count + last activity.
+--- Returns a table keyed by course_id -> { completed = n, last_activity_at = ts }.
+function ProgressQueries.summaryByCourse(namespace_id, user_uuid)
+    if not user_uuid then return {} end
+    local rows = db.query([[
+        SELECT course_id, COUNT(*) AS completed, MAX(updated_at) AS last_activity_at
+        FROM academy_lesson_progress
+        WHERE user_uuid = ? AND namespace_id = ?
+        GROUP BY course_id
+    ]], user_uuid, namespace_id)
+    local out = {}
+    for _, r in ipairs(rows or {}) do
+        out[r.course_id] = {
+            completed = tonumber(r.completed) or 0,
+            last_activity_at = r.last_activity_at,
+        }
+    end
+    return out
+end
+
+--- Courses a learner has touched (has >=1 completed lesson), newest activity first.
+function ProgressQueries.coursesWithProgress(namespace_id, user_uuid)
+    if not user_uuid then return {} end
+    local rows = db.query([[
+        SELECT c.* FROM academy_courses c
+        JOIN (
+            SELECT course_id, MAX(updated_at) AS last_activity_at
+            FROM academy_lesson_progress
+            WHERE user_uuid = ? AND namespace_id = ?
+            GROUP BY course_id
+        ) p ON p.course_id = c.id
+        WHERE c.deleted_at IS NULL
+        ORDER BY p.last_activity_at DESC
+    ]], user_uuid, namespace_id)
+    return rows or {}
+end
+
+--- Headline learning stats for the dashboard.
+--- minutes_completed sums the duration of the lessons actually completed.
+function ProgressQueries.statsForUser(namespace_id, user_uuid)
+    local empty = { lessons_completed = 0, minutes_completed = 0, courses_started = 0 }
+    if not user_uuid then return empty end
+    local rows = db.query([[
+        SELECT
+            COUNT(*)                              AS lessons_completed,
+            COUNT(DISTINCT p.course_id)           AS courses_started,
+            COALESCE(SUM(l.duration_seconds), 0)  AS seconds_completed
+        FROM academy_lesson_progress p
+        JOIN academy_lessons l ON l.id = p.lesson_id
+        WHERE p.user_uuid = ? AND p.namespace_id = ?
+    ]], user_uuid, namespace_id)
+    local r = rows and rows[1]
+    if not r then return empty end
+    return {
+        lessons_completed = tonumber(r.lessons_completed) or 0,
+        courses_started = tonumber(r.courses_started) or 0,
+        minutes_completed = math.floor((tonumber(r.seconds_completed) or 0) / 60),
+    }
+end
+
+return ProgressQueries

--- a/lapis/routes/academy.lua
+++ b/lapis/routes/academy.lua
@@ -228,6 +228,17 @@ return function(app)
             }
         end)))
 
+    -- A paid course with no price cannot be bought: Stripe rejects a zero amount,
+    -- so the learner's Buy button hard-fails with "Invalid course price". Refuse
+    -- to persist that state rather than let it surface at checkout.
+    local function price_error(is_free, price)
+        if is_free then return nil end
+        if not price or price <= 0 then
+            return "A paid course needs a price greater than 0 (minor units, e.g. 999 = 9.99)"
+        end
+        return nil
+    end
+
     app:post("/api/v2/academy/courses", AuthMiddleware.requireAuth(
         NamespaceMiddleware.requirePermission("courses", "create", function(self)
             local body = parse_body()
@@ -243,6 +254,11 @@ return function(app)
                 return api_response(400, nil, "Invalid status (draft|published|archived)")
             end
 
+            local is_free = to_bool(body.is_free, true)
+            local price = tonumber(body.price) or 0
+            local perr = price_error(is_free, price)
+            if perr then return api_response(400, nil, perr) end
+
             local ok, course_or_err = pcall(CourseQueries.create, self.namespace.id, {
                 title = body.title,
                 slug = body.slug,
@@ -251,8 +267,8 @@ return function(app)
                 thumbnail_url = body.thumbnail_url,
                 category = body.category or "general",
                 level = level,
-                is_free = to_bool(body.is_free, true),
-                price = tonumber(body.price) or 0,
+                is_free = is_free,
+                price = price,
                 currency = body.currency or "USD",
                 status = status,
                 owner_user_uuid = self.current_user.uuid,
@@ -294,13 +310,24 @@ return function(app)
             if body.is_free ~= nil then fields.is_free = to_bool(body.is_free, true) end
             if body.price ~= nil then fields.price = tonumber(body.price) or 0 end
 
+            local existing = CourseQueries.getByUuid(self.namespace.id, self.params.uuid)
+            if not existing then return api_response(404, nil, "Course not found") end
+
             if not can_manage_all(self) then
-                local existing = CourseQueries.getByUuid(self.namespace.id, self.params.uuid)
-                if not existing then return api_response(404, nil, "Course not found") end
                 if not ensure_owns(self, existing) then
                     return api_response(403, nil, "You can only manage your own courses")
                 end
             end
+
+            -- is_free/price may each be omitted, so validate the RESULTING course,
+            -- not just the fields in this request.
+            local eff_free = fields.is_free
+            if eff_free == nil then
+                eff_free = (existing.is_free == true or existing.is_free == "t")
+            end
+            local eff_price = fields.price or tonumber(existing.price) or 0
+            local perr = price_error(eff_free, eff_price)
+            if perr then return api_response(400, nil, perr) end
 
             local updated = CourseQueries.update(self.namespace.id, self.params.uuid, fields)
             if not updated then return api_response(404, nil, "Course not found") end

--- a/lapis/routes/academy.lua
+++ b/lapis/routes/academy.lua
@@ -29,6 +29,7 @@ local LessonQueries = require "queries.LessonQueries"
 local InstructorQueries = require "queries.InstructorQueries"
 local EnrollmentQueries = require "queries.EnrollmentQueries"
 local EntitlementQueries = require "queries.EntitlementQueries"
+local ProgressQueries = require "queries.ProgressQueries"
 local NamespaceQueries = require "queries.NamespaceQueries"
 local NamespaceRoleQueries = require "queries.NamespaceRoleQueries"
 local NamespaceMemberQueries = require "queries.NamespaceMemberQueries"
@@ -58,9 +59,17 @@ return function(app)
     local function parse_body()
         ngx.req.read_body()
 
-        -- Fast path: small form body kept in memory.
-        local post_args = ngx.req.get_post_args()
-        if post_args and next(post_args) then return post_args end
+        -- get_post_args() parses ANY body as urlencoded, which turns a JSON body
+        -- into a single bogus key (and silently drops the real fields). Only take
+        -- the form fast path when the client didn't declare JSON.
+        local ctype = ngx.var.content_type or ""
+        local is_json = ctype:find("application/json", 1, true) ~= nil
+
+        if not is_json then
+            -- Fast path: small form body kept in memory.
+            local post_args = ngx.req.get_post_args()
+            if post_args and next(post_args) then return post_args end
+        end
 
         -- Body may be in memory (small JSON) or spilled to a temp file (large).
         local body = ngx.req.get_body_data()
@@ -628,5 +637,148 @@ return function(app)
                 table.insert(out, public_course(c, ls))
             end
             return { status = 200, json = { courses = out, count = #out } }
+        end))
+
+    -- ------------------------------------------------------------------
+    -- LEARNER: lesson progress
+    -- A row in academy_lesson_progress means "completed"; toggling off deletes
+    -- it. Writes are gated on the learner actually having access to the course
+    -- (free / owned / purchased / subscribed), so progress can never be
+    -- recorded against a course the learner cannot open.
+    -- ------------------------------------------------------------------
+
+    -- Mark a lesson complete / incomplete. Body: { completed: boolean }.
+    app:post("/api/v2/public/academy/:namespace/lessons/:uuid/progress",
+        AuthMiddleware.requireAuth(function(self)
+            local ns = resolve_namespace(self)
+            if not ns then return api_response(404, nil, "Namespace not found") end
+            local user_uuid = self.current_user and self.current_user.uuid
+            if not user_uuid then return api_response(401, nil, "Authentication required") end
+
+            local lesson = LessonQueries.getByUuid(ns.id, self.params.uuid)
+            if not lesson then return api_response(404, nil, "Lesson not found") end
+
+            local course = CourseQueries.findById(ns.id, lesson.course_id)
+            if not course then return api_response(404, nil, "Course not found") end
+            if not EntitlementQueries.hasCourseAccess(user_uuid, course) then
+                return api_response(403, nil, "You do not have access to this course")
+            end
+
+            -- Accept JSON booleans and form-encoded strings alike.
+            local body = parse_body() or {}
+            local raw = body.completed
+            local completed = not (raw == false or raw == "false" or raw == 0 or raw == "0")
+
+            if completed then
+                ProgressQueries.complete(ns.id, course.id, lesson.id, user_uuid)
+            else
+                ProgressQueries.uncomplete(lesson.id, user_uuid)
+            end
+
+            local lessons = LessonQueries.listByCourse(course.id, { published_only = true })
+            local done = ProgressQueries.completedLessonIds(course.id, user_uuid)
+            local count = 0
+            for _, l in ipairs(lessons) do if done[l.id] then count = count + 1 end end
+
+            return { status = 200, json = {
+                completed = completed,
+                completed_count = count,
+                total = #lessons,
+            } }
+        end))
+
+    -- Which lessons of a course the current learner has completed.
+    app:get("/api/v2/public/academy/:namespace/courses/:slug/progress",
+        AuthMiddleware.requireAuth(function(self)
+            local ns = resolve_namespace(self)
+            if not ns then return api_response(404, nil, "Namespace not found") end
+            local user_uuid = self.current_user and self.current_user.uuid
+
+            local course = CourseQueries.getBySlug(ns.id, self.params.slug)
+            if not course then return api_response(404, nil, "Course not found") end
+
+            local lessons = LessonQueries.listByCourse(course.id, { published_only = true })
+            local done = ProgressQueries.completedLessonIds(course.id, user_uuid)
+
+            local ids, count, next_lesson = {}, 0, nil
+            for _, l in ipairs(lessons) do
+                if done[l.id] then
+                    table.insert(ids, l.uuid)
+                    count = count + 1
+                elseif not next_lesson then
+                    next_lesson = l.uuid
+                end
+            end
+
+            return { status = 200, json = {
+                completed_lesson_ids = #ids > 0 and ids or cJson.empty_array,
+                completed = count,
+                total = #lessons,
+                next_lesson_id = next_lesson,
+            } }
+        end))
+
+    -- The learner's dashboard feed: every course they're enrolled in (purchased)
+    -- or have made progress on (free courses need no enrollment), each with its
+    -- progress, plus headline stats.
+    app:get("/api/v2/public/academy/:namespace/me/learning",
+        AuthMiddleware.requireAuth(function(self)
+            local ns = resolve_namespace(self)
+            if not ns then return api_response(404, nil, "Namespace not found") end
+            local user_uuid = self.current_user and self.current_user.uuid
+
+            local courses, seen = {}, {}
+            for _, c in ipairs(EnrollmentQueries.listCoursesForUser(ns.id, user_uuid)) do
+                if not seen[c.id] then seen[c.id] = true; table.insert(courses, c) end
+            end
+            for _, c in ipairs(ProgressQueries.coursesWithProgress(ns.id, user_uuid)) do
+                if not seen[c.id] then seen[c.id] = true; table.insert(courses, c) end
+            end
+
+            local ids = {}
+            for _, c in ipairs(courses) do table.insert(ids, c.id) end
+            local lessons_by_course = LessonQueries.listByCourseIds(ids, { published_only = true })
+            local summary = ProgressQueries.summaryByCourse(ns.id, user_uuid)
+
+            local instructor_ids = {}
+            for _, c in ipairs(courses) do
+                if c.owner_user_uuid then table.insert(instructor_ids, c.owner_user_uuid) end
+            end
+            local instructors = CourseQueries.instructorsByUuids(instructor_ids)
+
+            local out, courses_completed = {}, 0
+            for _, c in ipairs(courses) do
+                local ls = lessons_by_course[c.id] or {}
+                local done = ProgressQueries.completedLessonIds(c.id, user_uuid)
+
+                local next_lesson = nil
+                for _, l in ipairs(ls) do
+                    if not done[l.id] and not next_lesson then next_lesson = l.uuid end
+                end
+
+                local completed = (summary[c.id] and summary[c.id].completed) or 0
+                local total = #ls
+                if total > 0 and completed >= total then courses_completed = courses_completed + 1 end
+
+                local shaped = public_course(c, {}, instructors[c.owner_user_uuid])
+                shaped.progress = {
+                    completed = completed,
+                    total = total,
+                    percent = total > 0 and math.floor((completed / total) * 100) or 0,
+                    next_lesson_id = next_lesson,
+                    last_activity_at = summary[c.id] and summary[c.id].last_activity_at or nil,
+                }
+                table.insert(out, shaped)
+            end
+
+            local stats = ProgressQueries.statsForUser(ns.id, user_uuid)
+            stats.courses_enrolled = #out
+            stats.courses_completed = courses_completed
+
+            return { status = 200, json = {
+                courses = #out > 0 and out or cJson.empty_array,
+                count = #out,
+                stats = stats,
+            } }
         end))
 end

--- a/lapis/routes/register.lua
+++ b/lapis/routes/register.lua
@@ -206,6 +206,12 @@ return function(app)
                 })
             end
 
+            -- Match the login token's userinfo shape (helper/jwt-helper.lua).
+            -- Without a name claim, a freshly-registered user has no display name
+            -- in their session and consumers fall back to showing their email.
+            local full_name = ((user.first_name or "") .. " " .. (user.last_name or ""))
+                :gsub("^%s*(.-)%s*$", "%1")
+
             local jwt_payload = {
                 userinfo = {
                     uuid = user.uuid,
@@ -213,6 +219,10 @@ return function(app)
                     email = user.email,
                     username = user.username,
                     role = user.role,
+                    -- Additive: lenient consumers (tax_copilot) ignore unknown claims.
+                    name = full_name,
+                    first_name = user.first_name,
+                    last_name = user.last_name,
                     -- Surface the freshly-saved business profile key
                     -- so the frontend can render the right onboarding
                     -- state and pre-fill classify without a second


### PR DESCRIPTION
## Why now

The academy learner site is **deployed to int** and its dashboard calls three routes that do not exist on `main`:

```
GET  /public/academy/:ns/me/learning              <- dashboard feed + stats
GET  /public/academy/:ns/courses/:slug/progress   <- completed lessons for a course
POST /public/academy/:ns/lessons/:uuid/progress   <- mark a lesson complete
```

Without this, the dashboard's "My Courses" tab renders its backend-unreachable state. This also unblocks standing up a dedicated `academy-opsapi` instance, which pulls `bwalia/opsapi:latest`.

## What's in it

**1. Lesson progress tracking** (migrations 819/820, ACADEMY-gated)

`academy_lesson_progress`: one row per completed (lesson, learner). Un-completing deletes the row, so counting rows *is* the progress, and `MAX(updated_at)` is the learner's last activity. Adds `ProgressQueries` and the three routes above.

Writes are gated on `hasCourseAccess`, so progress can never be recorded against a course the learner cannot open. "My courses" = enrolled (purchased) **∪** courses with progress, so a *free* course a learner starts shows up without needing an enrollment row.

**2. Feature-gated migrations could never create their tables** — a latent bug that bit us for real.

`conditional_array()` returned a **no-op function** for a disabled feature, which lapis ran and then **recorded in `lapis_migrations`**. So a DB migrated as `PROJECT_CODE=tax_copilot` marked all 19 academy migrations "applied" *without creating anything* — and switching to `PROJECT_CODE=academy` later skipped them forever. Routes load, tables don't exist, every endpoint 500s.

A disabled feature's migration is now simply **not registered** (`nil`), so lapis neither runs nor records it, and it stays genuinely pending until the feature is enabled. The skip is still reported in the run summary.

Verified on a scratch DB: migrate as `tax_copilot` → **0** academy keys recorded; migrate that same DB as `academy` → **all 11 academy tables created**. `tax_copilot`'s own 146 migrations ran unchanged.

**3. `parse_body()` silently dropped JSON fields.** `ngx.req.get_post_args()` parses *any* body as urlencoded, turning a JSON body into one bogus key — so `{"completed": false}` read as `nil` and flipped "un-complete" into "complete". Now the form fast path is only taken when the client didn't declare `application/json`. Both encodings verified.

**4. Registration JWT had no name.** `register.lua` omitted `name`/`first_name`/`last_name` (the login path in `helper/jwt-helper.lua` includes them), so consumers fell back to displaying the user's email address. Additive claim.

**5. A paid course could be saved with price 0** — Stripe rejects a zero amount, so Buy hard-failed with "Invalid course price" at checkout. Rejected on create *and* update; update validates the **resulting** course, so flipping `is_free`→false without a price is caught while a title-only edit on a paid course still passes.

## tax_copilot safety

Everything is either ACADEMY-feature-gated or additive:

- The migration fix changes only whether a *disabled* feature's migration is registered. Keys already recorded in an existing ledger are untouched, and `tax_copilot`'s own migrations are unaffected (verified: 146 ran normally).
- `register.lua` adds claims to the JWT; lenient consumers ignore unknown claims.
- `parse_body()` is local to `routes/academy.lua`.
- Price validation is on the academy course endpoints only.

Note `bwalia/opsapi:latest` is shared with the tax deployment (`pullPolicy: Always`), so tax will pick this up on its next pod restart — reviewed as safe for exactly the reasons above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)