### PR TITLE
fix(ci): don't fail the build when the GHA cache export blips

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -159,7 +159,14 @@ jobs:
             BUILD_NUMBER=${{ steps.version.outputs.BUILD_NUMBER }}
             BUILD_TIME=${{ steps.version.outputs.BUILD_TIME }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # ignore-error: the GitHub Actions Cache export is a pure build-speed
+          # optimisation. When that service has a blip it returns an HTML error
+          # page instead of JSON, buildx fails to parse it, and the WHOLE build
+          # aborts (cancelling the already-successful image push) — which then
+          # skips smoke + deploy. A build whose image built and pushed fine must
+          # not fail because the cache backend was briefly unavailable, so make
+          # the export non-fatal: on error it logs a warning and continues.
+          cache-to: type=gha,mode=max,ignore-error=true
 
   # =========================================================================
   # 2. SMOKE TEST


### PR DESCRIPTION
## What broke

Run [#479](https://github.com/bwalia/opsapi/actions/runs/29812462908/job/88576257480) failed even though the Docker image **built and pushed fine** (all 35 stages completed). The failure was in the very last build stage — exporting the layer cache to GitHub's Actions Cache service:

```
#43 exporting to GitHub Actions Cache
ERROR: failed to parse error response 400:
  <h2>Our services aren't available right now</h2>
  <p>We're working to restore all services as soon as possible...</p>
ERROR: failed to solve: ... invalid character '<' looking for beginning of value
```

That HTML page is a **GitHub Actions Cache outage**. `buildx` got an error page instead of JSON, couldn't parse it, and aborted the whole operation — which cancelled the already-successful image push, failed the build job, and cascaded to **skip smoke + deploy**.

## The fix

`cache-to: type=gha` is a pure build-speed optimisation. A transient outage in it must never fail a build whose image is otherwise good. buildx's documented `ignore-error=true` makes the export non-fatal — on error it logs a warning and the build continues:

```yaml
cache-to: type=gha,mode=max,ignore-error=true
```

## Scope

One-line change (plus an explanatory comment). This is independent of the smoke-test fix in #477, which is confirmed working — the [prior run](https://github.com/bwalia/opsapi/actions/runs/29751636788) shows **Smoke Test = success**.

## Still outstanding (unchanged, infra — not addressed here)

Deploy continues to fail on every run because `k3s0.diytaxreturn.co.uk:6443` refuses connections. That's cluster availability, not workflow code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)