### PR TITLE
feat(overseas-property): Land and property abroad (SA106) — hub backend

### DIFF
--- a/lapis/app.lua
+++ b/lapis/app.lua
@@ -516,6 +516,9 @@ load_if("tax_copilot", "routes.tax-properties")
 -- values + Capital Allowances grid. Business-scope questions stay under
 -- routes.profile-builder (?context=business&entity=).
 load_if("tax_copilot", "routes.tax-businesses")
+-- Overseas property hub ("Land and property abroad", SA106): same engine as
+-- tax-properties with entity_type='overseas_property' + overseas catalogue.
+load_if("tax_copilot", "routes.tax-overseas-properties")
 -- Billing (single-merchant Stripe: admin plans + subscription/one-time checkout)
 load_if("tax_copilot", "routes.billing-plans")
 load_if("tax_copilot", "routes.billing-checkout")

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -171,6 +171,11 @@ local property_income_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_CO
 -- and the Capital Allowances grid
 local self_employment_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.self-employment-system") or {}
 
+-- Overseas Property (tax_copilot feature) — "Land and property abroad" hub:
+-- reuses user_profile_entities + property_line_items with a catalogue
+-- schedule split, plus the overseas_property income type + question section
+local overseas_property_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.overseas-property-system") or {}
+
 -- Billing / payments (Stripe Connect: subscriptions + one-time). Gated on
 -- tax_copilot for now; broaden to a feature list (e.g. {ECOMMERCE, TAX_COPILOT})
 -- once multiple project codes need it. See migrations/billing-system.lua.
