### PR TITLE
fix(migration): explicit NULL parent_option_id in seed option inserts

### DIFF
--- a/lapis/migrations/property-income-system.lua
+++ b/lapis/migrations/property-income-system.lua
@@ -265,10 +265,14 @@ return {
             if not q or #q == 0 then return end
             local exists = db.select("id FROM profile_question_options WHERE question_id = ? AND value = ?", q[1].id, value)
             if exists and #exists > 0 then return end
+            -- parent_option_id must be an EXPLICIT NULL: the column is
+            -- types.integer({null = true}), which Lapis renders as
+            -- `integer DEFAULT 0` — omitting it inserts 0 and violates the
+            -- self-referencing fk_pqo_parent constraint (broke migrate on int).
             db.query([[
                 INSERT INTO profile_question_options
-                    (uuid, question_id, label, value, display_order, is_active, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, true, NOW(), NOW())
+                    (uuid, question_id, label, value, display_order, is_active, parent_option_id, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, true, NULL, NOW(), NOW())
             ]], MigrationUtils.generateUUID(), q[1].id, label, value, display_order)
         end
 


### PR DESCRIPTION
Fixes the int deploy failure `job diytaxreturn-lapis-migrate-56 failed: BackoffLimitExceeded`.

The migrate hook pod logs (captured via the enhanced diag workflow) show migration 730 dying on:

```
ERROR: insert or update on table "profile_question_options" violates foreign key constraint "fk_pqo_parent"
Key (parent_option_id)=(0) is not present in table "profile_question_options".
```

Root cause: `types.integer({null = true})` columns get `DEFAULT 0` in Lapis DDL, so the seed's `ensure_option` INSERT (which omitted `parent_option_id`) stored `0` — violating the self-referencing FK. The fix inserts an explicit `NULL`.

State on int: migrations 724–729 applied and recorded; 730 failed before recording and is fully idempotent (ensure_* helpers), so the next `lapis migrate` completes it.

After merging: wait for this repo's image push of `bwalia/opsapi:latest`, then re-dispatch `Deploy Single Environment` (ENV=int) in diy-tax-return-uk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)