### PR TITLE
fix(auth): OAuth callback SYSTEM_500 — integer user_id, not UUID

### DIFF
--- a/lapis/routes/auth.lua
+++ b/lapis/routes/auth.lua
@@ -916,7 +916,13 @@ return function(app)
         -- wrong tenant on OAuth login even when they'd explicitly selected
         -- tax_copilot as their default via the UI. Also write back
         -- last_active_namespace_id so a subsequent /auth/login stays sticky.
-        local default_namespace = NamespaceQueries.getUserDefaultNamespace(userWithRoles.id)
+        --
+        -- Use `internal_id` (integer PK), NOT `.id` (UserQueries.show
+        -- reassigns `.id = .uuid` on return, and getUserDefaultNamespace's
+        -- SQL bind is `WHERE user_id = ?` against an INTEGER column — a
+        -- UUID string there throws "invalid input syntax for type integer").
+        local user_int_id = userWithRoles.internal_id or user.id
+        local default_namespace = NamespaceQueries.getUserDefaultNamespace(user_int_id)
         local namespace_membership = nil
         if default_namespace then
             namespace_membership = NamespaceMemberQueries.findByUserAndNamespace(
@@ -924,7 +930,7 @@ return function(app)
                 default_namespace.id
             )
             pcall(NamespaceQueries.updateLastActiveNamespace,
-                userWithRoles.id, default_namespace.id)
+                user_int_id, default_namespace.id)
         end
 
         -- Generate JWT token with namespace context
@@ -1220,8 +1226,11 @@ return function(app)
             -- Namespace selection — see /auth/google/callback for the full
             -- rationale. Same fix: honor user_namespace_settings via
             -- getUserDefaultNamespace so a multi-namespace user lands in
-            -- the tenant they picked, not whichever ordered first.
-            local default_namespace = NamespaceQueries.getUserDefaultNamespace(userWithRoles.id)
+            -- the tenant they picked, not whichever ordered first. Use
+            -- `internal_id` (integer PK); `.id` was reassigned to `.uuid`
+            -- by UserQueries.show.
+            local user_int_id = userWithRoles.internal_id or user.id
+            local default_namespace = NamespaceQueries.getUserDefaultNamespace(user_int_id)
             local namespace_membership = nil
             if default_namespace then
                 namespace_membership = NamespaceMemberQueries.findByUserAndNamespace(
@@ -1229,7 +1238,7 @@ return function(app)
                     default_namespace.id
                 )
                 pcall(NamespaceQueries.updateLastActiveNamespace,
-                    userWithRoles.id, default_namespace.id)
+                    user_int_id, default_namespace.id)
             end
 
             -- Generate JWT token


### PR DESCRIPTION
## Summary

Hotfix for a SYSTEM_500 in `/auth/google/callback` (and `/auth/oauth/validate`) introduced by PR #491's OAuth default-namespace picker.

Live-reproduced on int with correlation_id `f1d76869-f6d3-5644-c1f8-2c2ffa0c7c40` when `honeymankoo22@gmail.com` tried to sign in with Google:

```
ERROR: invalid input syntax for type integer:
  "fa096f83-43fb-3873-a758-ad7c5b9f1c54"
  at NamespaceQueries.lua:524  getUserSettings
  at NamespaceQueries.lua:581  getUserDefaultNamespace
  at routes/auth.lua:919       handler
```

## Root cause

PR #491 replaced the ad-hoc `for _, ns in ipairs(getForUser(...)) ... break` namespace picker with `NamespaceQueries.getUserDefaultNamespace(user_id)`. That helper binds `WHERE user_id = ?` against an **INTEGER** column.

I passed `userWithRoles.id` — but `UserQueries.show` reassigns `.id = .uuid` on return ([queries/UserQueries.lua:181-182](../lua-apis/opsapi/lapis/queries/UserQueries.lua#L181-L182)), preserving the integer PK under `.internal_id`. So `getUserDefaultNamespace` received a UUID string, Postgres rejected it, request 500'd, JWT never minted.

## Fix

Read `userWithRoles.internal_id` (fall back to `user.id` from the fresh ORM object, which is still the integer PK). Applied identically at both OAuth entry points.

## User impact

Log ordering shows the assignment path ran **before** the crash — `honeymankoo22@gmail.com` is correctly a member of `tax-copilot` (namespace_id=2), they just couldn't finish the OAuth handshake to get a JWT. Retry-signing-in-with-Google after this deploys will complete the handshake against the existing membership row.

## Test plan

- [ ] Deploy to int → retry Google OAuth signin as honeymankoo22 → confirm callback succeeds + user lands in tax-copilot
- [ ] Fresh Google signup with an unused email → confirm new user + membership + JWT all created atomically
- [ ] Regression: existing user with only `system` membership → still logs in (default_namespace falls through to first_available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)