### PR TITLE
feat(income-engine): backend feature-flag helper (Phase 0 companion)

### DIFF
--- a/lapis/helper/income-engine.lua
+++ b/lapis/helper/income-engine.lua
@@ -1,0 +1,82 @@
+--[[
+  Income-engine feature-flag helper.
+
+  Backend companion to the frontend helper at
+  frontend/src/lib/income-engine.ts in the diy-tax-return-uk repo.
+  Reads which engine a given income type is served by in the current
+  env, and whether writes should be forked to the OTHER engine during
+  a migration window.
+
+  See docs/PROFILE_BUILDER_UNIFICATION_PLAN.md §4 in the diy-tax-return-uk
+  repo for the full flag surface and per-env rollout schedule.
+
+  Env-var convention:
+    INCOME_ENGINE_<UPPER_INCOME_TYPE_KEY>              = "profile_builder"
+                                                       (else "form_sections",
+                                                        the default)
+    INCOME_ENGINE_<UPPER_INCOME_TYPE_KEY>_DUAL_WRITE   = "true" or "1"
+                                                       (else false)
+
+  Same names as the frontend WITHOUT the NEXT_PUBLIC_ prefix, so the
+  Helm chart injects them into both pods per env with a single source
+  string in values.yaml.
+
+  Defaults are the current-behaviour engine ("form_sections") + no dual
+  write. Any income type not explicitly configured stays on the legacy
+  path — the rollout is opt-in per type per env, never accidental.
+
+  Kept intentionally tiny + dependency-free so it can be required from
+  any route/query without pulling in DB or ORM layers. Runtime evaluation
+  every call (no cache) — env changes in a pod's env are picked up at
+  restart, not process boot; if we ever memoize this we must invalidate
+  on SIGHUP.
+]]
+
+local M = {}
+
+local FORM_SECTIONS = "form_sections"
+local PROFILE_BUILDER = "profile_builder"
+
+M.FORM_SECTIONS = FORM_SECTIONS
+M.PROFILE_BUILDER = PROFILE_BUILDER
+
+--- Returns the engine that should serve the given income type key in
+--- this env. Falls back to "form_sections" (current-behaviour default)
+--- for missing / empty / unknown values — a new income type never
+--- accidentally opts into the unfinished engine.
+--- @param income_type_key string  e.g. "salary", "pension_payments"
+--- @return string                 "form_sections" | "profile_builder"
+function M.mode(income_type_key)
+    if type(income_type_key) ~= "string" or income_type_key == "" then
+        return FORM_SECTIONS
+    end
+    local env_name = "INCOME_ENGINE_" .. income_type_key:upper()
+    local val = os.getenv(env_name)
+    if val == PROFILE_BUILDER then return PROFILE_BUILDER end
+    return FORM_SECTIONS
+end
+
+--- Should writes be forked to the non-primary store for this income
+--- type? On during migration windows for rollback safety, off in
+--- steady state. Env var (per type):
+---   INCOME_ENGINE_<UPPER>_DUAL_WRITE=true
+--- @param income_type_key string
+--- @return boolean
+function M.dual_write_enabled(income_type_key)
+    if type(income_type_key) ~= "string" or income_type_key == "" then
+        return false
+    end
+    local env_name = "INCOME_ENGINE_" .. income_type_key:upper() .. "_DUAL_WRITE"
+    local val = os.getenv(env_name)
+    return val == "true" or val == "1"
+end
+
+--- Convenience predicate — reads more naturally at call sites than a
+--- string-equality comparison on M.mode(...).
+--- @param income_type_key string
+--- @return boolean
+function M.uses_profile_builder(income_type_key)
+    return M.mode(income_type_key) == PROFILE_BUILDER
+end
+
+return M


### PR DESCRIPTION
## Summary

Backend companion to the frontend flag helper (diy-tax-return-uk **PR #797**) that lands the profile-builder unification's Phase 0 infrastructure.

## Public API

\`\`\`lua
local IncomeEngine = require("helper.income-engine")

IncomeEngine.mode("salary")                 -- "form_sections" | "profile_builder"
IncomeEngine.uses_profile_builder("salary") -- boolean convenience
IncomeEngine.dual_write_enabled("salary")   -- boolean
\`\`\`

## Env-var convention

Per income type, WITHOUT the frontend's \`NEXT_PUBLIC_\` prefix (Helm injects both pods from one \`values.yaml\` source):

\`\`\`
INCOME_ENGINE_SALARY               = profile_builder    # (else form_sections)
INCOME_ENGINE_SALARY_DUAL_WRITE    = true               # (else off)
\`\`\`

## Defaults

- Missing / empty / unknown mode → \`form_sections\` (current behaviour). A new income type never accidentally opts into the unfinished engine.
- Missing dual-write flag → \`false\`.

## Design choices

- **Dependency-free** (no DB, no ORM) so any route or query module can \`require\` it without pulling infra.
- **No memoization** — env changes only take effect on pod restart, so a runtime cache would be a false economy.
- **Constants exposed** (\`M.FORM_SECTIONS\`, \`M.PROFILE_BUILDER\`) so callers can compare against them instead of hand-typing the strings.

## Non-goals for this PR

- No consumer wired up yet — Phase 1 (salary migration) uses \`M.mode(...)\` to branch its \`POST\` / \`PUT\` / \`DELETE\` writes and \`M.dual_write_enabled(...)\` to opt into the fork.
- No schema changes, no data migration, no route changes.

## Refs

- \`docs/PROFILE_BUILDER_UNIFICATION_PLAN.md\` (in the diy-tax-return-uk repo) §4
- diy-tax-return-uk PR #795 — design doc
- diy-tax-return-uk PR #797 — frontend companion + CI decoupling guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)