@@ -1892,6 +1897,16 @@ local _migrations = {
     ['734_create_business_ca_catalogues'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, self_employment_migrations, 4),
     ['735_create_business_ca_values'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, self_employment_migrations, 5),
     ['736_seed_business_section'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, self_employment_migrations, 6),
+
+    -- =========================================================================
+    -- OVERSEAS PROPERTY — "Land and property abroad" (SA106) hub. 737 adds
+    -- the catalogue schedule split; 738 seeds the overseas categories; 739
+    -- the income type; 740 the admin-editable per-holding question section.
+    -- =========================================================================
+    ['737_property_categories_schedule'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, overseas_property_migrations, 1),
+    ['738_seed_overseas_line_categories'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, overseas_property_migrations, 2),
+    ['739_seed_overseas_income_type'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, overseas_property_migrations, 3),
+    ['740_seed_overseas_section'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, overseas_property_migrations, 4),
 
     -- =========================================================================
     -- Academy (LMS): courses + lessons (namespace-scoped). Feature-gated, so

--- a/lapis/migrations/overseas-property-system.lua
+++ b/lapis/migrations/overseas-property-system.lua
@@ -1,0 +1,192 @@
+--[[
+  Overseas Property System — "Land and property abroad" (SA106 foreign
+  property pages), third instance of the hub + per-entity drill-down
+  architecture (rental → property, self-employment → business):
+
+  1. Overseas holdings are user_profile_entities rows with
+     entity_type='overseas_property' — one per country/holding, matching
+     the reference form's unit (Country + number of properties + address).
+  2. Per-holding QUESTIONS (country, number of properties, address,
+     accounting basis, property-income-allowance claim) are a Profile
+     Builder category with context='overseas_property', answered with
+     entity_uuid scope — admin-configurable, never hardcoded.
+  3. Line items REUSE property_line_items/property_line_categories: the
+     catalogue gains a `schedule` column ('uk_property' | 'overseas_property')
+     so each surface only sees its own categories. Overseas expenses are
+     FREE-FORM rows (description + amount + private use), which is what
+     the dormant disallowable_amount column was kept for.
+  4. A new income_types row makes "Overseas property" selectable — the
+     profile's selected_income_types question sources options straight
+     from that catalogue, so no option seeding is needed.
+
+  Only executed when PROJECT_CODE includes 'tax_copilot'.
+]]
+
+local schema = require("lapis.db.schema")
+local types = schema.types
+local db = require("lapis.db")
+local cjson = require("cjson")
+local MigrationUtils = require "helper.migration-utils"
+
+return {
+    -- =========================================================================
+    -- 1. property_line_categories.schedule — which surface a category
+    --    belongs to. Existing rows are UK ones; default keeps them that way.
+    -- =========================================================================
+    [1] = function()
+        db.query("ALTER TABLE property_line_categories ADD COLUMN IF NOT EXISTS schedule varchar NOT NULL DEFAULT 'uk_property'")
+        db.query("CREATE INDEX IF NOT EXISTS idx_plc_schedule ON property_line_categories (schedule)")
+        print("[Overseas Property] Added schedule column to property_line_categories")
+    end,
+
+    -- =========================================================================
+    -- 2. Seed the overseas (SA106-shaped) categories.
+    --    Idempotent: keyed on (kind, category_key), same as the UK seed.
+    --    Kinds beyond income/expense ('finance_cost', 'adjustment') exist so
+    --    restricted finance costs are NOT summed into expenses — the
+    --    reference form explicitly excludes them from the expense total.
+    -- =========================================================================
+    [2] = function()
+        local rows = {
+            { kind = "income", key = "op_rents", label = "Total rents and other receipts", box = "14", order = 1 },
+            { kind = "income", key = "op_lease_premiums", label = "Premiums paid for the grant of a lease", box = "14", order = 2 },
+            { kind = "expense", key = "op_expense", label = "Property expense", box = "24", order = 1,
+              desc = "Excluding finance costs for residential properties. Use the private-use column for any part that isn't wholly for the letting." },
+            { kind = "finance_cost", key = "op_finance_costs", label = "Interest and other finance costs", box = "24A", order = 1,
+              desc = "Residential finance costs are restricted to basic-rate relief — they don't reduce profits directly" },
+            { kind = "adjustment", key = "op_unused_rfc_bf", label = "Unused residential finance costs brought forward", box = "24B", order = 1 },
+        }
+        for _, r in ipairs(rows) do
+            local mapping = '{"sa106_box":"' .. r.box .. '"}'
+            local exists = db.select("id FROM property_line_categories WHERE kind = ? AND category_key = ?", r.kind, r.key)
+            if exists and #exists > 0 then
+                db.query([[
+                    UPDATE property_line_categories
+                       SET label = ?, description = ?, hmrc_mapping = ?, display_order = ?,
+                           schedule = 'overseas_property', updated_at = NOW()
+                     WHERE kind = ? AND category_key = ?
+                ]], r.label, r.desc or db.NULL, mapping, r.order, r.kind, r.key)
+            else
+                db.query([[
+                    INSERT INTO property_line_categories
+                        (uuid, kind, category_key, label, description, hmrc_mapping, display_order, schedule, is_active, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, 'overseas_property', true, NOW(), NOW())
+                ]], MigrationUtils.generateUUID(), r.kind, r.key, r.label, r.desc or db.NULL, mapping, r.order)
+            end
+        end
+        print("[Overseas Property] Seeded overseas_property line categories (SA106)")
+    end,
+
+    -- =========================================================================
+    -- 3. income_types catalogue row — makes "Overseas property" selectable
+    --    in the profile questionnaire (selected_income_types sources its
+    --    options from this catalogue) and on /my-income.
+    -- =========================================================================
+    [3] = function()
+        local docs = cjson.encode({
+            { key = "rental_statements", label = "Rental / letting statements", required = false },
+            { key = "overseas_tax_docs", label = "Overseas tax paid — statements or certificates", required = false },
+        })
+        db.query([[
+            INSERT INTO income_types
+                (uuid, income_type_key, display_name, description,
+                 required_documents, allows_manual_entry,
+                 keyword_rules, category_affinity, rules_markdown,
+                 hmrc_mapping, display_order, is_active, namespace_id,
+                 created_at, updated_at)
+            VALUES (?, 'overseas_property', 'Overseas property',
+                    'Rent from land and property outside the UK.',
+                    ?::jsonb, true,
+                    '[]'::jsonb, '{}'::jsonb, NULL,
+                    '{}'::jsonb, 45, true, NULL, NOW(), NOW())
+            ON CONFLICT (income_type_key) DO NOTHING
+        ]], MigrationUtils.generateUUID(), docs)
+        print("[Overseas Property] Seeded overseas_property income type")
+    end,
+
+    -- =========================================================================
+    -- 4. Seed the per-holding contexted question section
+    --    (context='overseas_property', answered with entity_uuid scope).
+    --    Same idempotent helpers as property-income-system [7].
+    -- =========================================================================
+    [4] = function()
+        local function ensure_category(slug, name, description, icon, display_order, context)
+            local exists = db.select("id FROM profile_categories WHERE slug = ?", slug)
+            if exists and #exists > 0 then
+                db.query([[
+                    UPDATE profile_categories
+                       SET name = ?, description = ?, icon = ?, display_order = ?, context = ?,
+                           is_active = true, is_archived = false, updated_at = NOW()
+                     WHERE slug = ?
+                ]], name, description, icon, display_order, context, slug)
+                return exists[1].id
+            end
+            db.query([[
+                INSERT INTO profile_categories
+                    (uuid, namespace_id, name, slug, description, icon, display_order, context, is_active, is_archived, created_at, updated_at)
+                VALUES (?, 0, ?, ?, ?, ?, ?, ?, true, false, NOW(), NOW())
+            ]], MigrationUtils.generateUUID(), name, slug, description, icon, display_order, context)
+            local row = db.select("id FROM profile_categories WHERE slug = ?", slug)
+            return row and row[1] and row[1].id or nil
+        end
+
+        local function ensure_question(cat_id, q)
+            local exists = db.select("id FROM profile_questions WHERE question_key = ?", q.question_key)
+            if exists and #exists > 0 then
+                db.query([[
+                    UPDATE profile_questions
+                       SET category_id = ?, label = ?, question_type = ?, is_required = ?,
+                           display_order = ?, help_text = ?, placeholder = ?,
+                           is_active = true, is_archived = false, updated_at = NOW()
+                     WHERE question_key = ?
+                ]], cat_id, q.label, q.question_type, q.is_required, q.display_order, q.help_text or "", q.placeholder or "", q.question_key)
+                return exists[1].id
+            end
+            db.query([[
+                INSERT INTO profile_questions
+                    (uuid, category_id, question_key, label, question_type, is_required, display_order, help_text, placeholder, is_active, version, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, true, 1, NOW(), NOW())
+            ]], MigrationUtils.generateUUID(), cat_id, q.question_key, q.label, q.question_type, q.is_required, q.display_order, q.help_text or "", q.placeholder or "")
+            local row = db.select("id FROM profile_questions WHERE question_key = ?", q.question_key)
+            return row and row[1] and row[1].id or nil
+        end
+
+        local function ensure_option(question_key, value, label, display_order)
+            local q = db.select("id FROM profile_questions WHERE question_key = ?", question_key)
+            if not q or #q == 0 then return end
+            local exists = db.select("id FROM profile_question_options WHERE question_id = ? AND value = ?", q[1].id, value)
+            if exists and #exists > 0 then return end
+            -- parent_option_id must be an EXPLICIT NULL — types.integer({null=true})
+            -- renders `integer DEFAULT 0`, which violates fk_pqo_parent (#476).
+            db.query([[
+                INSERT INTO profile_question_options
+                    (uuid, question_id, label, value, display_order, is_active, parent_option_id, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, true, NULL, NOW(), NOW())
+            ]], MigrationUtils.generateUUID(), q[1].id, label, value, display_order)
+        end
+
+        -- ── Overseas holding details (asked once PER holding) ───────────────
+        local od_id = ensure_category("overseas-property-details", "About this overseas property",
+            "Details about this land or property abroad", "globe", 1, "overseas_property")
+        if od_id then
+            -- question_type values MUST be in profile_questions.chk_question_type
+            -- ('short_text', not 'text' — see #481).
+            ensure_question(od_id, { question_key = "op_country", label = "Which country is the property in?",
+                question_type = "short_text", is_required = true, display_order = 1,
+                placeholder = "e.g. Spain" })
+            ensure_question(od_id, { question_key = "op_num_properties", label = "Number of properties in this country",
+                question_type = "number", is_required = false, display_order = 2, placeholder = "1" })
+            ensure_question(od_id, { question_key = "op_address", label = "Property address",
+                question_type = "address", is_required = false, display_order = 3 })
+            ensure_question(od_id, { question_key = "op_accounting_basis", label = "How do you record income and expenses?",
+                question_type = "single_select", is_required = false, display_order = 4,
+                help_text = "Cash basis counts money when it actually moves; accruals counts it when it's due." })
+            ensure_question(od_id, { question_key = "op_claim_property_allowance", label = "Claim the £1,000 property income allowance?",
+                question_type = "boolean", is_required = false, display_order = 5,
+                help_text = "If you claim the allowance your expenses are ignored — and it's ONE allowance across all your property income (UK and overseas), not one per property." })
+        end
+        ensure_option("op_accounting_basis", "cash", "Cash basis", 1)
+        ensure_option("op_accounting_basis", "accruals", "Accruals (traditional) basis", 2)
+        print("[Overseas Property] Seeded overseas-property-details section: 5 questions")
+    end,
+}

--- a/lapis/queries/PropertyLineQueries.lua
+++ b/lapis/queries/PropertyLineQueries.lua
@@ -42,22 +42,25 @@ end
 -- ────────────────────────────────────────────────────────────────────────────
 -- Catalogue
 -- ────────────────────────────────────────────────────────────────────────────
-function PropertyLineQueries.categories()
+-- schedule: which surface's catalogue — 'uk_property' (default, the UK
+-- rental hub) or 'overseas_property' (Land and property abroad). The
+-- default keeps every pre-existing caller's behaviour unchanged.
+function PropertyLineQueries.categories(schedule)
     local rows = db.query([[
         SELECT uuid, kind, category_key, label, description, hmrc_mapping, display_order
         FROM property_line_categories
-        WHERE is_active = true
+        WHERE is_active = true AND schedule = ?
         ORDER BY kind ASC, display_order ASC, label ASC
-    ]]) or {}
+    ]], schedule or "uk_property") or {}
     return rows
 end
 
 -- Set of active keys for one kind — validation helper for routes.
