### PR TITLE
Record mode for the form-sections engine + SA102 Salary/Employment

### DIFF
--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -185,6 +185,11 @@ local pension_payments_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_C
 -- ends per-screen Lua work for this screen family
 local form_sections_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.form-sections-system") or {}
 
+-- Salary / Employment (SA102) — content-only: seeds the record-mode
+-- section/field catalogue for the existing 'salary' income type and
+-- ports legacy flat entries. The engine work lives in form-sections.
+local salary_employment_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.salary-employment-system") or {}
+
 -- Dynamic answer scope — moves the "how are these answers scoped?"
 -- decision from a hardcoded map in routes/profile-builder.lua into two
 -- new columns on profile_categories (answer_scope + entity_type) and a
@@ -1975,6 +1980,11 @@ local _migrations = {
     ['752_create_tax_form_sections'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, form_sections_migrations, 1),
     ['753_create_tax_form_items'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, form_sections_migrations, 2),
     ['754_port_pension_form_sections'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, form_sections_migrations, 3),
+    -- 755 adds RECORD MODE to the engine (fixed field-forms per repeating
+    -- record — the SA102 employment shape); 756/757 are salary content.
+    ['755_create_tax_form_records'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, form_sections_migrations, 4),
+    ['756_seed_salary_sa102_sections'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, salary_employment_migrations, 1),
+    ['757_port_flat_salary_entries'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, salary_employment_migrations, 2),
 
     -- =========================================================================
     -- Academy (LMS): courses + lessons (namespace-scoped). Feature-gated, so

--- a/lapis/migrations/form-sections-system.lua
+++ b/lapis/migrations/form-sections-system.lua
@@ -24,6 +24,13 @@
   hubs (rental/self-employment/overseas — user_profile_entities) and
   fixed-box grids (SA103 business_line_values). Different paradigms.
 
+  RECORD MODE (second engine shape, added for SA102 employment):
+  a section may define config_json.fields — a fixed set of typed inputs
+  (money/number/text/textarea/date/boolean) — instead of repeating rows.
+  A type whose sections carry fields renders as a list of RECORDS (one
+  per employment/etc.), each record being the full field-form across all
+  sections, stored as one tax_form_records row with a JSON document.
+
   Only executed when PROJECT_CODE includes 'tax_copilot'.
 ]]
 
@@ -178,5 +185,34 @@ return {
                 it.archived_by or db.NULL, it.created_at, it.updated_at)
         end
         print("[Form Sections] Ported pension payments: " .. #cats .. " sections, " .. #items .. " items")
+    end,
+
+    -- =========================================================================
+    -- 4. tax_form_records — record mode. One row per record (e.g. one
+    --    employment); every field value lives in data_json, validated by the
+    --    route layer against the type's admin-defined field catalogue.
+    --    `total` is denormalised on write (sum of the record's money fields
+    --    flagged summary:true) so the overview-card query stays a plain SUM.
+    -- =========================================================================
+    [4] = function()
+        schema.create_table("tax_form_records", {
+            { "id",              types.serial },
+            { "uuid",            types.varchar({ unique = true }) },
+            { "user_id",         types.integer },
+            { "namespace_id",    types.integer({ null = true }) },
+            { "income_type_key", types.varchar },
+            { "tax_year",        types.varchar },                 -- YYYY-YY e.g. "2026-27"
+            { "data_json",       types.text({ null = true }) },   -- JSON {field_key: value, ...}
+            { "total",           "numeric(15,2) NOT NULL DEFAULT 0" },
+            { "is_archived",     types.boolean({ default = false }) },
+            { "archived_at",     types.time({ null = true }) },
+            { "archived_by",     types.integer({ null = true }) },
+            { "created_at",      types.time({ default = db.raw("NOW()") }) },
+            { "updated_at",      types.time({ default = db.raw("NOW()") }) },
+            "PRIMARY KEY (id)"
+        })
+        schema.create_index("tax_form_records", "user_id")
+        schema.create_index("tax_form_records", "user_id", "income_type_key", "tax_year", "is_archived")
+        print("[Form Sections] Created tax_form_records table")
     end,
 }

