### PR TITLE
feat(pension): Relief - Pension payments system (SA100 TR4)

### DIFF
--- a/lapis/app.lua
+++ b/lapis/app.lua
@@ -519,6 +519,9 @@ load_if("tax_copilot", "routes.tax-businesses")
 -- Overseas property hub ("Land and property abroad", SA106): same engine as
 -- tax-properties with entity_type='overseas_property' + overseas catalogue.
 load_if("tax_copilot", "routes.tax-overseas-properties")
+-- Pension payments ("Relief: Pension payments", SA100 TR4): section
+-- catalogue + payment rows straight off the user — no entity layer.
+load_if("tax_copilot", "routes.tax-pension-payments")
 -- Billing (single-merchant Stripe: admin plans + subscription/one-time checkout)
 load_if("tax_copilot", "routes.billing-plans")
 load_if("tax_copilot", "routes.billing-checkout")

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -176,6 +176,10 @@ local self_employment_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_CO
 -- schedule split, plus the overseas_property income type + question section
 local overseas_property_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.overseas-property-system") or {}
 
+-- Pension Payments (tax_copilot feature) — "Relief: Pension payments"
+-- (SA100 TR4): section catalogue + payment rows, no per-entity drill-down
+local pension_payments_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.pension-payments-system") or {}
+
 -- Billing / payments (Stripe Connect: subscriptions + one-time). Gated on
 -- tax_copilot for now; broaden to a feature list (e.g. {ECOMMERCE, TAX_COPILOT})
 -- once multiple project codes need it. See migrations/billing-system.lua.
