### PR TITLE
feat(property-income): entity-scoped answers, category contexts, SA105 line items

### DIFF
--- a/lapis/app.lua
+++ b/lapis/app.lua
@@ -509,6 +509,9 @@ load_if("tax_copilot", "routes.tax-custom-categories")
 load_if("tax_copilot", "routes.tax-categories")
 load_if("tax_copilot", "routes.tax-support")
 load_if("tax_copilot", "routes.my-incomes")
+-- Rental hub: properties (user_profile_entities) + SA105 line items.
+-- Property-scope questions stay under routes.profile-builder (?context=&entity=).
+load_if("tax_copilot", "routes.tax-properties")
 -- Billing (single-merchant Stripe: admin plans + subscription/one-time checkout)
 load_if("tax_copilot", "routes.billing-plans")
 load_if("tax_copilot", "routes.billing-checkout")

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -162,6 +162,10 @@ local income_types_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPIL
 -- dynamic Profile Builder questions; see dynamic-profile-builder.lua [38]).
 local income_questionnaire_cleanup_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.income-questionnaire-cleanup") or {}
 
+-- Property Income (tax_copilot feature) — rental hub + per-property entities,
+-- entity-scoped profile answers, and SA105 line-item catalogue/rows
+local property_income_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.property-income-system") or {}
+
 -- Billing / payments (Stripe Connect: subscriptions + one-time). Gated on
 -- tax_copilot for now; broaden to a feature list (e.g. {ECOMMERCE, TAX_COPILOT})
 -- once multiple project codes need it. See migrations/billing-system.lua.