--- a/lapis/migrations/salary-employment-system.lua
+++ b/lapis/migrations/salary-employment-system.lua
@@ -1,0 +1,247 @@
+--[[
+  Salary / Employment (SA102) — content-only migration.
+
+  Puts the existing `salary` income type onto the form-sections engine's
+  RECORD MODE: each employment is one tax_form_records row, and the form
+  the user fills (Employment Details / Close Company / Income / Benefits
+  / Expenses / Foreign / Notes — the IRIS SA102 layout) is defined here
+  as tax_form_sections rows with config_json.fields. Everything below is
+  catalogue DATA — the engine (migration 755 + the form-sections routes)
+  is what executes it, and an admin can reshape any of it in the Form
+  Sections UI afterwards with no deploy.
+
+  1. Seed the SA102 section/field catalogue for income type 'salary'
+     and turn off flat manual entry (the records page replaces it).
+  2. Port legacy flat my_incomes salary rows into records so nothing a
+     user already typed disappears from the new page. Source rows are
+     left in place (inert for the UI, still feeding the FastAPI calc
+     until records gain calc integration — same standing gap as every
+     engine type).
+
+  Box references follow SA102: 1 pay, 1.1 payrolled benefits, 2 UK tax,
+  3 tips, 4 PAYE reference, 5 employer name, 6/6.1 director, 7 close
+  company, 9–16 benefits, 17–20 expenses. They are informational
+  metadata (hmrc_mapping / per-field box) until calc integration.
+
+  Only executed when PROJECT_CODE includes 'tax_copilot'.
+]]
+
+local db = require("lapis.db")
+local cjson = require("cjson")
+local MigrationUtils = require "helper.migration-utils"
+
+-- One section row, idempotent on (income_type_key, section_key) — same
+-- convention as the pension port. Re-running never duplicates and never
+-- overwrites admin edits made since.
+local function ensure_section(s)
+    local exists = db.select(
+        "id FROM tax_form_sections WHERE income_type_key = ? AND section_key = ?",
+        "salary", s.key)
+    if exists and #exists > 0 then return end
+    db.query([[
+        INSERT INTO tax_form_sections
+            (uuid, income_type_key, section_key, label, description,
+             hmrc_mapping, config_json, display_order, is_active,
+             created_at, updated_at)
+        VALUES (?, 'salary', ?, ?, ?, ?, ?, ?, true, NOW(), NOW())
+    ]], MigrationUtils.generateUUID(), s.key, s.label,
+        s.description or db.NULL, s.hmrc_mapping or db.NULL,
+        cjson.encode(s.config), s.order or 0)
+end
+
+return {
+    -- =========================================================================
+    -- 1. SA102 section + field catalogue for 'salary'
+    -- =========================================================================
+    [1] = function()
+        ensure_section({
+            key = "employment_details",
+            label = "Employment details",
+            description = "Who you worked for — from your P60, P45 or payslips.",
+            hmrc_mapping = '{"sa102_boxes":"4-7"}',
+            order = 1,
+            config = {
+                -- Record-mode settings for the whole type live on the first
+                -- section (lowest display_order with a record block wins).
+                record = {
+                    noun = "Employment",
+                    title_field = "employer_name",
+                    subtitle_field = "paye_reference",
+                },
+                fields = {
+                    { key = "employer_name", label = "Employer's name", type = "text",
+                      required = true, box = "5" },
+                    { key = "paye_reference", label = "Employer's PAYE tax reference (NNN/XXXXXX)",
+                      type = "text", required = true, format = "paye_reference", box = "4",
+                      help = "On your P60 or P45 — three numbers, a slash, then letters and numbers." },
+                    { key = "start_date", label = "Date employment started", type = "date" },
+                    { key = "end_date", label = "Date employment ceased", type = "date" },
+                    { key = "is_director", label = "Were you a company director?", type = "boolean",
+                      box = "6" },
+                    { key = "director_ceased_date", label = "Date ceased being a director",
+                      type = "date", box = "6.1", show_if = { field = "is_director" } },
+                    { key = "is_close_company", label = "Is this a close company?", type = "boolean",
+                      box = "7",
+                      help = "A company controlled by 5 or fewer people (or by its directors)." },
+                },
+            },
+        })
+
+        ensure_section({
+            key = "close_company_details",
+            label = "Close company details",
+            order = 2,
+            config = {
+                fields = {
+                    { key = "registered_number", label = "Registered number", type = "text",
+                      show_if = { field = "is_close_company" } },
+                    { key = "close_company_dividends",
+                      label = "Dividends you received from this close company", type = "money",
+                      show_if = { field = "is_close_company" } },
+                    { key = "shareholding_percent",
+                      label = "Percentage shareholding in this close company", type = "number",
+                      show_if = { field = "is_close_company" } },
+                },
+            },
+        })
+
+        ensure_section({
+            key = "income",
+            label = "Income",
+            description = "From your P60 (or P45 if you left during the year).",
+            hmrc_mapping = '{"sa102_boxes":"1-3"}',
+            order = 3,
+            config = {
+                fields = {
+                    { key = "pay_before_tax",
+                      label = "Pay from this employment before tax was taken off", type = "money",
+                      box = "1", summary = true },
+                    { key = "payrolled_benefits",
+                      label = "Payrolled benefits included above which affect your student loan repayments",
+                      type = "money", box = "1.1" },
+                    { key = "uk_tax_taken_off", label = "UK tax taken off", type = "money",
+                      box = "2" },
+                    { key = "tips_not_on_p60", label = "Tips and other payments not on your P60",
+                      type = "money", box = "3", summary = true },
+                },
+            },
+        })
+
+        ensure_section({
+            key = "benefits",
+            label = "Benefits",
+            description = "These amounts will be on form P11D from your employer.",
+            hmrc_mapping = '{"sa102_boxes":"9-16"}',
+            order = 4,
+            config = {
+                fields = {
+                    { key = "company_cars", label = "Company cars", type = "money", box = "9" },
+                    { key = "fuel_company_cars", label = "Fuel for company cars", type = "money", box = "10" },
+                    { key = "company_vans", label = "Company vans", type = "money", box = "9" },
+                    { key = "fuel_company_vans", label = "Fuel for company vans", type = "money", box = "10" },
+                    { key = "travel_subsistence", label = "Travel and subsistence", type = "money", box = "16" },
+                    { key = "entertaining", label = "Entertaining", type = "money", box = "16" },
+                    { key = "private_medical", label = "Private medical and dental insurance", type = "money", box = "11" },
+                    { key = "telephone", label = "Telephone", type = "money", box = "16" },
+                    { key = "professional_fees_employer", label = "Professional fees & subscriptions paid by employer", type = "money", box = "16" },
+                    { key = "vouchers_credit_cards", label = "Vouchers and credit cards", type = "money", box = "12" },
+                    { key = "excess_mileage_allowance", label = "Excess mileage allowance", type = "money", box = "12" },
+                    { key = "goods_assets_provided", label = "Goods and other assets provided by employer", type = "money", box = "13" },
+                    { key = "accommodation_provided", label = "Accommodation provided by employer", type = "money", box = "14" },
+                    { key = "other_benefits", label = "Other benefits", type = "money", box = "15" },
+                    { key = "expenses_payments_received", label = "Expenses payments received", type = "money", box = "16" },
+                },
+            },
+        })
+
+        ensure_section({
+            key = "expenses",
+            label = "Expenses",
+            description = "Costs of doing your job that your employer didn't reimburse.",
+            hmrc_mapping = '{"sa102_boxes":"17-20"}',
+            order = 5,
+            config = {
+                fields = {
+                    { key = "business_travel", label = "Business travel", type = "money", box = "17" },
+                    { key = "hotel_meal_expenses", label = "Hotel and meal expenses", type = "money", box = "17" },
+                    { key = "fixed_deductions", label = "Fixed deductions for expenses", type = "money", box = "18" },
+                    { key = "professional_fees_subs", label = "Professional fees and subscriptions", type = "money", box = "19" },
+                    { key = "tools_work_clothes", label = "Cost of tools and work clothes", type = "money", box = "18" },
+                    { key = "vehicle_expenses", label = "Vehicle expenses", type = "money", box = "17" },
+                    { key = "mileage_shortfall", label = "Mileage allowance shortfall", type = "money", box = "17" },
+                    { key = "other_expenses_capital", label = "Other expenses and capital allowances", type = "money", box = "20" },
+                },
+            },
+        })
+
+        ensure_section({
+            key = "foreign",
+            label = "Foreign earnings and deductions",
+            order = 6,
+            config = {
+                fields = {
+                    { key = "seafarers_deduction", label = "Seafarers' earnings deduction", type = "money" },
+                    { key = "foreign_earnings_not_taxable", label = "Foreign earnings not taxable in the UK", type = "money" },
+                    { key = "foreign_tax_no_credit", label = "Foreign tax for which tax credit relief not claimed", type = "money" },
+                    { key = "exempt_overseas_pension", label = "Exempt employers' contributions to an overseas pension scheme", type = "money" },
+                },
+            },
+        })
+
+        ensure_section({
+            key = "notes",
+            label = "Additional information",
+            order = 7,
+            config = {
+                fields = {
+                    { key = "tax_return_note", label = "Additional text note for your tax return",
+                      type = "textarea",
+                      help = "Anything HMRC should know about this employment — goes in the 'any other information' box." },
+                },
+            },
+        })
+
+        -- The records page replaces flat one-amount entries for salary.
+        -- Existing my_incomes rows are grandfathered by the my-incomes
+        -- routes (unchanged-type edits still allowed) — this only stops
+        -- NEW flat entries / type changes onto salary.
+        db.query([[
+            UPDATE income_types SET allows_manual_entry = false, updated_at = NOW()
+            WHERE income_type_key = 'salary'
+        ]])
+        print("[Salary SA102] Seeded 7 form sections for 'salary'; flat manual entry off")
+    end,
+
+    -- =========================================================================
+    -- 2. Port legacy flat salary entries → one record each. Reuses the
+    --    source row's uuid so a re-run can never duplicate. Source rows are
+    --    NOT archived: the FastAPI calc aggregator still reads them (records
+    --    have no calc integration yet), and the new page simply doesn't
+    --    render the flat surface.
+    -- =========================================================================
+    [2] = function()
+        local rows = db.query([[
+            SELECT * FROM my_incomes
+            WHERE income_type = 'salary' AND is_archived = false
+        ]]) or {}
+        for _, r in ipairs(rows) do
+            local title = r.description
+            if type(title) ~= "string" or title == "" then title = "Employment" end
+            if #title > 200 then title = title:sub(1, 200) end
+            local data = {
+                employer_name = title,
+                pay_before_tax = tonumber(r.amount) or 0,
+            }
+            db.query([[
+                INSERT INTO tax_form_records
+                    (uuid, user_id, namespace_id, income_type_key, tax_year,
+                     data_json, total, is_archived, created_at, updated_at)
+                VALUES (?, ?, ?, 'salary', ?, ?, ?, false, ?, ?)
+                ON CONFLICT (uuid) DO NOTHING
+            ]], r.uuid, r.user_id, r.namespace_id or db.NULL, r.tax_year,
+                cjson.encode(data), tonumber(r.amount) or 0,
+                r.created_at, r.updated_at)
+        end
+        print("[Salary SA102] Ported " .. #rows .. " flat salary entries to records")
+    end,
+}

--- a/lapis/queries/FormSectionQueries.lua
+++ b/lapis/queries/FormSectionQueries.lua
@@ -53,9 +53,9 @@ local function resolveNamespaceId(internal_user_id)
     return nil
 end
 
--- Decode a section row's config_json into a table with a guaranteed
--- checkboxes array. Malformed/absent JSON degrades to an empty config
--- rather than erroring a read path.
+-- Decode a section row's config_json into a table with guaranteed
+-- checkboxes + fields arrays. Malformed/absent JSON degrades to an empty
+-- config rather than erroring a read path.
 function FormSectionQueries.decode_config(config_json)
     local config = {}
     if type(config_json) == "string" and config_json ~= "" then
@@ -63,6 +63,7 @@ function FormSectionQueries.decode_config(config_json)
         if ok and type(decoded) == "table" then config = decoded end
     end
     if type(config.checkboxes) ~= "table" then config.checkboxes = {} end
+    if type(config.fields) ~= "table" then config.fields = {} end
     return config
 end
 
@@ -79,13 +80,141 @@ function FormSectionQueries.checkbox_keys(config)
     return set
 end
 
+-- Typed field definitions of a section's config (record mode). Same
+-- sentinel guard as checkbox_keys.
+function FormSectionQueries.field_defs(config)
+    local out = {}
+    local fields = config and config.fields
+    if type(fields) ~= "table" then return out end
+    for _, f in ipairs(fields) do
+        if type(f) == "table" and type(f.key) == "string" then out[#out + 1] = f end
+    end
+    return out
+end
+
+-- All field definitions across a type's ACTIVE sections, in section
+-- order — the validation catalogue for one record's data document.
+-- Empty result ⇒ the type is not in record mode.
+function FormSectionQueries.collect_fields(income_type_key)
+    local defs = {}
+    for _, s in ipairs(FormSectionQueries.sections_for_type(income_type_key)) do
+        for _, f in ipairs(FormSectionQueries.field_defs(s.config)) do
+            defs[#defs + 1] = f
+        end
+    end
+    return defs
+end
+
+-- Truthy-boolean normalisation shared with the routes: JSON bodies carry
+-- real booleans, form bodies carry strings ("on" is a bare HTML checkbox).
+local function truthy(v)
+    return v == true or v == "true" or v == "1" or v == 1 or v == "on"
+end
+
+local function valid_iso_date(s)
+    if type(s) ~= "string" then return false end
+    local y, m, d = s:match("^(%d%d%d%d)%-(%d%d)%-(%d%d)$")
+    if not y then return false end
+    m, d = tonumber(m), tonumber(d)
+    return m >= 1 and m <= 12 and d >= 1 and d <= 31
+end
+
+-- Named formats an admin can attach to a text field. Deliberately a
+-- fixed whitelist — free-form admin regexes are a footgun (Lua patterns
+-- aren't PCRE, and a bad one would 500 every save).
+local FORMAT_CHECKS = {
+    paye_reference = {
+        check = function(v) return #v <= 14 and v:match("^%d%d%d/%w+$") ~= nil end,
+        message = "must look like 123/AB456 (three digits, a slash, then letters/numbers)",
+    },
+}
+FormSectionQueries.FORMAT_NAMES = { paye_reference = true }
+
+-- Validate one record's submitted `data` object against the type's field
+-- catalogue. Unknown keys are dropped; empty/zero/false values are
+-- dropped (absence == not filled in); required fields must survive.
+-- Returns validated_table, total (sum of money fields flagged
+-- summary:true) — or nil, err.
+function FormSectionQueries.validate_record_data(defs, data)
+    if type(data) ~= "table" then
+        return nil, "data must be an object of field values"
+    end
+    local out, total = {}, 0
+    for _, f in ipairs(defs) do
+        local v = data[f.key]
+        -- Body parsing only strips cjson.null at the TOP level of the
+        -- request body; inside the nested data object a JSON null must
+        -- also read as "not set", not as a bad value.
+        if v == cjson.null then v = nil end
+        if v ~= nil then
+            if f.type == "money" or f.type == "number" then
+                -- Skip blanks; a blank input submits "" and means "not set".
+                if v ~= "" then
+                    local n = tonumber(v)
+                    if not n or n ~= n or n < 0 then
+                        return nil, f.label .. " must be a number of 0 or more"
+                    end
+                    if n > MAX_AMOUNT then
+                        return nil, f.label .. " is too large"
+                    end
+                    if n > 0 then
+                        out[f.key] = n
+                        if f.type == "money" and f.summary == true then
+                            total = total + n
+                        end
+                    end
+                end
+            elseif f.type == "boolean" then
+                if truthy(v) then out[f.key] = true end
+            elseif f.type == "date" then
+                if v ~= "" then
+                    if not valid_iso_date(v) then
+                        return nil, f.label .. " must be a date (YYYY-MM-DD)"
+                    end
+                    out[f.key] = v
+                end
+            elseif f.type == "textarea" then
+                if type(v) ~= "string" then
+                    return nil, f.label .. " must be text"
+                end
+                if #v > 2000 then
+                    return nil, f.label .. " must be 2000 characters or fewer"
+                end
+                if v ~= "" then out[f.key] = v end
+            else -- text
+                if type(v) ~= "string" then
+                    return nil, f.label .. " must be text"
+                end
+                if #v > 200 then
+                    return nil, f.label .. " must be 200 characters or fewer"
+                end
+                if v ~= "" then
+                    local fmt = f.format and FORMAT_CHECKS[f.format]
+                    if fmt and not fmt.check(v) then
+                        return nil, f.label .. " " .. fmt.message
+                    end
+                    out[f.key] = v
+                end
+            end
+        end
+    end
+    for _, f in ipairs(defs) do
+        if f.required == true and out[f.key] == nil then
+            return nil, f.label .. " is required"
+        end
+    end
+    return out, total
+end
+
 local function present_section(r)
     local config = FormSectionQueries.decode_config(r.config_json)
     -- An EMPTY decoded array re-encodes as {} (object) through cjson,
     -- which crashes frontend .map()/for..of consumers — substitute the
-    -- empty-array sentinel so the wire always carries "checkboxes":[].
-    -- (checkbox_keys type-guards against the sentinel.)
+    -- empty-array sentinel so the wire always carries "checkboxes":[]
+    -- and "fields":[]. (The *_keys/field helpers type-guard against the
+    -- sentinel, which is lightuserdata.)
     if #config.checkboxes == 0 then config.checkboxes = cjson.empty_array end
+    if #config.fields == 0 then config.fields = cjson.empty_array end
     return {
         key = r.section_key,
         income_type_key = r.income_type_key,
@@ -390,6 +519,156 @@ function FormSectionQueries.archive_item(item_uuid, user)
 end
 
 -- ────────────────────────────────────────────────────────────────────────────
+-- Records (record mode) — one row per record (e.g. one employment), the
+-- whole field-form stored as a JSON document validated by the route.
+-- Same archived-rows-are-immutable convention as items.
+-- ────────────────────────────────────────────────────────────────────────────
+local function present_record(row)
+    row.id = row.uuid
+    row.user_id = nil
+    local data = {}
+    if type(row.data_json) == "string" and row.data_json ~= "" then
+        local ok, decoded = pcall(cjson.decode, row.data_json)
+        if ok and type(decoded) == "table" then data = decoded end
+    end
+    -- data is a MAP — an empty one correctly encodes as {} (object).
+    row.data = data
+    row.data_json = nil
+    row.total = tonumber(row.total) or 0
+    return row
+end
+
+-- params: { income_type?, tax_year?, include_archived? }
+function FormSectionQueries.records(params, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local where = { "user_id = ?" }
+    local args = { internal_user_id }
+    if type(params.income_type) == "string" and params.income_type ~= "" then
+        table.insert(where, "income_type_key = ?"); table.insert(args, params.income_type)
+    end
+    if type(params.tax_year) == "string" and params.tax_year ~= "" then
+        table.insert(where, "tax_year = ?"); table.insert(args, params.tax_year)
+    end
+    if params.include_archived ~= "true" and params.include_archived ~= true then
+        table.insert(where, "is_archived = false")
+    end
+
+    local rows = db.query(
+        "SELECT * FROM tax_form_records WHERE " .. table.concat(where, " AND ")
+        .. " ORDER BY created_at ASC",
+        unpack(args)) or {}
+    for _, r in ipairs(rows) do present_record(r) end
+    return { data = rows, total = #rows }
+end
+
+-- data: { income_type_key, tax_year, data_json, total } — the route has
+-- already validated the document against the field catalogue.
+function FormSectionQueries.create_record(data, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local uuid = Global.generateUUID()
+    db.query([[
+        INSERT INTO tax_form_records
+            (uuid, user_id, namespace_id, income_type_key, tax_year,
+             data_json, total, is_archived, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, false, NOW(), NOW())
+    ]],
+        uuid,
+        internal_user_id,
+        resolveNamespaceId(internal_user_id) or db.NULL,
+        data.income_type_key,
+        data.tax_year,
+        data.data_json,
+        data.total or 0
+    )
+    local row = db.query("SELECT * FROM tax_form_records WHERE uuid = ? LIMIT 1", uuid)[1]
+
+    TaxAuditLogQueries.log({
+        user_id = internal_user_id,
+        user_email = user.email,
+        entity_type = "FORM_RECORD",
+        entity_id = uuid,
+        action = "CREATE",
+        new_values = cjson.encode(row),
+    })
+    return present_record(row)
+end
+
+function FormSectionQueries.show_record(record_uuid, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+    local rows = db.query([[
+        SELECT * FROM tax_form_records
+        WHERE uuid = ? AND user_id = ? AND is_archived = false LIMIT 1
+    ]], record_uuid, internal_user_id)
+    if not rows or #rows == 0 then return nil end
+    return present_record(rows[1])
+end
+
+-- PUT is a full-document replace: { data_json, total }. income_type_key
+-- and tax_year are immutable (delete + re-add to move a record).
+function FormSectionQueries.update_record(record_uuid, data, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local existing = db.query([[
+        SELECT * FROM tax_form_records
+        WHERE uuid = ? AND user_id = ? AND is_archived = false LIMIT 1
+    ]], record_uuid, internal_user_id)
+    if not existing or #existing == 0 then return nil end
+    local old = existing[1]
+
+    db.query([[
+        UPDATE tax_form_records
+           SET data_json = ?, total = ?, updated_at = NOW()
+         WHERE uuid = ? AND user_id = ?
+    ]], data.data_json, data.total or 0, record_uuid, internal_user_id)
+
+    local refreshed = db.query("SELECT * FROM tax_form_records WHERE uuid = ? LIMIT 1", record_uuid)[1]
+
+    TaxAuditLogQueries.log({
+        user_id = internal_user_id,
+        user_email = user.email,
+        entity_type = "FORM_RECORD",
+        entity_id = record_uuid,
+        action = "UPDATE",
+        old_values = cjson.encode(old),
+        new_values = cjson.encode(refreshed),
+    })
+    return present_record(refreshed)
+end
+
+function FormSectionQueries.archive_record(record_uuid, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local existing = db.query([[
+        SELECT * FROM tax_form_records
+        WHERE uuid = ? AND user_id = ? AND is_archived = false LIMIT 1
+    ]], record_uuid, internal_user_id)
+    if not existing or #existing == 0 then return nil end
+
+    db.query([[
+        UPDATE tax_form_records
+           SET is_archived = true, archived_at = NOW(), archived_by = ?, updated_at = NOW()
+         WHERE uuid = ? AND user_id = ?
+    ]], internal_user_id, record_uuid, internal_user_id)
+
+    TaxAuditLogQueries.log({
+        user_id = internal_user_id,
+        user_email = user.email,
+        entity_type = "FORM_RECORD",
+        entity_id = record_uuid,
+        action = "DELETE",
+        old_values = cjson.encode(existing[1]),
+    })
+    return true
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
 -- Summaries — derived, read-only. Only ACTIVE sections count; rows in a
 -- retired section stay listed via items() but drop out of these numbers.
 -- ────────────────────────────────────────────────────────────────────────────
@@ -451,13 +730,37 @@ function FormSectionQueries.card_summary(user)
         WHERE s.is_active = true
         GROUP BY s.income_type_key
     ]], internal_user_id) or {}
-    local out = {}
+    local out, by_type = {}, {}
     for _, r in ipairs(rows) do
-        out[#out + 1] = {
+        local entry = {
             income_type_key = r.income_type_key,
             total = tonumber(r.total) or 0,
             row_count = tonumber(r.row_count) or 0,
         }
+        out[#out + 1] = entry
+        by_type[entry.income_type_key] = entry
+    end
+
+    -- Record-mode types: fold in the records' denormalised totals. Their
+    -- section side contributes the zero-row presence (needed for the CTA),
+    -- items contribute 0, so plain addition is correct either way.
+    local recs = db.query([[
+        SELECT income_type_key,
+               COALESCE(SUM(total), 0) AS total,
+               COUNT(id)               AS row_count
+        FROM tax_form_records
+        WHERE user_id = ? AND is_archived = false
+        GROUP BY income_type_key
+    ]], internal_user_id) or {}
+    for _, r in ipairs(recs) do
+        local entry = by_type[r.income_type_key]
+        if not entry then
+            entry = { income_type_key = r.income_type_key, total = 0, row_count = 0 }
+            out[#out + 1] = entry
+            by_type[r.income_type_key] = entry
+        end
+        entry.total = entry.total + (tonumber(r.total) or 0)
+        entry.row_count = entry.row_count + (tonumber(r.row_count) or 0)
     end
     return out
 end

--- a/lapis/queries/FormSectionQueries.lua
+++ b/lapis/queries/FormSectionQueries.lua
@@ -203,6 +203,11 @@ function FormSectionQueries.validate_record_data(defs, data)
             return nil, f.label .. " is required"
         end
     end
+    -- Each amount is bounded above, but their SUM lands in a
+    -- numeric(15,2) column too — without this it overflows to a 500.
+    if total > MAX_AMOUNT then
+        return nil, "the amounts add up to a total that is too large"
+    end
     return out, total
 end
 

--- a/lapis/routes/tax-admin-form-sections.lua
+++ b/lapis/routes/tax-admin-form-sections.lua
@@ -80,9 +80,80 @@ end
 
 local KEY_PATTERN = "^%l[%l%d_]*$"
 
+-- Field types a record-mode section may declare. Fixed whitelist — the
+-- user route validates submitted values by exactly these.
+local FIELD_TYPES = {
+    money = true, number = true, text = true,
+    textarea = true, date = true, boolean = true,
+}
+
+-- Validate + normalise config.fields (record mode). Returns list|nil, err.
+local function build_fields(fields)
+    if type(fields) ~= "table" then return nil, "fields must be an array" end
+    local seen, list = {}, {}
+    for i, f in ipairs(fields) do
+        if type(f) ~= "table" then return nil, "fields[" .. i .. "] must be an object" end
+        if type(f.key) ~= "string" or not f.key:match(KEY_PATTERN) or #f.key > 40 then
+            return nil, "field keys must be snake_case (a-z, 0-9, _), 40 characters or fewer"
+        end
+        if seen[f.key] then return nil, "duplicate field key: " .. f.key end
+        seen[f.key] = true
+        if type(f.label) ~= "string" or f.label == "" or #f.label > 200 then
+            return nil, "each field needs a label of 200 characters or fewer"
+        end
+        if not FIELD_TYPES[f.type] then
+            return nil, "field type must be one of: money, number, text, textarea, date, boolean"
+        end
+        if f.help ~= nil and (type(f.help) ~= "string" or #f.help > 300) then
+            return nil, "field help must be a string of 300 characters or fewer"
+        end
+        if f.placeholder ~= nil and (type(f.placeholder) ~= "string" or #f.placeholder > 200) then
+            return nil, "field placeholder must be a string of 200 characters or fewer"
+        end
+        if f.box ~= nil and (type(f.box) ~= "string" or #f.box > 40) then
+            return nil, "field box must be a string of 40 characters or fewer"
+        end
+        if f.format ~= nil and f.format ~= "" then
+            if f.type ~= "text" or not FormSectionQueries.FORMAT_NAMES[f.format] then
+                return nil, "field format is only valid on text fields (supported: paye_reference)"
+            end
+        end
+        local show_if
+        if f.show_if ~= nil and (type(f.show_if) ~= "table" or f.show_if.field == nil) then
+            return nil, "show_if must be an object like {\"field\":\"is_director\"}"
+        end
+        if type(f.show_if) == "table" and f.show_if.field ~= nil then
+            local dep = f.show_if.field
+            if type(dep) ~= "string" or not dep:match(KEY_PATTERN) or #dep > 40 then
+                return nil, "show_if.field must be a snake_case field key"
+            end
+            -- The frontend drops hidden fields on save while required is
+            -- enforced unconditionally server-side — the combination would
+            -- make every record unsavable while the condition is unticked.
+            if f.required == true then
+                return nil, "a conditionally-shown field (show_if) cannot be required"
+            end
+            show_if = { field = dep }
+        end
+        list[#list + 1] = {
+            key = f.key,
+            label = f.label,
+            type = f.type,
+            help = (f.help ~= "" and f.help or nil),
+            placeholder = (f.placeholder ~= "" and f.placeholder or nil),
+            box = (f.box ~= "" and f.box or nil),
+            format = (f.format ~= "" and f.format or nil),
+            required = f.required == true or nil,
+            summary = (f.type == "money" and f.summary == true) or nil,
+            show_if = show_if,
+        }
+    end
+    return list
+end
+
 -- Validate + normalise the `config` object into a config_json string.
--- Returns encoded_json|nil, err. Unknown top-level fields are stripped so
--- the stored config is exactly what the engine understands.
+-- Returns encoded_json|nil, err, has_fields. Unknown top-level fields are
+-- stripped so the stored config is exactly what the engine understands.
 local function build_config_json(config)
     if config == nil then return nil end
     if type(config) ~= "table" then return nil, "config must be an object" end
@@ -119,7 +190,66 @@ local function build_config_json(config)
     else
         out.checkboxes = cjson.empty_array
     end
-    return cjson.encode(out)
+
+    local has_fields = false
+    if config.fields ~= nil then
+        local list, ferr = build_fields(config.fields)
+        if not list then return nil, ferr end
+        has_fields = #list > 0
+        out.fields = has_fields and list or cjson.empty_array
+    else
+        out.fields = cjson.empty_array
+    end
+    -- One paradigm per section: repeating rows (checkboxes optional) OR a
+    -- fixed field-form — the user page renders one or the other.
+    if has_fields and type(out.checkboxes) == "table" and #out.checkboxes > 0 then
+        return nil, "a section cannot define both checkboxes (row mode) and fields (record mode)"
+    end
+
+    -- Record-mode presentation settings (noun + list card fields). Stored
+    -- on any section; the engine uses the first active section (by
+    -- display_order) that carries one.
+    if config.record ~= nil then
+        local r = config.record
+        if type(r) ~= "table" then return nil, "record must be an object" end
+        local rec = {}
+        if r.noun ~= nil and r.noun ~= "" then
+            if type(r.noun) ~= "string" or #r.noun > 60 then
+                return nil, "record.noun must be a string of 60 characters or fewer"
+            end
+            rec.noun = r.noun
+        end
+        for _, k in ipairs({ "title_field", "subtitle_field" }) do
+            local v = r[k]
+            if v ~= nil and v ~= "" then
+                if type(v) ~= "string" or not v:match(KEY_PATTERN) or #v > 40 then
+                    return nil, "record." .. k .. " must be a snake_case field key"
+                end
+                rec[k] = v
+            end
+        end
+        if next(rec) then out.record = rec end
+    end
+
+    return cjson.encode(out), nil, has_fields
+end
+
+-- Mixing paradigms across one type's ACTIVE sections would render half a
+-- page: the user surface is either a rows page or a records page. Returns
+-- an error string when the new/updated section disagrees with siblings.
+local function mode_conflict(income_type_key, new_has_fields, exclude_uuid)
+    for _, s in ipairs(FormSectionQueries.admin_list({ income_type = income_type_key })) do
+        if s.uuid ~= exclude_uuid then
+            local sibling_has_fields = #FormSectionQueries.field_defs(s.config) > 0
+            if sibling_has_fields ~= new_has_fields then
+                if new_has_fields then
+                    return "this income type already has repeating-row sections — one type can't mix rows and field-form sections"
+                end
+                return "this income type already has field-form (record) sections — one type can't mix rows and field-form sections"
+            end
+        end
+    end
+    return nil
 end
 
 -- hmrc_mapping arrives as an object (preferred) or a pre-encoded string;
@@ -167,10 +297,12 @@ return function(app)
         if body.description ~= nil and (type(body.description) ~= "string" or #body.description > 1000) then
             return { json = { error = "description must be a string of 1000 characters or fewer" }, status = 400 }
         end
-        local config_json, cerr = build_config_json(body.config or {})
+        local config_json, cerr, has_fields = build_config_json(body.config or {})
         if not config_json then
             return { json = { error = cerr or "invalid config" }, status = 400 }
         end
+        local mode_err = mode_conflict(body.income_type_key, has_fields == true, nil)
+        if mode_err then return { json = { error = mode_err }, status = 400 } end
         local hmrc, herr = build_hmrc_mapping(body.hmrc_mapping)
         if herr then return { json = { error = herr }, status = 400 } end
 
@@ -211,15 +343,41 @@ return function(app)
             if herr then return { json = { error = herr }, status = 400 } end
             data.hmrc_mapping = hmrc
         end
+        local new_has_fields -- nil = config untouched by this request
         if body.config ~= nil then
-            local config_json, cerr = build_config_json(body.config)
+            local config_json, cerr, has_fields = build_config_json(body.config)
             if not config_json then
                 return { json = { error = cerr or "invalid config" }, status = 400 }
             end
             data.config_json = config_json
+            new_has_fields = has_fields == true
         end
         if body.display_order ~= nil then data.display_order = body.display_order end
         if body.is_active ~= nil then data.is_active = body.is_active == true end
+
+        -- Guard the type's single paradigm when this edit could change it:
+        -- a config rewrite, or re-enabling a section into a type that may
+        -- have switched modes since it was disabled. Only sections that
+        -- will be ACTIVE after the edit participate in the mode.
+        if new_has_fields ~= nil or data.is_active == true then
+            local rows = db.query(
+                "SELECT income_type_key, config_json, is_active FROM tax_form_sections WHERE uuid = ? LIMIT 1",
+                tostring(self.params.uuid))
+            if rows and #rows > 0 then
+                local will_be_active = data.is_active
+                if will_be_active == nil then will_be_active = rows[1].is_active == true end
+                if will_be_active then
+                    local has_fields = new_has_fields
+                    if has_fields == nil then
+                        local stored = FormSectionQueries.decode_config(rows[1].config_json)
+                        has_fields = #FormSectionQueries.field_defs(stored) > 0
+                    end
+                    local mode_err = mode_conflict(rows[1].income_type_key, has_fields,
+                        tostring(self.params.uuid))
+                    if mode_err then return { json = { error = mode_err }, status = 400 } end
+                end
+            end
+        end
 
         local row = FormSectionQueries.admin_update(tostring(self.params.uuid), data)
         if not row then return { json = { error = "Section not found" }, status = 404 } end

--- a/lapis/routes/tax-form-sections.lua
+++ b/lapis/routes/tax-form-sections.lua
@@ -164,6 +164,13 @@ return function(app)
         if not section then
             return { json = { error = "section_key is not an active section of this income type" }, status = 400 }
         end
+        -- Record-mode sections take records, not row items. Without this
+        -- guard a stale client (old bundle, boolean engine probe) could
+        -- write items that inflate card_summary while being invisible on
+        -- the records page.
+        if #FormSectionQueries.field_defs(section.config) > 0 then
+            return { json = { error = "This section is part of a record form — use form-records" }, status = 400 }
+        end
         if not valid_tax_year(self.params.tax_year) then
             return { json = { error = "tax_year must be YYYY-YY (e.g. 2026-27)" }, status = 400 }
         end

--- a/lapis/routes/tax-form-sections.lua
+++ b/lapis/routes/tax-form-sections.lua
@@ -14,6 +14,16 @@
       GET    /api/v2/tax/form-summary?income_type=&tax_year=
       GET    /api/v2/tax/form-card-summary                 all-years per-type totals (overview cards)
 
+    RECORD MODE (types whose sections define config.fields — SA102
+    employment shape: repeating records, each a fixed field-form):
+      GET    /api/v2/tax/form-records?income_type=&tax_year=
+      POST   /api/v2/tax/form-records                      { income_type_key, tax_year, data }
+      PUT    /api/v2/tax/form-records/:uuid                { data }   (full-document replace)
+      DELETE /api/v2/tax/form-records/:uuid                soft archive
+    `data` is validated against the type's field catalogue: unknown keys
+    dropped, typed per field def, required fields enforced. A record's
+    income type / tax year are immutable — delete + re-add to move.
+
     `extra` is the checkbox values object. It is validated against the
     TARGET section's config: only configured keys persist (true-only,
     false is absence), unknown keys are stripped, and rows whose section
@@ -195,6 +205,70 @@ return function(app)
         local ok = FormSectionQueries.archive_item(tostring(self.params.uuid), self.current_user)
         if not ok then return { json = { error = "Entry not found" }, status = 404 } end
         return { json = { message = "Entry removed" }, status = 200 }
+    end))
+
+    -- ── Records (record mode) ───────────────────────────────────────────────
+    app:get("/api/v2/tax/form-records", AuthMiddleware.requireAuth(function(self)
+        local result, err = FormSectionQueries.records(self.params, self.current_user)
+        if not result then
+            return { json = { error = err or "Failed to list records" }, status = 400 }
+        end
+        if #result.data == 0 then result.data = cjson.empty_array end
+        return { json = result, status = 200 }
+    end))
+
+    app:post("/api/v2/tax/form-records", AuthMiddleware.requireAuth(function(self)
+        merge_params(self)
+        if type(self.params.income_type_key) ~= "string" or self.params.income_type_key == "" then
+            return { json = { error = "income_type_key is required" }, status = 400 }
+        end
+        if not valid_tax_year(self.params.tax_year) then
+            return { json = { error = "tax_year must be YYYY-YY (e.g. 2026-27)" }, status = 400 }
+        end
+        local defs = FormSectionQueries.collect_fields(self.params.income_type_key)
+        if #defs == 0 then
+            return { json = { error = "This income type does not take records" }, status = 400 }
+        end
+        -- Second return is the error on failure, the summary total on success.
+        local validated, total = FormSectionQueries.validate_record_data(defs, self.params.data)
+        if not validated then return { json = { error = total }, status = 400 } end
+        local row, err = FormSectionQueries.create_record({
+            income_type_key = self.params.income_type_key,
+            tax_year = self.params.tax_year,
+            data_json = cjson.encode(validated),
+            total = total,
+        }, self.current_user)
+        if not row then return { json = { error = err or "Failed to save" }, status = 400 } end
+        return { json = { data = row }, status = 201 }
+    end))
+
+    app:put("/api/v2/tax/form-records/:uuid", AuthMiddleware.requireAuth(function(self)
+        merge_params(self)
+        local existing = FormSectionQueries.show_record(tostring(self.params.uuid), self.current_user)
+        if not existing then return { json = { error = "Record not found" }, status = 404 } end
+        -- Full-document replace against the record's OWN type; the field
+        -- catalogue is read live so admin edits apply to the next save.
+        local defs = FormSectionQueries.collect_fields(existing.income_type_key)
+        if #defs == 0 then
+            -- Type retired from record mode since — freeze rather than
+            -- wiping the document against an empty catalogue.
+            return { json = { error = "This income type no longer takes records" }, status = 400 }
+        end
+        -- Second return is the error on failure, the summary total on success.
+        local validated, total = FormSectionQueries.validate_record_data(defs, self.params.data)
+        if not validated then return { json = { error = total }, status = 400 } end
+        local row, err = FormSectionQueries.update_record(tostring(self.params.uuid), {
+            data_json = cjson.encode(validated),
+            total = total,
+        }, self.current_user)
+        if not row then return { json = { error = err or "Record not found" }, status = err and 400 or 404 } end
+        return { json = { data = row }, status = 200 }
+    end))
+
+    app:delete("/api/v2/tax/form-records/:uuid", AuthMiddleware.requireAuth(function(self)
+        local ok = FormSectionQueries.archive_record(tostring(self.params.uuid), self.current_user)
+        if not ok then return { json = { error = "Record not found" }, status = 404 } end
+        return { json = { message = "Record removed" }, status = 200 }
     end))
 
     -- ── Summaries (read-only, derived) ──────────────────────────────────────


### PR DESCRIPTION
## What

Adds a **second shape to the form-sections engine — record mode** — and puts the existing `salary` income type onto it as the SA102 Employment screen (IRIS layout: Employment Details / Close Company / Income / Benefits / Expenses / Foreign earnings / Notes).

Pension payments proved the engine for *repeating-row* screens. Employment is a different shape: **repeating records** (one per employer), each edited as a **fixed form of typed fields**. This PR makes that shape pure catalogue data too — the next screen like it (SA105-style fixed forms etc.) is admin config, no Lua.

## Engine (migration 755 + routes)

- `tax_form_records` — one row per record; all field values in a `data_json` document; denormalised `total` (sum of money fields flagged `summary:true`) keeps the overview-card query a plain SUM.
- Sections may now define `config_json.fields`: typed inputs (`money | number | text | textarea | date | boolean`) with label/help/placeholder, `required`, SA box ref, named `format` checks (`paye_reference`), and `show_if` (render only while a boolean field is ticked).
- `GET/POST/PUT/DELETE /api/v2/tax/form-records` — PUT is a full-document replace validated live against the catalogue; income type + tax year immutable; archived rows immutable; unknown keys dropped; nested JSON `null` = unset; MAX_AMOUNT bound.
- Record presentation block (`config.record`: noun, title/subtitle fields) — first active section carrying one wins.
- Admin guards: one paradigm per section AND per income type (rows vs record form), `required` + `show_if` combination rejected (would make records unsavable), field key immutability conventions same as checkboxes.
- `form-card-summary` folds record totals into the per-type numbers.

## Salary content (756/757 — data only)

- Seeds the 7 SA102 sections/fields for `salary` with box references (1, 1.1, 2, 3, 4, 5, 6, 6.1, 7, 9–20) as informational metadata.
- `allows_manual_entry = false` for salary — the records page replaces flat one-amount entries.
- Ports legacy flat `my_incomes` salary rows 1:1 into records (description → employer name, amount → pay before tax; source uuid reused so re-runs never duplicate). **Source rows are left in place** so the FastAPI calc aggregator keeps working until records gain calc integration (same standing gap as every engine type; noted honestly in the UI).

## Deploy — merge together with the diy FE PR, then one int deploy

Order matters: the **old** frontend's engine probe is a boolean, so once this API deploys and salary has sections, an old FE would render salary with the repeating-ROWS page (wrong surface, and it would happily accept row items). Merge this + the diy PR (`FormRecordsPage`) together and deploy once. FE-first is harmless (salary just stays flat until the API lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)