-function PropertyLineQueries.active_keys(kind)
+function PropertyLineQueries.active_keys(kind, schedule)
     local rows = db.query([[
         SELECT category_key FROM property_line_categories
-        WHERE is_active = true AND kind = ?
-    ]], kind) or {}
+        WHERE is_active = true AND kind = ? AND schedule = ?
+    ]], kind, schedule or "uk_property") or {}
     local set = {}
     for _, r in ipairs(rows) do set[r.category_key] = true end
     return set
@@ -95,23 +98,27 @@ end
 -- Create — route layer validates kind/category/amount/tax_year and property
 -- ownership; re-checked defensively here.
 -- ────────────────────────────────────────────────────────────────────────────
-function PropertyLineQueries.create(property_uuid, data, user)
+-- entity_type: 'property' (default) or 'overseas_property' — the parent
+-- entity the line hangs off. Overseas lines also allow the extra kinds
+-- ('finance_cost', 'adjustment') their catalogue defines.
+function PropertyLineQueries.create(property_uuid, data, user, entity_type)
     local internal_user_id, err = resolveUserId(user)
     if not internal_user_id then return nil, err end
 
     -- The property must exist, belong to this user, and not be archived.
     local prop = db.query([[
         SELECT uuid, namespace_id FROM user_profile_entities
-        WHERE uuid = ? AND user_id = ? AND entity_type = 'property' AND is_archived = false
+        WHERE uuid = ? AND user_id = ? AND entity_type = ? AND is_archived = false
         LIMIT 1
-    ]], property_uuid, internal_user_id)
+    ]], property_uuid, internal_user_id, entity_type or "property")
     if not prop or #prop == 0 then return nil, "Property not found" end
 
     if not data.amount or tonumber(data.amount) == nil or tonumber(data.amount) <= 0 then
         return nil, "amount must be a positive number"
     end
