### PR TITLE
feat(self-employment): businesses, SA103 fixed-box values + Capital Allowances grid

### DIFF
--- a/lapis/app.lua
+++ b/lapis/app.lua
@@ -512,6 +512,10 @@ load_if("tax_copilot", "routes.my-incomes")
 -- Rental hub: properties (user_profile_entities) + SA105 line items.
 -- Property-scope questions stay under routes.profile-builder (?context=&entity=).
 load_if("tax_copilot", "routes.tax-properties")
+-- Self-employment hub: businesses (user_profile_entities) + SA103 fixed-box
+-- values + Capital Allowances grid. Business-scope questions stay under
+-- routes.profile-builder (?context=business&entity=).
+load_if("tax_copilot", "routes.tax-businesses")
 -- Billing (single-merchant Stripe: admin plans + subscription/one-time checkout)
 load_if("tax_copilot", "routes.billing-plans")
 load_if("tax_copilot", "routes.billing-checkout")

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -166,6 +166,11 @@ local income_questionnaire_cleanup_migrations = load_if_enabled(ProjectConfig.FE
 -- entity-scoped profile answers, and SA105 line-item catalogue/rows
 local property_income_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.property-income-system") or {}
 
+-- Self-Employment (tax_copilot feature) — sole-trader hub + per-business
+-- entities (reuses user_profile_entities), SA103 fixed-box catalogue/values,
+-- and the Capital Allowances grid
+local self_employment_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.self-employment-system") or {}
+
 -- Billing / payments (Stripe Connect: subscriptions + one-time). Gated on
 -- tax_copilot for now; broaden to a feature list (e.g. {ECOMMERCE, TAX_COPILOT})
 -- once multiple project codes need it. See migrations/billing-system.lua.
@@ -1873,6 +1878,20 @@ local _migrations = {
     ['728_seed_property_line_categories'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, property_income_migrations, 5),
     ['729_create_property_line_items'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, property_income_migrations, 6),
     ['730_seed_property_sections'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, property_income_migrations, 7),
+
+    -- =========================================================================
+    -- SELF-EMPLOYMENT — sole-trader hub + per-business drill-down (same
+    -- architecture as Property Income). 731-732 add the SA103 fixed-box
+    -- catalogue + seed; 733 the per-year values; 734-735 the Capital
+    -- Allowances grid catalogues + cells; 736 seeds the admin-editable
+    -- 'business' contexted question section.
+    -- =========================================================================
+    ['731_create_business_line_categories'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, self_employment_migrations, 1),
+    ['732_seed_business_line_categories'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, self_employment_migrations, 2),
+    ['733_create_business_line_values'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, self_employment_migrations, 3),
+    ['734_create_business_ca_catalogues'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, self_employment_migrations, 4),
+    ['735_create_business_ca_values'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, self_employment_migrations, 5),
+    ['736_seed_business_section'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, self_employment_migrations, 6),
 
     -- =========================================================================
     -- Academy (LMS): courses + lessons (namespace-scoped). Feature-gated, so

--- a/lapis/migrations/self-employment-system.lua
+++ b/lapis/migrations/self-employment-system.lua
@@ -1,0 +1,414 @@
+--[[
+  Self-Employment System — Sole-trader income redesign (hub + per-business
+  drill-down), following the Property Income System pattern one-for-one:
+
+  1. Businesses are user_profile_entities rows with entity_type='business'
+     (the table was built generic for exactly this reuse — no schema change).
+  2. Per-business QUESTIONS (description, address, dates, accounting basis)
+     are Profile Builder categories with context='business', answered with
+     entity_uuid scope — admin-configurable, never hardcoded in the frontend.
+  3. business_line_categories : admin catalogue of the SA103 "boxes" the
+     trade form renders — income / allowance / expense / capital_allowance /
+     adjustment / balance_sheet — with hmrc_mapping for box routing.
+     Unlike rental line items (free rows, add-as-many-as-you-like), the
+     self-employment form is FIXED-BOX: one value per category per business
+     per tax year, edited in place.
+  4. business_line_values     : those values (amount + optional disallowable
+     split for expenses). Upsert semantics — clearing a box deletes the row.
+  5. business_ca_pools/rows   : admin catalogues for the Capital Allowances
+     grid (columns = asset pools, rows = computation lines) replicated from
+     the reference layout.
+  6. business_ca_values       : one cell of that grid per (business, tax
+     year, pool, row).
+
+  Only executed when PROJECT_CODE includes 'tax_copilot'.
+]]
+
+local schema = require("lapis.db.schema")
+local types = schema.types
+local db = require("lapis.db")
+local MigrationUtils = require "helper.migration-utils"
+
+return {
+    -- =========================================================================
+    -- 1. business_line_categories (admin catalogue for the fixed-box form)
+    -- =========================================================================
+    [1] = function()
+        schema.create_table("business_line_categories", {
+            { "id",                    types.serial },
+            { "uuid",                  types.varchar({ unique = true }) },
+            { "namespace_id",          types.integer({ null = true }) },
+            { "kind",                  types.varchar },               -- income|allowance|expense|capital_allowance|adjustment|balance_sheet
+            { "category_key",          types.varchar },               -- stable key, e.g. 'turnover'
+            { "label",                 types.varchar },
+            { "description",           types.text({ null = true }) },
+            { "hmrc_mapping",          types.text({ null = true }) }, -- JSON, e.g. {"sa103f_box":"15"}
+            { "supports_disallowable", types.boolean({ default = false }) },
+            { "display_order",         types.integer({ default = 0 }) },
+            { "is_active",             types.boolean({ default = true }) },
+            { "created_at",            types.time({ default = db.raw("NOW()") }) },
+            { "updated_at",            types.time({ default = db.raw("NOW()") }) },
+            "PRIMARY KEY (id)"
+        })
+        schema.create_index("business_line_categories", "kind")
+        schema.create_index("business_line_categories", "is_active")
+        -- category_key is globally unique (not per-kind): value rows store
+        -- the key alone and the upsert conflict target must be unambiguous.
+        db.query("CREATE UNIQUE INDEX IF NOT EXISTS idx_blc_key ON business_line_categories (category_key)")
+        print("[Self Employment] Created business_line_categories table")
+    end,
+
+    -- =========================================================================
+    -- 2. Seed the SA103F-shaped catalogue.
+    --    Idempotent: keyed on category_key; re-running updates labels and
+    --    mappings but never duplicates or resurrects disabled rows.
+    -- =========================================================================
+    [2] = function()
+        local rows = {
+            -- Income (SA103F boxes 15/16)
+            { kind = "income", key = "turnover", label = "Business turnover", box = "15", order = 1,
+              desc = "Your takings, fees and sales before any expenses" },
+            { kind = "income", key = "other_income", label = "Any other business income", box = "16", order = 2,
+              desc = "e.g. grants or rental income from business premises — not the trading allowance" },
+            -- Trading income allowance (box 16.1)
+            { kind = "allowance", key = "trading_income_allowance", label = "Trading income allowance claimed (up to £1,000)", box = "16.1", order = 1,
+              desc = "If you claim the allowance you can't also claim expenses. Only worth it when expenses are under £1,000 — and it's one allowance across ALL your trades." },
+            -- Expenses (SA103F boxes 17–30, disallowable 32–45)
+            { kind = "expense", key = "cost_of_goods",         label = "Cost of goods bought for resale or goods used",     box = "17", dbox = "32", order = 1 },
+            { kind = "expense", key = "cis_subcontractors",    label = "Construction industry — payments to subcontractors", box = "18", dbox = "33", order = 2 },
+            { kind = "expense", key = "wages_staff",           label = "Wages, salaries and other staff costs",             box = "19", dbox = "34", order = 3,
+              desc = "Don't include money you took out for yourself — that's drawings, not an expense" },
+            { kind = "expense", key = "car_van_travel",        label = "Car, van and travel expenses",                      box = "20", dbox = "35", order = 4 },
+            { kind = "expense", key = "rent_rates_power",      label = "Rent, rates, power and insurance costs",            box = "21", dbox = "36", order = 5 },
+            { kind = "expense", key = "repairs_maintenance",   label = "Repairs and maintenance of property and equipment", box = "22", dbox = "37", order = 6 },
+            { kind = "expense", key = "phone_office",          label = "Phone, fax, stationery and other office costs",     box = "23", dbox = "38", order = 7 },
+            { kind = "expense", key = "advertising",           label = "Advertising costs",                                 box = "24", dbox = "39", order = 8 },
+            { kind = "expense", key = "business_entertainment", label = "Business entertainment costs",                     box = "24", dbox = "39", order = 9,
+              desc = "Client entertainment is normally disallowable for tax — record it in the disallowable column too" },
+            { kind = "expense", key = "interest_loans",        label = "Interest on bank and other loans",                  box = "25", dbox = "40", order = 10 },
+            { kind = "expense", key = "bank_charges",          label = "Bank, credit card and other financial charges",     box = "26", dbox = "41", order = 11 },
+            { kind = "expense", key = "irrecoverable_debts",   label = "Irrecoverable debts written off",                   box = "27", dbox = "42", order = 12 },
+            { kind = "expense", key = "professional_fees",     label = "Accountancy, legal and other professional fees",    box = "28", dbox = "43", order = 13 },
+            { kind = "expense", key = "depreciation",          label = "Depreciation and loss/profit on sale of assets",    box = "29", dbox = "44", order = 14,
+              desc = "Depreciation is always disallowable for tax — claim capital allowances instead" },
+            { kind = "expense", key = "other_expenses",        label = "Other business expenses",                           box = "30", dbox = "45", order = 15 },
+            -- Capital allowances & non-taxable items (SA103F boxes 49–59)
+            { kind = "capital_allowance", key = "aia",                        label = "Annual Investment Allowance",                                        box = "49", order = 1 },
+            { kind = "capital_allowance", key = "small_pool_balance",         label = "Small pool balance written off",                                     box = "50", order = 2 },
+            { kind = "capital_allowance", key = "ca_equipment_main",          label = "Capital allowance on equipment — main rate",                         box = "50", order = 3 },
+            { kind = "capital_allowance", key = "ca_equipment_special",       label = "Capital allowance on equipment — special rate",                      box = "51", order = 4 },
+            { kind = "capital_allowance", key = "ca_single_asset_main",       label = "Capital allowances on single asset pools — main rate",               box = "50", order = 5 },
+            { kind = "capital_allowance", key = "ca_single_asset_special",    label = "Capital allowances on single asset pools — special rate",            box = "51", order = 6 },
+            { kind = "capital_allowance", key = "zero_emission_goods_vehicle", label = "Zero-emission goods vehicle allowance",                             box = "52", order = 7 },
+            { kind = "capital_allowance", key = "zero_emission_car",          label = "Zero-emission car allowance",                                        box = "52", order = 8 },
+            { kind = "capital_allowance", key = "sba",                        label = "Structures and Buildings Allowance",                                 box = "53", order = 9 },
+            { kind = "capital_allowance", key = "freeport_sba",               label = "Freeport and Investment Zones Structures and Buildings Allowance",   box = "53", order = 10 },
+            { kind = "capital_allowance", key = "electric_charge_point",      label = "Electric charge-point allowance",                                    box = "54", order = 11 },
+            { kind = "capital_allowance", key = "enhanced_100",               label = "100% and other enhanced capital allowances",                         box = "54", order = 12 },
+            -- Transitional profit / losses / other deductions (SA103F 68–75 area)
+            { kind = "adjustment", key = "transitional_profit_bf",      label = "Transitional profit brought forward",       box = "73", order = 1,
+              desc = "Basis-period reform: profit being spread from the 2023–24 transition year" },
+            { kind = "adjustment", key = "accelerated_transition_profit", label = "Accelerated transition profit",           box = "73", order = 2,
+              desc = "Extra transition profit you choose to tax this year on top of the automatic spread" },
+            { kind = "adjustment", key = "transitional_profit_taxable", label = "Transitional profit taxable this year",     box = "73", order = 3 },
+            { kind = "adjustment", key = "loss_brought_forward",        label = "Loss brought forward from earlier years",   box = "74", order = 4 },
+            { kind = "adjustment", key = "non_arms_length_income",      label = "Any other business income (e.g. non-arm's-length reverse premiums)", box = "75", order = 5 },
+            { kind = "adjustment", key = "fig_claim",                   label = "Amount claimed under the foreign income and gains (FIG) regime",     box = "75", order = 6 },
+            { kind = "adjustment", key = "fig_loss_adjustment",         label = "Adjustment to losses from a FIG regime claim",                       box = "75", order = 7 },
+            -- Balance sheet (SA103F boxes 83–99; optional section)
+            { kind = "balance_sheet", key = "bs_equipment",            label = "Equipment, machinery and vehicles",     box = "83", order = 1 },
+            { kind = "balance_sheet", key = "bs_other_fixed_assets",   label = "Other fixed assets",                    box = "84", order = 2 },
+            { kind = "balance_sheet", key = "bs_stock",                label = "Stock and work in progress",            box = "85", order = 3 },
+            { kind = "balance_sheet", key = "bs_trade_debtors",        label = "Trade debtors",                         box = "86", order = 4 },
+            { kind = "balance_sheet", key = "bs_bank",                 label = "Bank and building society balances",    box = "87", order = 5 },
+            { kind = "balance_sheet", key = "bs_cash",                 label = "Cash in hand",                          box = "88", order = 6 },
+            { kind = "balance_sheet", key = "bs_other_current_assets", label = "Other current assets and prepayments",  box = "89", order = 7 },
+            { kind = "balance_sheet", key = "bs_trade_creditors",      label = "Trade creditors",                       box = "91", order = 8 },
+            { kind = "balance_sheet", key = "bs_loans_overdrafts",     label = "Loans and overdrafts",                  box = "92", order = 9 },
+            { kind = "balance_sheet", key = "bs_other_liabilities",    label = "Other liabilities and accruals",        box = "93", order = 10 },
+            { kind = "balance_sheet", key = "bs_balance_start",        label = "Balance at start of period",            box = "94", order = 11 },
+            { kind = "balance_sheet", key = "bs_capital_introduced",   label = "Capital introduced",                    box = "96", order = 12 },
+            { kind = "balance_sheet", key = "bs_drawings",             label = "Drawings",                              box = "97", order = 13 },
+        }
+        for _, r in ipairs(rows) do
+            local mapping = '{"sa103f_box":"' .. r.box .. '"'
+                .. (r.dbox and (',"disallowable_box":"' .. r.dbox .. '"') or "")
+                .. '}'
+            local supports_disallowable = r.dbox and true or false
+            local exists = db.select("id FROM business_line_categories WHERE category_key = ?", r.key)
+            if exists and #exists > 0 then
+                db.query([[
+                    UPDATE business_line_categories
+                       SET kind = ?, label = ?, description = ?, hmrc_mapping = ?,
+                           supports_disallowable = ?, display_order = ?, updated_at = NOW()
+                     WHERE category_key = ?
+                ]], r.kind, r.label, r.desc or db.NULL, mapping, supports_disallowable, r.order, r.key)
+            else
+                db.query([[
+                    INSERT INTO business_line_categories
+                        (uuid, kind, category_key, label, description, hmrc_mapping, supports_disallowable, display_order, is_active, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, true, NOW(), NOW())
+                ]], MigrationUtils.generateUUID(), r.kind, r.key, r.label, r.desc or db.NULL, mapping, supports_disallowable, r.order)
+            end
+        end
+        print("[Self Employment] Seeded business_line_categories (SA103F boxes)")
+    end,
+
+    -- =========================================================================
+    -- 3. business_line_values — ONE value per (business, tax year, category).
+    --    business_uuid references user_profile_entities.uuid — varchar, no FK,
+    --    same softness rationale as property_line_items.
+    -- =========================================================================
+    [3] = function()
+        schema.create_table("business_line_values", {
+            { "id",                  types.serial },
+            { "uuid",                types.varchar({ unique = true }) },
+            { "user_id",             types.integer },
+            { "namespace_id",        types.integer({ null = true }) },
+            { "business_uuid",       types.varchar },
+            { "tax_year",            types.varchar },               -- YYYY-YY e.g. "2026-27"
+            { "kind",                types.varchar },               -- denormalised from the catalogue for grouped sums
+            { "category_key",        types.varchar },
+            { "amount",              "numeric(15,2)" },             -- nullable: a disallowable-only entry keeps amount NULL
+            { "disallowable_amount", "numeric(15,2)" },
+            { "created_at",          types.time({ default = db.raw("NOW()") }) },
+            { "updated_at",          types.time({ default = db.raw("NOW()") }) },
+            "PRIMARY KEY (id)"
+        })
+        schema.create_index("business_line_values", "user_id")
+        schema.create_index("business_line_values", "business_uuid")
+        schema.create_index("business_line_values", "user_id", "tax_year")
+        db.query([[
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_blv_cell
+            ON business_line_values (user_id, business_uuid, tax_year, category_key)
+        ]])
+        print("[Self Employment] Created business_line_values table")
+    end,
+
+    -- =========================================================================
+    -- 4. Capital Allowances grid catalogues (columns = pools, rows = lines)
+    --    + seed replicating the reference layout. Admin-editable afterwards.
+    -- =========================================================================
+    [4] = function()
+        schema.create_table("business_ca_pools", {
+            { "id",            types.serial },
+            { "uuid",          types.varchar({ unique = true }) },
+            { "namespace_id",  types.integer({ null = true }) },
+            { "pool_key",      types.varchar({ unique = true }) },
+            { "label",         types.varchar },
+            { "display_order", types.integer({ default = 0 }) },
+            { "is_active",     types.boolean({ default = true }) },
+            { "created_at",    types.time({ default = db.raw("NOW()") }) },
+            { "updated_at",    types.time({ default = db.raw("NOW()") }) },
+            "PRIMARY KEY (id)"
+        })
+        schema.create_table("business_ca_rows", {
+            { "id",            types.serial },
+            { "uuid",          types.varchar({ unique = true }) },
+            { "namespace_id",  types.integer({ null = true }) },
+            { "row_key",       types.varchar({ unique = true }) },
+            { "label",         types.varchar },
+            { "display_order", types.integer({ default = 0 }) },
+            { "is_active",     types.boolean({ default = true }) },
+            { "created_at",    types.time({ default = db.raw("NOW()") }) },
+            { "updated_at",    types.time({ default = db.raw("NOW()") }) },
+            "PRIMARY KEY (id)"
+        })
+
+        local pools = {
+            { key = "pm_main",      label = "Plant & machinery — Main pool" },
+            { key = "pm_special",   label = "Plant & machinery — Special rate pool" },
+            { key = "short_life",   label = "Short life assets" },
+            { key = "private_use",  label = "Assets with private use" },
+            { key = "sba",          label = "Structures and Buildings Allowance" },
+            { key = "rd",           label = "Research & Development" },
+            { key = "know_how",     label = "Know-how" },
+            { key = "patents",      label = "Patents" },
+            { key = "freeport_sba", label = "Freeport and Investment Zones Structures and Buildings" },
+        }
+        for i, p in ipairs(pools) do
+            local exists = db.select("id FROM business_ca_pools WHERE pool_key = ?", p.key)
+            if exists and #exists > 0 then
+                db.query("UPDATE business_ca_pools SET label = ?, display_order = ?, updated_at = NOW() WHERE pool_key = ?",
+                    p.label, i, p.key)
+            else
+                db.query([[
+                    INSERT INTO business_ca_pools (uuid, pool_key, label, display_order, is_active, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, true, NOW(), NOW())
+                ]], MigrationUtils.generateUUID(), p.key, p.label, i)
+            end
+        end
+
+        local ca_rows = {
+            { key = "wdv_bf",                    label = "WDV B/Fwd" },
+            { key = "additions_fya",             label = "Additions eligible for FYA" },
+            { key = "fya_100",                   label = "FYA @ 100%" },
+            { key = "additions_fya_40",          label = "Additions eligible for FYA (40%)" },
+            { key = "fya_40_claimed",            label = "40% FYA claimed" },
+            { key = "additions_aia",             label = "Additions eligible for AIA" },
+            { key = "aia",                       label = "AIA (limit £1,000,000)" },
+            { key = "other_additions",           label = "Other additions" },
+            { key = "disposal_proceeds",         label = "Less: disposal proceeds" },
+            { key = "balancing",                 label = "Balancing (allowance)/charge" },
+            { key = "balancing_super_deduction", label = "Balancing charge on Super Deduction" },
+            { key = "balancing_full_expensing",  label = "Balancing charge on Full Expensing" },
+            { key = "residue",                   label = "Residue" },
+            { key = "small_pools_wda",           label = "Small pools WDA" },
+            { key = "wda",                       label = "WDA" },
+            { key = "private_use_adj",           label = "Private use" },
+            { key = "wda_not_claimed",           label = "WDA not claimed" },
+            { key = "wdv_cf",                    label = "WDV C/Fwd" },
+            { key = "allowances_claimed",        label = "Allowances claimed" },
+        }
+        for i, r in ipairs(ca_rows) do
+            local exists = db.select("id FROM business_ca_rows WHERE row_key = ?", r.key)
+            if exists and #exists > 0 then
+                db.query("UPDATE business_ca_rows SET label = ?, display_order = ?, updated_at = NOW() WHERE row_key = ?",
+                    r.label, i, r.key)
+            else
+                db.query([[
+                    INSERT INTO business_ca_rows (uuid, row_key, label, display_order, is_active, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, true, NOW(), NOW())
+                ]], MigrationUtils.generateUUID(), r.key, r.label, i)
+            end
+        end
+        print("[Self Employment] Created + seeded business_ca_pools / business_ca_rows")
+    end,
+
+    -- =========================================================================
+    -- 5. business_ca_values — one grid cell per (business, tax year, pool, row)
+    -- =========================================================================
+    [5] = function()
+        schema.create_table("business_ca_values", {
+            { "id",           types.serial },
+            { "uuid",         types.varchar({ unique = true }) },
+            { "user_id",      types.integer },
+            { "namespace_id", types.integer({ null = true }) },
+            { "business_uuid", types.varchar },
+            { "tax_year",     types.varchar },
+            { "pool_key",     types.varchar },
+            { "row_key",      types.varchar },
+            { "amount",       "numeric(15,2) NOT NULL" },
+            { "created_at",   types.time({ default = db.raw("NOW()") }) },
+            { "updated_at",   types.time({ default = db.raw("NOW()") }) },
+            "PRIMARY KEY (id)"
+        })
+        schema.create_index("business_ca_values", "user_id")
+        schema.create_index("business_ca_values", "business_uuid", "tax_year")
+        db.query([[
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_bcv_cell
+            ON business_ca_values (user_id, business_uuid, tax_year, pool_key, row_key)
+        ]])
+        print("[Self Employment] Created business_ca_values table")
+    end,
+
+    -- =========================================================================
+    -- 6. Seed the per-business contexted question section (context='business',
+    --    answered with entity_uuid scope — asked once PER business).
+    --    Same idempotent helpers as property-income-system [7].
+    -- =========================================================================
+    [6] = function()
+        local function ensure_category(slug, name, description, icon, display_order, context)
+            local exists = db.select("id FROM profile_categories WHERE slug = ?", slug)
+            if exists and #exists > 0 then
+                db.query([[
+                    UPDATE profile_categories
+                       SET name = ?, description = ?, icon = ?, display_order = ?, context = ?,
+                           is_active = true, is_archived = false, updated_at = NOW()
+                     WHERE slug = ?
+                ]], name, description, icon, display_order, context, slug)
+                return exists[1].id
+            end
+            db.query([[
+                INSERT INTO profile_categories
+                    (uuid, namespace_id, name, slug, description, icon, display_order, context, is_active, is_archived, created_at, updated_at)
+                VALUES (?, 0, ?, ?, ?, ?, ?, ?, true, false, NOW(), NOW())
+            ]], MigrationUtils.generateUUID(), name, slug, description, icon, display_order, context)
+            local row = db.select("id FROM profile_categories WHERE slug = ?", slug)
+            return row and row[1] and row[1].id or nil
+        end
+
+        local function ensure_question(cat_id, q)
+            local exists = db.select("id FROM profile_questions WHERE question_key = ?", q.question_key)
+            if exists and #exists > 0 then
+                db.query([[
+                    UPDATE profile_questions
+                       SET category_id = ?, label = ?, question_type = ?, is_required = ?,
+                           display_order = ?, help_text = ?, placeholder = ?,
+                           is_active = true, is_archived = false, updated_at = NOW()
+                     WHERE question_key = ?
+                ]], cat_id, q.label, q.question_type, q.is_required, q.display_order, q.help_text or "", q.placeholder or "", q.question_key)
+                return exists[1].id
+            end
+            db.query([[
+                INSERT INTO profile_questions
+                    (uuid, category_id, question_key, label, question_type, is_required, display_order, help_text, placeholder, is_active, version, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, true, 1, NOW(), NOW())
+            ]], MigrationUtils.generateUUID(), cat_id, q.question_key, q.label, q.question_type, q.is_required, q.display_order, q.help_text or "", q.placeholder or "")
+            local row = db.select("id FROM profile_questions WHERE question_key = ?", q.question_key)
+            return row and row[1] and row[1].id or nil
+        end
+
+        local function ensure_option(question_key, value, label, display_order)
+            local q = db.select("id FROM profile_questions WHERE question_key = ?", question_key)
+            if not q or #q == 0 then return end
+            local exists = db.select("id FROM profile_question_options WHERE question_id = ? AND value = ?", q[1].id, value)
+            if exists and #exists > 0 then return end
+            -- parent_option_id must be an EXPLICIT NULL: the column is
+            -- types.integer({null = true}), which Lapis renders as
+            -- `integer DEFAULT 0` — omitting it inserts 0 and violates the
+            -- self-referencing fk_pqo_parent constraint (broke migrate on int
+            -- for the property-income seed).
+            db.query([[
+                INSERT INTO profile_question_options
+                    (uuid, question_id, label, value, display_order, is_active, parent_option_id, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, true, NULL, NOW(), NOW())
+            ]], MigrationUtils.generateUUID(), q[1].id, label, value, display_order)
+        end
+
+        local function ensure_rule(target_key, source_key, rule_name, operator, expected_value)
+            local tgt = db.select("id FROM profile_questions WHERE question_key = ?", target_key)
+            local src = db.select("id FROM profile_questions WHERE question_key = ?", source_key)
+            if not tgt or #tgt == 0 or not src or #src == 0 then return end
+            local exists = db.select("id FROM profile_question_rules WHERE question_id = ? AND source_question_id = ?", tgt[1].id, src[1].id)
+            if exists and #exists > 0 then return end
+            db.query([[
+                INSERT INTO profile_question_rules
+                    (uuid, question_id, rule_name, rule_type, operator, source_question_id, expected_value, logic_group, is_active, created_at, updated_at)
+                VALUES (?, ?, ?, 'visibility', ?, ?, ?, 'AND', true, NOW(), NOW())
+            ]], MigrationUtils.generateUUID(), tgt[1].id, rule_name, operator, src[1].id, expected_value)
+        end
+
+        -- ── Business details (asked once PER business) ──────────────────────
+        local bd_id = ensure_category("business-details", "Business details",
+            "Details about this business", "briefcase", 1, "business")
+        if bd_id then
+            ensure_question(bd_id, { question_key = "se_description", label = "What does the business do?",
+                question_type = "text", is_required = false, display_order = 1,
+                placeholder = "e.g. Plumbing and heating services" })
+            ensure_question(bd_id, { question_key = "se_address", label = "Business address (unless you work from home)",
+                question_type = "address", is_required = false, display_order = 2 })
+            ensure_question(bd_id, { question_key = "se_details_changed", label = "Did the business name or address change in the last 12 months?",
+                question_type = "boolean", is_required = false, display_order = 3 })
+            ensure_question(bd_id, { question_key = "se_start_date", label = "When did the business start?",
+                question_type = "date", is_required = false, display_order = 4,
+                help_text = "Only needed if it started within this tax year" })
+            ensure_question(bd_id, { question_key = "se_ceased", label = "Has the business stopped trading?",
+                question_type = "boolean", is_required = false, display_order = 5 })
+            ensure_question(bd_id, { question_key = "se_cessation_date", label = "When did it stop?",
+                question_type = "date", is_required = false, display_order = 6 })
+            ensure_question(bd_id, { question_key = "se_accounting_basis", label = "How do you record income and expenses?",
+                question_type = "single_select", is_required = false, display_order = 7,
+                help_text = "Cash basis counts money when it actually moves; traditional (accruals) counts it when it's due. Most sole traders use cash basis." })
+            ensure_question(bd_id, { question_key = "se_period_start", label = "Start of accounting period",
+                question_type = "date", is_required = false, display_order = 8,
+                help_text = "Most sole traders use 6 April to 5 April — leave blank if unsure" })
+            ensure_question(bd_id, { question_key = "se_period_end", label = "End of accounting period",
+                question_type = "date", is_required = false, display_order = 9 })
+        end
+        ensure_option("se_accounting_basis", "cash", "Cash basis (recommended for most sole traders)", 1)
+        ensure_option("se_accounting_basis", "accruals", "Traditional (accruals) accounting", 2)
+        ensure_rule("se_cessation_date", "se_ceased", "Show when business has ceased", "equals", "true")
+        print("[Self Employment] Seeded business-details section: 9 questions, 1 rule")
+    end,
+}

--- a/lapis/queries/BusinessQueries.lua
+++ b/lapis/queries/BusinessQueries.lua
@@ -1,0 +1,273 @@
+--[[
+    Business Queries — user_profile_entities rows of entity_type 'business'.
+
+    A "business" is the drill-down unit of the Self-employment hub (one row
+    per sole-trader trade). Each business carries:
+      * a user-facing label (the business name shown in the hub list)
+      * entity-scoped Profile Builder answers (context='business')
+      * fixed-box SA103 values (business_line_values — see BusinessValueQueries)
+      * Capital Allowances grid cells (business_ca_values)
+
+    Mirrors PropertyQueries exactly: every read/write scoped to the
+    authenticated user, soft-delete via is_archived, uuid-as-id responses,
+    tax_audit_logs rows on mutation.
+]]
+
+local Global = require "helper.global"
+local TaxAuditLogQueries = require "queries.TaxAuditLogQueries"
+local db = require("lapis.db")
+local cjson = require("cjson")
+
+local BusinessQueries = {}
+
+local ENTITY_TYPE = "business"
+
+local function resolveUserId(user)
+    if not user then return nil, "User not authenticated" end
+    local user_uuid = user.uuid or user.id
+    local rows
+    if user.uuid then
+        rows = db.query("SELECT id FROM users WHERE uuid = ? LIMIT 1", user_uuid)
+    else
+        rows = db.query("SELECT id FROM users WHERE id = ? LIMIT 1", user_uuid)
+    end
+    if not rows or #rows == 0 then return nil, "User not found" end
+    return rows[1].id
+end
+
+local function resolveNamespaceId(internal_user_id)
+    local rows = db.query([[
+        SELECT default_namespace_id FROM user_namespace_settings
+        WHERE user_id = ? LIMIT 1
+    ]], internal_user_id)
+    if rows and #rows > 0 and rows[1].default_namespace_id then
+        return tonumber(rows[1].default_namespace_id)
+    end
+    return nil
+end
+
+local function present(row)
+    row.id = row.uuid
+    row.user_id = nil
+    return row
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- List — optionally decorated with income/expense totals for one tax year so
+-- the hub can render per-business figures in a single call.
+-- ────────────────────────────────────────────────────────────────────────────
+-- params: { tax_year?, include_archived? }
+function BusinessQueries.all(params, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local where = { "user_id = ?", "entity_type = ?" }
+    local args = { internal_user_id, ENTITY_TYPE }
+    if params.include_archived ~= "true" and params.include_archived ~= true then
+        table.insert(where, "is_archived = false")
+    end
+
+    local rows = db.query(
+        "SELECT * FROM user_profile_entities WHERE " .. table.concat(where, " AND ")
+        .. " ORDER BY display_order ASC, created_at ASC",
+        unpack(args)) or {}
+
+    -- Per-business totals for the requested tax year (one grouped query,
+    -- not N+1). value_count spans ALL kinds so the hub can tell "untouched"
+    -- from "no income yet".
+    local totals = {}
+    if params.tax_year and params.tax_year ~= "" and #rows > 0 then
+        local t_rows = db.query([[
+            SELECT business_uuid, kind,
+                   SUM(COALESCE(amount, 0)) AS total,
+                   COUNT(*) AS value_count
+            FROM business_line_values
+            WHERE user_id = ? AND tax_year = ?
+            GROUP BY business_uuid, kind
+        ]], internal_user_id, params.tax_year) or {}
+        for _, t in ipairs(t_rows) do
+            totals[t.business_uuid] = totals[t.business_uuid] or { income = 0, expense = 0, value_count = 0 }
+            local bucket = totals[t.business_uuid]
+            if t.kind == "income" then bucket.income = tonumber(t.total) or 0 end
+            if t.kind == "expense" then bucket.expense = tonumber(t.total) or 0 end
+            bucket.value_count = bucket.value_count + (tonumber(t.value_count) or 0)
+        end
+    end
+
+    for _, r in ipairs(rows) do
+        local t = totals[r.uuid]
+        r.income_total = t and t.income or 0
+        r.expense_total = t and t.expense or 0
+        r.value_count = t and t.value_count or 0
+        present(r)
+    end
+    return { data = rows, total = #rows }
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Show (ownership-scoped). Also used as the ownership guard by the values /
+-- CA-grid routes — keep the return shape stable.
+-- ────────────────────────────────────────────────────────────────────────────
+function BusinessQueries.show(business_uuid, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local rows = db.query([[
+        SELECT * FROM user_profile_entities
+        WHERE uuid = ? AND user_id = ? AND entity_type = ?
+        LIMIT 1
+    ]], business_uuid, internal_user_id, ENTITY_TYPE)
+    if not rows or #rows == 0 then return nil end
+    return present(rows[1])
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Create — label (the business name) is the only required field; everything
+-- else is admin-driven questions + fixed-box values entered later.
+-- ────────────────────────────────────────────────────────────────────────────
+function BusinessQueries.create(data, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    if not data.label or data.label == "" then
+        return nil, "label is required"
+    end
+
+    local uuid = Global.generateUUID()
+    -- namespace_id is always resolved server-side — a client-supplied value
+    -- would let callers stamp their rows into an arbitrary tenant.
+    db.query([[
+        INSERT INTO user_profile_entities
+            (uuid, user_id, user_uuid, namespace_id, entity_type, label, metadata_json, display_order, is_archived, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, false, NOW(), NOW())
+    ]],
+        uuid,
+        internal_user_id,
+        tostring(user.uuid or user.id),
+        resolveNamespaceId(internal_user_id) or db.NULL,
+        ENTITY_TYPE,
+        tostring(data.label),
+        data.metadata_json or db.NULL,
+        tonumber(data.display_order) or 0
+    )
+    local row = db.query("SELECT * FROM user_profile_entities WHERE uuid = ? LIMIT 1", uuid)[1]
+
+    TaxAuditLogQueries.log({
+        user_id = internal_user_id,
+        user_email = user.email,
+        entity_type = "BUSINESS",
+        entity_id = uuid,
+        action = "CREATE",
+        new_values = cjson.encode(row),
+    })
+    return present(row)
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Update (label / metadata / display_order)
+-- ────────────────────────────────────────────────────────────────────────────
+function BusinessQueries.update(business_uuid, data, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local existing = db.query([[
+        SELECT * FROM user_profile_entities
+        WHERE uuid = ? AND user_id = ? AND entity_type = ? LIMIT 1
+    ]], business_uuid, internal_user_id, ENTITY_TYPE)
+    if not existing or #existing == 0 then return nil end
+    local old = existing[1]
+
+    local updates, args = {}, {}
+    if data.label ~= nil then
+        if data.label == "" then return nil, "label cannot be empty" end
+        table.insert(updates, "label = ?"); table.insert(args, tostring(data.label))
+    end
+    if data.metadata_json ~= nil then
+        -- "" clears (stored as NULL) — same contract as PropertyQueries.
+        table.insert(updates, "metadata_json = ?")
+        table.insert(args, data.metadata_json ~= "" and data.metadata_json or db.NULL)
+    end
+    if data.display_order ~= nil then
+        table.insert(updates, "display_order = ?"); table.insert(args, tonumber(data.display_order) or 0)
+    end
+    if #updates == 0 then return present(old) end
+
+    table.insert(updates, "updated_at = NOW()")
+    table.insert(args, business_uuid)
+    table.insert(args, internal_user_id)
+    db.query("UPDATE user_profile_entities SET " .. table.concat(updates, ", ")
+        .. " WHERE uuid = ? AND user_id = ?", unpack(args))
+
+    local refreshed = db.query("SELECT * FROM user_profile_entities WHERE uuid = ? LIMIT 1", business_uuid)[1]
+
+    TaxAuditLogQueries.log({
+        user_id = internal_user_id,
+        user_email = user.email,
+        entity_type = "BUSINESS",
+        entity_id = business_uuid,
+        action = "UPDATE",
+        old_values = cjson.encode(old),
+        new_values = cjson.encode(refreshed),
+    })
+    return present(refreshed)
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Archive (soft delete) — hard-deletes nothing: fixed-box values and CA
+-- cells stay in place (they drop out of summaries because the business list
+-- excludes archived entities), and entity-scoped answers keep history.
+-- ────────────────────────────────────────────────────────────────────────────
+function BusinessQueries.archive(business_uuid, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local existing = db.query([[
+        SELECT * FROM user_profile_entities
+        WHERE uuid = ? AND user_id = ? AND entity_type = ? LIMIT 1
+    ]], business_uuid, internal_user_id, ENTITY_TYPE)
+    if not existing or #existing == 0 then return nil end
+
+    db.query([[
+        UPDATE user_profile_entities
+           SET is_archived = true, archived_at = NOW(), updated_at = NOW()
+         WHERE uuid = ? AND user_id = ?
+    ]], business_uuid, internal_user_id)
+
+    TaxAuditLogQueries.log({
+        user_id = internal_user_id,
+        user_email = user.email,
+        entity_type = "BUSINESS",
+        entity_id = business_uuid,
+        action = "DELETE",
+        old_values = cjson.encode(existing[1]),
+    })
+    return true
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Summary — the hub's read-only strip: totals for one tax year plus the
+-- per-business breakdown. profit is the naive income − expenses derivation
+-- (same contract as the rental summary); the tax engine applies allowances
+-- and adjustments properly downstream.
+-- ────────────────────────────────────────────────────────────────────────────
+function BusinessQueries.summary(tax_year, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local list = BusinessQueries.all({ tax_year = tax_year }, user)
+    local income, expense = 0, 0
+    for _, b in ipairs(list.data) do
+        income = income + (tonumber(b.income_total) or 0)
+        expense = expense + (tonumber(b.expense_total) or 0)
+    end
+    return {
+        tax_year = tax_year,
+        business_count = list.total,
+        income_total = income,
+        expense_total = expense,
+        profit = income - expense,
+        businesses = list.data,
+    }
+end
+
+return BusinessQueries

--- a/lapis/queries/BusinessQueries.lua
+++ b/lapis/queries/BusinessQueries.lua
@@ -74,7 +74,9 @@ function BusinessQueries.all(params, user)
 
     -- Per-business totals for the requested tax year (one grouped query,
     -- not N+1). value_count spans ALL kinds so the hub can tell "untouched"
-    -- from "no income yet".
+    -- from "no income yet". Values whose category was deactivated are
+    -- excluded — the trade form no longer renders their box, so counting
+    -- them would make the hub disagree with the form forever.
     local totals = {}
     if params.tax_year and params.tax_year ~= "" and #rows > 0 then
         local t_rows = db.query([[
@@ -83,6 +85,9 @@ function BusinessQueries.all(params, user)
                    COUNT(*) AS value_count
             FROM business_line_values
             WHERE user_id = ? AND tax_year = ?
+              AND category_key IN (
+                  SELECT category_key FROM business_line_categories WHERE is_active = true
+              )
             GROUP BY business_uuid, kind
         ]], internal_user_id, params.tax_year) or {}
         for _, t in ipairs(t_rows) do
@@ -132,6 +137,12 @@ function BusinessQueries.create(data, user)
     if not data.label or data.label == "" then
         return nil, "label is required"
     end
+    -- A JSON-object metadata_json decodes to a Lua table, which the db
+    -- layer can't escape (unhandled 500) — encode it, matching the
+    -- crm-accounts convention.
+    if type(data.metadata_json) == "table" then
+        data.metadata_json = cjson.encode(data.metadata_json)
+    end
 
     local uuid = Global.generateUUID()
     -- namespace_id is always resolved server-side — a client-supplied value
@@ -170,12 +181,19 @@ function BusinessQueries.update(business_uuid, data, user)
     local internal_user_id, err = resolveUserId(user)
     if not internal_user_id then return nil, err end
 
+    -- is_archived = false: every other write path 404s on archived
+    -- businesses, so rename must too — otherwise an archived page looks
+    -- half-alive (rename works, figures don't).
     local existing = db.query([[
         SELECT * FROM user_profile_entities
-        WHERE uuid = ? AND user_id = ? AND entity_type = ? LIMIT 1
+        WHERE uuid = ? AND user_id = ? AND entity_type = ? AND is_archived = false LIMIT 1
     ]], business_uuid, internal_user_id, ENTITY_TYPE)
     if not existing or #existing == 0 then return nil end
     local old = existing[1]
+
+    if type(data.metadata_json) == "table" then
+        data.metadata_json = cjson.encode(data.metadata_json)
+    end
 
     local updates, args = {}, {}
     if data.label ~= nil then

--- a/lapis/queries/BusinessValueQueries.lua
+++ b/lapis/queries/BusinessValueQueries.lua
@@ -45,12 +45,23 @@ local function owned_business(business_uuid, internal_user_id)
 end
 
 -- numeric(15,2)-safe parse: nil/"" → nil, otherwise a finite number within
--- column bounds (negative allowed — balance-sheet boxes can be negative).
+-- column bounds. The bound is the column's actual max (9999999999999.99),
+-- not 1e13 — doubles just below 1e13 would pass a 1e13 check but round to
+-- 14 integer digits in Postgres and overflow. Sign rules are per-kind and
+-- enforced by the callers.
+local MAX_AMOUNT = 9999999999999.99
 local function parse_amount(v)
     if v == nil or v == "" then return nil, true end
     local n = tonumber(v)
-    if not n or n ~= n or n >= 1e13 or n <= -1e13 then return nil, false end
+    if not n or n ~= n or n > MAX_AMOUNT or n < -MAX_AMOUNT then return nil, false end
     return n, true
+end
+
+-- Only balance-sheet and adjustment boxes may go negative; SA103F income,
+-- allowance, expense and capital-allowance boxes are non-negative, and a
+-- sign typo in turnover would otherwise flow silently into hub totals.
+local function kind_allows_negative(kind)
+    return kind == "balance_sheet" or kind == "adjustment"
 end
 
 -- ────────────────────────────────────────────────────────────────────────────
@@ -111,21 +122,27 @@ function BusinessValueQueries.upsert_values(business_uuid, tax_year, values, use
     for i, v in ipairs(values) do
         local key = v and v.category_key
         local cat = key and catalogue[key] or nil
-        if not cat then
+        local amount, ok_a = parse_amount(v and v.amount)
+        local disallowable, ok_d = parse_amount(v and v.disallowable_amount)
+        -- Clearing is allowed even for retired categories — otherwise a
+        -- value whose category an admin deactivates becomes permanently
+        -- stuck (no box renders it, and re-saving its key is rejected).
+        if key and amount == nil and disallowable == nil and ok_a and ok_d then
+            local res = db.query([[
+                DELETE FROM business_line_values
+                WHERE user_id = ? AND business_uuid = ? AND tax_year = ? AND category_key = ?
+            ]], internal_user_id, business_uuid, tax_year, key)
+            deleted = deleted + ((res and res.affected_rows) or 0)
+        elseif not cat then
             table.insert(errors, { index = i, error = "Unknown or inactive category: " .. tostring(key) })
         else
-            local amount, ok_a = parse_amount(v.amount)
-            local disallowable, ok_d = parse_amount(v.disallowable_amount)
             if not ok_a or not ok_d then
-                table.insert(errors, { index = i, error = "Amount for " .. key .. " must be a number" })
+                table.insert(errors, { index = i, error = "Amount for " .. key .. " must be a number within range" })
             elseif disallowable ~= nil and not cat.supports_disallowable then
                 table.insert(errors, { index = i, error = key .. " does not take a disallowable amount" })
-            elseif amount == nil and disallowable == nil then
-                local res = db.query([[
-                    DELETE FROM business_line_values
-                    WHERE user_id = ? AND business_uuid = ? AND tax_year = ? AND category_key = ?
-                ]], internal_user_id, business_uuid, tax_year, key)
-                deleted = deleted + ((res and res.affected_rows) or 0)
+            elseif not kind_allows_negative(cat.kind)
+                and ((amount and amount < 0) or (disallowable and disallowable < 0)) then
+                table.insert(errors, { index = i, error = key .. " cannot be negative" })
             else
                 db.query([[
                     INSERT INTO business_line_values

--- a/lapis/queries/BusinessValueQueries.lua
+++ b/lapis/queries/BusinessValueQueries.lua
@@ -1,0 +1,269 @@
+--[[
+    Business Value Queries — business_line_values + business_line_categories
+    + the Capital Allowances grid (business_ca_pools/rows/values).
+
+    The self-employment trade form is FIXED-BOX (one value per admin-managed
+    category per business per tax year), so writes are batch UPSERTS keyed on
+    (user, business, tax_year, category) rather than free rows — clearing a
+    box deletes its row so summaries never count stale zeros.
+
+    Ownership: the route layer 404s unknown/foreign businesses via
+    BusinessQueries.show first; every statement here still scopes to the
+    authenticated user defensively. Category/pool/row keys are stored as
+    plain varchar (no FK) so retiring a catalogue entry never breaks history.
+]]
+
+local Global = require "helper.global"
+local TaxAuditLogQueries = require "queries.TaxAuditLogQueries"
+local db = require("lapis.db")
+local cjson = require("cjson")
+
+local BusinessValueQueries = {}
+
+local function resolveUserId(user)
+    if not user then return nil, "User not authenticated" end
+    local user_uuid = user.uuid or user.id
+    local rows
+    if user.uuid then
+        rows = db.query("SELECT id FROM users WHERE uuid = ? LIMIT 1", user_uuid)
+    else
+        rows = db.query("SELECT id FROM users WHERE id = ? LIMIT 1", user_uuid)
+    end
+    if not rows or #rows == 0 then return nil, "User not found" end
+    return rows[1].id
+end
+
+-- The business must exist, belong to this user, and not be archived.
+-- Returns the row (for namespace_id) or nil.
+local function owned_business(business_uuid, internal_user_id)
+    local rows = db.query([[
+        SELECT uuid, namespace_id FROM user_profile_entities
+        WHERE uuid = ? AND user_id = ? AND entity_type = 'business' AND is_archived = false
+        LIMIT 1
+    ]], business_uuid, internal_user_id)
+    return rows and rows[1] or nil
+end
+
+-- numeric(15,2)-safe parse: nil/"" → nil, otherwise a finite number within
+-- column bounds (negative allowed — balance-sheet boxes can be negative).
+local function parse_amount(v)
+    if v == nil or v == "" then return nil, true end
+    local n = tonumber(v)
+    if not n or n ~= n or n >= 1e13 or n <= -1e13 then return nil, false end
+    return n, true
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Catalogue
+-- ────────────────────────────────────────────────────────────────────────────
+function BusinessValueQueries.categories()
+    return db.query([[
+        SELECT uuid, kind, category_key, label, description, hmrc_mapping,
+               supports_disallowable, display_order
+        FROM business_line_categories
+        WHERE is_active = true
+        ORDER BY kind ASC, display_order ASC, label ASC
+    ]]) or {}
+end
+
+-- key → { kind, supports_disallowable } for active categories (validation).
+function BusinessValueQueries.active_categories()
+    local rows = db.query([[
+        SELECT category_key, kind, supports_disallowable
+        FROM business_line_categories WHERE is_active = true
+    ]]) or {}
+    local map = {}
+    for _, r in ipairs(rows) do
+        map[r.category_key] = { kind = r.kind, supports_disallowable = r.supports_disallowable }
+    end
+    return map
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Fixed-box values
+-- ────────────────────────────────────────────────────────────────────────────
+function BusinessValueQueries.values_for(business_uuid, tax_year, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+    local rows = db.query([[
+        SELECT category_key, kind, amount, disallowable_amount, updated_at
+        FROM business_line_values
+        WHERE user_id = ? AND business_uuid = ? AND tax_year = ?
+        ORDER BY category_key ASC
+    ]], internal_user_id, business_uuid, tax_year) or {}
+    return { data = rows, total = #rows }
+end
+
+-- Batch upsert. values = array of { category_key, amount?, disallowable_amount? }.
+-- A value with BOTH amounts empty clears the box (row deleted). Unknown or
+-- retired categories are reported per-entry, valid ones still save.
+function BusinessValueQueries.upsert_values(business_uuid, tax_year, values, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local biz = owned_business(business_uuid, internal_user_id)
+    if not biz then return nil, "Business not found" end
+
+    local catalogue = BusinessValueQueries.active_categories()
+    local saved, deleted = 0, 0
+    local errors = {}
+
+    for i, v in ipairs(values) do
+        local key = v and v.category_key
+        local cat = key and catalogue[key] or nil
+        if not cat then
+            table.insert(errors, { index = i, error = "Unknown or inactive category: " .. tostring(key) })
+        else
+            local amount, ok_a = parse_amount(v.amount)
+            local disallowable, ok_d = parse_amount(v.disallowable_amount)
+            if not ok_a or not ok_d then
+                table.insert(errors, { index = i, error = "Amount for " .. key .. " must be a number" })
+            elseif disallowable ~= nil and not cat.supports_disallowable then
+                table.insert(errors, { index = i, error = key .. " does not take a disallowable amount" })
+            elseif amount == nil and disallowable == nil then
+                local res = db.query([[
+                    DELETE FROM business_line_values
+                    WHERE user_id = ? AND business_uuid = ? AND tax_year = ? AND category_key = ?
+                ]], internal_user_id, business_uuid, tax_year, key)
+                deleted = deleted + ((res and res.affected_rows) or 0)
+            else
+                db.query([[
+                    INSERT INTO business_line_values
+                        (uuid, user_id, namespace_id, business_uuid, tax_year, kind, category_key, amount, disallowable_amount, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+                    ON CONFLICT (user_id, business_uuid, tax_year, category_key)
+                    DO UPDATE SET amount = EXCLUDED.amount,
+                                  disallowable_amount = EXCLUDED.disallowable_amount,
+                                  kind = EXCLUDED.kind,
+                                  updated_at = NOW()
+                ]],
+                    Global.generateUUID(),
+                    internal_user_id,
+                    biz.namespace_id or db.NULL,
+                    business_uuid,
+                    tax_year,
+                    cat.kind,
+                    key,
+                    amount ~= nil and amount or db.NULL,
+                    disallowable ~= nil and disallowable or db.NULL
+                )
+                saved = saved + 1
+            end
+        end
+    end
+
+    -- One audit row per batch — per-box rows would flood the log on autosave.
+    if saved > 0 or deleted > 0 then
+        TaxAuditLogQueries.log({
+            user_id = internal_user_id,
+            user_email = user.email,
+            entity_type = "BUSINESS_VALUES",
+            entity_id = business_uuid,
+            action = "UPDATE",
+            new_values = cjson.encode({ tax_year = tax_year, saved = saved, deleted = deleted }),
+        })
+    end
+
+    local refreshed = BusinessValueQueries.values_for(business_uuid, tax_year, user)
+    return { saved = saved, deleted = deleted, errors = errors, data = refreshed and refreshed.data or {} }
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Capital Allowances grid
+-- ────────────────────────────────────────────────────────────────────────────
+function BusinessValueQueries.ca_catalogue()
+    local pools = db.query([[
+        SELECT uuid, pool_key, label, display_order FROM business_ca_pools
+        WHERE is_active = true ORDER BY display_order ASC, label ASC
+    ]]) or {}
+    local rows = db.query([[
+        SELECT uuid, row_key, label, display_order FROM business_ca_rows
+        WHERE is_active = true ORDER BY display_order ASC, label ASC
+    ]]) or {}
+    return { pools = pools, rows = rows }
+end
+
+function BusinessValueQueries.ca_values_for(business_uuid, tax_year, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+    local rows = db.query([[
+        SELECT pool_key, row_key, amount, updated_at
+        FROM business_ca_values
+        WHERE user_id = ? AND business_uuid = ? AND tax_year = ?
+    ]], internal_user_id, business_uuid, tax_year) or {}
+    return { data = rows, total = #rows }
+end
+
+-- Save one pool's column of the grid (the per-pool Edit dialog).
+-- cells = array of { row_key, amount? } — empty amount clears the cell.
+function BusinessValueQueries.upsert_ca(business_uuid, tax_year, pool_key, cells, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local biz = owned_business(business_uuid, internal_user_id)
+    if not biz then return nil, "Business not found" end
+
+    local pool = db.query(
+        "SELECT pool_key FROM business_ca_pools WHERE pool_key = ? AND is_active = true LIMIT 1",
+        pool_key)
+    if not pool or #pool == 0 then return nil, "Unknown or inactive pool: " .. tostring(pool_key) end
+
+    local active_rows = {}
+    for _, r in ipairs(db.query("SELECT row_key FROM business_ca_rows WHERE is_active = true") or {}) do
+        active_rows[r.row_key] = true
+    end
+
+    local saved, deleted = 0, 0
+    local errors = {}
+    for i, c in ipairs(cells) do
+        local row_key = c and c.row_key
+        if not row_key or not active_rows[row_key] then
+            table.insert(errors, { index = i, error = "Unknown or inactive row: " .. tostring(row_key) })
+        else
+            local amount, ok = parse_amount(c.amount)
+            if not ok then
+                table.insert(errors, { index = i, error = "Amount for " .. row_key .. " must be a number" })
+            elseif amount == nil then
+                local res = db.query([[
+                    DELETE FROM business_ca_values
+                    WHERE user_id = ? AND business_uuid = ? AND tax_year = ? AND pool_key = ? AND row_key = ?
+                ]], internal_user_id, business_uuid, tax_year, pool_key, row_key)
+                deleted = deleted + ((res and res.affected_rows) or 0)
+            else
+                db.query([[
+                    INSERT INTO business_ca_values
+                        (uuid, user_id, namespace_id, business_uuid, tax_year, pool_key, row_key, amount, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+                    ON CONFLICT (user_id, business_uuid, tax_year, pool_key, row_key)
+                    DO UPDATE SET amount = EXCLUDED.amount, updated_at = NOW()
+                ]],
+                    Global.generateUUID(),
+                    internal_user_id,
+                    biz.namespace_id or db.NULL,
+                    business_uuid,
+                    tax_year,
+                    pool_key,
+                    row_key,
+                    amount
+                )
+                saved = saved + 1
+            end
+        end
+    end
+
+    if saved > 0 or deleted > 0 then
+        TaxAuditLogQueries.log({
+            user_id = internal_user_id,
+            user_email = user.email,
+            entity_type = "BUSINESS_CA",
+            entity_id = business_uuid,
+            action = "UPDATE",
+            new_values = cjson.encode({ tax_year = tax_year, pool_key = pool_key, saved = saved, deleted = deleted }),
+        })
+    end
+
+    local refreshed = BusinessValueQueries.ca_values_for(business_uuid, tax_year, user)
+    return { saved = saved, deleted = deleted, errors = errors, data = refreshed and refreshed.data or {} }
+end
+
+return BusinessValueQueries

--- a/lapis/routes/profile-builder.lua
+++ b/lapis/routes/profile-builder.lua
@@ -30,6 +30,17 @@ local LOCK_FIELD_BY_QUESTION_KEY = {
     utr_number  = "utr",
 }
 
+-- Category contexts whose answers are scoped to a user_profile_entities row
+-- (asked once PER entity, saved with entity_uuid). Every other context —
+-- NULL (classic /profile) or asked-once surfaces like 'rental_business' —
+-- stores answers in the user-wide NULL scope. The /answers scope guard
+-- keys off this table, so a new per-entity surface (e.g. a future vehicle
+-- or partnership drill-down) only needs its context registered here.
+local PER_ENTITY_CONTEXTS = {
+    property = true,   -- rental hub → per-property pages
+    business = true,   -- self-employment hub → per-business pages
+}
+
 -- =========================================================================
 -- Helper Functions
 -- =========================================================================
@@ -3001,11 +3012,12 @@ return function(app)
 
                 -- Scope guard: the batch's entity scope must match the
                 -- question's category context. Per-entity batches may only
-                -- carry 'property'-context questions; classic batches must
-                -- not carry them. Without this, answers land in a scope no
-                -- surface renders (shadow rows) — and an entity-scoped save
-                -- of an identity question would stamp the NINO/UTR lock
-                -- without ever writing the canonical value.
+                -- carry questions from PER_ENTITY_CONTEXTS categories;
+                -- classic batches must not carry them. Without this,
+                -- answers land in a scope no surface renders (shadow rows)
+                -- — and an entity-scoped save of an identity question would
+                -- stamp the NINO/UTR lock without ever writing the
+                -- canonical value.
                 local q_ctx = nil
                 local reject = nil
                 if not question then
@@ -3013,12 +3025,12 @@ return function(app)
                 else
                     q_ctx = question.category_context
                     if q_ctx == cjson.null or q_ctx == "" then q_ctx = nil end
-                    if entity_uuid and q_ctx ~= "property" then
+                    if entity_uuid and not PER_ENTITY_CONTEXTS[q_ctx] then
                         reject = "Question " .. ans.question_uuid
-                            .. " is not a per-property question — save it without entity_uuid"
-                    elseif not entity_uuid and q_ctx == "property" then
+                            .. " is not a per-entity question — save it without entity_uuid"
+                    elseif not entity_uuid and PER_ENTITY_CONTEXTS[q_ctx] then
                         reject = "Question " .. ans.question_uuid
-                            .. " is a per-property question — entity_uuid is required"
+                            .. " is a per-entity question — entity_uuid is required"
                     end
                 end
 

--- a/lapis/routes/profile-builder.lua
+++ b/lapis/routes/profile-builder.lua
@@ -31,14 +31,18 @@ local LOCK_FIELD_BY_QUESTION_KEY = {
 }
 
 -- Category contexts whose answers are scoped to a user_profile_entities row
--- (asked once PER entity, saved with entity_uuid). Every other context —
+-- (asked once PER entity, saved with entity_uuid), mapped to the
+-- entity_type that context is allowed to attach to. Every other context —
 -- NULL (classic /profile) or asked-once surfaces like 'rental_business' —
--- stores answers in the user-wide NULL scope. The /answers scope guard
--- keys off this table, so a new per-entity surface (e.g. a future vehicle
--- or partnership drill-down) only needs its context registered here.
+-- stores answers in the user-wide NULL scope. The /answers scope guard and
+-- the contexted /schema endpoint key off this table, so a new per-entity
+-- surface (e.g. a future vehicle or partnership drill-down) only needs its
+-- context registered here. The entity_type value is what prevents
+-- cross-type shadow rows (business answers saved against a property
+-- entity, or a property's answers merged into a business schema).
 local PER_ENTITY_CONTEXTS = {
-    property = true,   -- rental hub → per-property pages
-    business = true,   -- self-employment hub → per-business pages
+    property = "property",   -- rental hub → per-property pages
+    business = "business",   -- self-employment hub → per-business pages
 }
 
 -- =========================================================================
@@ -719,11 +723,18 @@ return function(app)
         if entity_uuid == "" then entity_uuid = nil end
         if entity_uuid then
             local ok_ent, ent_rows = pcall(db.query, [[
-                SELECT id FROM user_profile_entities
+                SELECT id, entity_type FROM user_profile_entities
                 WHERE uuid = ? AND user_id = ? AND is_archived = false
                 LIMIT 1
             ]], entity_uuid, user_id or -1)
             if not ok_ent or not ent_rows or #ent_rows == 0 then
+                return { status = 404, json = { error = "Entity not found" } }
+            end
+            -- A per-entity context may only be served against an entity of
+            -- its own type — otherwise ?context=business&entity=<property>
+            -- would merge a property's answer rows into the business schema.
+            local required_type = schema_context and PER_ENTITY_CONTEXTS[schema_context]
+            if required_type and ent_rows[1].entity_type ~= required_type then
                 return { status = 404, json = { error = "Entity not found" } }
             end
         end
@@ -2973,15 +2984,17 @@ return function(app)
         -- be archived. NULL entity = classic questionnaire behaviour.
         local entity_uuid = params.entity_uuid
         if entity_uuid == "" or entity_uuid == cjson.null then entity_uuid = nil end
+        local entity_type = nil
         if entity_uuid then
             local ok_ent, ent_rows = pcall(db.query, [[
-                SELECT id FROM user_profile_entities
+                SELECT id, entity_type FROM user_profile_entities
                 WHERE uuid = ? AND user_id = ? AND is_archived = false
                 LIMIT 1
             ]], entity_uuid, user_id)
             if not ok_ent or not ent_rows or #ent_rows == 0 then
                 return { status = 404, json = { error = "Entity not found" } }
             end
+            entity_type = ent_rows[1].entity_type
         end
 
         local namespace_id = getNamespaceId(self)
@@ -3011,13 +3024,15 @@ return function(app)
                 local question = (ok_q and q_rows and q_rows[1]) or nil
 
                 -- Scope guard: the batch's entity scope must match the
-                -- question's category context. Per-entity batches may only
-                -- carry questions from PER_ENTITY_CONTEXTS categories;
-                -- classic batches must not carry them. Without this,
-                -- answers land in a scope no surface renders (shadow rows)
-                -- — and an entity-scoped save of an identity question would
-                -- stamp the NINO/UTR lock without ever writing the
-                -- canonical value.
+                -- question's category context — including the ENTITY TYPE,
+                -- so business questions can't be saved against a property
+                -- entity (or vice versa). Per-entity batches may only carry
+                -- questions whose context maps to the target entity's type;
+                -- classic batches must not carry per-entity questions.
+                -- Without this, answers land in a scope no surface renders
+                -- (shadow rows) — and an entity-scoped save of an identity
+                -- question would stamp the NINO/UTR lock without ever
+                -- writing the canonical value.
                 local q_ctx = nil
                 local reject = nil
                 if not question then
@@ -3025,10 +3040,15 @@ return function(app)
                 else
                     q_ctx = question.category_context
                     if q_ctx == cjson.null or q_ctx == "" then q_ctx = nil end
-                    if entity_uuid and not PER_ENTITY_CONTEXTS[q_ctx] then
+                    local required_type = PER_ENTITY_CONTEXTS[q_ctx]
+                    if entity_uuid and not required_type then
                         reject = "Question " .. ans.question_uuid
                             .. " is not a per-entity question — save it without entity_uuid"
-                    elseif not entity_uuid and PER_ENTITY_CONTEXTS[q_ctx] then
+                    elseif entity_uuid and required_type ~= entity_type then
+                        reject = "Question " .. ans.question_uuid
+                            .. " belongs to '" .. tostring(q_ctx)
+                            .. "' — it cannot be saved against a '" .. tostring(entity_type) .. "' entity"
+                    elseif not entity_uuid and required_type then
                         reject = "Question " .. ans.question_uuid
                             .. " is a per-entity question — entity_uuid is required"
                     end

--- a/lapis/routes/tax-businesses.lua
+++ b/lapis/routes/tax-businesses.lua
@@ -1,0 +1,270 @@
+--[[
+    Self-Employment Routes — the sole-trader hub's backend surface.
+
+    Endpoints (all auth-required):
+      GET    /api/v2/tax/business-line-categories             admin catalogue → fixed-box form
+      GET    /api/v2/tax/self-employment/summary?tax_year=    hub summary strip (read-only, derived)
+      GET    /api/v2/tax/businesses?tax_year=                 list + per-business totals
+      POST   /api/v2/tax/businesses                           { label }
+      GET    /api/v2/tax/businesses/:uuid
+      PUT    /api/v2/tax/businesses/:uuid                     { label?, metadata_json?, display_order? }
+      DELETE /api/v2/tax/businesses/:uuid                     soft archive
+      GET    /api/v2/tax/businesses/:uuid/values?tax_year=    fixed-box values for one year
+      PUT    /api/v2/tax/businesses/:uuid/values              { tax_year, values: [{category_key, amount?, disallowable_amount?}] }
+      GET    /api/v2/tax/business-ca-catalogue                CA grid pools + rows (admin catalogues)
+      GET    /api/v2/tax/businesses/:uuid/capital-allowances?tax_year=
+      PUT    /api/v2/tax/businesses/:uuid/capital-allowances  { tax_year, pool_key, cells: [{row_key, amount?}] }
+
+    Business-scope QUESTIONS are not served here — they come from the
+    Profile Builder (/api/v2/profile-builder/schema?context=business&entity=<uuid>)
+    so admins keep full control of what's asked per business.
+]]
+
+local cjson = require("cjson")
+local BusinessQueries = require "queries.BusinessQueries"
+local BusinessValueQueries = require "queries.BusinessValueQueries"
+local AuthMiddleware = require("middleware.auth")
+
+-- YYYY-YY (e.g. 2026-27) — same contract as my-incomes / tax-properties.
+local function valid_tax_year(s)
+    if type(s) ~= "string" then return false end
+    local y1, y2 = s:match("^(%d%d%d%d)%-(%d%d)$")
+    if not y1 or not y2 then return false end
+    return tonumber(y2) == (tonumber(y1) + 1) % 100
+end
+
+-- Parse JSON or form body with cjson.null normalisation at the boundary —
+-- same helper as tax-properties.lua (JSON null is a truthy lightuserdata
+-- that would otherwise reach tostring()/db escaping). Batch endpoints here
+-- carry nested arrays whose inner nulls ("clear this box") are handled by
+-- the queries' parse_amount, so only top-level nulls are stripped.
+local function parse_request_body()
+    ngx.req.read_body()
+    local content_type = ngx.var.content_type or ""
+    if content_type:find("application/json", 1, true) then
+        local ok, result = pcall(function()
+            local body = ngx.req.get_body_data()
+            if not body or body == "" then return {} end
+            return cjson.decode(body)
+        end)
+        if ok and type(result) == "table" then
+            for k, v in pairs(result) do
+                if v == cjson.null then result[k] = nil end
+            end
+            return result
+        end
+        return {}
+    end
+    local post_args = ngx.req.get_post_args()
+    if post_args and next(post_args) then return post_args end
+    return {}
+end
+
+local function merge_params(self)
+    local body_params = parse_request_body()
+    for k, v in pairs(body_params) do
+        if self.params[k] == nil then self.params[k] = v end
+    end
+end
+
+-- Normalise one batch entry: cjson.null fields → nil so "clear this box"
+-- and "field absent" behave identically all the way down.
+local function scrub_entry(entry)
+    if type(entry) ~= "table" then return nil end
+    local out = {}
+    for k, v in pairs(entry) do
+        if v ~= cjson.null then out[k] = v end
+    end
+    return out
+end
+
+return function(app)
+    -- ── Catalogues ──────────────────────────────────────────────────────────
+    app:get("/api/v2/tax/business-line-categories", AuthMiddleware.requireAuth(function(_)
+        local rows = BusinessValueQueries.categories()
+        local data = {}
+        for _, r in ipairs(rows) do
+            data[#data + 1] = {
+                key = r.category_key,
+                label = r.label,
+                kind = r.kind,
+                description = r.description,
+                hmrc_mapping = r.hmrc_mapping,
+                supports_disallowable = r.supports_disallowable,
+                display_order = r.display_order,
+            }
+        end
+        return { json = { data = #data > 0 and data or cjson.empty_array }, status = 200 }
+    end))
+
+    app:get("/api/v2/tax/business-ca-catalogue", AuthMiddleware.requireAuth(function(_)
+        local cat = BusinessValueQueries.ca_catalogue()
+        local pools, rows = {}, {}
+        for _, p in ipairs(cat.pools) do
+            pools[#pools + 1] = { key = p.pool_key, label = p.label, display_order = p.display_order }
+        end
+        for _, r in ipairs(cat.rows) do
+            rows[#rows + 1] = { key = r.row_key, label = r.label, display_order = r.display_order }
+        end
+        return {
+            json = {
+                data = {
+                    pools = #pools > 0 and pools or cjson.empty_array,
+                    rows = #rows > 0 and rows or cjson.empty_array,
+                },
+            },
+            status = 200,
+        }
+    end))
+
+    -- ── Hub summary (read-only, derived) ────────────────────────────────────
+    app:get("/api/v2/tax/self-employment/summary", AuthMiddleware.requireAuth(function(self)
+        local tax_year = self.params.tax_year
+        if not valid_tax_year(tax_year) then
+            return { json = { error = "tax_year must be YYYY-YY (e.g. 2026-27)" }, status = 400 }
+        end
+        local result, err = BusinessQueries.summary(tax_year, self.current_user)
+        if not result then
+            return { json = { error = err or "Failed to build summary" }, status = 400 }
+        end
+        -- Force [] (not {}) for an empty list — cjson encodes empty Lua
+        -- tables as objects.
+        if #result.businesses == 0 then result.businesses = cjson.empty_array end
+        return { json = { data = result }, status = 200 }
+    end))
+
+    -- ── Businesses ──────────────────────────────────────────────────────────
+    app:get("/api/v2/tax/businesses", AuthMiddleware.requireAuth(function(self)
+        local result, err = BusinessQueries.all(self.params, self.current_user)
+        if not result then
+            return { json = { error = err or "Failed to list businesses" }, status = 400 }
+        end
+        if #result.data == 0 then result.data = cjson.empty_array end
+        return { json = result, status = 200 }
+    end))
+
+    app:post("/api/v2/tax/businesses", AuthMiddleware.requireAuth(function(self)
+        merge_params(self)
+        if not self.params.label or tostring(self.params.label):gsub("%s", "") == "" then
+            return { json = { error = "label is required" }, status = 400 }
+        end
+        if #tostring(self.params.label) > 120 then
+            return { json = { error = "label must be 120 characters or fewer" }, status = 400 }
+        end
+        local row, err = BusinessQueries.create(self.params, self.current_user)
+        if not row then return { json = { error = err or "Failed to create business" }, status = 400 } end
+        return { json = { data = row }, status = 201 }
+    end))
+
+    app:get("/api/v2/tax/businesses/:uuid", AuthMiddleware.requireAuth(function(self)
+        local row = BusinessQueries.show(tostring(self.params.uuid), self.current_user)
+        if not row then return { json = { error = "Business not found" }, status = 404 } end
+        return { json = { data = row }, status = 200 }
+    end))
+
+    app:put("/api/v2/tax/businesses/:uuid", AuthMiddleware.requireAuth(function(self)
+        merge_params(self)
+        if self.params.label ~= nil and #tostring(self.params.label) > 120 then
+            return { json = { error = "label must be 120 characters or fewer" }, status = 400 }
+        end
+        local row, err = BusinessQueries.update(tostring(self.params.uuid), self.params, self.current_user)
+        if not row then return { json = { error = err or "Business not found" }, status = err and 400 or 404 } end
+        return { json = { data = row }, status = 200 }
+    end))
+
+    app:delete("/api/v2/tax/businesses/:uuid", AuthMiddleware.requireAuth(function(self)
+        local ok = BusinessQueries.archive(tostring(self.params.uuid), self.current_user)
+        if not ok then return { json = { error = "Business not found" }, status = 404 } end
+        return { json = { message = "Business archived" }, status = 200 }
+    end))
+
+    -- ── Fixed-box values ────────────────────────────────────────────────────
+    app:get("/api/v2/tax/businesses/:uuid/values", AuthMiddleware.requireAuth(function(self)
+        -- Ownership check first so an unknown/foreign business 404s rather
+        -- than returning an empty list.
+        local biz = BusinessQueries.show(tostring(self.params.uuid), self.current_user)
+        if not biz then return { json = { error = "Business not found" }, status = 404 } end
+        if not valid_tax_year(self.params.tax_year) then
+            return { json = { error = "tax_year must be YYYY-YY (e.g. 2026-27)" }, status = 400 }
+        end
+        local result, err = BusinessValueQueries.values_for(tostring(self.params.uuid), self.params.tax_year, self.current_user)
+        if not result then
+            return { json = { error = err or "Failed to list values" }, status = 400 }
+        end
+        if #result.data == 0 then result.data = cjson.empty_array end
+        return { json = result, status = 200 }
+    end))
+
+    app:put("/api/v2/tax/businesses/:uuid/values", AuthMiddleware.requireAuth(function(self)
+        merge_params(self)
+        if not valid_tax_year(self.params.tax_year) then
+            return { json = { error = "tax_year must be YYYY-YY (e.g. 2026-27)" }, status = 400 }
+        end
+        local values = self.params.values
+        if type(values) ~= "table" or #values == 0 then
+            return { json = { error = "values array is required" }, status = 400 }
+        end
+        if #values > 200 then
+            return { json = { error = "values batch too large (max 200)" }, status = 400 }
+        end
+        local cleaned = {}
+        for _, v in ipairs(values) do
+            cleaned[#cleaned + 1] = scrub_entry(v) or {}
+        end
+        local result, err = BusinessValueQueries.upsert_values(
+            tostring(self.params.uuid), self.params.tax_year, cleaned, self.current_user)
+        if not result then
+            local status = (err == "Business not found") and 404 or 400
+            return { json = { error = err or "Failed to save values" }, status = status }
+        end
+        if #result.data == 0 then result.data = cjson.empty_array end
+        if #result.errors == 0 then result.errors = cjson.empty_array end
+        return { json = result, status = 200 }
+    end))
+
+    -- ── Capital Allowances grid ─────────────────────────────────────────────
+    app:get("/api/v2/tax/businesses/:uuid/capital-allowances", AuthMiddleware.requireAuth(function(self)
+        local biz = BusinessQueries.show(tostring(self.params.uuid), self.current_user)
+        if not biz then return { json = { error = "Business not found" }, status = 404 } end
+        if not valid_tax_year(self.params.tax_year) then
+            return { json = { error = "tax_year must be YYYY-YY (e.g. 2026-27)" }, status = 400 }
+        end
+        local result, err = BusinessValueQueries.ca_values_for(tostring(self.params.uuid), self.params.tax_year, self.current_user)
+        if not result then
+            return { json = { error = err or "Failed to list capital allowances" }, status = 400 }
+        end
+        if #result.data == 0 then result.data = cjson.empty_array end
+        return { json = result, status = 200 }
+    end))
+
+    app:put("/api/v2/tax/businesses/:uuid/capital-allowances", AuthMiddleware.requireAuth(function(self)
+        merge_params(self)
+        if not valid_tax_year(self.params.tax_year) then
+            return { json = { error = "tax_year must be YYYY-YY (e.g. 2026-27)" }, status = 400 }
+        end
+        if not self.params.pool_key or self.params.pool_key == "" then
+            return { json = { error = "pool_key is required" }, status = 400 }
+        end
+        local cells = self.params.cells
+        if type(cells) ~= "table" or #cells == 0 then
+            return { json = { error = "cells array is required" }, status = 400 }
+        end
+        if #cells > 100 then
+            return { json = { error = "cells batch too large (max 100)" }, status = 400 }
+        end
+        local cleaned = {}
+        for _, c in ipairs(cells) do
+            cleaned[#cleaned + 1] = scrub_entry(c) or {}
+        end
+        local result, err = BusinessValueQueries.upsert_ca(
+            tostring(self.params.uuid), self.params.tax_year,
+            tostring(self.params.pool_key), cleaned, self.current_user)
+        if not result then
+            local status = (err == "Business not found") and 404 or 400
+            return { json = { error = err or "Failed to save capital allowances" }, status = status }
+        end
+        if #result.data == 0 then result.data = cjson.empty_array end
+        if #result.errors == 0 then result.errors = cjson.empty_array end
+        return { json = result, status = 200 }
+    end))
+end

--- a/lapis/routes/tax-businesses.lua
+++ b/lapis/routes/tax-businesses.lua
@@ -44,6 +44,20 @@ local function parse_request_body()
     if content_type:find("application/json", 1, true) then
         local ok, result = pcall(function()
             local body = ngx.req.get_body_data()
+            if not body or body == "" then
+                -- Bodies over client_body_buffer_size (16k default) are
+                -- spooled to disk and get_body_data() returns nil — the
+                -- 200-entry values batches this route allows can exceed
+                -- that. Same fallback as academy.lua.
+                local path = ngx.req.get_body_file()
+                if path then
+                    local f = io.open(path, "rb")
+                    if f then
+                        body = f:read("*a")
+                        f:close()
+                    end
+                end
+            end
             if not body or body == "" then return {} end
             return cjson.decode(body)
         end)


### PR DESCRIPTION
## Summary

Backend for the **Self-employment income redesign** (hub + per-business drill-down), reusing the Property Income architecture one-for-one. Companion frontend PR in diy-tax-return-uk.

- **Businesses** are `user_profile_entities` rows (`entity_type='business'`) — the table was built generic for exactly this reuse; no schema change needed.
- **Per-business questions** (description, address, dates, accounting basis/period) are Profile Builder categories with the new `business` context, answered with `entity_uuid` scope — fully admin-configurable, nothing hardcoded in the frontend.
- The answers **scope-guard** generalises from a hardcoded `'property'` check to a `PER_ENTITY_CONTEXTS` registry (`property`, `business`).
- **`business_line_categories`** — admin catalogue of SA103F boxes (kinds: `income` / `allowance` / `expense` / `capital_allowance` / `adjustment` / `balance_sheet`; 46 seeded entries with `{"sa103f_box":…,"disallowable_box":…}` mappings and per-category disallowable-split flags).
- **`business_line_values`** — fixed-box values: ONE value per (user, business, tax year, category), batch upsert keyed on a plain unique index; clearing a box deletes its row so summaries never count stale zeros.
- **`business_ca_pools` / `business_ca_rows` / `business_ca_values`** — the Capital Allowances grid (9 pools × 19 computation lines seeded, admin-editable), saved one pool-column at a time.
- **`routes/tax-businesses.lua`** — business CRUD, values get/upsert, CA catalogue + cells, `/tax/self-employment/summary`.

## Migrations

731–736, gated on `tax_copilot`. **New tables only** — no changes to existing tables or write paths, so none of the deploy-window hazard #474 had. The option seed keeps the explicit `parent_option_id NULL` fix from #476.

## Endpoints

```
GET    /api/v2/tax/business-line-categories
GET    /api/v2/tax/business-ca-catalogue
GET    /api/v2/tax/self-employment/summary?tax_year=
GET|POST /api/v2/tax/businesses
GET|PUT|DELETE /api/v2/tax/businesses/:uuid
GET|PUT /api/v2/tax/businesses/:uuid/values
GET|PUT /api/v2/tax/businesses/:uuid/capital-allowances
```

## Verification

- `luajit -bl` clean on all new/changed files.
- Ownership checks mirror tax-properties (404 before empty-list; namespace resolved server-side; per-batch audit rows).
- cjson.null stripped at the body boundary AND per batch entry (nested arrays).

## Follow-ups (documented, not in scope)

- FastAPI calculation integration for business_line_values (legacy my_incomes rows remain the calc source, surfaced on the hub's legacy card).
- Admin CRUD pages for the new catalogues (manageable via DB/migration today, same as property_line_categories).

🤖 Generated with [Claude Code](https://claude.com/claude-code)