### PR TITLE
fix(profile-builder): include category context in /schema response

### DIFF
--- a/lapis/routes/profile-builder.lua
+++ b/lapis/routes/profile-builder.lua
@@ -1004,6 +1004,12 @@ return function(app)
                 icon = cat.icon,
                 display_order = cat.display_order,
                 parent_id = cat.parent_id,
+                -- context lets clients VERIFY they got the surface they asked
+                -- for. ContextSections drops categories whose context doesn't
+                -- match its request, so a backend that ignores ?context=
+                -- (pre-migration deploys) can never render the classic
+                -- questionnaire inside the rental hub / property pages.
+                context = cat.context,
                 visibility_rule_json = cat.visibility_rule_json,
                 completion_rule_json = cat.completion_rule_json,
                 questions = q_list,


### PR DESCRIPTION
Adds `context` to each category object in the `/api/v2/profile-builder/schema` response so clients can verify they received the surface they requested. Pairs with bwalia/diy-tax-return-uk fix where ContextSections filters categories to its requested context.

Background: int currently serves pre-#474 opsapi because both deploy workflows fail for infra reasons (missing `/home/bwalia/.secrets/opsapi/diytaxreturnuk/int/.env` on the self-hosted runner; k3s API `k3s0:6443` connection refused — both also failed on the #473 merge). The stale backend ignores `?context=`, which made the full classic questionnaire render under "Your rental business" and 500'd `/rental/summary` (route absent → SYSTEM_500 envelope). Once the infra is fixed and this deploys, both symptoms resolve; the paired frontend filter makes any future stale-backend window degrade to an empty section instead of wrong questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)