-    if data.kind ~= "income" and data.kind ~= "expense" then
-        return nil, "kind must be 'income' or 'expense'"
+    local VALID_KINDS = { income = true, expense = true, finance_cost = true, adjustment = true }
+    if not VALID_KINDS[data.kind] then
+        return nil, "kind must be one of income, expense, finance_cost, adjustment"
     end
     if not data.category_key or data.category_key == "" then
         return nil, "category_key is required"

--- a/lapis/queries/PropertyQueries.lua
+++ b/lapis/queries/PropertyQueries.lua
@@ -22,7 +22,21 @@ local cjson = require("cjson")
 
 local PropertyQueries = {}
 
+-- Default entity type — the UK rental hub. Every function accepts an
+-- optional trailing entity_type so the overseas hub ("Land and property
+-- abroad", entity_type='overseas_property') reuses the exact same engine;
+-- omitting it keeps the original UK behaviour byte-for-byte.
 local ENTITY_TYPE = "property"
+
+local function resolve_type(entity_type)
+    return entity_type or ENTITY_TYPE
+end
+
+-- Audit label: 'property' stays "PROPERTY" (historical rows unchanged);
+-- 'overseas_property' becomes "OVERSEAS_PROPERTY".
+local function audit_label(entity_type)
+    return string.upper(resolve_type(entity_type))
+end
 
 local function resolveUserId(user)
     if not user then return nil, "User not authenticated" end
@@ -59,12 +73,12 @@ end
 -- hub can render "Income / Expenses / Net" per property in a single call.
 -- ────────────────────────────────────────────────────────────────────────────
 -- params: { tax_year?, include_archived? }
-function PropertyQueries.all(params, user)
+function PropertyQueries.all(params, user, entity_type)
     local internal_user_id, err = resolveUserId(user)
     if not internal_user_id then return nil, err end
 
     local where = { "user_id = ?", "entity_type = ?" }
-    local args = { internal_user_id, ENTITY_TYPE }
+    local args = { internal_user_id, resolve_type(entity_type) }
     if params.include_archived ~= "true" and params.include_archived ~= true then
         table.insert(where, "is_archived = false")
     end
@@ -108,7 +122,7 @@ end
 -- Show (ownership-scoped). Used by routes AND by profile-builder's
 -- entity-answer guard — keep the return shape stable.
 -- ────────────────────────────────────────────────────────────────────────────
-function PropertyQueries.show(property_uuid, user)
+function PropertyQueries.show(property_uuid, user, entity_type)
     local internal_user_id, err = resolveUserId(user)
     if not internal_user_id then return nil, err end
 
@@ -116,7 +130,7 @@ function PropertyQueries.show(property_uuid, user)
         SELECT * FROM user_profile_entities
         WHERE uuid = ? AND user_id = ? AND entity_type = ?
         LIMIT 1
-    ]], property_uuid, internal_user_id, ENTITY_TYPE)
+    ]], property_uuid, internal_user_id, resolve_type(entity_type))
     if not rows or #rows == 0 then return nil end
     return present(rows[1])
 end
@@ -125,7 +139,7 @@ end
 -- Create — label is the only required field; everything else about a
 -- property is admin-driven questions answered later on its page.
 -- ────────────────────────────────────────────────────────────────────────────