@@ -1907,6 +1911,18 @@ local _migrations = {
     ['738_seed_overseas_line_categories'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, overseas_property_migrations, 2),
     ['739_seed_overseas_income_type'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, overseas_property_migrations, 3),
     ['740_seed_overseas_section'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, overseas_property_migrations, 4),
+
+    -- ─────────────────────────────────────────────────────────────────────
+    -- PENSION PAYMENTS — "Relief: Pension payments" (SA100 TR4). 744-745
+    -- add the section catalogue + seed; 746 the payment rows; 747 the
+    -- income type. (Prefixes 741-743 are shared with unrelated invoicing
+    -- keys — full key strings differ, so ordering is unaffected; these
+    -- start at 744 purely for readability.)
+    -- ─────────────────────────────────────────────────────────────────────
+    ['744_create_pension_payment_categories'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, pension_payments_migrations, 1),
+    ['745_seed_pension_payment_categories'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, pension_payments_migrations, 2),
+    ['746_create_pension_payment_items'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, pension_payments_migrations, 3),
+    ['747_seed_pension_payments_income_type'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, pension_payments_migrations, 4),
 
     -- =========================================================================
     -- Academy (LMS): courses + lessons (namespace-scoped). Feature-gated, so

--- a/lapis/migrations/pension-payments-system.lua
+++ b/lapis/migrations/pension-payments-system.lua
@@ -68,7 +68,12 @@ return {
                 label = "Payments into registered schemes and retirement annuity contracts",
                 desc = "Personal payments into registered pension schemes and retirement annuity contracts. "
                     .. "Tick 'relief claimed by provider' where the scheme adds basic-rate tax relief for you (relief at source).",
-                mapping = '{"sa100_box":"TR4.1","sa100_box_no_relief":"TR4.2","sa100_box_one_off":"TR4.1.1"}',
+                -- gross_up: amounts are recorded NET (what the user paid);
+                -- TR4 box 1 wants the grossed-up figure (net × 100/80), so any
+                -- box-emitting consumer MUST apply basic-rate gross-up to
+                -- relief-at-source rows. Recording net + this marker mirrors
+                -- how the reference software collects the value.
+                mapping = '{"sa100_box":"TR4.1","sa100_box_no_relief":"TR4.2","sa100_box_one_off":"TR4.1.1","gross_up":"basic_rate"}',
                 relief_flag = true,
                 one_off_flag = true,
                 order = 1,
@@ -156,6 +161,13 @@ return {
     --    how users opt sections onto their return, so it lives in the same
     --    catalogue (display name spells out the distinction from the existing
     --    'pension' income type).
+    --
+    --    allows_manual_entry = FALSE is load-bearing: a my_incomes row typed
+    --    'pension_payments' would be SUMMED AS INCOME by the calculation —
+    --    the exact wrong direction for a relief. routes/my-incomes.lua
+    --    enforces this flag on create/type-change; the questionnaire options
+    --    and the /types dropdown filter on is_active only, so the section
+    --    stays selectable and the hub link stays visible.
     -- =========================================================================
     [4] = function()
         local docs = cjson.encode({
@@ -170,7 +182,7 @@ return {
                  created_at, updated_at)
             VALUES (?, 'pension_payments', 'Pension payments (tax relief)',
                     'Payments you made INTO pension schemes that qualify for tax relief — not pension income.',
-                    ?::jsonb, true,
+                    ?::jsonb, false,
                     '[]'::jsonb, '{}'::jsonb, NULL,
                     '{}'::jsonb, 65, true, NULL, NOW(), NOW())
             ON CONFLICT (income_type_key) DO NOTHING

--- a/lapis/migrations/pension-payments-system.lua
+++ b/lapis/migrations/pension-payments-system.lua
@@ -1,0 +1,180 @@
+--[[
+  Pension Payments System — "Relief: Pension payments" (SA100 page TR4,
+  boxes 1 / 1.1 / 2 / 3 / 4). Unlike rental / self-employment / overseas
+  property there is NO per-entity drill-down here: payments hang straight
+  off the user + tax year, grouped into admin-managed sections.
+
+  1. pension_payment_categories : the SECTIONS of the reference screen
+     ("Payments into registered schemes…", "Payments to employer
+      schemes…", "Payments to eligible overseas schemes…") — an admin
+     catalogue like property_line_categories, so new sections are a row
+     insert, not a deploy. supports_relief_flag / supports_one_off_flag
+     tell the frontend which sections show the two per-row checkboxes
+     (only registered schemes on the reference form).
+  2. pension_payment_items      : the user's payment rows (provider +
+     description, amount, the two flags), one per payment per tax year.
+     Soft-delete like property_line_items.
+  3. A new income_types row makes "Pension payments (tax relief)"
+     selectable in the profile questionnaire — selected_income_types
+     sources its options from that catalogue, so no option seeding.
+
+  The relief-at-source flag is what routes a registered-scheme row to
+  box 1 (provider claims basic-rate relief) vs box 2 (retirement annuity
+  contract, no relief at source); one_off feeds box 1.1.
+
+  Only executed when PROJECT_CODE includes 'tax_copilot'.
+]]
+
+local schema = require("lapis.db.schema")
+local types = schema.types
+local db = require("lapis.db")
+local cjson = require("cjson")
+local MigrationUtils = require "helper.migration-utils"
+
+return {
+    -- =========================================================================
+    -- 1. pension_payment_categories (admin catalogue — the form's sections)
+    -- =========================================================================
+    [1] = function()
+        schema.create_table("pension_payment_categories", {
+            { "id",                  types.serial },
+            { "uuid",                types.varchar({ unique = true }) },
+            { "namespace_id",        types.integer({ null = true }) },
+            { "category_key",        types.varchar({ unique = true }) },  -- stable key, e.g. 'pp_registered_schemes'
+            { "label",               types.varchar },
+            { "description",         types.text({ null = true }) },
+            { "hmrc_mapping",        types.text({ null = true }) },       -- JSON, e.g. {"sa100_box":"TR4.3"}
+            { "supports_relief_flag", types.boolean({ default = false }) }, -- show "Basic rate tax relief claimed by provider?"
+            { "supports_one_off_flag", types.boolean({ default = false }) }, -- show "Is this a one-off payment?"
+            { "display_order",       types.integer({ default = 0 }) },
+            { "is_active",           types.boolean({ default = true }) },
+            { "created_at",          types.time({ default = db.raw("NOW()") }) },
+            { "updated_at",          types.time({ default = db.raw("NOW()") }) },
+            "PRIMARY KEY (id)"
+        })
+        schema.create_index("pension_payment_categories", "is_active")
+        print("[Pension Payments] Created pension_payment_categories table")
+    end,
+
+    -- =========================================================================
+    -- 2. Seed the three TR4 sections.
+    --    Idempotent: keyed on category_key; re-running updates labels and box
+    --    mappings but never duplicates or resurrects disabled rows.
+    -- =========================================================================
+    [2] = function()
+        local rows = {
+            {
+                key = "pp_registered_schemes",
+                label = "Payments into registered schemes and retirement annuity contracts",
+                desc = "Personal payments into registered pension schemes and retirement annuity contracts. "
+                    .. "Tick 'relief claimed by provider' where the scheme adds basic-rate tax relief for you (relief at source).",
+                mapping = '{"sa100_box":"TR4.1","sa100_box_no_relief":"TR4.2","sa100_box_one_off":"TR4.1.1"}',
+                relief_flag = true,
+                one_off_flag = true,
+                order = 1,
+            },
+            {
+                key = "pp_employer_schemes",
+                label = "Payments to employer schemes not deducted from gross pay",
+                desc = "Contributions to your employer's pension scheme that were taken from pay AFTER tax, "
+                    .. "so no tax relief has been given yet.",
+                mapping = '{"sa100_box":"TR4.3"}',
+                relief_flag = false,
+                one_off_flag = false,
+                order = 2,
+            },
+            {
+                key = "pp_overseas_schemes",
+                label = "Payments to eligible overseas schemes not deducted from gross pay",
+                desc = "Payments to a qualifying overseas pension scheme, paid out of taxed income and "
+                    .. "eligible for UK tax relief.",
+                mapping = '{"sa100_box":"TR4.4"}',
+                relief_flag = false,
+                one_off_flag = false,
+                order = 3,
+            },
+        }
+        for _, r in ipairs(rows) do
+            local exists = db.select("id FROM pension_payment_categories WHERE category_key = ?", r.key)
+            if exists and #exists > 0 then
+                db.query([[
+                    UPDATE pension_payment_categories
+                       SET label = ?, description = ?, hmrc_mapping = ?,
+                           supports_relief_flag = ?, supports_one_off_flag = ?,
+                           display_order = ?, updated_at = NOW()
+                     WHERE category_key = ?
+                ]], r.label, r.desc, r.mapping, r.relief_flag, r.one_off_flag, r.order, r.key)
+            else
+                db.query([[
+                    INSERT INTO pension_payment_categories
+                        (uuid, category_key, label, description, hmrc_mapping,
+                         supports_relief_flag, supports_one_off_flag,
+                         display_order, is_active, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, true, NOW(), NOW())
+                ]], MigrationUtils.generateUUID(), r.key, r.label, r.desc, r.mapping,
+                    r.relief_flag, r.one_off_flag, r.order)
+            end
+        end
+        print("[Pension Payments] Seeded pension_payment_categories (SA100 TR4)")
+    end,
+
+    -- =========================================================================
+    -- 3. pension_payment_items
+    --    category_key references pension_payment_categories.category_key —
+    --    varchar, no FK, same softness rationale as property_line_items:
+    --    retiring a section must never cascade-destroy historical rows.
+    -- =========================================================================
+    [3] = function()
+        schema.create_table("pension_payment_items", {
+            { "id",               types.serial },
+            { "uuid",             types.varchar({ unique = true }) },
+            { "user_id",          types.integer },
+            { "namespace_id",     types.integer({ null = true }) },
+            { "tax_year",         types.varchar },                  -- YYYY-YY e.g. "2026-27"
+            { "category_key",     types.varchar },                  -- pension_payment_categories key
+            { "description",      types.text({ null = true }) },    -- "Provider and payment description"
+            { "amount",           "numeric(15,2) NOT NULL" },
+            { "relief_at_source", types.boolean({ default = false }) }, -- basic-rate relief claimed by provider
+            { "one_off",          types.boolean({ default = false }) },
+            { "is_archived",      types.boolean({ default = false }) },
+            { "archived_at",      types.time({ null = true }) },
+            { "archived_by",      types.integer({ null = true }) },
+            { "created_at",       types.time({ default = db.raw("NOW()") }) },
+            { "updated_at",       types.time({ default = db.raw("NOW()") }) },
+            "PRIMARY KEY (id)"
+        })
+        schema.create_index("pension_payment_items", "user_id")
+        schema.create_index("pension_payment_items", "tax_year")
+        schema.create_index("pension_payment_items", "user_id", "tax_year", "is_archived")
+        print("[Pension Payments] Created pension_payment_items table")
+    end,
+
+    -- =========================================================================
+    -- 4. income_types catalogue row — makes "Pension payments (tax relief)"
+    --    selectable in the profile questionnaire and on /my-income. It's a
+    --    RELIEF rather than income, but the selected_income_types question is
+    --    how users opt sections onto their return, so it lives in the same
+    --    catalogue (display name spells out the distinction from the existing
+    --    'pension' income type).
+    -- =========================================================================
+    [4] = function()
+        local docs = cjson.encode({
+            { key = "pension_contribution_statements", label = "Pension contribution statements or certificates", required = false },
+        })
+        db.query([[
+            INSERT INTO income_types
+                (uuid, income_type_key, display_name, description,
+                 required_documents, allows_manual_entry,
+                 keyword_rules, category_affinity, rules_markdown,
+                 hmrc_mapping, display_order, is_active, namespace_id,
+                 created_at, updated_at)
+            VALUES (?, 'pension_payments', 'Pension payments (tax relief)',
+                    'Payments you made INTO pension schemes that qualify for tax relief — not pension income.',
+                    ?::jsonb, true,
+                    '[]'::jsonb, '{}'::jsonb, NULL,
+                    '{}'::jsonb, 65, true, NULL, NOW(), NOW())
+            ON CONFLICT (income_type_key) DO NOTHING
+        ]], MigrationUtils.generateUUID(), docs)
+        print("[Pension Payments] Seeded pension_payments income type")
+    end,
+}

--- a/lapis/queries/IncomeTypeQueries.lua
+++ b/lapis/queries/IncomeTypeQueries.lua
@@ -78,6 +78,19 @@ function IncomeTypeQueries.active_keys()
     return set
 end
 
+-- Active keys that may be WRITTEN as my_incomes rows. Catalogue rows with
+-- allows_manual_entry = false (e.g. 'pension_payments' — a RELIEF whose
+-- amounts must never be summed as income) stay selectable in the profile
+-- questionnaire and visible in /types, but my-incomes create/type-change
+-- validates against THIS set.
+function IncomeTypeQueries.manual_entry_keys()
+    local rows = db.query(
+        "SELECT income_type_key FROM income_types WHERE is_active = true AND allows_manual_entry = true")
+    local set = {}
+    for _, r in ipairs(rows or {}) do set[r.income_type_key] = true end
+    return set
+end
+
 -- ── Admin CRUD (consumed by routes/tax-admin-income-types.lua) ───────────────
 
 -- params: { include_inactive? = "false" }. Each row carries usage_count.

--- a/lapis/queries/PensionPaymentQueries.lua
+++ b/lapis/queries/PensionPaymentQueries.lua
@@ -79,10 +79,12 @@ function PensionPaymentQueries.all(params, user)
 
     local where = { "user_id = ?" }
     local args = { internal_user_id }
-    if params.tax_year and params.tax_year ~= "" then
+    -- type() guards: a repeated query-string key arrives as a Lua table,
+    -- which passes `~= ""` and would blow up in SQL interpolation.
+    if type(params.tax_year) == "string" and params.tax_year ~= "" then
         table.insert(where, "tax_year = ?"); table.insert(args, params.tax_year)
     end
-    if params.category_key and params.category_key ~= "" then
+    if type(params.category_key) == "string" and params.category_key ~= "" then
         table.insert(where, "category_key = ?"); table.insert(args, params.category_key)
     end
     if params.include_archived ~= "true" and params.include_archived ~= true then
@@ -148,11 +150,16 @@ end
 -- ────────────────────────────────────────────────────────────────────────────
 -- Show / Update / Archive — addressed by row uuid, always ownership-scoped.
 -- ────────────────────────────────────────────────────────────────────────────
+-- Archived rows are readable history via all(include_archived=true) but are
+-- immutable: show/update/archive all 404 on them (same convention Business
+-- entities adopted), so a stale tab can't edit or double-archive a row and
+-- scramble the audit trail.
 function PensionPaymentQueries.show(item_uuid, user)
     local internal_user_id, err = resolveUserId(user)
     if not internal_user_id then return nil, err end
     local rows = db.query([[
-        SELECT * FROM pension_payment_items WHERE uuid = ? AND user_id = ? LIMIT 1
+        SELECT * FROM pension_payment_items
+        WHERE uuid = ? AND user_id = ? AND is_archived = false LIMIT 1
     ]], item_uuid, internal_user_id)
     if not rows or #rows == 0 then return nil end
     return present(rows[1])
@@ -163,7 +170,8 @@ function PensionPaymentQueries.update(item_uuid, data, user)
     if not internal_user_id then return nil, err end
 
     local existing = db.query([[
-        SELECT * FROM pension_payment_items WHERE uuid = ? AND user_id = ? LIMIT 1
+        SELECT * FROM pension_payment_items
+        WHERE uuid = ? AND user_id = ? AND is_archived = false LIMIT 1
     ]], item_uuid, internal_user_id)
     if not existing or #existing == 0 then return nil end
     local old = existing[1]
@@ -224,7 +232,8 @@ function PensionPaymentQueries.archive(item_uuid, user)
     if not internal_user_id then return nil, err end
 
     local existing = db.query([[
-        SELECT * FROM pension_payment_items WHERE uuid = ? AND user_id = ? LIMIT 1
+        SELECT * FROM pension_payment_items
+        WHERE uuid = ? AND user_id = ? AND is_archived = false LIMIT 1
     ]], item_uuid, internal_user_id)
     if not existing or #existing == 0 then return nil end
 

--- a/lapis/queries/PensionPaymentQueries.lua
+++ b/lapis/queries/PensionPaymentQueries.lua
@@ -1,0 +1,289 @@
+--[[
+    Pension Payment Queries — pension_payment_items + pension_payment_categories.
+
+    Payment rows are the user's "Relief: Pension payments" entries (provider +
+    description, amount, relief-at-source / one-off flags), grouped by an
+    admin-managed section catalogue and scoped per tax year. No parent entity —
+    unlike property/business lines these hang straight off the user.
+
+    Ownership: every row is scoped to the authenticated user. Category keys
+    are stored as plain varchar (no FK) so retiring a section never breaks
+    history; updates grandfather an unchanged key the same way property lines
+    grandfather a retired category. Totals only count ACTIVE sections (a
+    deactivated section's rows stay listed and deletable but drop out of the
+    summary), matching the business-values convention.
+]]
+
+local Global = require "helper.global"
+local TaxAuditLogQueries = require "queries.TaxAuditLogQueries"
+local db = require("lapis.db")
+local cjson = require("cjson")
+
+local PensionPaymentQueries = {}
+
+-- numeric(15,2) tops out at 9,999,999,999,999.99 — reject beyond-range
+-- amounts up front instead of surfacing a numeric-overflow 500.
+local MAX_AMOUNT = 9999999999999.99
+PensionPaymentQueries.MAX_AMOUNT = MAX_AMOUNT
+
+local function resolveUserId(user)
+    if not user then return nil, "User not authenticated" end
+    local user_uuid = user.uuid or user.id
+    local rows
+    if user.uuid then
+        rows = db.query("SELECT id FROM users WHERE uuid = ? LIMIT 1", user_uuid)
+    else
+        rows = db.query("SELECT id FROM users WHERE id = ? LIMIT 1", user_uuid)
+    end
+    if not rows or #rows == 0 then return nil, "User not found" end
+    return rows[1].id
+end
+
+local function present(row)
+    row.id = row.uuid
+    row.user_id = nil
+    return row
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Catalogue
+-- ────────────────────────────────────────────────────────────────────────────
+function PensionPaymentQueries.categories()
+    local rows = db.query([[
+        SELECT uuid, category_key, label, description, hmrc_mapping,
+               supports_relief_flag, supports_one_off_flag, display_order
+        FROM pension_payment_categories
+        WHERE is_active = true
+        ORDER BY display_order ASC, label ASC
+    ]]) or {}
+    return rows
+end
+
+-- key → catalogue row for active sections — validation helper for routes
+-- (both existence and which flags the section supports).
+function PensionPaymentQueries.active_categories()
+    local map = {}
+    for _, r in ipairs(PensionPaymentQueries.categories()) do
+        map[r.category_key] = r
+    end
+    return map
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- List
+-- ────────────────────────────────────────────────────────────────────────────
+-- params: { tax_year?, category_key?, include_archived? }
+function PensionPaymentQueries.all(params, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local where = { "user_id = ?" }
+    local args = { internal_user_id }
+    if params.tax_year and params.tax_year ~= "" then
+        table.insert(where, "tax_year = ?"); table.insert(args, params.tax_year)
+    end
+    if params.category_key and params.category_key ~= "" then
+        table.insert(where, "category_key = ?"); table.insert(args, params.category_key)
+    end
+    if params.include_archived ~= "true" and params.include_archived ~= true then
+        table.insert(where, "is_archived = false")
+    end
+
+    local rows = db.query(
+        "SELECT * FROM pension_payment_items WHERE " .. table.concat(where, " AND ")
+        .. " ORDER BY created_at ASC",
+        unpack(args)) or {}
+    for _, r in ipairs(rows) do present(r) end
+    return { data = rows, total = #rows }
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Create — route layer validates category/amount/tax_year/flags; the amount
+-- and category checks are re-run defensively here.
+-- ────────────────────────────────────────────────────────────────────────────
+function PensionPaymentQueries.create(data, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local n = tonumber(data.amount)
+    if not n or n ~= n or n <= 0 or n > MAX_AMOUNT then
+        return nil, "amount must be a positive number"
+    end
+    if not data.category_key or data.category_key == "" then
+        return nil, "category_key is required"
+    end
+    if not data.tax_year or data.tax_year == "" then
+        return nil, "tax_year is required"
+    end
+
+    local uuid = Global.generateUUID()
+    db.query([[
+        INSERT INTO pension_payment_items
+            (uuid, user_id, namespace_id, tax_year, category_key, description,
+             amount, relief_at_source, one_off, is_archived, created_at, updated_at)
+        VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, false, NOW(), NOW())
+    ]],
+        uuid,
+        internal_user_id,
+        data.tax_year,
+        data.category_key,
+        (data.description and data.description ~= "") and data.description or db.NULL,
+        n,
+        data.relief_at_source == true,
+        data.one_off == true
+    )
+    local row = db.query("SELECT * FROM pension_payment_items WHERE uuid = ? LIMIT 1", uuid)[1]
+
+    TaxAuditLogQueries.log({
+        user_id = internal_user_id,
+        user_email = user.email,
+        entity_type = "PENSION_PAYMENT",
+        entity_id = uuid,
+        action = "CREATE",
+        new_values = cjson.encode(row),
+    })
+    return present(row)
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Show / Update / Archive — addressed by row uuid, always ownership-scoped.
+-- ────────────────────────────────────────────────────────────────────────────
+function PensionPaymentQueries.show(item_uuid, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+    local rows = db.query([[
+        SELECT * FROM pension_payment_items WHERE uuid = ? AND user_id = ? LIMIT 1
+    ]], item_uuid, internal_user_id)
+    if not rows or #rows == 0 then return nil end
+    return present(rows[1])
+end
+
+function PensionPaymentQueries.update(item_uuid, data, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local existing = db.query([[
+        SELECT * FROM pension_payment_items WHERE uuid = ? AND user_id = ? LIMIT 1
+    ]], item_uuid, internal_user_id)
+    if not existing or #existing == 0 then return nil end
+    local old = existing[1]
+
+    local updates, args = {}, {}
+    if data.amount ~= nil then
+        local n = tonumber(data.amount)
+        if not n or n ~= n or n <= 0 or n > MAX_AMOUNT then
+            return nil, "amount must be a positive number"
+        end
+        table.insert(updates, "amount = ?"); table.insert(args, n)
+    end
+    if data.category_key then
+        table.insert(updates, "category_key = ?"); table.insert(args, data.category_key)
+    end
+    if data.tax_year then
+        table.insert(updates, "tax_year = ?"); table.insert(args, data.tax_year)
+    end
+    if data.description ~= nil then
+        -- "" clears the description (stored as NULL, matching create) —
+        -- JSON null can't express "clear" because body parsing strips
+        -- cjson.null before it reaches the SQL layer.
+        table.insert(updates, "description = ?")
+        table.insert(args, data.description ~= "" and data.description or db.NULL)
+    end
+    if data.relief_at_source ~= nil then
+        table.insert(updates, "relief_at_source = ?")
+        table.insert(args, data.relief_at_source == true)
+    end
+    if data.one_off ~= nil then
+        table.insert(updates, "one_off = ?")
+        table.insert(args, data.one_off == true)
+    end
+    if #updates == 0 then return present(old) end
+
+    table.insert(updates, "updated_at = NOW()")
+    table.insert(args, item_uuid)
+    table.insert(args, internal_user_id)
+    db.query("UPDATE pension_payment_items SET " .. table.concat(updates, ", ")
+        .. " WHERE uuid = ? AND user_id = ?", unpack(args))
+
+    local refreshed = db.query("SELECT * FROM pension_payment_items WHERE uuid = ? LIMIT 1", item_uuid)[1]
+
+    TaxAuditLogQueries.log({
+        user_id = internal_user_id,
+        user_email = user.email,
+        entity_type = "PENSION_PAYMENT",
+        entity_id = item_uuid,
+        action = "UPDATE",
+        old_values = cjson.encode(old),
+        new_values = cjson.encode(refreshed),
+    })
+    return present(refreshed)
+end
+
+function PensionPaymentQueries.archive(item_uuid, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local existing = db.query([[
+        SELECT * FROM pension_payment_items WHERE uuid = ? AND user_id = ? LIMIT 1
+    ]], item_uuid, internal_user_id)
+    if not existing or #existing == 0 then return nil end
+
+    db.query([[
+        UPDATE pension_payment_items
+           SET is_archived = true, archived_at = NOW(), archived_by = ?, updated_at = NOW()
+         WHERE uuid = ? AND user_id = ?
+    ]], internal_user_id, item_uuid, internal_user_id)
+
+    TaxAuditLogQueries.log({
+        user_id = internal_user_id,
+        user_email = user.email,
+        entity_type = "PENSION_PAYMENT",
+        entity_id = item_uuid,
+        action = "DELETE",
+        old_values = cjson.encode(existing[1]),
+    })
+    return true
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Summary — per-section totals for the hub, derived and read-only. Only
+-- ACTIVE sections count (same convention as business totals); rows in a
+-- retired section stay listed via all() but drop out of these numbers.
+-- ────────────────────────────────────────────────────────────────────────────
+function PensionPaymentQueries.summary(tax_year, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local totals = db.query([[
+        SELECT category_key,
+               COALESCE(SUM(amount), 0) AS total,
+               COUNT(*)                 AS row_count
+        FROM pension_payment_items
+        WHERE user_id = ? AND tax_year = ? AND is_archived = false
+        GROUP BY category_key
+    ]], internal_user_id, tax_year) or {}
+    local by_key = {}
+    for _, t in ipairs(totals) do by_key[t.category_key] = t end
+
+    local sections = {}
+    local grand_total = 0
+    for _, c in ipairs(PensionPaymentQueries.categories()) do
+        local t = by_key[c.category_key]
+        local total = t and tonumber(t.total) or 0
+        sections[#sections + 1] = {
+            key = c.category_key,
+            label = c.label,
+            total = total,
+            row_count = t and tonumber(t.row_count) or 0,
+        }
+        grand_total = grand_total + total
+    end
+
+    return {
+        tax_year = tax_year,
+        total = grand_total,
+        sections = sections,
+    }
+end
+
+return PensionPaymentQueries

--- a/lapis/routes/my-incomes.lua
+++ b/lapis/routes/my-incomes.lua
@@ -20,13 +20,19 @@ local AuthMiddleware = require("middleware.auth")
 -- than a hard-coded Lua list. Both helpers read the active set on demand —
 -- low-frequency paths (validation + the /types dropdown), so no cache needed.
 -- See queries/IncomeTypeQueries.lua and routes/tax-admin-income-types.lua.
+-- Writes validate against manual_entry_keys(), not active_keys(): catalogue
+-- rows with allows_manual_entry = false (e.g. 'pension_payments', a RELIEF)
+-- are selectable in the questionnaire but must never become my_incomes rows —
+-- the calculation sums my_incomes as INCOME, which would move the estimate
+-- the wrong way for a relief. Unchanged types on update are grandfathered
+-- below, so existing rows stay editable if an admin flips the flag later.
 local function valid_income_type(key)
     if not key or key == "" then return false end
-    return IncomeTypeQueries.active_keys()[key] == true
+    return IncomeTypeQueries.manual_entry_keys()[key] == true
 end
 local function income_type_list()
     local keys = {}
-    for k in pairs(IncomeTypeQueries.active_keys()) do keys[#keys + 1] = k end
+    for k in pairs(IncomeTypeQueries.manual_entry_keys()) do keys[#keys + 1] = k end
     table.sort(keys)
     return keys
 end

--- a/lapis/routes/tax-pension-payments.lua
+++ b/lapis/routes/tax-pension-payments.lua
@@ -1,0 +1,206 @@
+--[[
+    Pension Payment Routes — the "Relief: Pension payments" backend surface
+    (SA100 page TR4). No per-entity drill-down: rows hang straight off the
+    user + tax year, grouped by the admin-managed section catalogue.
+
+    Endpoints (all auth-required):
+      GET    /api/v2/tax/pension-payment-categories    admin catalogue → section cards
+      GET    /api/v2/tax/pension/summary?tax_year=     per-section totals (read-only, derived)
+      GET    /api/v2/tax/pension-payments?tax_year=&category_key=
+      POST   /api/v2/tax/pension-payments              { category_key, amount, tax_year, description?, relief_at_source?, one_off? }
+      PUT    /api/v2/tax/pension-payments/:uuid
+      DELETE /api/v2/tax/pension-payments/:uuid        soft archive
+
+    relief_at_source = the form's "Basic rate tax relief claimed by
+    provider?" checkbox (routes a registered-scheme row to TR4 box 1 vs
+    box 2); one_off = "Is this a one off payment?" (box 1.1). Both are only
+    accepted where the section's catalogue row supports them — otherwise
+    they're forced false so a section switch can't leave stale flags behind.
+]]
+
+local cjson = require("cjson")
+local PensionPaymentQueries = require "queries.PensionPaymentQueries"
+local AuthMiddleware = require("middleware.auth")
+
+-- YYYY-YY (e.g. 2026-27) — same contract as my-incomes / tax-properties.
+local function valid_tax_year(s)
+    if type(s) ~= "string" then return false end
+    local y1, y2 = s:match("^(%d%d%d%d)%-(%d%d)$")
+    if not y1 or not y2 then return false end
+    return tonumber(y2) == (tonumber(y1) + 1) % 100
+end
+
+-- Parse JSON or form body — same helper as tax-properties.lua: cjson.null
+-- stripped at the boundary, body-file fallback for spooled bodies.
+local function parse_request_body()
+    ngx.req.read_body()
+    local content_type = ngx.var.content_type or ""
+    if content_type:find("application/json", 1, true) then
+        local ok, result = pcall(function()
+            local body = ngx.req.get_body_data()
+            if not body or body == "" then
+                local path = ngx.req.get_body_file()
+                if path then
+                    local f = io.open(path, "rb")
+                    if f then
+                        body = f:read("*a")
+                        f:close()
+                    end
+                end
+            end
+            if not body or body == "" then return {} end
+            return cjson.decode(body)
+        end)
+        if ok and type(result) == "table" then
+            for k, v in pairs(result) do
+                if v == cjson.null then result[k] = nil end
+            end
+            return result
+        end
+        return {}
+    end
+    local post_args = ngx.req.get_post_args()
+    if post_args and next(post_args) then return post_args end
+    return {}
+end
+
+local function merge_params(self)
+    local body_params = parse_request_body()
+    for k, v in pairs(body_params) do
+        if self.params[k] == nil then self.params[k] = v end
+    end
+end
+
+-- JSON bodies carry real booleans; form bodies carry strings — normalise
+-- both ("false"/"0" are truthy in Lua, so a plain truthiness check lies).
+local function to_bool(v)
+    return v == true or v == "true" or v == "1" or v == 1
+end
+
+-- Validate a payment payload against the catalogue. `category` (resolved by
+-- the caller: the target section's catalogue row, or nil when the row is
+-- grandfathered on a retired section) gates the two flags.
+local function validate_payment(params, is_create, category)
+    if is_create or params.amount ~= nil then
+        local n = tonumber(params.amount)
+        if not n or n ~= n or n <= 0 then
+            return false, "amount is required and must be a positive number"
+        end
+        if n > PensionPaymentQueries.MAX_AMOUNT then
+            return false, "amount is too large"
+        end
+        params.amount = n
+    end
+    if is_create or params.tax_year ~= nil then
+        if not valid_tax_year(params.tax_year) then
+            return false, "tax_year must be YYYY-YY (e.g. 2026-27)"
+        end
+    end
+    if params.description and type(params.description) == "string" and #params.description > 500 then
+        return false, "description must be 500 characters or fewer"
+    end
+    -- Normalise flags, and force them off where the section doesn't offer
+    -- the checkbox — a section switch must not smuggle stale flags along.
+    if params.relief_at_source ~= nil then
+        params.relief_at_source = to_bool(params.relief_at_source)
+    end
+    if params.one_off ~= nil then
+        params.one_off = to_bool(params.one_off)
+    end
+    if category then
+        if not category.supports_relief_flag and params.relief_at_source then
+            params.relief_at_source = false
+        end
+        if not category.supports_one_off_flag and params.one_off then
+            params.one_off = false
+        end
+    end
+    return true
+end
+
+return function(app)
+    -- ── Catalogue ───────────────────────────────────────────────────────────
+    app:get("/api/v2/tax/pension-payment-categories", AuthMiddleware.requireAuth(function(_)
+        local rows = PensionPaymentQueries.categories()
+        local data = {}
+        for _, r in ipairs(rows) do
+            data[#data + 1] = {
+                key = r.category_key,
+                label = r.label,
+                description = r.description,
+                hmrc_mapping = r.hmrc_mapping,
+                supports_relief_flag = r.supports_relief_flag == true,
+                supports_one_off_flag = r.supports_one_off_flag == true,
+                display_order = r.display_order,
+            }
+        end
+        return { json = { data = #data > 0 and data or cjson.empty_array }, status = 200 }
+    end))
+
+    -- ── Summary (read-only, derived) ────────────────────────────────────────
+    app:get("/api/v2/tax/pension/summary", AuthMiddleware.requireAuth(function(self)
+        local tax_year = self.params.tax_year
+        if not valid_tax_year(tax_year) then
+            return { json = { error = "tax_year must be YYYY-YY (e.g. 2026-27)" }, status = 400 }
+        end
+        local result, err = PensionPaymentQueries.summary(tax_year, self.current_user)
+        if not result then
+            return { json = { error = err or "Failed to build summary" }, status = 400 }
+        end
+        if #result.sections == 0 then result.sections = cjson.empty_array end
+        return { json = { data = result }, status = 200 }
+    end))
+
+    -- ── Payment rows ────────────────────────────────────────────────────────
+    app:get("/api/v2/tax/pension-payments", AuthMiddleware.requireAuth(function(self)
+        local result, err = PensionPaymentQueries.all(self.params, self.current_user)
+        if not result then
+            return { json = { error = err or "Failed to list pension payments" }, status = 400 }
+        end
+        if #result.data == 0 then result.data = cjson.empty_array end
+        return { json = result, status = 200 }
+    end))
+
+    app:post("/api/v2/tax/pension-payments", AuthMiddleware.requireAuth(function(self)
+        merge_params(self)
+        local active = PensionPaymentQueries.active_categories()
+        local category = active[self.params.category_key]
+        if not category then
+            return { json = { error = "category_key is not an active pension payment section" }, status = 400 }
+        end
+        local ok, vmsg = validate_payment(self.params, true, category)
+        if not ok then return { json = { error = vmsg }, status = 400 } end
+        local row, err = PensionPaymentQueries.create(self.params, self.current_user)
+        if not row then return { json = { error = err or "Failed to save the payment" }, status = 400 } end
+        return { json = { data = row }, status = 201 }
+    end))
+
+    app:put("/api/v2/tax/pension-payments/:uuid", AuthMiddleware.requireAuth(function(self)
+        merge_params(self)
+        local existing = PensionPaymentQueries.show(tostring(self.params.uuid), self.current_user)
+        if not existing then return { json = { error = "Payment not found" }, status = 404 } end
+        local active = PensionPaymentQueries.active_categories()
+        -- Grandfather an unchanged category_key (admin may have retired the
+        -- section since) — but a CHANGED key must name an active section.
+        local target_key = self.params.category_key or existing.category_key
+        local category = active[target_key]
+        if self.params.category_key ~= nil then
+            if self.params.category_key == existing.category_key then
+                self.params.category_key = nil
+            elseif not category then
+                return { json = { error = "category_key is not an active pension payment section" }, status = 400 }
+            end
+        end
+        local ok, vmsg = validate_payment(self.params, false, category)
+        if not ok then return { json = { error = vmsg }, status = 400 } end
+        local row, err = PensionPaymentQueries.update(tostring(self.params.uuid), self.params, self.current_user)
+        if not row then return { json = { error = err or "Payment not found" }, status = err and 400 or 404 } end
+        return { json = { data = row }, status = 200 }
+    end))
+
+    app:delete("/api/v2/tax/pension-payments/:uuid", AuthMiddleware.requireAuth(function(self)
+        local ok = PensionPaymentQueries.archive(tostring(self.params.uuid), self.current_user)
+        if not ok then return { json = { error = "Payment not found" }, status = 404 } end
+        return { json = { message = "Payment removed" }, status = 200 }
+    end))
+end

--- a/lapis/routes/tax-pension-payments.lua
+++ b/lapis/routes/tax-pension-payments.lua
@@ -13,9 +13,11 @@
 
     relief_at_source = the form's "Basic rate tax relief claimed by
     provider?" checkbox (routes a registered-scheme row to TR4 box 1 vs
-    box 2); one_off = "Is this a one off payment?" (box 1.1). Both are only
-    accepted where the section's catalogue row supports them — otherwise
-    they're forced false so a section switch can't leave stale flags behind.
+    box 2); one_off = "Is this a one off payment?" (box 1.1). Flags are
+    forced false against the RESOLVED target section whether or not the
+    payload carries them, so neither a section switch nor an edit can leave
+    a true flag on a section that doesn't offer the checkbox; on rows whose
+    section an admin retired, flags are frozen (updates to them ignored).
 ]]
 
 local cjson = require("cjson")
@@ -73,8 +75,9 @@ end
 
 -- JSON bodies carry real booleans; form bodies carry strings — normalise
 -- both ("false"/"0" are truthy in Lua, so a plain truthiness check lies).
+-- "on" is what a bare HTML form posts for a checked checkbox.
 local function to_bool(v)
-    return v == true or v == "true" or v == "1" or v == 1
+    return v == true or v == "true" or v == "1" or v == 1 or v == "on"
 end
 
 -- Validate a payment payload against the catalogue. `category` (resolved by
@@ -96,11 +99,20 @@ local function validate_payment(params, is_create, category)
             return false, "tax_year must be YYYY-YY (e.g. 2026-27)"
         end
     end
-    if params.description and type(params.description) == "string" and #params.description > 500 then
-        return false, "description must be 500 characters or fewer"
+    if params.description ~= nil then
+        -- Reject non-strings up front: a JSON number/bool/object (or a
+        -- repeated form key, which arrives as a Lua table) would otherwise
+        -- sail past the length check into SQL interpolation → 500.
+        if type(params.description) ~= "string" then
+            return false, "description must be a string"
+        end
+        if #params.description > 500 then
+            return false, "description must be 500 characters or fewer"
+        end
     end
-    -- Normalise flags, and force them off where the section doesn't offer
-    -- the checkbox — a section switch must not smuggle stale flags along.
+    -- Normalise flags, then enforce them against the RESOLVED target
+    -- section unconditionally — forcing only payload-present flags would
+    -- let a category switch smuggle the row's stored true flags along.
     if params.relief_at_source ~= nil then
         params.relief_at_source = to_bool(params.relief_at_source)
     end
@@ -108,12 +120,14 @@ local function validate_payment(params, is_create, category)
         params.one_off = to_bool(params.one_off)
     end
     if category then
-        if not category.supports_relief_flag and params.relief_at_source then
-            params.relief_at_source = false
-        end
-        if not category.supports_one_off_flag and params.one_off then
-            params.one_off = false
-        end
+        if not category.supports_relief_flag then params.relief_at_source = false end
+        if not category.supports_one_off_flag then params.one_off = false end
+    else
+        -- Grandfathered retired section: its catalogue row isn't visible,
+        -- so flag support can't be checked — freeze the stored flags
+        -- (ignore any sent values) rather than accept or clobber them.
+        params.relief_at_source = nil
+        params.one_off = nil
     end
     return true
 end


### PR DESCRIPTION
## Summary

Fourth tax_copilot income-type surface: **"Relief – Pension payments"** (SA100 page TR4, boxes 1 / 1.1 / 2 / 3 / 4). First one with **no per-entity drill-down** — payment rows hang straight off the user + tax year, grouped by an admin-managed section catalogue mirroring the reference form's three grids.

Frontend counterpart: bwalia/diy-tax-return-uk PR (pension payments hub).

## What's in it

**Migrations 744–747** (`pension-payments-system.lua`, gated on `tax_copilot`):
- `pension_payment_categories` — the form's SECTIONS as an admin catalogue. `supports_relief_flag` / `supports_one_off_flag` drive which sections show the two per-row checkboxes; `hmrc_mapping` carries TR4 box routing (relief-at-source → box 1, no relief → box 2, one-off → box 1.1, employer → box 3, overseas → box 4).
- Seed of the three TR4 sections (idempotent on `category_key`, re-run updates labels/mappings, never resurrects disabled rows).
- `pension_payment_items` — description ("Provider and payment description"), `amount numeric(15,2)`, `relief_at_source`, `one_off`; soft archive like property_line_items.
- `income_types` row **`pension_payments`** ("Pension payments (tax relief)") — display name + description spell out this is money paid INTO schemes, distinct from the existing `pension` income type. Order 65, right after Pension income (60).
- Key prefixes 744–747: the 741–743 lexical space is shared with unrelated invoicing keys; full key strings differ so ordering is unaffected — 744+ chosen for readability.

**Queries** (`PensionPaymentQueries.lua`):
- User-scoped CRUD, audit-logged (`PENSION_PAYMENT`).
- `MAX_AMOUNT` bound (9,999,999,999,999.99) checked up front — no numeric-overflow 500s.
- `""` clears description (JSON null is stripped at the body boundary, same contract as property lines).
- Summary totals only count ACTIVE sections; rows in a retired section stay listed/deletable but drop out of totals (business-values convention).

**Routes** (`tax-pension-payments.lua`, all auth-required):
```
GET    /api/v2/tax/pension-payment-categories
GET    /api/v2/tax/pension/summary?tax_year=
GET    /api/v2/tax/pension-payments?tax_year=&category_key=
POST   /api/v2/tax/pension-payments
PUT    /api/v2/tax/pension-payments/:uuid
DELETE /api/v2/tax/pension-payments/:uuid
```
- Flags normalised from JSON booleans AND form strings (`"false"` is truthy in Lua), and **forced false where the section doesn't offer the checkbox** — a section switch can't smuggle stale flags.
- Unchanged `category_key` grandfathered on update when an admin has retired the section; a CHANGED key must be active.
- Spooled >16KB body fallback via `ngx.req.get_body_file()`.

## Deliberately NOT here

- No calc integration — pension relief must plug into the FastAPI calculation as a **relief** (band extension), not income; tracked with the other calc-gap follow-ups.
- No contexted profile category — there are no entities to hang per-entity questions on.

## Test plan
- [x] luajit syntax check on all touched files
- [x] Migration gate in CI applies 744–747 from zero state
- [ ] Manual: catalogue/CRUD/summary endpoints on int after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)