### PR TITLE
fix(academy): an author cannot see their own course in My Courses

### DIFF
--- a/lapis/routes/academy.lua
+++ b/lapis/routes/academy.lua
@@ -838,6 +838,24 @@ return function(app)
             for _, c in ipairs(ProgressQueries.coursesWithProgress(ns.id, user_uuid)) do
                 if not seen[c.id] then seen[c.id] = true; table.insert(courses, c) end
             end
+            -- Courses this user AUTHORED.
+            --
+            -- An instructor is never "enrolled" on their own course and has no
+            -- progress against it, so the two sources above miss it entirely and
+            -- the author's own work is invisible on their dashboard — while
+            -- hasCourseAccess (used by the watch page, progress and streaming)
+            -- has always treated the owner as fully entitled. This closes that
+            -- disagreement: "has access" and "shows in My Courses" now answer
+            -- the same way for an owner.
+            --
+            -- Unpublished ones are included on purpose: a draft you are writing
+            -- is exactly what you want a link to. `seen` keeps a course you both
+            -- own and are enrolled on from appearing twice.
+            for _, c in ipairs((CourseQueries.list(ns.id, {
+                owner_user_uuid = user_uuid, perPage = 200,
+            }) or {}).data or {}) do
+                if not seen[c.id] then seen[c.id] = true; table.insert(courses, c) end
+            end
 
             local ids = {}
             for _, c in ipairs(courses) do table.insert(ids, c.id) end


### PR DESCRIPTION
An instructor authors a course, opens the learner site, and **My Courses is
empty**.

`/me/learning` unions *enrolled* courses + courses *with progress*. An author is
never "enrolled" on their own course and has no progress against it, so both
sources miss it entirely.

## Two endpoints disagreeing

Reproduced live against int, as the actual owner of the course:

```
GET /me/learning                 -> 0 courses          <- dashboard is empty
GET /courses/<slug>/enrollment   -> enrolled: true     <- "you are entitled"
```

`hasCourseAccess` has always treated the owner as fully entitled — it is what
lets them watch, track progress and stream. Only this one listing disagreed.

## The fix

Owned courses become a third source in the union, so **"has access" and "shows
in My Courses" now answer the same way for an owner**. It reuses
`CourseQueries.list(ns, { owner_user_uuid })`, which already existed.

Drafts are included deliberately: an unpublished course you are still writing is
exactly the one you want a link to. The existing `seen` set keeps a course you
both own *and* are enrolled on from appearing twice.

Academy-only (`load_if("academy", ...)`), no schema change, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)