-function PropertyQueries.create(data, user)
+function PropertyQueries.create(data, user, entity_type)
     local internal_user_id, err = resolveUserId(user)
     if not internal_user_id then return nil, err end
 
@@ -145,7 +159,7 @@ function PropertyQueries.create(data, user)
         internal_user_id,
         tostring(user.uuid or user.id),
         resolveNamespaceId(internal_user_id) or db.NULL,
-        ENTITY_TYPE,
+        resolve_type(entity_type),
         tostring(data.label),
         data.metadata_json or db.NULL,
         tonumber(data.display_order) or 0
@@ -155,7 +169,7 @@ function PropertyQueries.create(data, user)
     TaxAuditLogQueries.log({
         user_id = internal_user_id,
         user_email = user.email,
-        entity_type = "PROPERTY",
+        entity_type = audit_label(entity_type),
         entity_id = uuid,
         action = "CREATE",
         new_values = cjson.encode(row),
@@ -166,14 +180,14 @@ end
 -- ────────────────────────────────────────────────────────────────────────────
 -- Update (label / metadata / display_order)
 -- ────────────────────────────────────────────────────────────────────────────
-function PropertyQueries.update(property_uuid, data, user)
+function PropertyQueries.update(property_uuid, data, user, entity_type)
     local internal_user_id, err = resolveUserId(user)
     if not internal_user_id then return nil, err end
 
     local existing = db.query([[
         SELECT * FROM user_profile_entities
         WHERE uuid = ? AND user_id = ? AND entity_type = ? LIMIT 1
-    ]], property_uuid, internal_user_id, ENTITY_TYPE)
+    ]], property_uuid, internal_user_id, resolve_type(entity_type))
     if not existing or #existing == 0 then return nil end
     local old = existing[1]
 
