### PR TITLE
fix(migration): se_description question_type 'text' → 'short_text' (unblocks int migrate 736)

### DIFF
--- a/lapis/migrations/self-employment-system.lua
+++ b/lapis/migrations/self-employment-system.lua
@@ -383,8 +383,11 @@ return {
         local bd_id = ensure_category("business-details", "Business details",
             "Details about this business", "briefcase", 1, "business")
         if bd_id then
+            -- 'short_text', not 'text' — profile_questions.chk_question_type
+            -- has a fixed whitelist and 'text' is not in it (broke migrate
+            -- 736 on int with a check-constraint violation).
             ensure_question(bd_id, { question_key = "se_description", label = "What does the business do?",
-                question_type = "text", is_required = false, display_order = 1,
+                question_type = "short_text", is_required = false, display_order = 1,
                 placeholder = "e.g. Plumbing and heating services" })
             ensure_question(bd_id, { question_key = "se_address", label = "Business address (unless you work from home)",
                 question_type = "address", is_required = false, display_order = 2 })


### PR DESCRIPTION
Migrate hook Job `diytaxreturn-lapis-migrate-58` failed on int: `chk_question_type` violation — the seeded `se_description` question used `question_type='text'`, which is not in the constraint's whitelist (`short_text` is the correct type; every other seeded type was valid). One-line fix. Migrations 731–735 already recorded; 736 is idempotent and resumes cleanly on redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)