### PR TITLE
fix: get workstation-opsapi deploying to k3s1 (DNS token, ESO v1, config env, rollout)

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -465,18 +465,34 @@ jobs:
             PROJECT_CODE_ARG="--set projectCode=${{ github.event.inputs.PROJECT_CODE }}"
           fi
 
+          # No --wait here on purpose. The app's config.lua lives in a Secret
+          # (rendered by the ExternalSecret), not the pod template, so a
+          # config-only change does not alter the Deployment and helm --wait
+          # would just block on the EXISTING pods. We drive the rollout
+          # explicitly in the next step instead.
           helm upgrade --install "${RELEASE_NAME}" "${HELM_CHART_PATH}" \
             -f "$VALUES" \
             --namespace "${TARGET_ENV}" --create-namespace \
             --set image.repository="${IMAGE_REGISTRY}/${IMAGE_NAME}" \
             --set image.tag="${TAG}" \
-            $PROJECT_CODE_ARG \
-            --wait --timeout 5m
+            $PROJECT_CODE_ARG
 
-      - name: Rollout status
+      - name: Roll out and wait
         run: |
-          kubectl -n "${TARGET_ENV}" rollout status "deploy/${RELEASE_NAME}" --timeout=5m
-          kubectl -n "${TARGET_ENV}" get pods -o wide -l app="${RELEASE_NAME}"
+          set -euo pipefail
+          NS="${TARGET_ENV}"; REL="${RELEASE_NAME}"
+          # Wait for ESO to sync the Secret (which carries config.lua) BEFORE
+          # rolling, so the new pods start with the current config rather than
+          # a stale/half-rendered one.
+          kubectl -n "$NS" wait --for=condition=Ready "externalsecret/${REL}-secrets" --timeout=120s \
+            || echo "::warning::ExternalSecret ${REL}-secrets not Ready within 120s — rolling anyway"
+          # Force a fresh rollout so pods pick up Secret/config changes even
+          # when the pod template is unchanged (this is what a Secret-only
+          # change is). This makes config-only deploys reliable and skips any
+          # stale pod stuck in CrashLoopBackOff.
+          kubectl -n "$NS" rollout restart "deploy/$REL"
+          kubectl -n "$NS" rollout status "deploy/$REL" --timeout=6m
+          kubectl -n "$NS" get pods -o wide -l app="$REL"
 
       - name: Public URL probe (informational)
         run: |

--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -353,12 +353,13 @@ jobs:
 
       - name: Ensure the CNAME for this environment
         env:
-          # opsapi authenticates to Cloudflare with the legacy global key +
-          # account email (cloudflare-dns.sh supports this path). CLOUDFLARE_ZONE
-          # is set to workstation.co.uk here, overriding the repo's default zone
-          # secret, so the record lands in the right zone.
-          CLOUDFLARE_ACCOUNT_EMAIL: ${{ secrets.CLOUDFLARE_ACCOUNT_EMAIL }}
-          CLOUDFLARE_ACCOUNT_API_KEY: ${{ secrets.CLOUDFLARE_ACCOUNT_API_KEY }}
+          # Scoped API token (Bearer) — cloudflare-dns.sh prefers this over the
+          # legacy global key. We switched because opsapi's legacy
+          # CLOUDFLARE_ACCOUNT_EMAIL/API_KEY are invalid (Cloudflare 9103
+          # "Unknown X-Auth-Key or X-Auth-Email"). This token has Zone:Read +
+          # Zone:DNS:Edit and covers the workstation.co.uk zone. CLOUDFLARE_ZONE
+          # gives the script the zone name to resolve the id from.
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ZONE: ${{ env.DNS_ZONE }}
         run: |
           set -euo pipefail

--- a/devops/helm-charts/diytaxreturn-lapis/templates/externalsecret.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/templates/externalsecret.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.externalSecret.enabled }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ .Release.Name }}-secrets

--- a/devops/helm-charts/diytaxreturn-lapis/templates/externalsecret.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/templates/externalsecret.yaml
@@ -27,13 +27,15 @@ spec:
         LAPIS_CONFIG_LUA_FILE: |
           -- Read DB / OAuth / secret values from the process ENVIRONMENT
           -- (injected via envFrom this same Secret), NOT from ESO string