@@ -204,7 +218,7 @@ function PropertyQueries.update(property_uuid, data, user)
     TaxAuditLogQueries.log({
         user_id = internal_user_id,
         user_email = user.email,
-        entity_type = "PROPERTY",
+        entity_type = audit_label(entity_type),
         entity_id = property_uuid,
         action = "UPDATE",
         old_values = cjson.encode(old),
@@ -218,14 +232,14 @@ end
 -- figures drop out of summaries; entity-scoped answers are left in place
 -- (they're harmless once the parent is archived and keep history intact).
 -- ────────────────────────────────────────────────────────────────────────────
-function PropertyQueries.archive(property_uuid, user)
+function PropertyQueries.archive(property_uuid, user, entity_type)
     local internal_user_id, err = resolveUserId(user)
     if not internal_user_id then return nil, err end
 
     local existing = db.query([[
         SELECT * FROM user_profile_entities
         WHERE uuid = ? AND user_id = ? AND entity_type = ? LIMIT 1
-    ]], property_uuid, internal_user_id, ENTITY_TYPE)
+    ]], property_uuid, internal_user_id, resolve_type(entity_type))
     if not existing or #existing == 0 then return nil end
 
     db.query([[
@@ -242,7 +256,7 @@ function PropertyQueries.archive(property_uuid, user)
     TaxAuditLogQueries.log({
         user_id = internal_user_id,
         user_email = user.email,
-        entity_type = "PROPERTY",
+        entity_type = audit_label(entity_type),
         entity_id = property_uuid,
         action = "DELETE",
         old_values = cjson.encode(existing[1]),
@@ -254,11 +268,11 @@ end
 -- Summary — the hub's read-only strip: business-wide totals for one tax
 -- year plus the per-property breakdown.
 -- ────────────────────────────────────────────────────────────────────────────
-function PropertyQueries.summary(tax_year, user)
+function PropertyQueries.summary(tax_year, user, entity_type)
     local internal_user_id, err = resolveUserId(user)
     if not internal_user_id then return nil, err end
 
-    local list = PropertyQueries.all({ tax_year = tax_year }, user)
+    local list = PropertyQueries.all({ tax_year = tax_year }, user, entity_type)
     local income, expense = 0, 0
     for _, p in ipairs(list.data) do
         income = income + (tonumber(p.income_total) or 0)

--- a/lapis/routes/profile-builder.lua
+++ b/lapis/routes/profile-builder.lua
@@ -41,8 +41,9 @@ local LOCK_FIELD_BY_QUESTION_KEY = {
 -- cross-type shadow rows (business answers saved against a property
 -- entity, or a property's answers merged into a business schema).
 local PER_ENTITY_CONTEXTS = {
-    property = "property",   -- rental hub → per-property pages
-    business = "business",   -- self-employment hub → per-business pages
+    property = "property",                     -- rental hub → per-property pages
+    business = "business",                     -- self-employment hub → per-business pages
+    overseas_property = "overseas_property",   -- land & property abroad → per-holding pages
 }
 
 -- =========================================================================

--- a/lapis/routes/tax-overseas-properties.lua
+++ b/lapis/routes/tax-overseas-properties.lua
@@ -1,0 +1,260 @@
+--[[
+    Overseas Property Routes — the "Land and property abroad" hub's backend
+    surface (SA106). Thin mirror of tax-properties.lua running the SAME
+    query engine with entity_type='overseas_property' and the overseas
+    catalogue schedule.
+
+    Endpoints (all auth-required):
+      GET    /api/v2/tax/overseas-line-categories             admin catalogue → line forms
+      GET    /api/v2/tax/overseas/summary?tax_year=           hub summary strip (read-only, derived)
+      GET    /api/v2/tax/overseas-properties?tax_year=        list + per-holding totals
+      POST   /api/v2/tax/overseas-properties                  { label }
+      GET    /api/v2/tax/overseas-properties/:uuid
+      PUT    /api/v2/tax/overseas-properties/:uuid            { label?, metadata_json?, display_order? }
+      DELETE /api/v2/tax/overseas-properties/:uuid            soft archive (also archives its lines)
+      GET    /api/v2/tax/overseas-properties/:uuid/lines?tax_year=&kind=
+      POST   /api/v2/tax/overseas-properties/:uuid/lines      { kind, category_key, amount, tax_year, description?, disallowable_amount? }
+      PUT    /api/v2/tax/overseas-property-lines/:uuid
+      DELETE /api/v2/tax/overseas-property-lines/:uuid        soft archive
+
+    Kinds go beyond income/expense: 'finance_cost' (restricted residential
+    finance costs — excluded from expense totals, as on the SA106 form) and
+    'adjustment' (unused residential finance costs brought forward).
+    disallowable_amount carries the form's "Private use (£)" split.
+
+    Holding-scope QUESTIONS (country, number of properties, address,
+    accounting basis, PIA claim) come from the Profile Builder
+    (?context=overseas_property&entity=<uuid>) — admin-configurable.
+]]
+
+local cjson = require("cjson")
+local PropertyQueries = require "queries.PropertyQueries"
+local PropertyLineQueries = require "queries.PropertyLineQueries"
+local AuthMiddleware = require("middleware.auth")
+
+local ENTITY_TYPE = "overseas_property"
+local SCHEDULE = "overseas_property"
+local VALID_KINDS = { income = true, expense = true, finance_cost = true, adjustment = true }
+
+-- YYYY-YY (e.g. 2026-27) — same contract as my-incomes / tax-properties.
+local function valid_tax_year(s)
+    if type(s) ~= "string" then return false end
+    local y1, y2 = s:match("^(%d%d%d%d)%-(%d%d)$")
+    if not y1 or not y2 then return false end
+    return tonumber(y2) == (tonumber(y1) + 1) % 100
+end
+
+-- Parse JSON or form body — same helper as tax-properties.lua: cjson.null
+-- stripped at the boundary, body-file fallback for spooled bodies.
+local function parse_request_body()
+    ngx.req.read_body()
+    local content_type = ngx.var.content_type or ""
+    if content_type:find("application/json", 1, true) then
+        local ok, result = pcall(function()
+            local body = ngx.req.get_body_data()
+            if not body or body == "" then
+                local path = ngx.req.get_body_file()
+                if path then
+                    local f = io.open(path, "rb")
+                    if f then
+                        body = f:read("*a")
+                        f:close()
+                    end
+                end
+            end
+            if not body or body == "" then return {} end
+            return cjson.decode(body)
+        end)
+        if ok and type(result) == "table" then
+            for k, v in pairs(result) do
+                if v == cjson.null then result[k] = nil end
+            end
+            return result
+        end
+        return {}
+    end
+    local post_args = ngx.req.get_post_args()
+    if post_args and next(post_args) then return post_args end
+    return {}
+end
+
+local function merge_params(self)
+    local body_params = parse_request_body()
+    for k, v in pairs(body_params) do
+        if self.params[k] == nil then self.params[k] = v end
+    end
+end
+
+-- Validate a line-item payload against the OVERSEAS catalogue.
+local function validate_line(params, is_create)
+    if is_create or params.kind ~= nil then
+        if not VALID_KINDS[params.kind] then
+            return false, "kind must be one of income, expense, finance_cost, adjustment"
+        end
+    end
+    if is_create or params.amount ~= nil then
+        local n = tonumber(params.amount)
+        if not n or n <= 0 then
+            return false, "amount is required and must be a positive number"
+        end
+        params.amount = n
+    end
+    if params.disallowable_amount ~= nil and params.disallowable_amount ~= "" then
+        local d = tonumber(params.disallowable_amount)
+        if not d or d < 0 then
+            return false, "disallowable_amount (private use) must be a non-negative number"
+        end
+        params.disallowable_amount = d
+    end
+    if is_create or params.tax_year ~= nil then
+        if not valid_tax_year(params.tax_year) then
+            return false, "tax_year must be YYYY-YY (e.g. 2026-27)"
+        end
+    end
+    if is_create or params.category_key ~= nil then
+        local kind = params.kind
+        if not kind or not VALID_KINDS[kind] then
+            return false, "kind must accompany category_key"
+        end
+        if not PropertyLineQueries.active_keys(kind, SCHEDULE)[params.category_key] then
+            return false, "category_key is not an active overseas " .. kind .. " category"
+        end
+    end
+    if params.description and type(params.description) == "string" and #params.description > 500 then
+        return false, "description must be 500 characters or fewer"
+    end
+    return true
+end
+
+return function(app)
+    -- ── Catalogue ───────────────────────────────────────────────────────────
+    app:get("/api/v2/tax/overseas-line-categories", AuthMiddleware.requireAuth(function(_)
+        local rows = PropertyLineQueries.categories(SCHEDULE)
+        local data = {}
+        for _, r in ipairs(rows) do
+            data[#data + 1] = {
+                key = r.category_key,
+                label = r.label,
+                kind = r.kind,
+                description = r.description,
+                hmrc_mapping = r.hmrc_mapping,
+                display_order = r.display_order,
+            }
+        end
+        return { json = { data = #data > 0 and data or cjson.empty_array }, status = 200 }
+    end))
+
+    -- ── Hub summary (read-only, derived) ────────────────────────────────────
+    app:get("/api/v2/tax/overseas/summary", AuthMiddleware.requireAuth(function(self)
+        local tax_year = self.params.tax_year
+        if not valid_tax_year(tax_year) then
+            return { json = { error = "tax_year must be YYYY-YY (e.g. 2026-27)" }, status = 400 }
+        end
+        local result, err = PropertyQueries.summary(tax_year, self.current_user, ENTITY_TYPE)
+        if not result then
+            return { json = { error = err or "Failed to build summary" }, status = 400 }
+        end
+        if #result.properties == 0 then result.properties = cjson.empty_array end
+        return { json = { data = result }, status = 200 }
+    end))
+
+    -- ── Holdings ────────────────────────────────────────────────────────────
+    app:get("/api/v2/tax/overseas-properties", AuthMiddleware.requireAuth(function(self)
+        local result, err = PropertyQueries.all(self.params, self.current_user, ENTITY_TYPE)
+        if not result then
+            return { json = { error = err or "Failed to list overseas properties" }, status = 400 }
+        end
+        if #result.data == 0 then result.data = cjson.empty_array end
+        return { json = result, status = 200 }
+    end))
+
+    app:post("/api/v2/tax/overseas-properties", AuthMiddleware.requireAuth(function(self)
+        merge_params(self)
+        if not self.params.label or tostring(self.params.label):gsub("%s", "") == "" then
+            return { json = { error = "label is required" }, status = 400 }
+        end
+        if #tostring(self.params.label) > 120 then
+            return { json = { error = "label must be 120 characters or fewer" }, status = 400 }
+        end
+        local row, err = PropertyQueries.create(self.params, self.current_user, ENTITY_TYPE)
+        if not row then return { json = { error = err or "Failed to create overseas property" }, status = 400 } end
+        return { json = { data = row }, status = 201 }
+    end))
+
+    app:get("/api/v2/tax/overseas-properties/:uuid", AuthMiddleware.requireAuth(function(self)
+        local row = PropertyQueries.show(tostring(self.params.uuid), self.current_user, ENTITY_TYPE)
+        if not row then return { json = { error = "Overseas property not found" }, status = 404 } end
+        return { json = { data = row }, status = 200 }
+    end))
+
+    app:put("/api/v2/tax/overseas-properties/:uuid", AuthMiddleware.requireAuth(function(self)
+        merge_params(self)
+        if self.params.label ~= nil and #tostring(self.params.label) > 120 then
+            return { json = { error = "label must be 120 characters or fewer" }, status = 400 }
+        end
+        local row, err = PropertyQueries.update(tostring(self.params.uuid), self.params, self.current_user, ENTITY_TYPE)
+        if not row then return { json = { error = err or "Overseas property not found" }, status = err and 400 or 404 } end
+        return { json = { data = row }, status = 200 }
+    end))
+
+    app:delete("/api/v2/tax/overseas-properties/:uuid", AuthMiddleware.requireAuth(function(self)
+        local ok = PropertyQueries.archive(tostring(self.params.uuid), self.current_user, ENTITY_TYPE)
+        if not ok then return { json = { error = "Overseas property not found" }, status = 404 } end
+        return { json = { message = "Overseas property archived" }, status = 200 }
+    end))
+
+    -- ── Line items ──────────────────────────────────────────────────────────
+    app:get("/api/v2/tax/overseas-properties/:uuid/lines", AuthMiddleware.requireAuth(function(self)
+        -- Ownership check first so an unknown/foreign holding 404s rather
+        -- than returning an empty list.
+        local prop = PropertyQueries.show(tostring(self.params.uuid), self.current_user, ENTITY_TYPE)
+        if not prop then return { json = { error = "Overseas property not found" }, status = 404 } end
+        local result, err = PropertyLineQueries.all(prop.id, self.params, self.current_user)
+        if not result then
+            return { json = { error = err or "Failed to list line items" }, status = 400 }
+        end
+        if #result.data == 0 then result.data = cjson.empty_array end
+        return { json = result, status = 200 }
+    end))
+
+    app:post("/api/v2/tax/overseas-properties/:uuid/lines", AuthMiddleware.requireAuth(function(self)
+        merge_params(self)
+        local ok, vmsg = validate_line(self.params, true)
+        if not ok then return { json = { error = vmsg }, status = 400 } end
+        local row, err = PropertyLineQueries.create(tostring(self.params.uuid), self.params, self.current_user, ENTITY_TYPE)
+        if not row then
+            local status = (err == "Property not found") and 404 or 400
+            return { json = { error = err or "Failed to create line item" }, status = status }
+        end
+        return { json = { data = row }, status = 201 }
+    end))
+
+    app:put("/api/v2/tax/overseas-property-lines/:uuid", AuthMiddleware.requireAuth(function(self)
+        merge_params(self)
+        local existing = PropertyLineQueries.show(tostring(self.params.uuid), self.current_user)
+        if not existing then return { json = { error = "Line item not found" }, status = 404 } end
+        -- kind is immutable; inject the stored kind so category validation
+        -- checks against the right catalogue slice. Grandfather an unchanged
+        -- category_key (admin may have retired it since).
+        self.params.kind = nil
+        if self.params.category_key ~= nil then
+            if existing.category_key == self.params.category_key then
+                self.params.category_key = nil
+            else
+                self.params.kind = existing.kind
+            end
+        end
+        local ok, vmsg = validate_line(self.params, false)
+        if not ok then return { json = { error = vmsg }, status = 400 } end
+        self.params.kind = nil -- never persisted on update
+        local row, err = PropertyLineQueries.update(tostring(self.params.uuid), self.params, self.current_user)
+        if not row then return { json = { error = err or "Line item not found" }, status = 404 } end
+        return { json = { data = row }, status = 200 }
+    end))
+
+    app:delete("/api/v2/tax/overseas-property-lines/:uuid", AuthMiddleware.requireAuth(function(self)
+        local ok = PropertyLineQueries.archive(tostring(self.params.uuid), self.current_user)
+        if not ok then return { json = { error = "Line item not found" }, status = 404 } end
+        return { json = { message = "Line item archived" }, status = 200 }
+    end))
+end


### PR DESCRIPTION
## Summary

Backend for the **Land and property abroad** hub (SA106) — third instance of the hub + per-entity drill-down architecture. Companion frontend PR in diy-tax-return-uk.

- **Holdings** = `user_profile_entities` rows (`entity_type='overseas_property'`), one per country/holding. `PropertyQueries`/`PropertyLineQueries` are parameterised with optional `entity_type`/`schedule` — omitted params keep UK behaviour byte-for-byte, so the rental surface is untouched.
- **Catalogue split**: `property_line_categories.schedule` (`'uk_property'` default | `'overseas_property'`). Overseas seed: rents + lease premiums (income), one free-form expense category (the reference form's expenses are description + amount + **Private use (£)** — carried by the existing `disallowable_amount` column), and `finance_cost`/`adjustment` kinds for restricted residential finance costs, which are **excluded from expense totals** exactly as the form excludes them.
- **Income type**: new `income_types` row `overseas_property` — the profile's `selected_income_types` question sources options from the catalogue, so it becomes selectable everywhere with no extra seeding.
- **Questions**: contexted section (`context='overseas_property'`): country (required), number of properties, address, accounting basis, £1,000 PIA claim (help text covers the expenses-ignored rule and one-allowance-across-all-property). Context registered in `PER_ENTITY_CONTEXTS` with its entity type — the entity-type match from the review fixes covers it automatically.
- **Routes**: `tax-overseas-properties.lua` mirrors `tax-properties.lua` (holdings CRUD, lines CRUD, catalogue, `/tax/overseas/summary`), including the body-file fallback and per-kind validation.

## Migrations

737–740, gated on `tax_copilot`; additive only (one new column with default, three seeds). The pipeline's **migration gate** verifies the full chain from a zero-state database on push to main before any deploy can start.

## Notes

- Question types verified against `chk_question_type` (lesson from #481).
- Option seed keeps the explicit `parent_option_id NULL` (#476).
- Known accepted gap, same as rental/SE: overseas figures don't feed the FastAPI calculation yet — the frontend ships the "Used in your tax calculation" my_incomes card as the honest bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)