### PR TITLE
fix(build): pin openresty base image to 1.31-alpine-fat

### DIFF
--- a/lapis/Dockerfile
+++ b/lapis/Dockerfile
@@ -1,4 +1,4 @@
-FROM openresty/openresty:alpine
+FROM openresty/openresty:1.31-alpine-fat
 
 ARG TARGET_NGINX_CONF=nginx.conf
 ARG TAG=latest


### PR DESCRIPTION
One-line fix: change `FROM openresty/openresty:alpine` → `FROM openresty/openresty:1.31-alpine-fat` in `lapis/Dockerfile`.

## Why

The `:alpine` floating tag rolled forward on Docker Hub between **2026-06-27** (last successful Build and Deploy — PR #454) and **2026-07-02** (first of 10 consecutive smoke-test failures). Every merge to main since — 10 unrelated PRs (#458 → #468) — has failed with the same signature:

```
[notice] 13#13: openresty/1.31.1.1                      ← the crashing runtime
[alert]  13#13: worker process 33 exited on signal 11   ← SIGSEGV
[notice] 13#13: start worker process 35
(~3s later)
[alert]  13#13: worker process 35 exited on signal 11
...
Attempt 30: HTTP 000     ← curl never reaches nginx
Smoke test failed - container not responding
```

Same failure, 10 different PR numbers, none of them caused it. The problem is upstream, not in the code.

## Root cause (short version)

`RUN luarocks install luaossl / lua-resty-jwt / bcrypt / …` compiles C code **at build time** against the base image's LuaJIT / musl / OpenSSL headers. When upstream ships a new `:alpine` build with different runtime libs, those compiled `.so` files segfault on first call. Classic floating-tag failure mode.

## Why `1.31-alpine-fat` specifically

- ✓ **Pins to the 1.31 line** — no longer subject to whatever `:alpine` happens to point at (`:alpine` currently redirects to `1.31.1.1`; will silently move to 1.33 or 2.0 when they ship).
- ✓ **`-fat` variant** includes PCRE, build tools, OpenSSL headers — this is the recommended base for images that `luarocks install` compiled modules. The plain `:alpine` is the "prebuilt Lua-only" variant, and its use with `luarocks install` is a documented source of exactly the SIGSEGV pattern seen here.

## Caveat — this is not a permanent pin

`1.31-alpine-fat` still floats on patch versions within 1.31 (e.g. it'll rewrite when upstream ships 1.31.2). A truly stable pin would be `1.31.1.1-2-alpine-fat` (specific build) or a digest. The [systemic follow-up](https://github.com/bwalia/opsapi/pull/) — pin every Dockerfile FROM by digest + Renovate for controlled updates — was laid out separately.

For now: **unblock main** so PRs can merge again.

## Test plan

- [x] Verified `openresty/openresty:1.31-alpine-fat` exists on Docker Hub (168 MB, amd64 + arm64, last_updated 2026-07-10)
- [ ] After merge — next Build and Deploy run should pass the smoke test
- [ ] If it still segfaults, fall back to `1.29-alpine-fat` (older 1.29 line, predates the current build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)