-          -- templating. This cluster's external-secrets (v1 CRD) does not
-          -- substitute `{{`{{ .KEY }}`}}` placeholders in template.data — it
-          -- left the baked config.lua with a literal "{{`{{ .POSTGRES_HOST }}`}}"
-          -- host, so pgmoon failed with "host or service not provided" and the
-          -- pod crash-looped on its postStart migrate. os.getenv keeps config
-          -- correct regardless of ESO's templating behaviour, and matches the
-          -- image's own /app/config.lua.
+          -- templating. This cluster's external-secrets did not substitute the
+          -- Go-template placeholders this file used to contain, leaving a
+          -- literal placeholder as the postgres host, so pgmoon failed with
+          -- "host or service not provided" and the pod crash-looped on its
+          -- postStart migrate. os.getenv keeps config correct regardless of
+          -- ESO templating and matches the image's own /app/config.lua.
+          -- NOTE: never put a Go-template action (double-brace .KEY) anywhere
+          -- in this block, including comments — ESO engineVersion v2 executes
+          -- it and fails the whole ExternalSecret with "map has no entry".
           local config = require("lapis.config")
           config("production", {
             port = 80,

--- a/devops/helm-charts/diytaxreturn-lapis/templates/externalsecret.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/templates/externalsecret.yaml
@@ -25,6 +25,15 @@ spec:
       mergePolicy: Merge
       data:
         LAPIS_CONFIG_LUA_FILE: |
+          -- Read DB / OAuth / secret values from the process ENVIRONMENT
+          -- (injected via envFrom this same Secret), NOT from ESO string
+          -- templating. This cluster's external-secrets (v1 CRD) does not
+          -- substitute `{{`{{ .KEY }}`}}` placeholders in template.data — it
+          -- left the baked config.lua with a literal "{{`{{ .POSTGRES_HOST }}`}}"
+          -- host, so pgmoon failed with "host or service not provided" and the
+          -- pod crash-looped on its postStart migrate. os.getenv keeps config
+          -- correct regardless of ESO's templating behaviour, and matches the
+          -- image's own /app/config.lua.
           local config = require("lapis.config")
           config("production", {
             port = 80,
@@ -32,19 +41,19 @@ spec:
             code_cache = "on",
             num_workers = "1",
             session_name = "opsapi_session",
-            secret = "{{`{{ .JWT_SECRET_KEY }}`}}",
+            secret = os.getenv("JWT_SECRET_KEY"),
             postgres = {
-              host = "{{ .Values.database.host | default "{{`{{ .POSTGRES_HOST }}`}}" }}",
-              user = "{{`{{ .POSTGRES_USER }}`}}",
-              password = "{{`{{ .POSTGRES_PASSWORD }}`}}",
-              database = "opsapi",
-              port = {{`{{ .POSTGRES_PORT }}`}},
-              ssl = true
+              host = {{ if .Values.database.host }}"{{ .Values.database.host }}"{{ else }}os.getenv("POSTGRES_HOST"){{ end }},
+              user = os.getenv("POSTGRES_USER"),
+              password = os.getenv("POSTGRES_PASSWORD"),
+              database = os.getenv("POSTGRES_DB") or "opsapi",
+              port = tonumber(os.getenv("POSTGRES_PORT")) or 5432,
+              ssl = os.getenv("POSTGRES_SSL") == "true"
             },
             google = {
-              client_id = "{{`{{ .GOOGLE_CLIENT_ID }}`}}",
-              client_secret = "{{`{{ .GOOGLE_CLIENT_SECRET }}`}}",
-              redirect_uri = "{{`{{ .GOOGLE_REDIRECT_URI }}`}}"
+              client_id = os.getenv("GOOGLE_CLIENT_ID"),
+              client_secret = os.getenv("GOOGLE_CLIENT_SECRET"),
+              redirect_uri = os.getenv("GOOGLE_REDIRECT_URI")
             }
           })
   dataFrom:


### PR DESCRIPTION
Makes the single-workflow deploy of `workstation-opsapi` to k3s1 actually reach a healthy, publicly-served pod. Found and fixed five distinct blockers by driving the live rollout to `int` end-to-end.

**Verified live:** `https://int-opsapi.workstation.co.uk/health` → **HTTP 200**, database + MinIO healthy, pod `1/1 Running`, and the full workflow run is **green** (build → smoke → dns → wslproxy → deploy).

## The five fixes (in the order they surfaced)

1. **Cloudflare DNS — `9103 Unknown X-Auth-Key`.** opsapi's legacy `CLOUDFLARE_ACCOUNT_*` creds are invalid. Switched the DNS job to `CLOUDFLARE_API_TOKEN` (Bearer). *(requires the `CLOUDFLARE_API_TOKEN` secret — set)*
2. **ExternalSecret — `no matches for kind ExternalSecret in v1beta1`.** k3s1's ESO serves only `external-secrets.io/v1`. Bumped the chart template.
3. **config.lua — `postgres failed to connect: host or service not provided`.** The ESO `engineVersion: v2` template didn't substitute `{{ .POSTGRES_HOST }}`, baking a literal placeholder as the DB host. Switched config.lua to `os.getenv()` (the env vars are correctly injected via `envFrom`). Verified against the live int DB.
4. **ExternalSecret sync error — `map has no entry for key`.** A Go-template action left in a code comment was executed by ESO and broke the whole secret. Made the block brace-free.
5. **Deploy rollout — `Progress deadline exceeded`.** config.lua lives in a Secret, not the pod template, so helm `--wait` blocked on stale pods. Replaced with an explicit ExternalSecret-wait + `rollout restart` + `rollout status`, so config-only deploys roll pods reliably.

## Credentials set on the repo (out of band)
`WSLPROXY_GATEWAY_DOMAIN`, `WSLPROXY_ADMIN_EMAIL` (vars); `ADMIN_PASSWORD`, `CLOUDFLARE_API_TOKEN`, refreshed `KUBE_CONFIG_DATA_K3S` (secrets).

## Still manual-only (unchanged)
`test`/`acc`/`prod` deploy via `workflow_dispatch`. `test`/`acc` Vault paths verified present; `prod` has none yet (expected — never auto-deployed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)