### PR TITLE
feat(tax-profile): add Making Tax Digital (MTD) enrolment flag

### DIFF
--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -1837,6 +1837,7 @@ local _migrations = {
     ['819_tax_identity_lock_columns'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 88),
     ['820_tax_identity_lock_settings_and_module'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 89),
     ['821_tax_identity_lock_message_catalog'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 90),
+    ['822_tax_user_profile_mtd_enabled'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, tax_copilot_migrations, 91),
 
     -- MY INCOME — manually-entered income source-of-truth
     -- =========================================================================

--- a/lapis/migrations/tax-copilot-system.lua
+++ b/lapis/migrations/tax-copilot-system.lua
@@ -3196,4 +3196,27 @@ return {
         ]])
         print("[Tax Copilot] Seeded IDENTITY_LOCK_ACTIVE + NINO_ALREADY_REGISTERED in message_catalog")
     end,
+
+    -- 91. Making Tax Digital (MTD) enrolment flag on tax_user_profiles.
+    --
+    -- ─── Purpose ────────────────────────────────────────────────────────
+    -- MTD is HMRC's mandatory digital-filing initiative for self-assessment
+    -- (sole traders + landlords). The user's MTD status is a first-class
+    -- profile fact: it drives which filing pipeline the app routes them
+    -- through (SA100 legacy vs quarterly MTD updates), which reminders they
+    -- see, and which permissions the HMRC OAuth request asks for.
+    --
+    -- Stored per-user (1:1 with tax_user_profiles, keyed via user_uuid).
+    -- Not per-business — HMRC MTD registration is per-taxpayer (per NINO).
+    --
+    -- Default false so existing rows are safe (users are on legacy SA100
+    -- unless they explicitly say otherwise). NOT NULL keeps every read
+    -- path free of null-check gymnastics.
+    [91] = function()
+        db.query([[
+            ALTER TABLE tax_user_profiles
+            ADD COLUMN IF NOT EXISTS mtd_enabled BOOLEAN NOT NULL DEFAULT false
+        ]])
+        print("[Tax Copilot] Added mtd_enabled column to tax_user_profiles")
+    end,
 }

--- a/lapis/queries/TaxUserProfileQueries.lua
+++ b/lapis/queries/TaxUserProfileQueries.lua
@@ -214,6 +214,18 @@ function TaxUserProfileQueries.setDefaultTaxYear(user_uuid, tax_year)
     return { success = true }
 end
 
+-- Update Making Tax Digital (MTD) enrolment flag. HMRC's MTD is a per-taxpayer
+-- registration (per NINO), so this lives on tax_user_profiles rather than
+-- per-business. See migration [91] for the column definition and rationale.
+function TaxUserProfileQueries.setMtdEnabled(user_uuid, enabled)
+    db.query([[
+        UPDATE tax_user_profiles
+        SET mtd_enabled = ?, updated_at = NOW()
+        WHERE user_uuid = ?
+    ]], enabled and true or false, user_uuid)
+    return { success = true }
+end
+
 -- Update the user's default business profile key (e.g. "sole_trader", "amazon_seller").
 function TaxUserProfileQueries.setDefaultProfileKey(user_uuid, profile_key)
     db.query([[

--- a/lapis/routes/tax-profile.lua
+++ b/lapis/routes/tax-profile.lua
@@ -115,6 +115,11 @@ return function(app)
                 default_business_id = profile.default_business_id,
                 default_tax_year = profile.default_tax_year,
                 default_profile_key = profile.default_profile_key,
+                -- Making Tax Digital (MTD) enrolment. Drives filing pipeline
+                -- selection (SA100 legacy vs quarterly MTD updates) and the
+                -- HMRC OAuth scopes we request. See migration [91]. Boolean,
+                -- NOT NULL — default false on older rows.
+                mtd_enabled = profile.mtd_enabled and true or false,
                 businesses = business_list,
                 open_obligations_count = open_count,
                 created_at = profile.created_at,
@@ -295,6 +300,18 @@ return function(app)
             if not ok_pk then
                 ngx.log(ngx.ERR, "[Tax Profile] setDefaultProfileKey error: ", tostring(pk_err))
                 return { status = 500, json = { error = "Failed to update business profile" } }
+            end
+        end
+
+        -- Making Tax Digital (MTD) enrolment toggle. Presence-based (not
+        -- truthy-based) so `{"mtd_enabled": false}` can turn it OFF —
+        -- if we gated on `if params.mtd_enabled` the false path would
+        -- silently drop through unchanged.
+        if params.mtd_enabled ~= nil then
+            local ok_mtd, mtd_err = pcall(TaxUserProfileQueries.setMtdEnabled, user_uuid, params.mtd_enabled)
+            if not ok_mtd then
+                ngx.log(ngx.ERR, "[Tax Profile] setMtdEnabled error: ", tostring(mtd_err))
+                return { status = 500, json = { error = "Failed to update MTD enrolment" } }
             end
         end
 


### PR DESCRIPTION
## Why

Frontend settings page needs a persistent MTD yes/no toggle that other parts of the app can read (filing-pipeline picker, HMRC OAuth scope requests, quarterly-update reminders). Piggyback on `tax_user_profiles` — 1:1 with users, already holds every other HMRC-specific setting.

## What

**Migration `[91]` — column** (wired into manifest as `822_tax_user_profile_mtd_enabled`)
```sql
ALTER TABLE tax_user_profiles
ADD COLUMN IF NOT EXISTS mtd_enabled BOOLEAN NOT NULL DEFAULT false
```

**Query — `TaxUserProfileQueries.setMtdEnabled(user_uuid, enabled)`**
Coerces the argument to a real boolean before the UPDATE.

**Route — extend `PUT /api/v2/tax/profile/preferences`**
Accepts `mtd_enabled` in the body. **Presence-based check** (`if params.mtd_enabled ~= nil`), NOT truthy-based — so `{"mtd_enabled": false}` actually turns it OFF. A truthy gate would silently drop the false path.

**Route — extend `GET /api/v2/tax/profile`**
Returns `mtd_enabled` in the response object.

## Verified end-to-end (running container)

```
1. lapis migrate                                            → 1 new migration ran, column exists
2. GET  /api/v2/tax/profile                                 → mtd_enabled = false
3. PUT  /api/v2/tax/profile/preferences {"mtd_enabled":true}  → 200
4. GET  /api/v2/tax/profile                                 → mtd_enabled = true
5. PUT  /api/v2/tax/profile/preferences {"mtd_enabled":false} → 200
6. GET  /api/v2/tax/profile                                 → mtd_enabled = false
7. SELECT mtd_enabled FROM tax_user_profiles                → f
```

## Paired frontend PR

The settings-page UI toggle lives in `diy-tax-return-uk` — see PR opened alongside this one. That PR depends on this one landing first (the FE reads/writes the field this PR exposes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)