@@ -1855,6 +1859,20 @@ local _migrations = {
     -- =========================================================================
     ['722_drop_income_questionnaire_bespoke'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, income_questionnaire_cleanup_migrations, 1),
     ['723_profile_seed_income_questions'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, profile_builder_migrations, 38),
+
+    -- =========================================================================
+    -- PROPERTY INCOME — rental hub + per-property drill-down (UX option A).
+    -- 724-726 extend the Profile Builder with entity scoping + category
+    -- contexts; 727-729 add the SA105 line-item catalogue and rows; 730
+    -- seeds the admin-editable rental_business / property question sections.
+    -- =========================================================================
+    ['724_create_profile_entities'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, property_income_migrations, 1),
+    ['725_answers_entity_scope'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, property_income_migrations, 2),
+    ['726_categories_context'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, property_income_migrations, 3),
+    ['727_create_property_line_categories'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, property_income_migrations, 4),
+    ['728_seed_property_line_categories'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, property_income_migrations, 5),
+    ['729_create_property_line_items'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, property_income_migrations, 6),
+    ['730_seed_property_sections'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, property_income_migrations, 7),
 
     -- =========================================================================
     -- Academy (LMS): courses + lessons (namespace-scoped). Feature-gated, so

--- a/lapis/migrations/property-income-system.lua
+++ b/lapis/migrations/property-income-system.lua
@@ -1,0 +1,337 @@
+--[[
+  Property Income System — Rental / Property income redesign.
+
+  Adds the pieces that let the Rental income panel become a
+  "hub + per-property drill-down" (option A of the UX redesign) while
+  keeping every question admin-configurable through the existing
+  Dynamic Profile Builder:
+
+  1. user_profile_entities      : user-owned instances ("9 McClintock…")
+                                  that answers can be scoped to. Today
+                                  entity_type is always 'property'; the
+                                  table is deliberately generic so a later
+                                  feature (e.g. multiple self-employments)
+                                  can reuse it.
+  2. user_profile_answers       : gains entity_uuid. NULL = the classic
+                                  one-answer-per-user questionnaire;
+                                  non-NULL = the answer belongs to that
+                                  entity (asked once PER PROPERTY).
+  3. profile_categories.context : NULL  = normal /profile questionnaire
+                                  'rental_business' = asked once, on the
+                                                      rental hub
+                                  'property'        = asked per property
+                                  Contexted categories are EXCLUDED from
+                                  the default /schema + completion gate.
+  4. property_line_categories   : admin-managed catalogue for the income
+                                  and expense line-item dropdowns, with
+                                  hmrc_mapping for SA105 box routing
+                                  (same pattern as income_types).
+  5. property_line_items        : the user's rental income/expense rows,
+                                  one row per line item per property per
+                                  tax year. Soft-delete like my_incomes.
+
+  Only executed when PROJECT_CODE includes 'tax_copilot'.
+]]
+
+local schema = require("lapis.db.schema")
+local types = schema.types
+local db = require("lapis.db")
+local MigrationUtils = require "helper.migration-utils"
+
+return {
+    -- =========================================================================
+    -- 1. user_profile_entities
+    -- =========================================================================
+    [1] = function()
+        schema.create_table("user_profile_entities", {
+            { "id",            types.serial },
+            { "uuid",          types.varchar({ unique = true }) },
+            { "user_id",       types.integer },
+            { "user_uuid",     types.varchar },
+            { "namespace_id",  types.integer({ null = true }) },
+            { "entity_type",   types.varchar },                    -- 'property' (generic for future reuse)
+            { "label",         types.varchar },                    -- user-facing nickname, e.g. "9 McClintock Road"
+            { "metadata_json", types.text({ null = true }) },
+            { "display_order", types.integer({ default = 0 }) },
+            { "is_archived",   types.boolean({ default = false }) },
+            { "archived_at",   types.time({ null = true }) },
+            { "created_at",    types.time({ default = db.raw("NOW()") }) },
+            { "updated_at",    types.time({ default = db.raw("NOW()") }) },
+            "PRIMARY KEY (id)"
+        })
+        schema.create_index("user_profile_entities", "user_id")
+        schema.create_index("user_profile_entities", "user_uuid")
+        schema.create_index("user_profile_entities", "entity_type")
+        schema.create_index("user_profile_entities", "user_id", "entity_type", "is_archived")
+        print("[Property Income] Created user_profile_entities table")
+    end,
+
+    -- =========================================================================
+    -- 2. entity_uuid on user_profile_answers
+    --
+    -- The single unique index (user_id, question_id) becomes TWO partial
+    -- unique indexes so the same question can hold one answer per entity
+    -- while classic questionnaire answers stay one-per-user:
+    --   * entity_uuid IS NULL     → unique on (user_id, question_id)
+    --   * entity_uuid IS NOT NULL → unique on (user_id, question_id, entity_uuid)
+    -- The answers upsert in routes/profile-builder.lua targets whichever
+    -- predicate applies (ON CONFLICT ... WHERE ...) — keep in lock-step.
+    --
+    -- ⚠ DEPLOY WINDOW: pre-migration code upserts with a bare
+    -- `ON CONFLICT (user_id, question_id)`, which Postgres CANNOT satisfy
+    -- from a partial index (42P10) — so between this migration running and
+    -- the new code serving, answer saves on old pods fail (per-answer
+    -- errors, nothing persisted; no crash). A plain unique index can't be
+    -- kept alongside (it would forbid the per-entity rows this feature
+    -- exists for), so the window is unavoidable in a single release:
+    -- deploy at a quiet time and let the rollout complete promptly.
+    -- =========================================================================
+    [2] = function()
+        db.query("ALTER TABLE user_profile_answers ADD COLUMN IF NOT EXISTS entity_uuid varchar NULL")
+        db.query("DROP INDEX IF EXISTS idx_upa_user_question")
+        db.query([[
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_upa_user_question
+            ON user_profile_answers (user_id, question_id)
+            WHERE entity_uuid IS NULL
+        ]])
+        db.query([[
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_upa_user_question_entity
+            ON user_profile_answers (user_id, question_id, entity_uuid)
+            WHERE entity_uuid IS NOT NULL
+        ]])
+        db.query("CREATE INDEX IF NOT EXISTS idx_upa_entity ON user_profile_answers (entity_uuid) WHERE entity_uuid IS NOT NULL")
+        print("[Property Income] Added entity_uuid scope to user_profile_answers")
+    end,
+
+    -- =========================================================================
+    -- 3. profile_categories.context
+    -- =========================================================================
+    [3] = function()
+        db.query("ALTER TABLE profile_categories ADD COLUMN IF NOT EXISTS context varchar NULL")
+        db.query("CREATE INDEX IF NOT EXISTS idx_pc_context ON profile_categories (context)")
+        print("[Property Income] Added context column to profile_categories")
+    end,
+
+    -- =========================================================================
+    -- 4. property_line_categories (admin catalogue for line-item dropdowns)
+    -- =========================================================================
+    [4] = function()
+        schema.create_table("property_line_categories", {
+            { "id",            types.serial },
+            { "uuid",          types.varchar({ unique = true }) },
+            { "namespace_id",  types.integer({ null = true }) },
+            { "kind",          types.varchar },                    -- 'income' | 'expense'
+            { "category_key",  types.varchar },                    -- stable key, e.g. 'repairs_maintenance'
+            { "label",         types.varchar },
+            { "description",   types.text({ null = true }) },
+            { "hmrc_mapping",  types.text({ null = true }) },      -- JSON, e.g. {"sa105_box":"25"}
+            { "display_order", types.integer({ default = 0 }) },
+            { "is_active",     types.boolean({ default = true }) },
+            { "created_at",    types.time({ default = db.raw("NOW()") }) },
+            { "updated_at",    types.time({ default = db.raw("NOW()") }) },
+            "PRIMARY KEY (id)"
+        })
+        schema.create_index("property_line_categories", "kind")
+        schema.create_index("property_line_categories", "is_active")
+        db.query("CREATE UNIQUE INDEX IF NOT EXISTS idx_plc_kind_key ON property_line_categories (kind, category_key)")
+        print("[Property Income] Created property_line_categories table")
+    end,
+
+    -- =========================================================================
+    -- 5. Seed SA105-shaped line categories.
+    --    Idempotent: keyed on (kind, category_key); re-running updates labels
+    --    and box mappings but never duplicates or resurrects disabled rows.
+    -- =========================================================================
+    [5] = function()
+        local rows = {
+            -- Income (SA105 boxes 20/22)
+            { kind = "income",  key = "rents",              label = "Rental income",                                 box = "20", order = 1 },
+            { kind = "income",  key = "other_income",       label = "Other property income",                         box = "20", order = 2,
+              desc = "e.g. insurance payouts, service charges you keep" },
+            { kind = "income",  key = "lease_premiums",     label = "Premiums for the grant of a lease",             box = "22", order = 3 },
+            -- Expenses (SA105 boxes 24–29)
+            { kind = "expense", key = "rates_insurance",    label = "Rent, rates, insurance and ground rents",       box = "24", order = 1 },
+            { kind = "expense", key = "repairs_maintenance", label = "Property repairs and maintenance",             box = "25", order = 2 },
+            { kind = "expense", key = "finance_costs",      label = "Loan interest and other financial costs",       box = "26", order = 3,
+              desc = "Residential mortgage interest is restricted to basic-rate relief (box 44)" },
+            { kind = "expense", key = "professional_fees",  label = "Legal, management and other professional fees", box = "27", order = 4 },
+            { kind = "expense", key = "services_wages",     label = "Costs of services provided, including wages",   box = "28", order = 5 },
+            { kind = "expense", key = "travel",             label = "Property-related travel costs",                 box = "29", order = 6 },
+            { kind = "expense", key = "other_expenses",     label = "Other allowable property expenses",             box = "29", order = 7 },
+        }
+        for _, r in ipairs(rows) do
+            local mapping = '{"sa105_box":"' .. r.box .. '"}'
+            local exists = db.select("id FROM property_line_categories WHERE kind = ? AND category_key = ?", r.kind, r.key)
+            if exists and #exists > 0 then
+                db.query([[
+                    UPDATE property_line_categories
+                       SET label = ?, description = ?, hmrc_mapping = ?, display_order = ?, updated_at = NOW()
+                     WHERE kind = ? AND category_key = ?
+                ]], r.label, r.desc or db.NULL, mapping, r.order, r.kind, r.key)
+            else
+                db.query([[
+                    INSERT INTO property_line_categories
+                        (uuid, kind, category_key, label, description, hmrc_mapping, display_order, is_active, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, true, NOW(), NOW())
+                ]], MigrationUtils.generateUUID(), r.kind, r.key, r.label, r.desc or db.NULL, mapping, r.order)
+            end
+        end
+        print("[Property Income] Seeded property_line_categories (SA105 boxes)")
+    end,
+
+    -- =========================================================================
+    -- 6. property_line_items
+    --    property_uuid references user_profile_entities.uuid — varchar, no FK,
+    --    same softness rationale as my_incomes.income_type: archiving a
+    --    property must never cascade-destroy its historical line items.
+    -- =========================================================================
+    [6] = function()
+        schema.create_table("property_line_items", {
+            { "id",                  types.serial },
+            { "uuid",                types.varchar({ unique = true }) },
+            { "user_id",             types.integer },
+            { "namespace_id",        types.integer({ null = true }) },
+            { "property_uuid",       types.varchar },
+            { "tax_year",            types.varchar },               -- YYYY-YY e.g. "2026-27"
+            { "kind",                types.varchar },               -- 'income' | 'expense'
+            { "category_key",        types.varchar },               -- property_line_categories key
+            { "description",         types.text({ null = true }) },
+            { "amount",              "numeric(15,2) NOT NULL" },
+            { "disallowable_amount", "numeric(15,2)" },             -- nullable; IRIS-style split kept for later UI
+            { "is_archived",         types.boolean({ default = false }) },
+            { "archived_at",         types.time({ null = true }) },
+            { "archived_by",         types.integer({ null = true }) },
+            { "created_at",          types.time({ default = db.raw("NOW()") }) },
+            { "updated_at",          types.time({ default = db.raw("NOW()") }) },
+            "PRIMARY KEY (id)"
+        })
+        schema.create_index("property_line_items", "user_id")
+        schema.create_index("property_line_items", "property_uuid")
+        schema.create_index("property_line_items", "tax_year")
+        schema.create_index("property_line_items", "user_id", "property_uuid", "tax_year", "is_archived")
+        schema.create_index("property_line_items", "user_id", "tax_year", "is_archived")
+        print("[Property Income] Created property_line_items table")
+    end,
+
+    -- =========================================================================
+    -- 7. Seed the two contexted question sections.
+    --    Same ensure_* idempotent helpers as dynamic-profile-builder [38];
+    --    admins can freely edit/extend these from the admin panel afterwards.
+    -- =========================================================================
+    [7] = function()
+        local function ensure_category(slug, name, description, icon, display_order, context)
+            local exists = db.select("id FROM profile_categories WHERE slug = ?", slug)
+            if exists and #exists > 0 then
+                db.query([[
+                    UPDATE profile_categories
+                       SET name = ?, description = ?, icon = ?, display_order = ?, context = ?,
+                           is_active = true, is_archived = false, updated_at = NOW()
+                     WHERE slug = ?
+                ]], name, description, icon, display_order, context, slug)
+                return exists[1].id
+            end
+            db.query([[
+                INSERT INTO profile_categories
+                    (uuid, namespace_id, name, slug, description, icon, display_order, context, is_active, is_archived, created_at, updated_at)
+                VALUES (?, 0, ?, ?, ?, ?, ?, ?, true, false, NOW(), NOW())
+            ]], MigrationUtils.generateUUID(), name, slug, description, icon, display_order, context)
+            local row = db.select("id FROM profile_categories WHERE slug = ?", slug)
+            return row and row[1] and row[1].id or nil
+        end
+
+        local function ensure_question(cat_id, q)
+            local exists = db.select("id FROM profile_questions WHERE question_key = ?", q.question_key)
+            if exists and #exists > 0 then
+                db.query([[
+                    UPDATE profile_questions
+                       SET category_id = ?, label = ?, question_type = ?, is_required = ?,
+                           display_order = ?, help_text = ?, placeholder = ?,
+                           is_active = true, is_archived = false, updated_at = NOW()
+                     WHERE question_key = ?
+                ]], cat_id, q.label, q.question_type, q.is_required, q.display_order, q.help_text or "", q.placeholder or "", q.question_key)
+                return exists[1].id
+            end
+            db.query([[
+                INSERT INTO profile_questions
+                    (uuid, category_id, question_key, label, question_type, is_required, display_order, help_text, placeholder, is_active, version, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, true, 1, NOW(), NOW())
+            ]], MigrationUtils.generateUUID(), cat_id, q.question_key, q.label, q.question_type, q.is_required, q.display_order, q.help_text or "", q.placeholder or "")
+            local row = db.select("id FROM profile_questions WHERE question_key = ?", q.question_key)
+            return row and row[1] and row[1].id or nil
+        end
+
+        local function ensure_option(question_key, value, label, display_order)
+            local q = db.select("id FROM profile_questions WHERE question_key = ?", question_key)
+            if not q or #q == 0 then return end
+            local exists = db.select("id FROM profile_question_options WHERE question_id = ? AND value = ?", q[1].id, value)
+            if exists and #exists > 0 then return end
+            db.query([[
+                INSERT INTO profile_question_options
+                    (uuid, question_id, label, value, display_order, is_active, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, true, NOW(), NOW())
+            ]], MigrationUtils.generateUUID(), q[1].id, label, value, display_order)
+        end
+
+        local function ensure_rule(target_key, source_key, rule_name, operator, expected_value)
+            local tgt = db.select("id FROM profile_questions WHERE question_key = ?", target_key)
+            local src = db.select("id FROM profile_questions WHERE question_key = ?", source_key)
+            if not tgt or #tgt == 0 or not src or #src == 0 then return end
+            local exists = db.select("id FROM profile_question_rules WHERE question_id = ? AND source_question_id = ?", tgt[1].id, src[1].id)
+            if exists and #exists > 0 then return end
+            db.query([[
+                INSERT INTO profile_question_rules
+                    (uuid, question_id, rule_name, rule_type, operator, source_question_id, expected_value, logic_group, is_active, created_at, updated_at)
+                VALUES (?, ?, ?, 'visibility', ?, ?, ?, 'AND', true, NOW(), NOW())
+            ]], MigrationUtils.generateUUID(), tgt[1].id, rule_name, operator, src[1].id, expected_value)
+        end
+
+        -- ── Rental business (asked once, shown on the rental hub) ───────────
+        local rb_id = ensure_category("rental-business", "Your rental business",
+            "Details that apply to your property letting as a whole", "home", 1, "rental_business")
+        if rb_id then
+            ensure_question(rb_id, { question_key = "rb_accounting_basis", label = "How do you record income and expenses?",
+                question_type = "single_select", is_required = true, display_order = 1,
+                help_text = "Cash basis counts money when it actually moves; accruals counts it when it's due. Most landlords use cash basis." })
+            ensure_question(rb_id, { question_key = "rb_claim_property_allowance", label = "Claim the £1,000 property income allowance?",
+                question_type = "boolean", is_required = false, display_order = 2,
+                help_text = "If you claim the allowance you can't also deduct expenses. Worth it only when your expenses are under £1,000." })
+            ensure_question(rb_id, { question_key = "rb_jointly_let", label = "Do you let any property jointly with someone else?",
+                question_type = "boolean", is_required = false, display_order = 3,
+                help_text = "For jointly-let property, only your share of income and expenses goes on your return." })
+            ensure_question(rb_id, { question_key = "rb_non_resident_landlord", label = "Did you live outside the UK while letting?",
+                question_type = "boolean", is_required = false, display_order = 4 })
+            ensure_question(rb_id, { question_key = "rb_first_letting_date", label = "When did you first start letting property?",
+                question_type = "date", is_required = false, display_order = 5 })
+        end
+        ensure_option("rb_accounting_basis", "cash", "Cash basis (recommended for most landlords)", 1)
+        ensure_option("rb_accounting_basis", "accruals", "Accruals (traditional) basis", 2)
+        print("[Property Income] Seeded rental-business section: 5 questions")
+
+        -- ── Property details (asked once PER property) ──────────────────────
+        local pd_id = ensure_category("property-details", "Property details",
+            "Details about this specific property", "home", 1, "property")
+        if pd_id then
+            ensure_question(pd_id, { question_key = "prop_address", label = "Property address",
+                question_type = "address", is_required = true, display_order = 1 })
+            ensure_question(pd_id, { question_key = "prop_let_type", label = "What kind of let is this?",
+                question_type = "single_select", is_required = true, display_order = 2 })
+            ensure_question(pd_id, { question_key = "prop_ownership_share", label = "Your ownership share (%)",
+                question_type = "percentage", is_required = false, display_order = 3,
+                help_text = "100% unless you own the property jointly", placeholder = "100" })
+            ensure_question(pd_id, { question_key = "prop_furnished", label = "Is it let furnished?",
+                question_type = "boolean", is_required = false, display_order = 4 })
+            ensure_question(pd_id, { question_key = "prop_first_let_date", label = "When was this property first let?",
+                question_type = "date", is_required = false, display_order = 5 })
+            ensure_question(pd_id, { question_key = "prop_has_mortgage", label = "Is there a mortgage on this property?",
+                question_type = "boolean", is_required = false, display_order = 6 })
+            ensure_question(pd_id, { question_key = "prop_mortgage_interest_only", label = "Is it an interest-only mortgage?",
+                question_type = "boolean", is_required = false, display_order = 7 })
+        end
+        ensure_option("prop_let_type", "residential", "Residential letting", 1)
+        ensure_option("prop_let_type", "fhl", "Furnished holiday let", 2)
+        ensure_option("prop_let_type", "commercial", "Commercial property", 3)
+        ensure_option("prop_let_type", "rent_a_room", "Rent-a-room in my own home", 4)
+        ensure_rule("prop_mortgage_interest_only", "prop_has_mortgage", "Show if property has a mortgage", "equals", "true")
+        print("[Property Income] Seeded property-details section: 7 questions, 1 rule")
+    end,
+}

--- a/lapis/queries/PropertyLineQueries.lua
+++ b/lapis/queries/PropertyLineQueries.lua
@@ -1,0 +1,248 @@
+--[[
+    Property Line Queries — property_line_items + property_line_categories.
+
+    Line items are the user's per-property income/expense rows (description +
+    admin-managed category + amount, per tax year). The category catalogue
+    drives the dropdowns AND server-side validation, mirroring how
+    income_types backs my_incomes.
+
+    Ownership: every line item is scoped to the authenticated user AND must
+    reference one of their non-archived properties on create. Category keys
+    are stored as plain varchar (no FK) so retiring a category never breaks
+    history; updates grandfather an unchanged key the same way my-incomes
+    grandfathers a disabled income_type.
+]]
+
+local Global = require "helper.global"
+local TaxAuditLogQueries = require "queries.TaxAuditLogQueries"
+local db = require("lapis.db")
+local cjson = require("cjson")
+
+local PropertyLineQueries = {}
+
+local function resolveUserId(user)
+    if not user then return nil, "User not authenticated" end
+    local user_uuid = user.uuid or user.id
+    local rows
+    if user.uuid then
+        rows = db.query("SELECT id FROM users WHERE uuid = ? LIMIT 1", user_uuid)
+    else
+        rows = db.query("SELECT id FROM users WHERE id = ? LIMIT 1", user_uuid)
+    end
+    if not rows or #rows == 0 then return nil, "User not found" end
+    return rows[1].id
+end
+
+local function present(row)
+    row.id = row.uuid
+    row.user_id = nil
+    return row
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Catalogue
+-- ────────────────────────────────────────────────────────────────────────────
+function PropertyLineQueries.categories()
+    local rows = db.query([[
+        SELECT uuid, kind, category_key, label, description, hmrc_mapping, display_order
+        FROM property_line_categories
+        WHERE is_active = true
+        ORDER BY kind ASC, display_order ASC, label ASC
+    ]]) or {}
+    return rows
+end
+
+-- Set of active keys for one kind — validation helper for routes.
+function PropertyLineQueries.active_keys(kind)
+    local rows = db.query([[
+        SELECT category_key FROM property_line_categories
+        WHERE is_active = true AND kind = ?
+    ]], kind) or {}
+    local set = {}
+    for _, r in ipairs(rows) do set[r.category_key] = true end
+    return set
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- List for one property
+-- ────────────────────────────────────────────────────────────────────────────
+-- params: { tax_year?, kind?, include_archived? }
+function PropertyLineQueries.all(property_uuid, params, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local where = { "user_id = ?", "property_uuid = ?" }
+    local args = { internal_user_id, property_uuid }
+    if params.tax_year and params.tax_year ~= "" then
+        table.insert(where, "tax_year = ?"); table.insert(args, params.tax_year)
+    end
+    if params.kind and params.kind ~= "" then
+        table.insert(where, "kind = ?"); table.insert(args, params.kind)
+    end
+    if params.include_archived ~= "true" and params.include_archived ~= true then
+        table.insert(where, "is_archived = false")
+    end
+
+    local rows = db.query(
+        "SELECT * FROM property_line_items WHERE " .. table.concat(where, " AND ")
+        .. " ORDER BY kind ASC, created_at ASC",
+        unpack(args)) or {}
+    for _, r in ipairs(rows) do present(r) end
+    return { data = rows, total = #rows }
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Create — route layer validates kind/category/amount/tax_year and property
+-- ownership; re-checked defensively here.
+-- ────────────────────────────────────────────────────────────────────────────
+function PropertyLineQueries.create(property_uuid, data, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    -- The property must exist, belong to this user, and not be archived.
+    local prop = db.query([[
+        SELECT uuid, namespace_id FROM user_profile_entities
+        WHERE uuid = ? AND user_id = ? AND entity_type = 'property' AND is_archived = false
+        LIMIT 1
+    ]], property_uuid, internal_user_id)
+    if not prop or #prop == 0 then return nil, "Property not found" end
+
+    if not data.amount or tonumber(data.amount) == nil or tonumber(data.amount) <= 0 then
+        return nil, "amount must be a positive number"
+    end
+    if data.kind ~= "income" and data.kind ~= "expense" then
+        return nil, "kind must be 'income' or 'expense'"
+    end
+    if not data.category_key or data.category_key == "" then
+        return nil, "category_key is required"
+    end
+    if not data.tax_year or data.tax_year == "" then
+        return nil, "tax_year is required"
+    end
+
+    local uuid = Global.generateUUID()
+    db.query([[
+        INSERT INTO property_line_items
+            (uuid, user_id, namespace_id, property_uuid, tax_year, kind, category_key, description, amount, disallowable_amount, is_archived, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, false, NOW(), NOW())
+    ]],
+        uuid,
+        internal_user_id,
+        prop[1].namespace_id or db.NULL,
+        property_uuid,
+        data.tax_year,
+        data.kind,
+        data.category_key,
+        data.description or db.NULL,
+        tonumber(data.amount),
+        tonumber(data.disallowable_amount) or db.NULL
+    )
+    local row = db.query("SELECT * FROM property_line_items WHERE uuid = ? LIMIT 1", uuid)[1]
+
+    TaxAuditLogQueries.log({
+        user_id = internal_user_id,
+        user_email = user.email,
+        entity_type = "PROPERTY_LINE",
+        entity_id = uuid,
+        action = "CREATE",
+        new_values = cjson.encode(row),
+    })
+    return present(row)
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Show / Update / Archive — addressed by line uuid (globally unique), always
+-- ownership-scoped.
+-- ────────────────────────────────────────────────────────────────────────────
+function PropertyLineQueries.show(line_uuid, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+    local rows = db.query([[
+        SELECT * FROM property_line_items WHERE uuid = ? AND user_id = ? LIMIT 1
+    ]], line_uuid, internal_user_id)
+    if not rows or #rows == 0 then return nil end
+    return present(rows[1])
+end
+
+function PropertyLineQueries.update(line_uuid, data, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local existing = db.query([[
+        SELECT * FROM property_line_items WHERE uuid = ? AND user_id = ? LIMIT 1
+    ]], line_uuid, internal_user_id)
+    if not existing or #existing == 0 then return nil end
+    local old = existing[1]
+
+    local updates, args = {}, {}
+    if data.amount ~= nil then
+        local n = tonumber(data.amount)
+        if not n or n <= 0 then return nil, "amount must be a positive number" end
+        table.insert(updates, "amount = ?"); table.insert(args, n)
+    end
+    if data.disallowable_amount ~= nil then
+        table.insert(updates, "disallowable_amount = ?")
+        table.insert(args, tonumber(data.disallowable_amount) or db.NULL)
+    end
+    if data.category_key then
+        table.insert(updates, "category_key = ?"); table.insert(args, data.category_key)
+    end
+    if data.tax_year then
+        table.insert(updates, "tax_year = ?"); table.insert(args, data.tax_year)
+    end
+    if data.description ~= nil then
+        -- "" clears the description (stored as NULL, matching create):
+        -- JSON null can't express "clear" here because body parsing strips
+        -- cjson.null to keep it out of the SQL layer.
+        table.insert(updates, "description = ?")
+        table.insert(args, data.description ~= "" and data.description or db.NULL)
+    end
+    if #updates == 0 then return present(old) end
+
+    table.insert(updates, "updated_at = NOW()")
+    table.insert(args, line_uuid)
+    table.insert(args, internal_user_id)
+    db.query("UPDATE property_line_items SET " .. table.concat(updates, ", ")
+        .. " WHERE uuid = ? AND user_id = ?", unpack(args))
+
+    local refreshed = db.query("SELECT * FROM property_line_items WHERE uuid = ? LIMIT 1", line_uuid)[1]
+
+    TaxAuditLogQueries.log({
+        user_id = internal_user_id,
+        user_email = user.email,
+        entity_type = "PROPERTY_LINE",
+        entity_id = line_uuid,
+        action = "UPDATE",
+        old_values = cjson.encode(old),
+        new_values = cjson.encode(refreshed),
+    })
+    return present(refreshed)
+end
+
+function PropertyLineQueries.archive(line_uuid, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local existing = db.query([[
+        SELECT * FROM property_line_items WHERE uuid = ? AND user_id = ? LIMIT 1
+    ]], line_uuid, internal_user_id)
+    if not existing or #existing == 0 then return nil end
+
+    db.query([[
+        UPDATE property_line_items
+           SET is_archived = true, archived_at = NOW(), archived_by = ?, updated_at = NOW()
+         WHERE uuid = ? AND user_id = ?
+    ]], internal_user_id, line_uuid, internal_user_id)
+
+    TaxAuditLogQueries.log({
+        user_id = internal_user_id,
+        user_email = user.email,
+        entity_type = "PROPERTY_LINE",
+        entity_id = line_uuid,
+        action = "DELETE",
+        old_values = cjson.encode(existing[1]),
+    })
+    return true
+end
+
+return PropertyLineQueries

--- a/lapis/queries/PropertyQueries.lua
+++ b/lapis/queries/PropertyQueries.lua
@@ -1,0 +1,277 @@
+--[[
+    Property Queries — user_profile_entities rows of entity_type 'property'.
+
+    A "property" is the drill-down unit of the Rental income hub. Each
+    property carries:
+      * a user-facing label (nickname shown in the hub list)
+      * entity-scoped Profile Builder answers (via user_profile_answers.entity_uuid)
+      * income/expense line items (property_line_items — see PropertyLineQueries)
+
+    Every read/write is scoped to the authenticated user. Soft-delete via
+    is_archived so entity-scoped answers and line items keep a resolvable
+    parent for historical calculations.
+
+    Pattern: mirrors MyIncomeQueries (resolveUserId + uuid-as-id responses
+    + tax_audit_logs rows on mutation).
+]]
+
+local Global = require "helper.global"
+local TaxAuditLogQueries = require "queries.TaxAuditLogQueries"
+local db = require("lapis.db")
+local cjson = require("cjson")
+
+local PropertyQueries = {}
+
+local ENTITY_TYPE = "property"
+
+local function resolveUserId(user)
+    if not user then return nil, "User not authenticated" end
+    local user_uuid = user.uuid or user.id
+    local rows
+    if user.uuid then
+        rows = db.query("SELECT id FROM users WHERE uuid = ? LIMIT 1", user_uuid)
+    else
+        rows = db.query("SELECT id FROM users WHERE id = ? LIMIT 1", user_uuid)
+    end
+    if not rows or #rows == 0 then return nil, "User not found" end
+    return rows[1].id
+end
+
+local function resolveNamespaceId(internal_user_id)
+    local rows = db.query([[
+        SELECT default_namespace_id FROM user_namespace_settings
+        WHERE user_id = ? LIMIT 1
+    ]], internal_user_id)
+    if rows and #rows > 0 and rows[1].default_namespace_id then
+        return tonumber(rows[1].default_namespace_id)
+    end
+    return nil
+end
+
+local function present(row)
+    row.id = row.uuid
+    row.user_id = nil
+    return row
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- List — optionally decorated with line-item totals for one tax year so the
+-- hub can render "Income / Expenses / Net" per property in a single call.
+-- ────────────────────────────────────────────────────────────────────────────
+-- params: { tax_year?, include_archived? }
+function PropertyQueries.all(params, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local where = { "user_id = ?", "entity_type = ?" }
+    local args = { internal_user_id, ENTITY_TYPE }
+    if params.include_archived ~= "true" and params.include_archived ~= true then
+        table.insert(where, "is_archived = false")
+    end
+
+    local rows = db.query(
+        "SELECT * FROM user_profile_entities WHERE " .. table.concat(where, " AND ")
+        .. " ORDER BY display_order ASC, created_at ASC",
+        unpack(args)) or {}
+
+    -- Per-property totals for the requested tax year (one grouped query,
+    -- not N+1). Only when a tax_year is given — the list itself is
+    -- year-agnostic.
+    local totals = {}
+    if params.tax_year and params.tax_year ~= "" and #rows > 0 then
+        local t_rows = db.query([[
+            SELECT property_uuid, kind, SUM(amount) AS total, COUNT(*) AS line_count
+            FROM property_line_items
+            WHERE user_id = ? AND tax_year = ? AND is_archived = false
+            GROUP BY property_uuid, kind
+        ]], internal_user_id, params.tax_year) or {}
+        for _, t in ipairs(t_rows) do
+            totals[t.property_uuid] = totals[t.property_uuid] or { income = 0, expense = 0, line_count = 0 }
+            local bucket = totals[t.property_uuid]
+            if t.kind == "income" then bucket.income = tonumber(t.total) or 0 end
+            if t.kind == "expense" then bucket.expense = tonumber(t.total) or 0 end
+            bucket.line_count = bucket.line_count + (tonumber(t.line_count) or 0)
+        end
+    end
+
+    for _, r in ipairs(rows) do
+        local t = totals[r.uuid]
+        r.income_total = t and t.income or 0
+        r.expense_total = t and t.expense or 0
+        r.line_count = t and t.line_count or 0
+        present(r)
+    end
+    return { data = rows, total = #rows }
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Show (ownership-scoped). Used by routes AND by profile-builder's
+-- entity-answer guard — keep the return shape stable.
+-- ────────────────────────────────────────────────────────────────────────────
+function PropertyQueries.show(property_uuid, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local rows = db.query([[
+        SELECT * FROM user_profile_entities
+        WHERE uuid = ? AND user_id = ? AND entity_type = ?
+        LIMIT 1
+    ]], property_uuid, internal_user_id, ENTITY_TYPE)
+    if not rows or #rows == 0 then return nil end
+    return present(rows[1])
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Create — label is the only required field; everything else about a
+-- property is admin-driven questions answered later on its page.
+-- ────────────────────────────────────────────────────────────────────────────
+function PropertyQueries.create(data, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    if not data.label or data.label == "" then
+        return nil, "label is required"
+    end
+
+    local uuid = Global.generateUUID()
+    -- namespace_id is always resolved server-side — a client-supplied value
+    -- would let callers stamp their rows into an arbitrary tenant.
+    db.query([[
+        INSERT INTO user_profile_entities
+            (uuid, user_id, user_uuid, namespace_id, entity_type, label, metadata_json, display_order, is_archived, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, false, NOW(), NOW())
+    ]],
+        uuid,
+        internal_user_id,
+        tostring(user.uuid or user.id),
+        resolveNamespaceId(internal_user_id) or db.NULL,
+        ENTITY_TYPE,
+        tostring(data.label),
+        data.metadata_json or db.NULL,
+        tonumber(data.display_order) or 0
+    )
+    local row = db.query("SELECT * FROM user_profile_entities WHERE uuid = ? LIMIT 1", uuid)[1]
+
+    TaxAuditLogQueries.log({
+        user_id = internal_user_id,
+        user_email = user.email,
+        entity_type = "PROPERTY",
+        entity_id = uuid,
+        action = "CREATE",
+        new_values = cjson.encode(row),
+    })
+    return present(row)
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Update (label / metadata / display_order)
+-- ────────────────────────────────────────────────────────────────────────────
+function PropertyQueries.update(property_uuid, data, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local existing = db.query([[
+        SELECT * FROM user_profile_entities
+        WHERE uuid = ? AND user_id = ? AND entity_type = ? LIMIT 1
+    ]], property_uuid, internal_user_id, ENTITY_TYPE)
+    if not existing or #existing == 0 then return nil end
+    local old = existing[1]
+
+    local updates, args = {}, {}
+    if data.label ~= nil then
+        if data.label == "" then return nil, "label cannot be empty" end
+        table.insert(updates, "label = ?"); table.insert(args, tostring(data.label))
+    end
+    if data.metadata_json ~= nil then
+        -- "" clears (stored as NULL) — see description handling in
+        -- PropertyLineQueries.update for the contract rationale.
+        table.insert(updates, "metadata_json = ?")
+        table.insert(args, data.metadata_json ~= "" and data.metadata_json or db.NULL)
+    end
+    if data.display_order ~= nil then
+        table.insert(updates, "display_order = ?"); table.insert(args, tonumber(data.display_order) or 0)
+    end
+    if #updates == 0 then return present(old) end
+
+    table.insert(updates, "updated_at = NOW()")
+    table.insert(args, property_uuid)
+    table.insert(args, internal_user_id)
+    db.query("UPDATE user_profile_entities SET " .. table.concat(updates, ", ")
+        .. " WHERE uuid = ? AND user_id = ?", unpack(args))
+
+    local refreshed = db.query("SELECT * FROM user_profile_entities WHERE uuid = ? LIMIT 1", property_uuid)[1]
+
+    TaxAuditLogQueries.log({
+        user_id = internal_user_id,
+        user_email = user.email,
+        entity_type = "PROPERTY",
+        entity_id = property_uuid,
+        action = "UPDATE",
+        old_values = cjson.encode(old),
+        new_values = cjson.encode(refreshed),
+    })
+    return present(refreshed)
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Archive (soft delete) — also archives the property's line items so its
+-- figures drop out of summaries; entity-scoped answers are left in place
+-- (they're harmless once the parent is archived and keep history intact).
+-- ────────────────────────────────────────────────────────────────────────────
+function PropertyQueries.archive(property_uuid, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local existing = db.query([[
+        SELECT * FROM user_profile_entities
+        WHERE uuid = ? AND user_id = ? AND entity_type = ? LIMIT 1
+    ]], property_uuid, internal_user_id, ENTITY_TYPE)
+    if not existing or #existing == 0 then return nil end
+
+    db.query([[
+        UPDATE user_profile_entities
+           SET is_archived = true, archived_at = NOW(), updated_at = NOW()
+         WHERE uuid = ? AND user_id = ?
+    ]], property_uuid, internal_user_id)
+    db.query([[
+        UPDATE property_line_items
+           SET is_archived = true, archived_at = NOW(), archived_by = ?, updated_at = NOW()
+         WHERE property_uuid = ? AND user_id = ? AND is_archived = false
+    ]], internal_user_id, property_uuid, internal_user_id)
+
+    TaxAuditLogQueries.log({
+        user_id = internal_user_id,
+        user_email = user.email,
+        entity_type = "PROPERTY",
+        entity_id = property_uuid,
+        action = "DELETE",
+        old_values = cjson.encode(existing[1]),
+    })
+    return true
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Summary — the hub's read-only strip: business-wide totals for one tax
+-- year plus the per-property breakdown.
+-- ────────────────────────────────────────────────────────────────────────────
+function PropertyQueries.summary(tax_year, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local list = PropertyQueries.all({ tax_year = tax_year }, user)
+    local income, expense = 0, 0
+    for _, p in ipairs(list.data) do
+        income = income + (tonumber(p.income_total) or 0)
+        expense = expense + (tonumber(p.expense_total) or 0)
+    end
+    return {
+        tax_year = tax_year,
+        property_count = list.total,
+        income_total = income,
+        expense_total = expense,
+        profit = income - expense,
+        properties = list.data,
+    }
+end
+
+return PropertyQueries

--- a/lapis/routes/profile-builder.lua
+++ b/lapis/routes/profile-builder.lua
@@ -175,12 +175,15 @@ local function recalculateCompletion(user_id, user_uuid, category_id)
 
         -- Pre-load the user's answers once; ipairs(questions) iterates
         -- over the SAME data the evaluators need.
+        -- entity_uuid IS NULL: per-entity (property) rows must not shadow
+        -- classic answers — with several entities there can be many rows per
+        -- question_id and the map would keep whichever came back last.
         local answer_map = {}
         local ok_ans, ans_rows = pcall(db.query, [[
             SELECT question_id, answer_text, answer_number, answer_boolean,
                    answer_date, answer_json, is_draft
             FROM user_profile_answers
-            WHERE user_id = ?
+            WHERE user_id = ? AND entity_uuid IS NULL
         ]], user_id)
         if ok_ans and ans_rows then
             for _, a in ipairs(ans_rows) do
@@ -266,12 +269,15 @@ local function evaluateTagRules(user_id, user_uuid)
         ]])
         if not rules or #rules == 0 then return end
 
-        -- Get user's current answers indexed by question_id (include drafts for visibility)
+        -- Get user's current answers indexed by question_id (include drafts for
+        -- visibility). entity_uuid IS NULL: tag rules evaluate against the
+        -- classic answer set only — per-property rows would collide on
+        -- question_id and make tag assignment depend on row order.
         local answer_map = {}
         local answers = db.query([[
             SELECT question_id, answer_text, answer_number, answer_boolean, answer_date, answer_json
             FROM user_profile_answers
-            WHERE user_id = ?
+            WHERE user_id = ? AND entity_uuid IS NULL
         ]], user_id)
         for _, a in ipairs(answers or {}) do
             answer_map[a.question_id] = a
@@ -689,6 +695,34 @@ return function(app)
         local user_id = getUserIdByUuid(user_uuid)
         local namespace_id = getNamespaceId(self)
 
+        -- Contexted schemas: ?context=rental_business|property returns ONLY
+        -- categories flagged with that context (profile_categories.context).
+        -- Without the param, only classic NULL-context categories are served
+        -- so the /profile questionnaire and its completion gate never see
+        -- hub/per-property sections. ?entity=<uuid> scopes the merged-in
+        -- answers to that user_profile_entities row (asked-once-PER-property
+        -- questions); the entity must belong to the caller.
+        local schema_context = self.params.context
+        if schema_context == "" then schema_context = nil end
+        local entity_uuid = self.params.entity
+        if entity_uuid == "" then entity_uuid = nil end
+        if entity_uuid then
+            local ok_ent, ent_rows = pcall(db.query, [[
+                SELECT id FROM user_profile_entities
+                WHERE uuid = ? AND user_id = ? AND is_archived = false
+                LIMIT 1
+            ]], entity_uuid, user_id or -1)
+            if not ok_ent or not ent_rows or #ent_rows == 0 then
+                return { status = 404, json = { error = "Entity not found" } }
+            end
+        end
+        local ctx_filter
+        if schema_context then
+            ctx_filter = " AND context = " .. db.escape_literal(schema_context)
+        else
+            ctx_filter = " AND context IS NULL"
+        end
+
         -- Include global categories (namespace_id = 0) and user's namespace categories
         local ns_filter = ""
         if namespace_id and namespace_id > 0 then
@@ -697,7 +731,7 @@ return function(app)
         local ok_cats, categories = pcall(db.query, [[
             SELECT * FROM profile_categories
             WHERE is_active = true AND is_archived = false
-            ]] .. ns_filter .. [[
+            ]] .. ns_filter .. ctx_filter .. [[
             ORDER BY display_order ASC, name ASC
         ]])
         if not ok_cats then
@@ -705,14 +739,26 @@ return function(app)
             return { status = 500, json = { error = "Failed to load schema" } }
         end
 
-        -- Pre-load all user answers indexed by question_id (include drafts for visibility/completion)
+        -- Pre-load all user answers indexed by question_id (include drafts for
+        -- visibility/completion). Entity scoping keeps the map unambiguous:
+        -- classic answers are entity_uuid IS NULL; per-entity requests load
+        -- ONLY that entity's rows so rules evaluate against that property.
         local answer_map = {}
         if user_id then
-            local ok_all_ans, all_ans = pcall(db.query, [[
-                SELECT question_id, answer_text, answer_number, answer_boolean, answer_date, answer_json
-                FROM user_profile_answers
-                WHERE user_id = ?
-            ]], user_id)
+            local ok_all_ans, all_ans
+            if entity_uuid then
+                ok_all_ans, all_ans = pcall(db.query, [[
+                    SELECT question_id, answer_text, answer_number, answer_boolean, answer_date, answer_json
+                    FROM user_profile_answers
+                    WHERE user_id = ? AND entity_uuid = ?
+                ]], user_id, entity_uuid)
+            else
+                ok_all_ans, all_ans = pcall(db.query, [[
+                    SELECT question_id, answer_text, answer_number, answer_boolean, answer_date, answer_json
+                    FROM user_profile_answers
+                    WHERE user_id = ? AND entity_uuid IS NULL
+                ]], user_id)
+            end
             if ok_all_ans and all_ans then
                 for _, a in ipairs(all_ans) do
                     answer_map[a.question_id] = a
@@ -1056,12 +1102,16 @@ return function(app)
         -- what the user sees on the /profile UI — otherwise text-only
         -- categories sit at 0% on the server while showing 100% to
         -- the user, exactly the trap we just hit.
+        -- entity_uuid IS NULL: per-entity answers (rental properties) must
+        -- never leak into the profile gate — with several entities there can
+        -- be many rows per question_id and the map would become whichever
+        -- row happened to come back last.
         local answer_map = {}
         local ok_ans, ans_rows = pcall(db.query, [[
             SELECT question_id, answer_text, answer_number, answer_boolean,
                    answer_date, answer_json
             FROM user_profile_answers
-            WHERE user_id = ?
+            WHERE user_id = ? AND entity_uuid IS NULL
         ]], user_id)
         if ok_ans and ans_rows then
             for _, a in ipairs(ans_rows) do
@@ -1132,12 +1182,16 @@ return function(app)
               )]]
         end
 
+        -- pc.context IS NULL: contexted categories (rental hub / per-property
+        -- sections) are separate surfaces with their own client-side
+        -- completion — they must never gate the dashboard.
         local ok_qs, questions = pcall(db.query, [[
             SELECT pq.id, pq.question_key, pq.label, pq.is_required
             FROM profile_questions pq
             JOIN profile_categories pc ON pc.id = pq.category_id
             WHERE pq.is_active = true AND pq.is_archived = false
               AND pc.is_active = true AND pc.is_archived = false
+              AND pc.context IS NULL
             ]] .. ns_filter .. bp_filter, unpack(query_params))
         if not ok_qs then
             ngx.log(ngx.ERR, "[ProfileBuilder] completion-status questions query failed: ", tostring(questions))
@@ -1777,9 +1831,15 @@ return function(app)
         local admin_uuid = admin.uuid or admin.id
         local admin_id = resolveUserId(admin_uuid)
 
+        -- context: NULL = classic /profile section; 'rental_business' /
+        -- 'property' = contexted sections rendered on the rental hub /
+        -- per-property pages. Empty string normalises to NULL.
+        local context = params.context
+        if context == "" or context == cjson.null then context = nil end
+
         local ok, result = pcall(db.query, [[
-            INSERT INTO profile_categories (uuid, namespace_id, name, slug, description, icon, display_order, parent_id, is_active, is_archived, visibility_rule_json, completion_rule_json, created_by, updated_by, created_at, updated_at)
-            VALUES (gen_random_uuid()::text, ?, ?, ?, ?, ?, ?, ?, true, false, ?, ?, ?, ?, NOW(), NOW())
+            INSERT INTO profile_categories (uuid, namespace_id, name, slug, description, icon, display_order, parent_id, context, is_active, is_archived, visibility_rule_json, completion_rule_json, created_by, updated_by, created_at, updated_at)
+            VALUES (gen_random_uuid()::text, ?, ?, ?, ?, ?, ?, ?, ?, true, false, ?, ?, ?, ?, NOW(), NOW())
             RETURNING *
         ]],
             namespace_id or 0,
@@ -1789,6 +1849,7 @@ return function(app)
             params.icon or db.NULL,
             params.display_order or 0,
             params.parent_id or db.NULL,
+            context or db.NULL,
             params.visibility_rule_json or db.NULL,
             params.completion_rule_json or db.NULL,
             admin_id,
@@ -1841,11 +1902,15 @@ return function(app)
 
         local set_parts = {}
         local set_vals = {}
-        local allowed = {"name", "slug", "description", "icon", "display_order", "parent_id", "is_active", "is_archived", "visibility_rule_json", "completion_rule_json"}
+        local allowed = {"name", "slug", "description", "icon", "display_order", "parent_id", "context", "is_active", "is_archived", "visibility_rule_json", "completion_rule_json"}
         for _, field in ipairs(allowed) do
             if params[field] ~= nil then
+                -- context: empty string from the admin form means "classic
+                -- profile section" → store NULL, not ''.
+                local v = params[field]
+                if field == "context" and (v == "" or v == cjson.null) then v = db.NULL end
                 table.insert(set_parts, db.escape_identifier(field) .. " = ?")
-                table.insert(set_vals, params[field])
+                table.insert(set_vals, v)
             end
         end
 
@@ -2825,6 +2890,15 @@ return function(app)
 
         local category_slug = self.params.category_slug
 
+        -- ?entity=<uuid> returns that entity's answers (per-property scope);
+        -- default returns only classic questionnaire answers.
+        local entity_uuid = self.params.entity
+        if entity_uuid == "" then entity_uuid = nil end
+        local entity_filter = " AND upa.entity_uuid IS NULL"
+        if entity_uuid then
+            entity_filter = " AND upa.entity_uuid = " .. db.escape_literal(tostring(entity_uuid))
+        end
+
         local sql
         local vals = {user_id}
         if category_slug and category_slug ~= "" then
@@ -2834,7 +2908,7 @@ return function(app)
                 FROM user_profile_answers upa
                 JOIN profile_questions pq ON pq.id = upa.question_id
                 JOIN profile_categories pc ON pc.id = pq.category_id
-                WHERE upa.user_id = ? AND pc.slug = ?
+                WHERE upa.user_id = ? AND pc.slug = ?]] .. entity_filter .. [[
                 ORDER BY pq.display_order ASC
             ]]
             table.insert(vals, category_slug)
@@ -2843,7 +2917,7 @@ return function(app)
                 SELECT upa.*, pq.question_key, pq.label AS question_label, pq.uuid AS question_uuid
                 FROM user_profile_answers upa
                 JOIN profile_questions pq ON pq.id = upa.question_id
-                WHERE upa.user_id = ?
+                WHERE upa.user_id = ?]] .. entity_filter .. [[
                 ORDER BY pq.display_order ASC
             ]]
         end
@@ -2876,21 +2950,81 @@ return function(app)
             return { status = 400, json = { error = "answers array is required" } }
         end
 
+        -- Optional entity scope for the whole batch: answers are stored
+        -- against that user_profile_entities row (asked-once-PER-property
+        -- questions). The entity must exist, belong to the caller, and not
+        -- be archived. NULL entity = classic questionnaire behaviour.
+        local entity_uuid = params.entity_uuid
+        if entity_uuid == "" or entity_uuid == cjson.null then entity_uuid = nil end
+        if entity_uuid then
+            local ok_ent, ent_rows = pcall(db.query, [[
+                SELECT id FROM user_profile_entities
+                WHERE uuid = ? AND user_id = ? AND is_archived = false
+                LIMIT 1
+            ]], entity_uuid, user_id)
+            if not ok_ent or not ent_rows or #ent_rows == 0 then
+                return { status = 404, json = { error = "Entity not found" } }
+            end
+        end
+
         local namespace_id = getNamespaceId(self)
         local saved = 0
         local errors = {}
         local affected_category_ids = {}
 
+        -- JSON null arrives as cjson.null (truthy lightuserdata); the DB
+        -- layer can't escape it. Map nil/cjson.null to db.NULL so clearing
+        -- an answer persists instead of failing the upsert.
+        local function scrub(v)
+            if v == nil or v == cjson.null then return db.NULL end
+            return v
+        end
+
         for i, ans in ipairs(answers) do
             if not ans.question_uuid or ans.question_uuid == "" then
                 table.insert(errors, { index = i, error = "question_uuid is required" })
             else
-                local ok_q, q_rows = pcall(db.query, "SELECT id, version, category_id, question_key FROM profile_questions WHERE uuid = ? AND is_active = true LIMIT 1", ans.question_uuid)
-                if not ok_q or not q_rows or #q_rows == 0 then
-                    table.insert(errors, { index = i, error = "Question not found: " .. ans.question_uuid })
+                local ok_q, q_rows = pcall(db.query, [[
+                    SELECT pq.id, pq.version, pq.category_id, pq.question_key,
+                           pc.context AS category_context
+                    FROM profile_questions pq
+                    JOIN profile_categories pc ON pc.id = pq.category_id
+                    WHERE pq.uuid = ? AND pq.is_active = true LIMIT 1
+                ]], ans.question_uuid)
+                local question = (ok_q and q_rows and q_rows[1]) or nil
+
+                -- Scope guard: the batch's entity scope must match the
+                -- question's category context. Per-entity batches may only
+                -- carry 'property'-context questions; classic batches must
+                -- not carry them. Without this, answers land in a scope no
+                -- surface renders (shadow rows) — and an entity-scoped save
+                -- of an identity question would stamp the NINO/UTR lock
+                -- without ever writing the canonical value.
+                local q_ctx = nil
+                local reject = nil
+                if not question then
+                    reject = "Question not found: " .. ans.question_uuid
                 else
-                    local question = q_rows[1]
-                    affected_category_ids[question.category_id] = true
+                    q_ctx = question.category_context
+                    if q_ctx == cjson.null or q_ctx == "" then q_ctx = nil end
+                    if entity_uuid and q_ctx ~= "property" then
+                        reject = "Question " .. ans.question_uuid
+                            .. " is not a per-property question — save it without entity_uuid"
+                    elseif not entity_uuid and q_ctx == "property" then
+                        reject = "Question " .. ans.question_uuid
+                            .. " is a per-property question — entity_uuid is required"
+                    end
+                end
+
+                if reject then
+                    table.insert(errors, { index = i, error = reject })
+                else
+                    -- Completion is a classic-profile concept; contexted
+                    -- (hub / per-property) categories are excluded from the
+                    -- gate, so never cache completion rows for them.
+                    if q_ctx == nil then
+                        affected_category_ids[question.category_id] = true
+                    end
 
                     -- ─── Identity-lock guard for NINO / UTR back-door ─────────
                     -- If this question_key is one of the identity fields
@@ -2906,19 +3040,35 @@ return function(app)
                         IdentityLock.assertNotLocked(user_uuid, namespace_id or 0, lock_field)
                     end
 
-                    -- Get existing answer for history
+                    -- Get existing answer for history (scoped to this batch's
+                    -- entity — NULL scope and per-entity scope are distinct rows)
                     local old_answer = nil
-                    local ok_old, old_rows = pcall(db.query, [[
-                        SELECT * FROM user_profile_answers WHERE user_id = ? AND question_id = ? LIMIT 1
-                    ]], user_id, question.id)
+                    local ok_old, old_rows
+                    if entity_uuid then
+                        ok_old, old_rows = pcall(db.query, [[
+                            SELECT * FROM user_profile_answers WHERE user_id = ? AND question_id = ? AND entity_uuid = ? LIMIT 1
+                        ]], user_id, question.id, entity_uuid)
+                    else
+                        ok_old, old_rows = pcall(db.query, [[
+                            SELECT * FROM user_profile_answers WHERE user_id = ? AND question_id = ? AND entity_uuid IS NULL LIMIT 1
+                        ]], user_id, question.id)
+                    end
                     if ok_old and old_rows and #old_rows > 0 then
                         old_answer = old_rows[1]
                     end
 
+                    -- The unique indexes are partial (see migration 725), so
+                    -- the conflict target must name the matching predicate.
+                    local conflict_clause
+                    if entity_uuid then
+                        conflict_clause = "ON CONFLICT (user_id, question_id, entity_uuid) WHERE entity_uuid IS NOT NULL DO UPDATE SET"
+                    else
+                        conflict_clause = "ON CONFLICT (user_id, question_id) WHERE entity_uuid IS NULL DO UPDATE SET"
+                    end
                     local ok_upsert, upsert_err = pcall(db.query, [[
-                        INSERT INTO user_profile_answers (uuid, user_id, user_uuid, namespace_id, question_id, question_version, answer_text, answer_number, answer_boolean, answer_date, answer_json, answer_file_url, is_draft, answered_at, updated_at)
-                        VALUES (gen_random_uuid()::text, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
-                        ON CONFLICT (user_id, question_id) DO UPDATE SET
+                        INSERT INTO user_profile_answers (uuid, user_id, user_uuid, namespace_id, question_id, entity_uuid, question_version, answer_text, answer_number, answer_boolean, answer_date, answer_json, answer_file_url, is_draft, answered_at, updated_at)
+                        VALUES (gen_random_uuid()::text, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+                        ]] .. conflict_clause .. [[
                             question_version = EXCLUDED.question_version,
                             answer_text = EXCLUDED.answer_text,
                             answer_number = EXCLUDED.answer_number,
@@ -2934,14 +3084,15 @@ return function(app)
                         user_uuid,
                         namespace_id or 0,
                         question.id,
+                        entity_uuid or db.NULL,
                         question.version or 1,
-                        ans.answer_text or db.NULL,
-                        ans.answer_number or db.NULL,
-                        ans.answer_boolean == nil and db.NULL or ans.answer_boolean,
-                        ans.answer_date or db.NULL,
-                        ans.answer_json or db.NULL,
-                        ans.answer_file_url or db.NULL,
-                        ans.is_draft == nil and false or ans.is_draft
+                        scrub(ans.answer_text),
+                        scrub(ans.answer_number),
+                        scrub(ans.answer_boolean),
+                        scrub(ans.answer_date),
+                        scrub(ans.answer_json),
+                        scrub(ans.answer_file_url),
+                        (ans.is_draft == nil or ans.is_draft == cjson.null) and false or ans.is_draft
                     )
 
                     if not ok_upsert then
@@ -2957,7 +3108,13 @@ return function(app)
                         -- COALESCE(...) that preserves the original stamp.
                         -- Also emits an audit row for the "first time this
                         -- user wrote a locking answer" event.
-                        if lock_field then
+                        -- `not entity_uuid`: identity questions are classic-
+                        -- scope only (the scope guard above enforces it); the
+                        -- extra check keeps an entity-scoped write from ever
+                        -- stamping the lock without the canonical value even
+                        -- if an admin mis-files an identity question into a
+                        -- property-context category.
+                        if lock_field and not entity_uuid then
                             IdentityLock.stampLock(user_uuid, namespace_id or 0, lock_field)
                             IdentityLock.emitAuditRow({
                                 user_id      = user_id,
@@ -2987,14 +3144,14 @@ return function(app)
                                 old_answer.answer_boolean == nil and db.NULL or old_answer.answer_boolean,
                                 old_answer.answer_date or db.NULL,
                                 old_answer.answer_json or db.NULL,
-                                ans.answer_text or db.NULL,
-                                ans.answer_number or db.NULL,
-                                ans.answer_boolean == nil and db.NULL or ans.answer_boolean,
-                                ans.answer_date or db.NULL,
-                                ans.answer_json or db.NULL,
+                                scrub(ans.answer_text),
+                                scrub(ans.answer_number),
+                                scrub(ans.answer_boolean),
+                                scrub(ans.answer_date),
+                                scrub(ans.answer_json),
                                 user_id,
                                 "user",
-                                ans.change_reason or db.NULL
+                                scrub(ans.change_reason)
                             )
                         end
                     end
@@ -3002,13 +3159,19 @@ return function(app)
             end
         end
 
-        -- Recalculate completion for affected categories
-        for category_id, _ in pairs(affected_category_ids) do
-            recalculateCompletion(user_id, user_uuid, category_id)
-        end
+        -- Completion + auto-tag machinery is profile-global (it reads the
+        -- NULL-entity answer set); running it for a per-entity batch would
+        -- both waste work and mis-count. Entity saves return current tags
+        -- untouched.
+        if not entity_uuid then
+            -- Recalculate completion for affected categories
+            for category_id, _ in pairs(affected_category_ids) do
+                recalculateCompletion(user_id, user_uuid, category_id)
+            end
 
-        -- Evaluate auto-tag rules based on updated answers
-        evaluateTagRules(user_id, user_uuid)
+            -- Evaluate auto-tag rules based on updated answers
+            evaluateTagRules(user_id, user_uuid)
+        end
 
         -- Get updated tags to return to frontend
         local updated_tags = getUserTags(user_id)

--- a/lapis/routes/tax-properties.lua
+++ b/lapis/routes/tax-properties.lua
@@ -1,0 +1,239 @@
+--[[
+    Property Income Routes — the Rental hub's backend surface.
+
+    Endpoints (all auth-required):
+      GET    /api/v2/tax/property-line-categories        admin catalogue → dropdowns
+      GET    /api/v2/tax/rental/summary?tax_year=        hub summary strip (read-only, derived)
+      GET    /api/v2/tax/properties?tax_year=            list + per-property totals
+      POST   /api/v2/tax/properties                      { label }
+      GET    /api/v2/tax/properties/:uuid
+      PUT    /api/v2/tax/properties/:uuid                { label?, metadata_json?, display_order? }
+      DELETE /api/v2/tax/properties/:uuid                soft archive (also archives its lines)
+      GET    /api/v2/tax/properties/:uuid/lines?tax_year=&kind=
+      POST   /api/v2/tax/properties/:uuid/lines          { kind, category_key, amount, tax_year, description?, disallowable_amount? }
+      PUT    /api/v2/tax/property-lines/:uuid
+      DELETE /api/v2/tax/property-lines/:uuid            soft archive
+
+    Property-scope QUESTIONS are not served here — they come from the
+    Profile Builder (/api/v2/profile-builder/schema?context=property&entity=<uuid>)
+    so admins keep full control of what's asked per property.
+]]
+
+local cjson = require("cjson")
+local PropertyQueries = require "queries.PropertyQueries"
+local PropertyLineQueries = require "queries.PropertyLineQueries"
+local AuthMiddleware = require("middleware.auth")
+
+-- YYYY-YY (e.g. 2026-27) — same contract as my-incomes.
+local function valid_tax_year(s)
+    if type(s) ~= "string" then return false end
+    local y1, y2 = s:match("^(%d%d%d%d)%-(%d%d)$")
+    if not y1 or not y2 then return false end
+    return tonumber(y2) == (tonumber(y1) + 1) % 100
+end
+
+-- Parse JSON or form body — same inline helper as my-incomes.lua, plus
+-- cjson.null normalisation: JSON null decodes to a TRUTHY lightuserdata
+-- that passes `if not x` guards (tostring() then stores "userdata: NULL"
+-- as data) and crashes db escaping. Strip nulls at the boundary so a
+-- null field behaves exactly like an absent one.
+local function parse_request_body()
+    ngx.req.read_body()
+    local content_type = ngx.var.content_type or ""
+    if content_type:find("application/json", 1, true) then
+        local ok, result = pcall(function()
+            local body = ngx.req.get_body_data()
+            if not body or body == "" then return {} end
+            return cjson.decode(body)
+        end)
+        if ok and type(result) == "table" then
+            for k, v in pairs(result) do
+                if v == cjson.null then result[k] = nil end
+            end
+            return result
+        end
+        return {}
+    end
+    local post_args = ngx.req.get_post_args()
+    if post_args and next(post_args) then return post_args end
+    return {}
+end
+
+local function merge_params(self)
+    local body_params = parse_request_body()
+    for k, v in pairs(body_params) do
+        if self.params[k] == nil then self.params[k] = v end
+    end
+end
+
+-- Validate a line-item payload. `is_create` enforces required fields.
+local function validate_line(params, is_create)
+    if is_create or params.kind ~= nil then
+        if params.kind ~= "income" and params.kind ~= "expense" then
+            return false, "kind must be 'income' or 'expense'"
+        end
+    end
+    if is_create or params.amount ~= nil then
+        local n = tonumber(params.amount)
+        if not n or n <= 0 then
+            return false, "amount is required and must be a positive number"
+        end
+        params.amount = n
+    end
+    if is_create or params.tax_year ~= nil then
+        if not valid_tax_year(params.tax_year) then
+            return false, "tax_year must be YYYY-YY (e.g. 2026-27)"
+        end
+    end
+    if is_create or params.category_key ~= nil then
+        -- Category must be active for the line's kind. On update the kind
+        -- can't change (not exposed), so validate against the stored kind
+        -- passed in by the route.
+        local kind = params.kind
+        if not kind or (kind ~= "income" and kind ~= "expense") then
+            return false, "kind must accompany category_key"
+        end
+        if not PropertyLineQueries.active_keys(kind)[params.category_key] then
+            return false, "category_key is not an active " .. kind .. " category"
+        end
+    end
+    if params.description and type(params.description) == "string" and #params.description > 500 then
+        return false, "description must be 500 characters or fewer"
+    end
+    return true
+end
+
+return function(app)
+    -- ── Catalogue ───────────────────────────────────────────────────────────
+    app:get("/api/v2/tax/property-line-categories", AuthMiddleware.requireAuth(function(_)
+        local rows = PropertyLineQueries.categories()
+        local data = {}
+        for _, r in ipairs(rows) do
+            data[#data + 1] = {
+                key = r.category_key,
+                label = r.label,
+                kind = r.kind,
+                description = r.description,
+                hmrc_mapping = r.hmrc_mapping,
+                display_order = r.display_order,
+            }
+        end
+        return { json = { data = #data > 0 and data or cjson.empty_array }, status = 200 }
+    end))
+
+    -- ── Hub summary (read-only, derived) ────────────────────────────────────
+    app:get("/api/v2/tax/rental/summary", AuthMiddleware.requireAuth(function(self)
+        local tax_year = self.params.tax_year
+        if not valid_tax_year(tax_year) then
+            return { json = { error = "tax_year must be YYYY-YY (e.g. 2026-27)" }, status = 400 }
+        end
+        local result, err = PropertyQueries.summary(tax_year, self.current_user)
+        if not result then
+            return { json = { error = err or "Failed to build summary" }, status = 400 }
+        end
+        -- Force [] (not {}) for an empty list — same guard as the list
+        -- endpoints; cjson encodes empty Lua tables as objects.
+        if #result.properties == 0 then result.properties = cjson.empty_array end
+        return { json = { data = result }, status = 200 }
+    end))
+
+    -- ── Properties ──────────────────────────────────────────────────────────
+    app:get("/api/v2/tax/properties", AuthMiddleware.requireAuth(function(self)
+        local result, err = PropertyQueries.all(self.params, self.current_user)
+        if not result then
+            return { json = { error = err or "Failed to list properties" }, status = 400 }
+        end
+        if #result.data == 0 then result.data = cjson.empty_array end
+        return { json = result, status = 200 }
+    end))
+
+    app:post("/api/v2/tax/properties", AuthMiddleware.requireAuth(function(self)
+        merge_params(self)
+        if not self.params.label or tostring(self.params.label):gsub("%s", "") == "" then
+            return { json = { error = "label is required" }, status = 400 }
+        end
+        if #tostring(self.params.label) > 120 then
+            return { json = { error = "label must be 120 characters or fewer" }, status = 400 }
+        end
+        local row, err = PropertyQueries.create(self.params, self.current_user)
+        if not row then return { json = { error = err or "Failed to create property" }, status = 400 } end
+        return { json = { data = row }, status = 201 }
+    end))
+
+    app:get("/api/v2/tax/properties/:uuid", AuthMiddleware.requireAuth(function(self)
+        local row = PropertyQueries.show(tostring(self.params.uuid), self.current_user)
+        if not row then return { json = { error = "Property not found" }, status = 404 } end
+        return { json = { data = row }, status = 200 }
+    end))
+
+    app:put("/api/v2/tax/properties/:uuid", AuthMiddleware.requireAuth(function(self)
+        merge_params(self)
+        if self.params.label ~= nil and #tostring(self.params.label) > 120 then
+            return { json = { error = "label must be 120 characters or fewer" }, status = 400 }
+        end
+        local row, err = PropertyQueries.update(tostring(self.params.uuid), self.params, self.current_user)
+        if not row then return { json = { error = err or "Property not found" }, status = err and 400 or 404 } end
+        return { json = { data = row }, status = 200 }
+    end))
+
+    app:delete("/api/v2/tax/properties/:uuid", AuthMiddleware.requireAuth(function(self)
+        local ok = PropertyQueries.archive(tostring(self.params.uuid), self.current_user)
+        if not ok then return { json = { error = "Property not found" }, status = 404 } end
+        return { json = { message = "Property archived" }, status = 200 }
+    end))
+
+    -- ── Line items ──────────────────────────────────────────────────────────
+    app:get("/api/v2/tax/properties/:uuid/lines", AuthMiddleware.requireAuth(function(self)
+        -- Ownership check first so an unknown/foreign property 404s rather
+        -- than returning an empty list.
+        local prop = PropertyQueries.show(tostring(self.params.uuid), self.current_user)
+        if not prop then return { json = { error = "Property not found" }, status = 404 } end
+        local result, err = PropertyLineQueries.all(prop.id, self.params, self.current_user)
+        if not result then
+            return { json = { error = err or "Failed to list line items" }, status = 400 }
+        end
+        if #result.data == 0 then result.data = cjson.empty_array end
+        return { json = result, status = 200 }
+    end))
+
+    app:post("/api/v2/tax/properties/:uuid/lines", AuthMiddleware.requireAuth(function(self)
+        merge_params(self)
+        local ok, vmsg = validate_line(self.params, true)
+        if not ok then return { json = { error = vmsg }, status = 400 } end
+        local row, err = PropertyLineQueries.create(tostring(self.params.uuid), self.params, self.current_user)
+        if not row then
+            local status = (err == "Property not found") and 404 or 400
+            return { json = { error = err or "Failed to create line item" }, status = status }
+        end
+        return { json = { data = row }, status = 201 }
+    end))
+
+    app:put("/api/v2/tax/property-lines/:uuid", AuthMiddleware.requireAuth(function(self)
+        merge_params(self)
+        local existing = PropertyLineQueries.show(tostring(self.params.uuid), self.current_user)
+        if not existing then return { json = { error = "Line item not found" }, status = 404 } end
+        -- kind is immutable; inject the stored kind so category validation
+        -- checks against the right catalogue half. Grandfather an unchanged
+        -- category_key (admin may have retired it since).
+        self.params.kind = nil
+        if self.params.category_key ~= nil then
+            if existing.category_key == self.params.category_key then
+                self.params.category_key = nil
+            else
+                self.params.kind = existing.kind
+            end
+        end
+        local ok, vmsg = validate_line(self.params, false)
+        if not ok then return { json = { error = vmsg }, status = 400 } end
+        self.params.kind = nil -- never persisted on update
+        local row, err = PropertyLineQueries.update(tostring(self.params.uuid), self.params, self.current_user)
+        if not row then return { json = { error = err or "Line item not found" }, status = 404 } end
+        return { json = { data = row }, status = 200 }
+    end))
+
+    app:delete("/api/v2/tax/property-lines/:uuid", AuthMiddleware.requireAuth(function(self)
+        local ok = PropertyLineQueries.archive(tostring(self.params.uuid), self.current_user)
+        if not ok then return { json = { error = "Line item not found" }, status = 404 } end
+        return { json = { message = "Line item archived" }, status = 200 }
+    end))
+end


### PR DESCRIPTION
## What

Backend for the Rental / Property income redesign in diy-tax-return-uk (hub + per-property drill-down), keeping every question admin-configurable through the existing Dynamic Profile Builder:

- **`user_profile_entities`** — user-owned instances (properties). `user_profile_answers` gains **`entity_uuid`**: the old unique `(user_id, question_id)` index becomes two partial unique indexes so a question can hold one classic answer per user *and* one answer per property.
- **`profile_categories.context`** — `NULL` = classic /profile section; `rental_business` = rental hub (asked once); `property` = per-property pages. Contexted categories are excluded from the default `/schema`, `/completion-status`, and completion recalculation.
- **`property_line_categories`** (seeded with SA105 box mappings) + **`property_line_items`** — income/expense rows per property per tax year, with CRUD under `/api/v2/tax/properties*` and a derived `/api/v2/tax/rental/summary`.
- `/schema` + `/answers` accept `context`/`entity` (entity ownership enforced); admin category CRUD accepts `context`.

Migrations **724–730** (`lapis migrate`).

## Review fixes included

A multi-agent review ran over this diff; critical findings fixed here:
- **Answer-scope validation**: entity batches may only carry `property`-context questions and vice versa — kills shadow answers and the entity-scoped NINO/UTR save that stamped the identity lock without a canonical value (`stampLock` additionally gated to classic saves).
- **Tag/completion answer maps** filter `entity_uuid IS NULL` — no nondeterministic tags/completion once a user has multiple properties.
- **Completion never recalculated for contexted categories** — hub answers can't drag `GET /completion` / admin dashboards below 100%.
- **`cjson.null` scrubbed** at body-parsing/upsert boundaries — no `"userdata: NULL"` labels, no 500s on JSON null, clearing an answer actually persists.
- **`namespace_id` always resolved server-side** on property create (was client-trustable).
- `""` clears description/metadata on update (stored as NULL).

## Deploy caveat (documented in migration 725)

Between `lapis migrate` and new pods serving, old pods' bare `ON CONFLICT (user_id, question_id)` answer upserts fail (42P10, per-answer errors, no crash) because the index is now partial. A plain unique index can't coexist with per-entity rows, so deploy at a quiet time and let the rollout complete promptly.

## Non-critical follow-ups from the review

Entity-aware completion caching, `/schema/preview` context/entity awareness, archived-property filter on show/update, context allow-list/CHECK constraint, shared `resolveUserId`/`RequestParser`/`NamespaceResolver` reuse, thin model files, luacheck line lengths.

Frontend counterpart: bwalia/diy-tax-return-uk#764.

🤖 Generated with [Claude Code](https://claude.com/claude-code)