### PR TITLE
feat(salary-migration): Phase 1 — port salary onto Profile Builder (opsapi)

### DIFF
--- a/lapis/app.lua
+++ b/lapis/app.lua
@@ -519,6 +519,11 @@ load_if("tax_copilot", "routes.tax-businesses")
 -- Overseas property hub ("Land and property abroad", SA106): same engine as
 -- tax-properties with entity_type='overseas_property' + overseas catalogue.
 load_if("tax_copilot", "routes.tax-overseas-properties")
+-- Employment hub (Salary via Profile Builder — Phase 1 of the profile-builder
+-- unification plan). Entity CRUD over user_profile_entities of entity_type
+-- 'employment'; questions come from routes.profile-builder scoped by that
+-- entity, so admins add / edit fields without shipping code.
+load_if("tax_copilot", "routes.tax-employments")
 -- Form Sections engine: generic admin-defined sections + sub-form rows
 -- (pension payments and every future screen of that shape). The admin
 -- surface is what lets new screens ship without code changes.

--- a/lapis/helper/income-engine.lua
+++ b/lapis/helper/income-engine.lua
@@ -40,10 +40,26 @@ local PROFILE_BUILDER = "profile_builder"
 M.FORM_SECTIONS = FORM_SECTIONS
 M.PROFILE_BUILDER = PROFILE_BUILDER
 
+-- Income types whose migration to Profile Builder has shipped end-to-
+-- end (catalog seed + backfill + dual-write fork + hub page + admin
+-- support). Their DEFAULT engine is `profile_builder`; env-var still
+-- wins in either direction. Keep in step with MIGRATED_TYPES on the
+-- frontend (lib/income-engine.ts) — a divergence would put the two
+-- pods on different engines for the same type, which the fork was
+-- specifically designed to avoid.
+local MIGRATED_TYPES = {
+    salary = true,
+    pension_payments = true,
+}
+
 --- Returns the engine that should serve the given income type key in
---- this env. Falls back to "form_sections" (current-behaviour default)
---- for missing / empty / unknown values — a new income type never
---- accidentally opts into the unfinished engine.
+--- this env.
+---
+--- Precedence (highest wins):
+---   1. INCOME_ENGINE_<TYPE> env-var override (either direction)
+---   2. `profile_builder` if the type is in MIGRATED_TYPES
+---   3. `form_sections` (safe default for un-migrated types)
+---
 --- @param income_type_key string  e.g. "salary", "pension_payments"
 --- @return string                 "form_sections" | "profile_builder"
 function M.mode(income_type_key)
@@ -53,6 +69,8 @@ function M.mode(income_type_key)
     local env_name = "INCOME_ENGINE_" .. income_type_key:upper()
     local val = os.getenv(env_name)
     if val == PROFILE_BUILDER then return PROFILE_BUILDER end
+    if val == FORM_SECTIONS then return FORM_SECTIONS end
+    if MIGRATED_TYPES[income_type_key:lower()] then return PROFILE_BUILDER end
     return FORM_SECTIONS
 end
 

--- a/lapis/helper/pension-profile-builder-fork.lua
+++ b/lapis/helper/pension-profile-builder-fork.lua
@@ -1,0 +1,180 @@
+--[[
+  Pension → Profile Builder — dual-write fork.
+
+  Wraps the primary tax_form_items write path for
+  income_type='pension_payments' and mirrors the row into the unified
+  Profile Builder store (user_profile_answers with aggregated
+  answer_json arrays) so the shadow engine stays current during the
+  Phase 2 migration window.
+
+  Gated by IncomeEngine.dual_write_enabled("pension_payments") — off
+  by default, turned on per env via the INCOME_ENGINE_PENSION_PAYMENTS_DUAL_WRITE
+  env var (see docs/PROFILE_BUILDER_UNIFICATION_PLAN.md §4 in the
+  diy-tax-return-uk repo, and lapis/helper/income-engine.lua here).
+
+  Shape differs from salary fork in one important way: pension is a
+  MANY-rows-per-bucket model (many payments per section per year).
+  Every mutation therefore doesn't just upsert its own row — it
+  RE-AGGREGATES the whole bucket for that (user, year, section) and
+  upserts the single user_profile_answers row that holds the JSON
+  array. This keeps the shadow in exact lock-step with tax_form_items
+  regardless of whether the mutation was a create, update, or delete.
+
+  Delete-to-empty: if the last row in a bucket goes, we delete the
+  answer row rather than storing `[]` — matches how the frontend's
+  ContextSections treats missing vs. empty (missing = "no payments
+  entered", empty array = "explicit empty" which we don't need).
+
+  Same design rules as salary fork:
+
+    1. NEVER breaks the primary write. Every entry point pcalls the
+       DB work.
+    2. Section → question_key map is DUPLICATED from the backfill
+       (pension-profile-builder-backfill.lua) on purpose — routes vs
+       migrations run in different contexts, no shared code, keep in
+       sync by hand.
+    3. ON CONFLICT DO UPDATE (year-scoped partial unique index) —
+       the user just wrote a new value; the shadow MUST reflect it.
+
+  Public API:
+
+      PensionFork.on_change(user_id, tax_year, section_key)
+
+  Every entry point is safe to call unconditionally — the flag check
+  is inside the helper. Callers pass the identifying triple; the fork
+  reads current tax_form_items state itself so create / update /
+  delete all funnel through the same code path.
+]]
+
+local db = require("lapis.db")
+local cjson = require("cjson")
+local IncomeEngine = require("helper.income-engine")
+
+local M = {}
+
+-- Same map as pension-profile-builder-backfill.lua's SECTION_MAP.
+-- Keep aligned by hand.
+local SECTION_MAP = {
+    pp_registered_schemes = { question_key = "pp_registered_payments", includes_flags = true },
+    pp_employer_schemes   = { question_key = "pp_employer_payments",   includes_flags = false },
+    pp_overseas_schemes   = { question_key = "pp_overseas_payments",   includes_flags = false },
+}
+
+local function parse_extra(raw)
+    if raw == nil or raw == cjson.null or raw == "" then return {} end
+    if type(raw) ~= "string" then return {} end
+    local ok, parsed = pcall(cjson.decode, raw)
+    if not ok or type(parsed) ~= "table" then return {} end
+    return parsed
+end
+
+local function log_mismatch(op, user_id, section, err)
+    ngx.log(ngx.ERR, string.format(
+        "[PensionFork] INCOME_ENGINE_DUAL_WRITE_MISMATCH op=%s user=%s section=%s err=%s",
+        op, tostring(user_id), tostring(section), tostring(err)
+    ))
+end
+
+-- Rebuild the aggregate for one bucket. Reads every non-archived
+-- tax_form_items row for (user, year, section), builds the JSON array
+-- in creation order, and upserts (or deletes) the answer row.
+local function rebuild_bucket(user_id, tax_year, section_key)
+    local mapping = SECTION_MAP[section_key]
+    if not mapping then return false, "unknown section_key: " .. tostring(section_key) end
+
+    local qrows = db.query(
+        "SELECT id FROM profile_questions WHERE question_key = ? LIMIT 1",
+        mapping.question_key
+    )
+    if not qrows or #qrows == 0 then
+        return false, "question " .. mapping.question_key .. " not seeded yet"
+    end
+    local qid = qrows[1].id
+
+    local urows = db.query("SELECT uuid FROM users WHERE id = ? LIMIT 1", user_id)
+    if not urows or #urows == 0 then return false, "user not found" end
+    local user_uuid = urows[1].uuid
+
+    local items = db.query([[
+        SELECT description, amount, extra_json, namespace_id
+        FROM tax_form_items
+        WHERE user_id = ? AND income_type_key = 'pension_payments'
+          AND section_key = ? AND tax_year = ? AND is_archived = false
+        ORDER BY created_at
+    ]], user_id, section_key, tax_year) or {}
+
+    -- Empty bucket → drop the shadow answer row entirely (matches the
+    -- backfill's absent-key convention, avoids leaving an empty [] in
+    -- the JSON store the frontend would still render as "0 payments
+    -- explicitly").
+    if #items == 0 then
+        db.query([[
+            DELETE FROM user_profile_answers
+            WHERE user_id = ? AND question_id = ? AND tax_year = ?
+              AND entity_uuid IS NULL
+        ]], user_id, qid, tax_year)
+        return true
+    end
+
+    -- Namespace: take it from the first row. All rows in a bucket
+    -- belong to the same user and were written with the same
+    -- namespace context — mixed values would indicate corruption
+    -- elsewhere.
+    local namespace_id = items[1].namespace_id
+
+    local rows = {}
+    for _, it in ipairs(items) do
+        local row_obj = {
+            description = it.description or "",
+            amount = tonumber(it.amount) or 0,
+        }
+        if mapping.includes_flags then
+            local extra = parse_extra(it.extra_json)
+            row_obj.relief_at_source = extra.relief_at_source == true
+            row_obj.one_off = extra.one_off == true
+        end
+        rows[#rows + 1] = row_obj
+    end
+    local json_str = cjson.encode(rows)
+
+    -- Same ON CONFLICT shape as the backfill — inferred against the
+    -- year-scoped partial unique index idx_upa_user_question_year
+    -- (WHERE entity_uuid IS NULL AND tax_year IS NOT NULL). Answer
+    -- column is TEXT, no jsonb cast.
+    db.query([[
+        INSERT INTO user_profile_answers
+            (uuid, user_id, user_uuid, namespace_id, question_id,
+             entity_uuid, tax_year, answer_json,
+             is_draft, answered_at, updated_at)
+        VALUES (gen_random_uuid()::text, ?, ?, ?, ?,
+                NULL, ?, ?,
+                false, NOW(), NOW())
+        ON CONFLICT (user_id, question_id, tax_year)
+        WHERE entity_uuid IS NULL AND tax_year IS NOT NULL
+        DO UPDATE SET
+            answer_json = EXCLUDED.answer_json,
+            updated_at = NOW()
+    ]], user_id, user_uuid, namespace_id or db.NULL, qid,
+        tax_year, json_str)
+
+    return true
+end
+
+-- Public entry point -------------------------------------------------
+--
+-- Called after any successful mutation on tax_form_items for a
+-- pension_payments row. Because the shadow is an AGGREGATE per
+-- (user, year, section), every create / update / delete of any row
+-- in a bucket produces the same rebuild — no need for per-op
+-- variants.
+--
+-- Safe to call unconditionally — the income_type_key + flag checks
+-- run inside.
+function M.on_change(user_id, tax_year, section_key)
+    if not IncomeEngine.dual_write_enabled("pension_payments") then return end
+    if not user_id or not tax_year or not section_key then return end
+    local ok, err = pcall(rebuild_bucket, user_id, tax_year, section_key)
+    if not ok then log_mismatch("change", user_id, section_key, err) end
+end
+
+return M

--- a/lapis/helper/salary-profile-builder-fork.lua
+++ b/lapis/helper/salary-profile-builder-fork.lua
@@ -1,0 +1,307 @@
+--[[
+  Salary → Profile Builder — dual-write fork.
+
+  Wraps the primary tax_form_records write path for income_type='salary'
+  and mirrors the row into the unified Profile Builder store
+  (user_profile_entities + user_profile_answers) so the shadow engine
+  stays current during the Phase 1 migration window.
+
+  Gated by IncomeEngine.dual_write_enabled("salary") — off by default,
+  turned on per env via the INCOME_ENGINE_SALARY_DUAL_WRITE env var
+  (see docs/PROFILE_BUILDER_UNIFICATION_PLAN.md §4 in the
+  diy-tax-return-uk repo, and lapis/helper/income-engine.lua here).
+
+  Design rules:
+
+    1. NEVER breaks the primary write. Every entry point pcalls the
+       DB work. On failure, the primary write still succeeds and we
+       log the discrepancy — the design doc's mismatch counter
+       tolerates this and blocks cutover if it doesn't clear.
+
+    2. Same deterministic entity UUID derivation as the backfill
+       (`salary-profile-builder-backfill.lua`). A record that was
+       backfilled once and later edited by the user via form-records
+       ends up with the ONE entity row + updated answers — no
+       duplicates.
+
+    3. ON CONFLICT DO UPDATE on answers (not DO NOTHING as the
+       backfill uses). The user just wrote a new value on the
+       primary; the shadow MUST reflect it. Backfill's DO NOTHING
+       was there so a re-run wouldn't overwrite the user's later
+       edits on the profile-builder side — for the fork, the user's
+       edit IS the source of truth and must propagate.
+
+    4. Field mapping is DUPLICATED in this file and the backfill on
+       purpose. The two run in different execution contexts (routes
+       vs migrations) and share no other code. A single source-of-
+       truth constant would introduce a require-cycle risk between
+       queries + migrations. Cost: both places must be kept in sync.
+       Mitigation: dev checklist called out in the design doc and a
+       test that asserts both maps are equal (added in Phase 2's
+       shared-utility pass).
+
+  Public API:
+
+      SalaryFork.on_create(record)     -- record is the freshly-created tax_form_records row
+      SalaryFork.on_update(record)     -- record is the just-updated row
+      SalaryFork.on_delete(record)     -- record is the pre-delete row (we need its uuid + user)
+
+  Every entry point is safe to call unconditionally — the flag check
+  is inside the helper.
+]]
+
+local db = require("lapis.db")
+local cjson = require("cjson")
+local IncomeEngine = require("helper.income-engine")
+
+local M = {}
+
+-- Same key set as salary-profile-builder-backfill.lua's FIELD_MAP.
+-- Keep aligned by hand or via the Phase-2 shared-utility check.
+local FIELD_MAP = {
+    employer_name             = { key = "emp_employer_name",         type = "text" },
+    paye_reference            = { key = "emp_paye_reference",        type = "text" },
+    start_date                = { key = "emp_start_date",            type = "date" },
+    end_date                  = { key = "emp_end_date",              type = "date" },
+    is_director               = { key = "emp_is_director",           type = "boolean" },
+    director_ceased_date      = { key = "emp_director_ceased_date",  type = "date" },
+    is_close_company          = { key = "emp_is_close_company",      type = "boolean" },
+    registered_number         = { key = "emp_cc_registered_number",  type = "text" },
+    close_company_dividends   = { key = "emp_cc_dividends",          type = "number" },
+    shareholding_percent      = { key = "emp_cc_shareholding_percent", type = "number" },
+    pay_before_tax            = { key = "emp_pay_before_tax",        type = "number" },
+    payrolled_benefits        = { key = "emp_payrolled_benefits",    type = "number" },
+    uk_tax_taken_off          = { key = "emp_uk_tax_taken_off",      type = "number" },
+    tips_not_on_p60           = { key = "emp_tips_not_on_p60",       type = "number" },
+    company_cars              = { key = "emp_ben_company_cars",          type = "number" },
+    fuel_company_cars         = { key = "emp_ben_fuel_company_cars",     type = "number" },
+    company_vans              = { key = "emp_ben_company_vans",          type = "number" },
+    fuel_company_vans         = { key = "emp_ben_fuel_company_vans",     type = "number" },
+    travel_subsistence        = { key = "emp_ben_travel_subsistence",    type = "number" },
+    entertaining              = { key = "emp_ben_entertaining",          type = "number" },
+    private_medical           = { key = "emp_ben_private_medical",       type = "number" },
+    telephone                 = { key = "emp_ben_telephone",             type = "number" },
+    professional_fees_employer = { key = "emp_ben_professional_fees",     type = "number" },
+    vouchers_credit_cards     = { key = "emp_ben_vouchers_credit_cards", type = "number" },
+    excess_mileage_allowance  = { key = "emp_ben_excess_mileage",        type = "number" },
+    goods_assets_provided     = { key = "emp_ben_goods_assets",          type = "number" },
+    accommodation_provided    = { key = "emp_ben_accommodation",         type = "number" },
+    other_benefits            = { key = "emp_ben_other",                 type = "number" },
+    expenses_payments_received = { key = "emp_ben_expenses_payments",    type = "number" },
+    business_travel           = { key = "emp_exp_business_travel",       type = "number" },
+    hotel_meal_expenses       = { key = "emp_exp_hotel_meal",            type = "number" },
+    fixed_deductions          = { key = "emp_exp_fixed_deductions",      type = "number" },
+    professional_fees_subs    = { key = "emp_exp_professional_fees",     type = "number" },
+    tools_work_clothes        = { key = "emp_exp_tools_clothes",         type = "number" },
+    vehicle_expenses          = { key = "emp_exp_vehicle",               type = "number" },
+    mileage_shortfall         = { key = "emp_exp_mileage_shortfall",     type = "number" },
+    other_expenses_capital    = { key = "emp_exp_other_capital",         type = "number" },
+    seafarers_deduction         = { key = "emp_foreign_seafarers",         type = "number" },
+    foreign_earnings_not_taxable = { key = "emp_foreign_not_taxable",      type = "number" },
+    foreign_tax_no_credit       = { key = "emp_foreign_tax_no_credit",     type = "number" },
+    exempt_overseas_pension     = { key = "emp_foreign_exempt_pension",    type = "number" },
+    tax_return_note           = { key = "emp_tax_return_note",       type = "text" },
+}
+
+-- Deterministic entity UUID from the source record uuid — matches
+-- salary-profile-builder-backfill.lua's deriveEntityUuid exactly.
+-- If the two ever drift, backfilled rows and fork rows will land on
+-- different entities, doubling storage silently.
+local function derive_entity_uuid(record_uuid)
+    local rows = db.query([[
+        WITH h AS (SELECT md5('phase1-employment:' || ?) AS hex)
+        SELECT substring(hex FROM 1  FOR 8)  || '-' ||
+               substring(hex FROM 9  FOR 4)  || '-' ||
+               substring(hex FROM 13 FOR 4)  || '-' ||
+               substring(hex FROM 17 FOR 4)  || '-' ||
+               substring(hex FROM 21 FOR 12) AS derived_uuid
+        FROM h
+    ]], record_uuid)
+    return rows[1] and rows[1].derived_uuid or nil
+end
+
+local function coerce(field_type, raw)
+    if raw == nil or raw == cjson.null then return nil end
+    if field_type == "number" then
+        local n = tonumber(raw)
+        if n and n == n then return n end
+        return nil
+    end
+    if field_type == "text" then
+        if type(raw) == "string" then return raw end
+        return tostring(raw)
+    end
+    if field_type == "boolean" then
+        if raw == true or raw == false then return raw end
+        if raw == "true" then return true end
+        if raw == "false" then return false end
+        return nil
+    end
+    if field_type == "date" then
+        if type(raw) == "string" and raw ~= "" then return raw end
+    end
+    return nil
+end
+
+-- Log a fork failure to the same channel the design doc's discrepancy
+-- counter tallies. Keeps the primary write on its happy path but makes
+-- the miss visible for the cutover gate.
+local function log_mismatch(op, record_uuid, err)
+    ngx.log(ngx.ERR, string.format(
+        "[SalaryFork] INCOME_ENGINE_DUAL_WRITE_MISMATCH op=%s record=%s err=%s",
+        op, tostring(record_uuid), tostring(err)
+    ))
+end
+
+-- Upsert the entity row + one answer row per known field value.
+local function upsert_entity_and_answers(record)
+    local entity_uuid = derive_entity_uuid(record.uuid)
+    if not entity_uuid then return false, "derive_entity_uuid failed" end
+
+    local urows = db.query("SELECT uuid FROM users WHERE id = ? LIMIT 1", record.user_id)
+    if not urows or #urows == 0 then return false, "user not found" end
+    local user_uuid = urows[1].uuid
+
+    local data
+    if type(record.data_json) == "string" then
+        local ok, decoded = pcall(cjson.decode, record.data_json)
+        if not ok then return false, "invalid data_json" end
+        data = decoded
+    else
+        data = record.data_json or {}
+    end
+    if type(data) ~= "table" then return false, "data_json not an object" end
+
+    local label = data.employer_name
+    if type(label) ~= "string" or label == "" then label = "Employment" end
+    if #label > 200 then label = label:sub(1, 200) end
+    local metadata = cjson.encode({
+        origin = "phase1_salary_fork",
+        legacy_form_record_uuid = record.uuid,
+    })
+
+    db.query([[
+        INSERT INTO user_profile_entities
+            (uuid, user_id, user_uuid, namespace_id, entity_type,
+             label, metadata_json, display_order, is_archived,
+             created_at, updated_at)
+        VALUES (?, ?, ?, ?, 'employment', ?, ?, 0, false, NOW(), NOW())
+        ON CONFLICT (uuid) DO UPDATE
+        SET label = EXCLUDED.label,
+            metadata_json = EXCLUDED.metadata_json,
+            is_archived = false,
+            archived_at = NULL,
+            updated_at = NOW()
+    ]], entity_uuid, record.user_id, user_uuid,
+        record.namespace_id or db.NULL, label, metadata)
+
+    -- Batch the question-id lookup — a single SELECT for every
+    -- known question_key (small fixed set) is cheaper than one per
+    -- data field.
+    local keys_list = {}
+    for _, m in pairs(FIELD_MAP) do keys_list[#keys_list + 1] = m.key end
+    local qrows = db.query(
+        "SELECT id, question_key FROM profile_questions WHERE question_key = ANY(?)",
+        db.array(keys_list)
+    ) or {}
+    local qid_by_key = {}
+    for _, qr in ipairs(qrows) do qid_by_key[qr.question_key] = qr.id end
+
+    for field_key, raw in pairs(data) do
+        local mapping = FIELD_MAP[field_key]
+        if mapping then
+            local qid = qid_by_key[mapping.key]
+            local typed = coerce(mapping.type, raw)
+            if qid and typed ~= nil then
+                local col_text, col_num, col_bool, col_date =
+                    db.NULL, db.NULL, db.NULL, db.NULL
+                if mapping.type == "text" then col_text = typed
+                elseif mapping.type == "number" then col_num = typed
+                elseif mapping.type == "boolean" then col_bool = typed
+                elseif mapping.type == "date" then col_date = typed
+                end
+                -- Fork is authoritative for the primary user's write —
+                -- ON CONFLICT DO UPDATE, not DO NOTHING like backfill.
+                --
+                -- The conflict target `idx_upa_user_question_entity` is a
+                -- PARTIAL unique index (WHERE entity_uuid IS NOT NULL),
+                -- not a constraint — Postgres's `ON CONFLICT ON
+                -- CONSTRAINT <name>` doesn't accept indexes. We use the
+                -- inferred form with a matching index_predicate so
+                -- Postgres uniquely identifies the partial index.
+                db.query([[
+                    INSERT INTO user_profile_answers
+                        (uuid, user_id, user_uuid, namespace_id,
+                         question_id, question_version, entity_uuid,
+                         answer_text, answer_number, answer_boolean,
+                         answer_date, is_draft, answered_at, updated_at)
+                    VALUES (gen_random_uuid()::text, ?, ?, ?, ?, 1, ?,
+                            ?, ?, ?, ?, false, NOW(), NOW())
+                    ON CONFLICT (user_id, question_id, entity_uuid)
+                    WHERE entity_uuid IS NOT NULL
+                    DO UPDATE SET
+                        answer_text = EXCLUDED.answer_text,
+                        answer_number = EXCLUDED.answer_number,
+                        answer_boolean = EXCLUDED.answer_boolean,
+                        answer_date = EXCLUDED.answer_date,
+                        updated_at = NOW()
+                ]], record.user_id, user_uuid, record.namespace_id or db.NULL,
+                    qid, entity_uuid,
+                    col_text, col_num, col_bool, col_date)
+            end
+        end
+        -- Unknown / unmapped fields are silently dropped — the shadow
+        -- catalogue is the source of truth; anything the primary knows
+        -- but the shadow doesn't is not our problem to preserve.
+    end
+
+    return true, entity_uuid
+end
+
+-- Archive the entity + its answers. Same idempotent shape — a re-run
+-- (or a delete on an already-archived record) is a no-op.
+local function archive_entity(record)
+    local entity_uuid = derive_entity_uuid(record.uuid)
+    if not entity_uuid then return false, "derive_entity_uuid failed" end
+    db.query([[
+        UPDATE user_profile_entities
+        SET is_archived = true, archived_at = NOW(), updated_at = NOW()
+        WHERE uuid = ? AND is_archived = false
+    ]], entity_uuid)
+    -- We do NOT delete answer rows — they hang off entity_uuid and the
+    -- unique-index still holds. Leaving them lets a Phase-1 rollback
+    -- restore the record cheaply. Phase 3's cleanup drops them.
+    return true, entity_uuid
+end
+
+-- Public entry points -------------------------------------------------
+
+--- Called after a successful POST /form-records. `record` is the row
+--- FormSectionQueries.create_record returned (uuid, user_id, tax_year,
+--- income_type_key, data_json, namespace_id).
+function M.on_create(record)
+    if not record or record.income_type_key ~= "salary" then return end
+    if not IncomeEngine.dual_write_enabled("salary") then return end
+    local ok, err = pcall(upsert_entity_and_answers, record)
+    if not ok then log_mismatch("create", record.uuid, err) end
+end
+
+--- Called after a successful PUT /form-records/:uuid. `record` is the
+--- updated row (same shape as create).
+function M.on_update(record)
+    if not record or record.income_type_key ~= "salary" then return end
+    if not IncomeEngine.dual_write_enabled("salary") then return end
+    local ok, err = pcall(upsert_entity_and_answers, record)
+    if not ok then log_mismatch("update", record.uuid, err) end
+end
+
+--- Called after a successful DELETE /form-records/:uuid. Pass the
+--- pre-delete record so we know which entity to archive.
+function M.on_delete(record)
+    if not record or record.income_type_key ~= "salary" then return end
+    if not IncomeEngine.dual_write_enabled("salary") then return end
+    local ok, err = pcall(archive_entity, record)
+    if not ok then log_mismatch("delete", record.uuid, err) end
+end
+
+return M

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -2024,6 +2024,19 @@ local _migrations = {
     -- doc. Feature-flag flip on the frontend is separate (env var).
     ['758_seed_salary_profile_builder_catalog'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, salary_profile_builder_catalog_migrations, 1),
     ['759_backfill_salary_to_profile_builder'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, salary_profile_builder_backfill_migrations, 1),
+    -- 760/761 — re-run pass. In an earlier iteration the catalog seed
+    -- passed nil to db.query for the categories with no description
+    -- (close-company / foreign / notes); Lua truncates varargs at the
+    -- first nil, so the SQL fired with unfilled placeholders and the
+    -- whole seed aborted after "Employment details". Envs that ran the
+    -- buggy 758 have only 1 of the 7 employment categories. 760 re-runs
+    -- the (now fixed) seed and 761 re-runs the backfill so any answers
+    -- that were silently dropped (because their question_id didn't yet
+    -- exist) get their user_profile_answers row this time. Both are
+    -- idempotent — a fresh env where 758/759 already succeeded treats
+    -- 760/761 as no-ops.
+    ['760_reseed_salary_profile_builder_catalog'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, salary_profile_builder_catalog_migrations, 2),
+    ['761_rebackfill_salary_to_profile_builder'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, salary_profile_builder_backfill_migrations, 2),
 
     -- =========================================================================
     -- Academy (LMS): courses + lessons (namespace-scoped). Feature-gated, so

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -228,6 +228,16 @@ local rental_joint_owner_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX
 local salary_profile_builder_catalog_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.salary-profile-builder-catalog") or {}
 local salary_profile_builder_backfill_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.salary-profile-builder-backfill") or {}
 
+-- Phase 2 pension migration (see docs/PROFILE_BUILDER_UNIFICATION_PLAN.md
+-- §5-6 in the diy-tax-return-uk repo) — three catalog entries and one
+-- aggregating backfill. Same shape as the Phase 1 salary pair but the
+-- data model differs: year-scoped answers (answer_scope='year', no
+-- entities) each holding an aggregated JSON array of payment rows via
+-- the repeating_group question type. See catalog file's docstring
+-- for the SA100 TR4 mapping.
+local pension_profile_builder_catalog_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.pension-profile-builder-catalog") or {}
+local pension_profile_builder_backfill_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.pension-profile-builder-backfill") or {}
+
 -- Billing / payments (Stripe Connect: subscriptions + one-time). Gated on
 -- tax_copilot for now; broaden to a feature list (e.g. {ECOMMERCE, TAX_COPILOT})
 -- once multiple project codes need it. See migrations/billing-system.lua.
@@ -2037,6 +2047,20 @@ local _migrations = {
     -- 760/761 as no-ops.
     ['760_reseed_salary_profile_builder_catalog'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, salary_profile_builder_catalog_migrations, 2),
     ['761_rebackfill_salary_to_profile_builder'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, salary_profile_builder_backfill_migrations, 2),
+    -- 762/763 — Phase 2 profile-builder unification for pension_payments.
+    -- Catalog MUST run before backfill (backfill looks up question_id
+    -- by question_key). Both are idempotent + reversible per the design
+    -- doc. Feature-flag flip on the frontend is separate (env var).
+    -- Data model note: pension is year-scoped (no user_profile_entities
+    -- rows) with one aggregated JSON array per (user, year, section) —
+    -- differs from salary's per-entity + typed-column shape.
+    ['762_seed_pension_profile_builder_catalog'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, pension_profile_builder_catalog_migrations, 1),
+    ['763_backfill_pension_to_profile_builder'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, pension_profile_builder_backfill_migrations, 1),
+    -- 764/765 — safety-net re-run for pension (same pattern as
+    -- 760/761 for salary). Idempotent — a fresh env where 762/763
+    -- already fully succeeded treats these as no-ops.
+    ['764_reseed_pension_profile_builder_catalog'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, pension_profile_builder_catalog_migrations, 2),
+    ['765_rebackfill_pension_to_profile_builder'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, pension_profile_builder_backfill_migrations, 2),
 
     -- =========================================================================
     -- Academy (LMS): courses + lessons (namespace-scoped). Feature-gated, so

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -213,6 +213,21 @@ local sa100_dividend_questions_migrations = load_if_enabled(ProjectConfig.FEATUR
 -- seed migration in the same shape with zero widget changes.
 local rental_joint_owner_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.rental-joint-owner-questions") or {}
 
+-- Phase 1 of the profile-builder unification (see the diy-tax-return-uk
+-- repo's docs/PROFILE_BUILDER_UNIFICATION_PLAN.md). Ports the salary
+-- income type from tax_form_sections onto the unified Profile Builder
+-- store:
+--   - catalog: seed 7 profile_categories + 42 profile_questions +
+--     4 visibility rules under entity_type='employment' (mirrors the
+--     salary-employment-system.lua field catalog)
+--   - backfill: walk every non-archived tax_form_records salary row,
+--     upsert into user_profile_entities + user_profile_answers with
+--     a deterministic-hashed entity UUID (idempotent + reversible)
+-- The two are separate step files so a re-run of one doesn't force
+-- the other. Both are gated on TAX_COPILOT.
+local salary_profile_builder_catalog_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.salary-profile-builder-catalog") or {}
+local salary_profile_builder_backfill_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.salary-profile-builder-backfill") or {}
+
 -- Billing / payments (Stripe Connect: subscriptions + one-time). Gated on
 -- tax_copilot for now; broaden to a feature list (e.g. {ECOMMERCE, TAX_COPILOT})
 -- once multiple project codes need it. See migrations/billing-system.lua.
@@ -2003,6 +2018,12 @@ local _migrations = {
     ['755_create_tax_form_records'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, form_sections_migrations, 4),
     ['756_seed_salary_sa102_sections'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, salary_employment_migrations, 1),
     ['757_port_flat_salary_entries'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, salary_employment_migrations, 2),
+    -- 758/759 — Phase 1 profile-builder unification for salary. Catalog
+    -- MUST run before backfill (backfill looks up question_id by
+    -- question_key). Both are idempotent + reversible per the design
+    -- doc. Feature-flag flip on the frontend is separate (env var).
+    ['758_seed_salary_profile_builder_catalog'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, salary_profile_builder_catalog_migrations, 1),
+    ['759_backfill_salary_to_profile_builder'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, salary_profile_builder_backfill_migrations, 1),
 
     -- =========================================================================
     -- Academy (LMS): courses + lessons (namespace-scoped). Feature-gated, so

--- a/lapis/migrations/pension-profile-builder-backfill.lua
+++ b/lapis/migrations/pension-profile-builder-backfill.lua
@@ -1,0 +1,210 @@
+--[[
+  Pension Payments — Phase 2 backfill.
+
+  Copies every existing `tax_form_items WHERE income_type_key='pension_payments'`
+  row into the unified Profile Builder store:
+
+    N tax_form_items rows for a given (user, tax_year, section_key)
+      → ONE user_profile_answers row with question_id = the section's
+        repeating_group question and answer_json = JSON array of the
+        row objects the user entered.
+
+  Aggregation vs. Phase 1 (salary):
+    - Salary was one-record-per-entity: each tax_form_records row
+      became one user_profile_entities row and many user_profile_answers.
+    - Pension is many-rows-per-year-per-section: N tax_form_items rows
+      collapse into ONE user_profile_answers.answer_json array. There
+      are no entities to create — the answer is scoped by (user,
+      question_id, tax_year), matching the seed's answer_scope='year'.
+
+  The source rows are LEFT IN PLACE. Retirement is Phase 3's job.
+
+  Idempotency
+    - answer_scope='year' answers use the (user_id, question_id,
+      tax_year) partial unique index. ON CONFLICT DO UPDATE overwrites
+      answer_json — a re-run always rebuilds the full array from
+      current tax_form_items state. This is different from the salary
+      backfill's ON CONFLICT DO NOTHING because a partial-then-full
+      re-run needs the FULL aggregated array, not the first-write's
+      partial one.
+
+  Reversibility
+    - Rebuilds from tax_form_items (still authoritative) on every run,
+      so rolling back is: unset the flag, ignore user_profile_answers
+      for pension_payments question_keys. Phase 3 will actually delete
+      those answers.
+
+  Only executed when PROJECT_CODE includes 'tax_copilot'.
+]]
+
+local db = require("lapis.db")
+local cjson = require("cjson")
+
+-- Map: tax_form_items.section_key → { question_key, includes_flags }
+-- Only the registered-schemes section carries relief_at_source /
+-- one_off flags — employer + overseas rows store just description +
+-- amount. Emitting the flags on rows that never had them would leave
+-- garbage `false` values in the JSON array; skip.
+local SECTION_MAP = {
+    pp_registered_schemes = { question_key = "pp_registered_payments", includes_flags = true },
+    pp_employer_schemes   = { question_key = "pp_employer_payments",   includes_flags = false },
+    pp_overseas_schemes   = { question_key = "pp_overseas_payments",   includes_flags = false },
+}
+
+-- Parse a tax_form_items.extra_json blob (may be nil, "", or a JSON
+-- object). Falls through to an empty table on any decode error so a
+-- corrupted extra doesn't fail the whole row.
+local function parse_extra(raw)
+    if raw == nil or raw == cjson.null or raw == "" then return {} end
+    if type(raw) ~= "string" then return {} end
+    local ok, parsed = pcall(cjson.decode, raw)
+    if not ok or type(parsed) ~= "table" then return {} end
+    return parsed
+end
+
+-- Backfill body extracted to module scope so a re-run step ([2]) can
+-- call it. Idempotent: ON CONFLICT DO UPDATE on the answer row so
+-- every run leaves user_profile_answers.answer_json in exact sync
+-- with the current tax_form_items state for that (user, year,
+-- section).
+local function backfill_pension()
+    -- 1. Question-id lookup, batched — one SELECT for all 3 keys.
+    local keys = {}
+    for _, m in pairs(SECTION_MAP) do keys[#keys + 1] = m.question_key end
+    local q_rows = db.query(
+        "SELECT id, question_key FROM profile_questions WHERE question_key = ANY(?)",
+        db.array(keys)
+    ) or {}
+    if #q_rows < #keys then
+        print("[Pension backfill] Skipping — catalog seed hasn't fully applied yet ("
+            .. #q_rows .. "/" .. #keys .. " questions present). Re-run 764 catches up.")
+        return
+    end
+    local q_id_by_key = {}
+    for _, r in ipairs(q_rows) do q_id_by_key[r.question_key] = r.id end
+
+    -- 2. Users → uuid, batched. answer_scope='year' rows still need
+    -- both user_id and user_uuid populated (schema convention across
+    -- all profile answers).
+    local users_needed = {}
+    local user_rows = db.query([[
+        SELECT DISTINCT user_id FROM tax_form_items
+        WHERE income_type_key = 'pension_payments' AND is_archived = false
+    ]]) or {}
+    for _, u in ipairs(user_rows) do users_needed[#users_needed + 1] = u.user_id end
+    if #users_needed == 0 then
+        print("[Pension backfill] Nothing to backfill (0 pension_payments items).")
+        return
+    end
+    local uuid_rows = db.query(
+        "SELECT id, uuid FROM users WHERE id = ANY(?)",
+        db.array(users_needed)
+    ) or {}
+    local user_uuid_by_id = {}
+    for _, r in ipairs(uuid_rows) do user_uuid_by_id[r.id] = r.uuid end
+
+    -- 3. Pull every non-archived pension item, then bucket by
+    -- (user_id, tax_year, section_key). Each bucket becomes one
+    -- user_profile_answers row.
+    local items = db.query([[
+        SELECT user_id, namespace_id, tax_year, section_key, description,
+               amount, extra_json, created_at
+        FROM tax_form_items
+        WHERE income_type_key = 'pension_payments' AND is_archived = false
+        ORDER BY user_id, tax_year, section_key, created_at
+    ]]) or {}
+
+    local buckets = {}
+    local order_seen = {}
+    for _, it in ipairs(items) do
+        local mapping = SECTION_MAP[it.section_key]
+        if mapping then
+            local key = it.user_id .. "|" .. it.tax_year .. "|" .. it.section_key
+            if not buckets[key] then
+                buckets[key] = {
+                    user_id = it.user_id,
+                    namespace_id = it.namespace_id,
+                    tax_year = it.tax_year,
+                    section_key = it.section_key,
+                    mapping = mapping,
+                    rows = {},
+                }
+                order_seen[#order_seen + 1] = key
+            end
+            local row_obj = {
+                description = it.description or "",
+                amount = tonumber(it.amount) or 0,
+            }
+            if mapping.includes_flags then
+                local extra = parse_extra(it.extra_json)
+                row_obj.relief_at_source = extra.relief_at_source == true
+                row_obj.one_off = extra.one_off == true
+            end
+            table.insert(buckets[key].rows, row_obj)
+        end
+    end
+
+    -- 4. Upsert one row per bucket. ON CONFLICT DO UPDATE (not DO
+    -- NOTHING) because a re-run must replace the array, not skip it —
+    -- otherwise a user's fresh row added to tax_form_items post-first-
+    -- backfill would never appear in the profile-builder shadow.
+    local stats = { answers = 0, skipped_buckets = 0 }
+    for _, key in ipairs(order_seen) do
+        local b = buckets[key]
+        local qid = q_id_by_key[b.mapping.question_key]
+        local user_uuid = user_uuid_by_id[b.user_id]
+        if not qid or not user_uuid then
+            stats.skipped_buckets = stats.skipped_buckets + 1
+        else
+            local json_str = cjson.encode(b.rows)
+            -- No `source` column on user_profile_answers to mark
+            -- backfilled rows — identity of a pension backfilled row
+            -- is (question_id ∈ pp_*_payments question_keys) plus the
+            -- answer_scope='year' partial index. Phase 3's retirement
+            -- filters on those to identify what to drop, so no marker
+            -- column is needed here.
+            -- answer_json column is TEXT, not jsonb — no cast needed.
+            -- Matches how routes/profile-builder.lua's upsert writer
+            -- passes the value (see :3303 in that file).
+            local ok = pcall(db.query, [[
+                INSERT INTO user_profile_answers
+                    (uuid, user_id, user_uuid, namespace_id, question_id,
+                     entity_uuid, tax_year, answer_json,
+                     is_draft, created_at, updated_at)
+                VALUES (gen_random_uuid()::text, ?, ?, ?, ?,
+                        NULL, ?, ?,
+                        false, NOW(), NOW())
+                ON CONFLICT (user_id, question_id, tax_year)
+                WHERE entity_uuid IS NULL AND tax_year IS NOT NULL
+                DO UPDATE SET
+                    answer_json = EXCLUDED.answer_json,
+                    updated_at = NOW()
+            ]], b.user_id, user_uuid, b.namespace_id or db.NULL, qid,
+                b.tax_year, json_str)
+            if ok then
+                stats.answers = stats.answers + 1
+            else
+                stats.skipped_buckets = stats.skipped_buckets + 1
+            end
+        end
+    end
+
+    print(string.format(
+        "[Pension backfill] Ported %d aggregated answers (from %d source items). Skipped %d buckets.",
+        stats.answers, #items, stats.skipped_buckets
+    ))
+end
+
+return {
+    -- =========================================================================
+    -- 1. Original backfill pass. Registered as 763 in migrations.lua.
+    -- =========================================================================
+    [1] = backfill_pension,
+
+    -- =========================================================================
+    -- 2. Re-run pass. Registered as 765 in migrations.lua. Idempotent
+    --    for the same reason as [1]: ON CONFLICT DO UPDATE rebuilds
+    --    the aggregated JSON from current tax_form_items state.
+    -- =========================================================================
+    [2] = backfill_pension,
+}

--- a/lapis/migrations/pension-profile-builder-catalog.lua
+++ b/lapis/migrations/pension-profile-builder-catalog.lua
@@ -1,0 +1,214 @@
+--[[
+  Pension Payments (TR4) — Profile Builder catalog.
+
+  Phase 2 of the profile-builder unification (see the diy-tax-return-uk
+  repo's docs/PROFILE_BUILDER_UNIFICATION_PLAN.md). Ports the pension
+  payments SA100 TR4 catalogue currently held in
+  pension_payment_categories + tax_form_sections/items (both live in
+  parallel today) onto the unified profile_categories +
+  profile_questions store, so /my-income/pension_payments can be served
+  by the same engine as rental / self-employment / dividends and now
+  salary.
+
+  Shape differs from Phase 1 (salary) in an important way: pension
+  payments have NO per-entity drill-down — a taxpayer just has N
+  payment rows per SECTION per tax year. So this catalog uses:
+
+    - context='pension_payments'
+    - answer_scope='year'   (not 'entity' — no user_profile_entities row)
+    - entity_type=NULL
+
+  And each category is a SINGLE profile_question of type
+  `repeating_group` (introduced in Phase 0 PR #796 for exactly this
+  shape). The question's config_json declares the sub-fields — one
+  question, many rows.
+
+    1. pension-registered   → { description, amount, relief_at_source, one_off }
+    2. pension-employer     → { description, amount }
+    3. pension-overseas     → { description, amount }
+
+  On the answer side, one user_profile_answers row per (user,
+  question_id, tax_year) with answer_json = JSON array of the row
+  objects the user has entered. Reads and writes go through the
+  standard repeating-group widget on the frontend — zero new UI code
+  needed for the render path.
+
+  Idempotency: same helper convention as the salary catalog — keyed on
+  category slug + question_key. Re-running touches labels /
+  config_json but never duplicates rows or resurrects admin-archived
+  ones.
+
+  Only executed when PROJECT_CODE includes 'tax_copilot'.
+]]
+
+local db = require("lapis.db")
+local cjson = require("cjson")
+local MigrationUtils = require "helper.migration-utils"
+
+-- Seed body at module scope so a re-run step (see [2] below) can call
+-- it without duplicating logic. Everything inside is idempotent — the
+-- re-run pass is a safety net for envs where a future edit to this
+-- file (like Phase 1's varargs bug) leaves the seed half-applied.
+local function seed_pension_catalog()
+    -- Same nil-safe ensure_category as the salary catalog (post-fix):
+    -- coerce nil description / nil icon to db.NULL BEFORE the db.query
+    -- call so Lua's vararg truncation at first nil can't drop trailing
+    -- placeholders. See salary-profile-builder-catalog.lua for the
+    -- incident that motivated the fix.
+    local function ensure_category(slug, name, description, icon, display_order)
+        local desc = description ~= nil and description or db.NULL
+        local ico  = icon        ~= nil and icon        or db.NULL
+        local exists = db.select("id FROM profile_categories WHERE slug = ?", slug)
+        if exists and #exists > 0 then
+            db.query([[
+                UPDATE profile_categories
+                   SET name = ?, description = ?, icon = ?, display_order = ?,
+                       context = 'pension_payments',
+                       answer_scope = 'year',
+                       entity_type = NULL,
+                       is_active = true, is_archived = false, updated_at = NOW()
+                 WHERE slug = ?
+            ]], name, desc, ico, display_order, slug)
+            return exists[1].id
+        end
+        db.query([[
+            INSERT INTO profile_categories
+                (uuid, namespace_id, name, slug, description, icon,
+                 display_order, context, answer_scope, entity_type,
+                 is_active, is_archived, created_at, updated_at)
+            VALUES (?, 0, ?, ?, ?, ?, ?, 'pension_payments', 'year', NULL,
+                    true, false, NOW(), NOW())
+        ]], MigrationUtils.generateUUID(), name, slug, desc, ico, display_order)
+        local row = db.select("id FROM profile_categories WHERE slug = ?", slug)
+        return row and row[1] and row[1].id or nil
+    end
+
+    -- ensure_repeating_group_question upserts a single repeating_group
+    -- question under `cat_id`. On UPDATE we refresh config_json + label
+    -- + help_text so an admin's edit gets overwritten only by re-running
+    -- THIS migration — the admin UI still owns the question. Same
+    -- idempotency convention (keyed on question_key) as the salary
+    -- catalog's ensure_question.
+    local function ensure_repeating_group_question(cat_id, q)
+        local config_str = cjson.encode(q.config)
+        local help = q.help_text or ""
+        local exists = db.select("id FROM profile_questions WHERE question_key = ?", q.question_key)
+        if exists and #exists > 0 then
+            db.query([[
+                UPDATE profile_questions
+                   SET category_id = ?, label = ?, question_type = 'repeating_group',
+                       is_required = ?, display_order = ?, help_text = ?,
+                       placeholder = '', config_json = ?,
+                       is_active = true, is_archived = false, updated_at = NOW()
+                 WHERE question_key = ?
+            ]], cat_id, q.label, q.is_required, q.display_order, help,
+                config_str, q.question_key)
+            return exists[1].id
+        end
+        db.query([[
+            INSERT INTO profile_questions
+                (uuid, category_id, question_key, label, question_type, is_required,
+                 display_order, help_text, placeholder, config_json,
+                 is_active, version, created_at, updated_at)
+            VALUES (?, ?, ?, ?, 'repeating_group', ?, ?, ?, '', ?, true, 1, NOW(), NOW())
+        ]], MigrationUtils.generateUUID(), cat_id, q.question_key, q.label,
+            q.is_required, q.display_order, help, config_str)
+        local row = db.select("id FROM profile_questions WHERE question_key = ?", q.question_key)
+        return row and row[1] and row[1].id or nil
+    end
+
+    -- ── Category 1: Registered pension schemes ──────────────────────
+    -- SA100 TR4.1 / TR4.1.1 / TR4.2. Registered schemes have BOTH the
+    -- relief-at-source and one-off flags; employer + overseas have
+    -- neither. Sub-field keys match the tax_form_items columns so the
+    -- backfill (pension-profile-builder-backfill.lua) is a direct
+    -- rename map.
+    local reg_id = ensure_category(
+        "pension-registered",
+        "Registered pension schemes",
+        "Personal payments into registered pension schemes and retirement annuity contracts. Tick 'relief claimed by provider' where the scheme adds basic-rate tax relief for you (relief at source).",
+        "pound-sign", 1)
+    if reg_id then
+        ensure_repeating_group_question(reg_id, {
+            question_key = "pp_registered_payments",
+            label = "Payments into registered schemes",
+            is_required = false,
+            display_order = 1,
+            help_text = "Add one row per payment. Provider name goes in the description; amount is what YOU paid (net) — relief will be grossed up at basic rate for box TR4.1.",
+            config = {
+                item_label = "Payment",
+                fields = {
+                    { key = "description",      label = "Provider / description", type = "short_text" },
+                    { key = "amount",           label = "Amount paid (net)",      type = "currency" },
+                    { key = "relief_at_source", label = "Basic rate tax relief claimed by provider", type = "boolean" },
+                    { key = "one_off",          label = "One-off payment",        type = "boolean" },
+                },
+            },
+        })
+    end
+
+    -- ── Category 2: Employer schemes (net-pay-not-taken) ────────────
+    -- SA100 TR4.3. Only description + amount — no flags.
+    local emp_id = ensure_category(
+        "pension-employer",
+        "Employer schemes not deducted from gross pay",
+        "Contributions to your employer's pension scheme that were taken from pay AFTER tax, so no tax relief has been given yet.",
+        "pound-sign", 2)
+    if emp_id then
+        ensure_repeating_group_question(emp_id, {
+            question_key = "pp_employer_payments",
+            label = "Payments to employer schemes",
+            is_required = false,
+            display_order = 1,
+            help_text = "Only include contributions taken from your pay AFTER tax (usually shown as 'net' on your payslip). Pre-tax contributions are already relieved via PAYE and go nowhere on the return.",
+            config = {
+                item_label = "Payment",
+                fields = {
+                    { key = "description", label = "Provider / description", type = "short_text" },
+                    { key = "amount",      label = "Amount paid",            type = "currency" },
+                },
+            },
+        })
+    end
+
+    -- ── Category 3: Overseas schemes ────────────────────────────────
+    -- SA100 TR4.4. Same shape as employer.
+    local ovr_id = ensure_category(
+        "pension-overseas",
+        "Overseas schemes eligible for UK tax relief",
+        "Payments to a qualifying overseas pension scheme, paid out of taxed income and eligible for UK tax relief.",
+        "pound-sign", 3)
+    if ovr_id then
+        ensure_repeating_group_question(ovr_id, {
+            question_key = "pp_overseas_payments",
+            label = "Payments to overseas schemes",
+            is_required = false,
+            display_order = 1,
+            help_text = "Only qualifying overseas schemes recognised by HMRC. Amounts must be paid out of already-taxed income.",
+            config = {
+                item_label = "Payment",
+                fields = {
+                    { key = "description", label = "Provider / description", type = "short_text" },
+                    { key = "amount",      label = "Amount paid",            type = "currency" },
+                },
+            },
+        })
+    end
+
+    print("[Pension → Profile Builder] Seeded 3 categories, 3 repeating_group questions under context='pension_payments' (answer_scope='year')")
+end
+
+return {
+    -- =========================================================================
+    -- 1. Original seed pass. Registered as 762 in migrations.lua.
+    -- =========================================================================
+    [1] = seed_pension_catalog,
+
+    -- =========================================================================
+    -- 2. Re-run pass. Registered as 764 in migrations.lua. Safety net
+    --    for future edits to this file that could leave the seed half-
+    --    applied (see the salary catalog's 760 for the incident that
+    --    established this convention).
+    -- =========================================================================
+    [2] = seed_pension_catalog,
+}

--- a/lapis/migrations/salary-profile-builder-backfill.lua
+++ b/lapis/migrations/salary-profile-builder-backfill.lua
@@ -160,11 +160,15 @@ local function coerce(field_type, raw)
     return nil, "unknown field type"
 end
 
-return {
-    -- =========================================================================
-    -- 1. Walk every non-archived salary record → insert entity + answers.
-    -- =========================================================================
-    [1] = function()
+-- Backfill body extracted to module scope so multiple migration steps
+-- can call it. Step [1] is the original run; step [2] is the re-run
+-- pass that catches up any answers the first pass silently skipped
+-- because the catalog seed (see salary-profile-builder-catalog.lua)
+-- hadn't yet inserted the profile_questions rows for those fields.
+-- Idempotent: ON CONFLICT DO NOTHING on both the entity insert
+-- (deterministic md5 UUID) and the answer inserts, so re-runs never
+-- overwrite a user's later profile-builder-side edit.
+local function backfill_salary()
         local rows = db.query([[
             SELECT id, uuid, user_id, namespace_id, tax_year, data_json,
                    created_at, updated_at
@@ -289,5 +293,23 @@ return {
             "[Salary backfill] Ported %d entities + %d answers. Skipped %d rows, %d unknown fields.",
             stats.entities, stats.answers, stats.skipped_rows, stats.skipped_fields
         ))
-    end,
+end
+
+return {
+    -- =========================================================================
+    -- 1. Original backfill pass. Registered as 759 in migrations.lua.
+    -- =========================================================================
+    [1] = backfill_salary,
+
+    -- =========================================================================
+    -- 2. Re-run pass. Registered as 761 in migrations.lua.
+    --    Runs AFTER the catalog re-seed (760) so the profile_questions
+    --    rows for the previously-missing categories (close-company,
+    --    foreign, notes) now exist. The lookup batch in this function
+    --    reads them via SELECT ... WHERE question_key = ANY(...), so
+    --    once seeded the same source data_json produces answers on the
+    --    previously-skipped question_ids. ON CONFLICT DO NOTHING keeps
+    --    already-backfilled answers untouched.
+    -- =========================================================================
+    [2] = backfill_salary,
 }

--- a/lapis/migrations/salary-profile-builder-backfill.lua
+++ b/lapis/migrations/salary-profile-builder-backfill.lua
@@ -1,0 +1,293 @@
+--[[
+  Salary / Employment — Phase 1 backfill.
+
+  Copies every existing `tax_form_records WHERE income_type_key='salary'`
+  row into the unified Profile Builder store:
+
+    tax_form_records row (JSON blob `data_json`)
+      → user_profile_entities row (entity_type='employment')
+      +  one user_profile_answers row per known question_key present
+         in `data_json`, typed correctly per the question's type.
+
+  The source rows are LEFT IN PLACE. Retirement is Phase 3's job, after
+  the profile-builder-served page has been live in prod for 14+ days
+  and the discrepancy log for INCOME_ENGINE_SALARY_DUAL_WRITE has been
+  clean.
+
+  Idempotency
+    - New entity uuid is DETERMINISTIC — a namespaced UUIDv5-style
+      derivation from the source record's uuid. Re-running the
+      migration produces the same target uuid, so the ON CONFLICT
+      guards skip cleanly.
+    - Answer inserts use the existing partial unique indexes on
+      (user_id, question_id, entity_uuid) — `ON CONFLICT DO NOTHING`
+      makes a second run a no-op.
+    - Backfill can be re-run any time without corrupting state; safe
+      to run before dual-write is enabled, during the dual-write
+      window, or after cutover as a repair pass.
+
+  Reversibility
+    - `deriveEntityUuid` is documented so the reverse walk (Phase 3
+      or an emergency rollback) can identify which entities came from
+      the backfill vs. which were created via the new page.
+    - Rollback: mark those entities `is_archived=true`, delete their
+      answers, done. See docs/PROFILE_BUILDER_UNIFICATION_PLAN.md §6.
+
+  Field-mapping table
+    Each key here mirrors what salary-employment-system.lua's
+    ensure_section() puts in `data_json`. If an admin has added new
+    fields to the tax_form_sections config since (via /admin/form-
+    sections), those field values are DROPPED by this backfill — the
+    catalog migration seeds the same names into Profile Builder so
+    only fields BOTH sides know about survive. That's an intentional
+    safety-first choice; add the field on both sides + re-run the
+    backfill if you need to preserve a custom field.
+
+  Only executed when PROJECT_CODE includes 'tax_copilot'.
+]]
+
+local db = require("lapis.db")
+local cjson = require("cjson")
+
+-- Map: tax_form_records data_json field key → { question_key, type }
+-- The tuple's `type` decides which typed column on user_profile_answers
+-- gets populated (answer_number / answer_text / answer_boolean /
+-- answer_date). Do NOT rename these — they are the exact keys the old
+-- salary-employment-system.lua wrote and the exact question_keys the
+-- Phase-1 catalog migration created.
+local FIELD_MAP = {
+    -- Employment details
+    employer_name             = { key = "emp_employer_name",         type = "text" },
+    paye_reference            = { key = "emp_paye_reference",        type = "text" },
+    start_date                = { key = "emp_start_date",            type = "date" },
+    end_date                  = { key = "emp_end_date",              type = "date" },
+    is_director               = { key = "emp_is_director",           type = "boolean" },
+    director_ceased_date      = { key = "emp_director_ceased_date",  type = "date" },
+    is_close_company          = { key = "emp_is_close_company",      type = "boolean" },
+    -- Close company details
+    registered_number         = { key = "emp_cc_registered_number",  type = "text" },
+    close_company_dividends   = { key = "emp_cc_dividends",          type = "number" },
+    shareholding_percent      = { key = "emp_cc_shareholding_percent", type = "number" },
+    -- Income
+    pay_before_tax            = { key = "emp_pay_before_tax",        type = "number" },
+    payrolled_benefits        = { key = "emp_payrolled_benefits",    type = "number" },
+    uk_tax_taken_off          = { key = "emp_uk_tax_taken_off",      type = "number" },
+    tips_not_on_p60           = { key = "emp_tips_not_on_p60",       type = "number" },
+    -- Benefits
+    company_cars              = { key = "emp_ben_company_cars",          type = "number" },
+    fuel_company_cars         = { key = "emp_ben_fuel_company_cars",     type = "number" },
+    company_vans              = { key = "emp_ben_company_vans",          type = "number" },
+    fuel_company_vans         = { key = "emp_ben_fuel_company_vans",     type = "number" },
+    travel_subsistence        = { key = "emp_ben_travel_subsistence",    type = "number" },
+    entertaining              = { key = "emp_ben_entertaining",          type = "number" },
+    private_medical           = { key = "emp_ben_private_medical",       type = "number" },
+    telephone                 = { key = "emp_ben_telephone",             type = "number" },
+    professional_fees_employer = { key = "emp_ben_professional_fees",     type = "number" },
+    vouchers_credit_cards     = { key = "emp_ben_vouchers_credit_cards", type = "number" },
+    excess_mileage_allowance  = { key = "emp_ben_excess_mileage",        type = "number" },
+    goods_assets_provided     = { key = "emp_ben_goods_assets",          type = "number" },
+    accommodation_provided    = { key = "emp_ben_accommodation",         type = "number" },
+    other_benefits            = { key = "emp_ben_other",                 type = "number" },
+    expenses_payments_received = { key = "emp_ben_expenses_payments",    type = "number" },
+    -- Expenses
+    business_travel           = { key = "emp_exp_business_travel",       type = "number" },
+    hotel_meal_expenses       = { key = "emp_exp_hotel_meal",            type = "number" },
+    fixed_deductions          = { key = "emp_exp_fixed_deductions",      type = "number" },
+    professional_fees_subs    = { key = "emp_exp_professional_fees",     type = "number" },
+    tools_work_clothes        = { key = "emp_exp_tools_clothes",         type = "number" },
+    vehicle_expenses          = { key = "emp_exp_vehicle",               type = "number" },
+    mileage_shortfall         = { key = "emp_exp_mileage_shortfall",     type = "number" },
+    other_expenses_capital    = { key = "emp_exp_other_capital",         type = "number" },
+    -- Foreign
+    seafarers_deduction         = { key = "emp_foreign_seafarers",         type = "number" },
+    foreign_earnings_not_taxable = { key = "emp_foreign_not_taxable",      type = "number" },
+    foreign_tax_no_credit       = { key = "emp_foreign_tax_no_credit",     type = "number" },
+    exempt_overseas_pension     = { key = "emp_foreign_exempt_pension",    type = "number" },
+    -- Notes
+    tax_return_note           = { key = "emp_tax_return_note",       type = "text" },
+}
+
+-- Deterministic UUID for the target entity so re-runs cleanly ON CONFLICT
+-- DO NOTHING. Same input → same output, always. Uses built-in md5()
+-- (32 hex chars) reformatted into UUID shape — no pgcrypto dependency
+-- (some pods don't have the extension enabled). Namespace prefix
+-- 'phase1-employment:' ensures the derived uuid can't collide with any
+-- other migration that might hash the same source uuid for a different
+-- purpose.
+--
+-- The reverse walk (Phase 3 or emergency rollback) identifies these
+-- entities via user_profile_entities.metadata_json.origin, not by
+-- attempting to reverse the hash.
+local function deriveEntityUuid(source_uuid)
+    local rows = db.query([[
+        WITH h AS (SELECT md5('phase1-employment:' || ?) AS hex)
+        SELECT substring(hex FROM 1  FOR 8)  || '-' ||
+               substring(hex FROM 9  FOR 4)  || '-' ||
+               substring(hex FROM 13 FOR 4)  || '-' ||
+               substring(hex FROM 17 FOR 4)  || '-' ||
+               substring(hex FROM 21 FOR 12) AS derived_uuid
+        FROM h
+    ]], source_uuid)
+    return rows[1].derived_uuid
+end
+
+-- Coerce a JSON value to something the typed column accepts. Returns
+-- (typed_value_for_the_named_column, nil) on success; (nil, reason)
+-- when the value can't be represented in that column type (row is
+-- silently skipped — better to lose one bad value than block the
+-- backfill).
+local function coerce(field_type, raw)
+    if raw == nil or raw == cjson.null then return nil, "null" end
+    if field_type == "number" then
+        local n = tonumber(raw)
+        if n and n == n then return n, nil end -- reject NaN
+        return nil, "not a number"
+    end
+    if field_type == "text" then
+        if type(raw) == "string" then return raw, nil end
+        return tostring(raw), nil
+    end
+    if field_type == "boolean" then
+        if raw == true or raw == false then return raw, nil end
+        if raw == "true" then return true, nil end
+        if raw == "false" then return false, nil end
+        return nil, "not a boolean"
+    end
+    if field_type == "date" then
+        if type(raw) == "string" and raw ~= "" then return raw, nil end
+        return nil, "empty date"
+    end
+    return nil, "unknown field type"
+end
+
+return {
+    -- =========================================================================
+    -- 1. Walk every non-archived salary record → insert entity + answers.
+    -- =========================================================================
+    [1] = function()
+        local rows = db.query([[
+            SELECT id, uuid, user_id, namespace_id, tax_year, data_json,
+                   created_at, updated_at
+            FROM tax_form_records
+            WHERE income_type_key = 'salary' AND is_archived = false
+        ]]) or {}
+
+        if #rows == 0 then
+            print("[Salary backfill] Nothing to backfill (0 salary records).")
+            return
+        end
+
+        -- Question id lookup: question_key → id. Batched to a single
+        -- SELECT so a re-run doesn't scan profile_questions per row.
+        local q_lookup = {}
+        for _, m in pairs(FIELD_MAP) do q_lookup[m.key] = true end
+        local keys_list = {}
+        for k in pairs(q_lookup) do keys_list[#keys_list + 1] = k end
+        local question_rows = db.query(
+            "SELECT id, question_key FROM profile_questions WHERE question_key = ANY(?)",
+            db.array(keys_list)
+        ) or {}
+        local qid_by_key = {}
+        for _, qr in ipairs(question_rows) do
+            qid_by_key[qr.question_key] = qr.id
+        end
+        if next(qid_by_key) == nil then
+            print("[Salary backfill] Question catalog not seeded yet — skipping " ..
+                  #rows .. " records. Re-run after the seed migration lands.")
+            return
+        end
+
+        -- Look up the user's uuid once per unique user_id in the batch.
+        local user_uuid_by_id = {}
+        for _, r in ipairs(rows) do user_uuid_by_id[r.user_id] = true end
+        local uid_list = {}
+        for uid in pairs(user_uuid_by_id) do uid_list[#uid_list + 1] = uid end
+        local uuid_rows = db.query(
+            "SELECT id, uuid FROM users WHERE id = ANY(?)", db.array(uid_list)
+        ) or {}
+        for _, ur in ipairs(uuid_rows) do user_uuid_by_id[ur.id] = ur.uuid end
+
+        local stats = { entities = 0, answers = 0, skipped_rows = 0, skipped_fields = 0 }
+
+        for _, r in ipairs(rows) do
+            local ok, data = pcall(cjson.decode, r.data_json or "{}")
+            if not ok or type(data) ~= "table" then
+                stats.skipped_rows = stats.skipped_rows + 1
+            else
+                local user_uuid = user_uuid_by_id[r.user_id]
+                if type(user_uuid) ~= "string" then
+                    stats.skipped_rows = stats.skipped_rows + 1
+                else
+                    local entity_uuid = deriveEntityUuid(r.uuid)
+                    local label = data.employer_name
+                    if type(label) ~= "string" or label == "" then label = "Employment" end
+                    if #label > 200 then label = label:sub(1, 200) end
+                    local metadata = cjson.encode({
+                        origin = "phase1_salary_backfill",
+                        legacy_form_record_uuid = r.uuid,
+                    })
+
+                    -- Entity row — ON CONFLICT DO NOTHING makes re-runs safe.
+                    -- namespace_id can be null; propagate as-is.
+                    db.query([[
+                        INSERT INTO user_profile_entities
+                            (uuid, user_id, user_uuid, namespace_id, entity_type,
+                             label, metadata_json, display_order, is_archived,
+                             created_at, updated_at)
+                        VALUES (?, ?, ?, ?, 'employment', ?, ?, 0, false, ?, ?)
+                        ON CONFLICT (uuid) DO NOTHING
+                    ]], entity_uuid, r.user_id, user_uuid,
+                        r.namespace_id or db.NULL, label, metadata,
+                        r.created_at, r.updated_at)
+                    stats.entities = stats.entities + 1
+
+                    for field_key, value in pairs(data) do
+                        local mapping = FIELD_MAP[field_key]
+                        if not mapping then
+                            stats.skipped_fields = stats.skipped_fields + 1
+                        else
+                            local qid = qid_by_key[mapping.key]
+                            local typed_value, _ = coerce(mapping.type, value)
+                            if qid and typed_value ~= nil then
+                                -- One partial unique index guards this:
+                                -- (user_id, question_id, entity_uuid) WHERE
+                                -- entity_uuid IS NOT NULL. ON CONFLICT DO
+                                -- NOTHING makes a re-run a no-op — we never
+                                -- overwrite a value the user may have edited
+                                -- on the profile-builder side after backfill.
+                                local col_text, col_num, col_bool, col_date =
+                                    db.NULL, db.NULL, db.NULL, db.NULL
+                                if mapping.type == "text" then col_text = typed_value
+                                elseif mapping.type == "number" then col_num = typed_value
+                                elseif mapping.type == "boolean" then col_bool = typed_value
+                                elseif mapping.type == "date" then col_date = typed_value
+                                end
+                                db.query([[
+                                    INSERT INTO user_profile_answers
+                                        (uuid, user_id, user_uuid, namespace_id,
+                                         question_id, question_version, entity_uuid,
+                                         answer_text, answer_number, answer_boolean,
+                                         answer_date, is_draft, answered_at, updated_at)
+                                    VALUES (gen_random_uuid()::text, ?, ?, ?, ?, 1, ?,
+                                            ?, ?, ?, ?, false, ?, ?)
+                                    ON CONFLICT DO NOTHING
+                                ]], r.user_id, user_uuid, r.namespace_id or db.NULL,
+                                    qid, entity_uuid,
+                                    col_text, col_num, col_bool, col_date,
+                                    r.created_at, r.updated_at)
+                                stats.answers = stats.answers + 1
+                            elseif not qid then
+                                stats.skipped_fields = stats.skipped_fields + 1
+                            end
+                        end
+                    end
+                end
+            end
+        end
+
+        print(string.format(
+            "[Salary backfill] Ported %d entities + %d answers. Skipped %d rows, %d unknown fields.",
+            stats.entities, stats.answers, stats.skipped_rows, stats.skipped_fields
+        ))
+    end,
+}

--- a/lapis/migrations/salary-profile-builder-catalog.lua
+++ b/lapis/migrations/salary-profile-builder-catalog.lua
@@ -65,14 +65,14 @@
 local db = require("lapis.db")
 local MigrationUtils = require "helper.migration-utils"
 
-return {
-    -- =========================================================================
-    -- 1. Seed the 7 employment categories + ~42 questions + visibility rules.
-    --    Structured as one step so a re-run either succeeds fully or leaves
-    --    the DB unchanged (each ensure_* is idempotent, but the whole set
-    --    is a package).
-    -- =========================================================================
-    [1] = function()
+-- Seed body extracted to module scope so multiple migration steps can
+-- call it. Step [1] is the original run; step [2] is the re-run pass
+-- that catches up envs where step [1] hit the varargs bug (nil
+-- description silently truncating params, aborting mid-way through the
+-- 7 categories). Every ensure_* helper inside is idempotent, so on
+-- envs where the first pass fully succeeded the re-run is a no-op —
+-- only labels/ordering get UPDATEd, no duplicate rows appear.
+local function seed_salary_catalog()
         -- Same helpers as property-income-system.lua [7] and
         -- self-employment-system.lua [6]. Duplicated here (not extracted)
         -- because each seed migration is self-contained — future refactor
@@ -83,7 +83,15 @@ return {
         -- dynamic-answer-scope.lua [5]'s backfill which only knows about
         -- the older contexts; new contexts (like employment) must set
         -- the columns themselves at seed time.
+        -- Coerce nils to db.NULL BEFORE the db.query call. Lua truncates
+        -- varargs at the first nil (`{...}` stops there), which would drop
+        -- every parameter after description for categories that pass a nil
+        -- description — leaving the SQL with unfilled placeholders and
+        -- erroring the whole migration mid-way through. Categories 2
+        -- (close-company), 6 (foreign) and 7 (notes) all pass nil here.
         local function ensure_category(slug, name, description, icon, display_order, context)
+            local desc = description ~= nil and description or db.NULL
+            local ico  = icon        ~= nil and icon        or db.NULL
             local exists = db.select("id FROM profile_categories WHERE slug = ?", slug)
             if exists and #exists > 0 then
                 db.query([[
@@ -92,7 +100,7 @@ return {
                            context = ?, answer_scope = 'entity', entity_type = 'employment',
                            is_active = true, is_archived = false, updated_at = NOW()
                      WHERE slug = ?
-                ]], name, description, icon, display_order, context, slug)
+                ]], name, desc, ico, display_order, context, slug)
                 return exists[1].id
             end
             db.query([[
@@ -102,7 +110,7 @@ return {
                      is_active, is_archived, created_at, updated_at)
                 VALUES (?, 0, ?, ?, ?, ?, ?, ?, 'entity', 'employment',
                         true, false, NOW(), NOW())
-            ]], MigrationUtils.generateUUID(), name, slug, description, icon,
+            ]], MigrationUtils.generateUUID(), name, slug, desc, ico,
                 display_order, context)
             local row = db.select("id FROM profile_categories WHERE slug = ?", slug)
             return row and row[1] and row[1].id or nil
@@ -313,5 +321,25 @@ return {
         end
 
         print("[Salary → Profile Builder] Seeded 7 categories, 42 questions, 4 visibility rules under entity_type='employment'")
-    end,
+end
+
+return {
+    -- =========================================================================
+    -- 1. Original seed pass. Registered as 758 in migrations.lua.
+    -- =========================================================================
+    [1] = seed_salary_catalog,
+
+    -- =========================================================================
+    -- 2. Re-run pass. Registered as 760 in migrations.lua.
+    --    Rationale: step [1] in an early iteration passed nil to db.query
+    --    for categories with no description (close-company / foreign /
+    --    notes), and Lua truncates varargs at the first nil — so the SQL
+    --    fired with unfilled placeholders and the whole seed aborted
+    --    after category 1. Envs that ran the buggy [1] have only
+    --    "Employment details" in profile_categories under
+    --    context='employment'. This step re-executes the (now fixed)
+    --    seed to catch them up. Fresh envs where [1] already succeeded
+    --    treat [2] as a harmless idempotent no-op.
+    -- =========================================================================
+    [2] = seed_salary_catalog,
 }

--- a/lapis/migrations/salary-profile-builder-catalog.lua
+++ b/lapis/migrations/salary-profile-builder-catalog.lua
@@ -1,0 +1,317 @@
+--[[
+  Salary / Employment (SA102) — Profile Builder catalog.
+
+  Phase 1 of the profile-builder unification (see the diy-tax-return-uk
+  repo's docs/PROFILE_BUILDER_UNIFICATION_PLAN.md). Ports the 7 form
+  sections and ~42 fields currently held in tax_form_sections
+  (income_type_key='salary') into the unified profile_categories +
+  profile_questions store, so /my-income/salary can be served by the
+  same engine as rental / self-employment / overseas / dividends.
+
+  Modelling choices — copied straight from the self-employment seed
+  (property-income-system.lua [7] → self-employment-system.lua [6])
+  which is the reference implementation for "list of entities, each
+  with drill-down questions":
+
+    1. Employments become user_profile_entities rows with
+       entity_type='employment'. The user_profile_entities table was
+       built generic for exactly this reuse — no schema change.
+
+    2. Per-employment questions are Profile Builder categories with
+       context='employment', answered with entity_uuid scope
+       (answer_scope='entity', entity_type='employment'). We set both
+       explicitly at seed time because dynamic-answer-scope.lua [5]'s
+       backfill only knows about the older contexts (property,
+       business, overseas_property).
+
+    3. One PROFILE CATEGORY per section from the tax_form_sections
+       catalogue — 7 categories, each with the section's fields as
+       profile_questions. ContextSections renders each as its own
+       card, which gives the same visual grouping the FormRecordsPage
+       had for free.
+
+  What this migration does NOT do:
+    - It does NOT delete or archive tax_form_sections rows for salary
+      (Phase 3's job, after the profile-builder path has been live
+      in prod for 14+ days).
+    - It does NOT flip the frontend engine for salary (that's driven
+      by the NEXT_PUBLIC_INCOME_ENGINE_SALARY env var per env — see
+      docs/PROFILE_BUILDER_UNIFICATION_PLAN.md §4).
+    - It does NOT backfill existing user data
+      (`salary-profile-builder-backfill.lua`, the sibling migration
+      in this PR, does that — kept separate so a re-run of one
+      doesn't force the other).
+
+  Idempotency: keyed on category slug + question_key, same convention
+  as every other profile-builder seed. Re-running touches labels /
+  ordering but never duplicates rows or resurrects admin-archived
+  ones.
+
+  Only executed when PROJECT_CODE includes 'tax_copilot'.
+
+  Type mapping from tax_form_sections config.fields → profile_questions:
+
+    text      → short_text
+    money     → currency
+    number    → number
+    date      → date
+    boolean   → boolean
+    textarea  → long_text
+
+  show_if visibility rules become profile_question_rules rows
+  (rule_type='visibility', operator='equals', expected_value='true').
+]]
+
+local db = require("lapis.db")
+local MigrationUtils = require "helper.migration-utils"
+
+return {
+    -- =========================================================================
+    -- 1. Seed the 7 employment categories + ~42 questions + visibility rules.
+    --    Structured as one step so a re-run either succeeds fully or leaves
+    --    the DB unchanged (each ensure_* is idempotent, but the whole set
+    --    is a package).
+    -- =========================================================================
+    [1] = function()
+        -- Same helpers as property-income-system.lua [7] and
+        -- self-employment-system.lua [6]. Duplicated here (not extracted)
+        -- because each seed migration is self-contained — future refactor
+        -- can lift to a shared migration utility once we have 3+ callers.
+        --
+        -- Extended vs the reference: writes answer_scope='entity' and
+        -- entity_type='employment' explicitly. The reference relied on
+        -- dynamic-answer-scope.lua [5]'s backfill which only knows about
+        -- the older contexts; new contexts (like employment) must set
+        -- the columns themselves at seed time.
+        local function ensure_category(slug, name, description, icon, display_order, context)
+            local exists = db.select("id FROM profile_categories WHERE slug = ?", slug)
+            if exists and #exists > 0 then
+                db.query([[
+                    UPDATE profile_categories
+                       SET name = ?, description = ?, icon = ?, display_order = ?,
+                           context = ?, answer_scope = 'entity', entity_type = 'employment',
+                           is_active = true, is_archived = false, updated_at = NOW()
+                     WHERE slug = ?
+                ]], name, description, icon, display_order, context, slug)
+                return exists[1].id
+            end
+            db.query([[
+                INSERT INTO profile_categories
+                    (uuid, namespace_id, name, slug, description, icon,
+                     display_order, context, answer_scope, entity_type,
+                     is_active, is_archived, created_at, updated_at)
+                VALUES (?, 0, ?, ?, ?, ?, ?, ?, 'entity', 'employment',
+                        true, false, NOW(), NOW())
+            ]], MigrationUtils.generateUUID(), name, slug, description, icon,
+                display_order, context)
+            local row = db.select("id FROM profile_categories WHERE slug = ?", slug)
+            return row and row[1] and row[1].id or nil
+        end
+
+        local function ensure_question(cat_id, q)
+            local exists = db.select("id FROM profile_questions WHERE question_key = ?", q.question_key)
+            if exists and #exists > 0 then
+                db.query([[
+                    UPDATE profile_questions
+                       SET category_id = ?, label = ?, question_type = ?, is_required = ?,
+                           display_order = ?, help_text = ?, placeholder = ?,
+                           is_active = true, is_archived = false, updated_at = NOW()
+                     WHERE question_key = ?
+                ]], cat_id, q.label, q.question_type, q.is_required, q.display_order,
+                    q.help_text or "", q.placeholder or "", q.question_key)
+                return exists[1].id
+            end
+            db.query([[
+                INSERT INTO profile_questions
+                    (uuid, category_id, question_key, label, question_type, is_required,
+                     display_order, help_text, placeholder, is_active, version,
+                     created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, true, 1, NOW(), NOW())
+            ]], MigrationUtils.generateUUID(), cat_id, q.question_key, q.label,
+                q.question_type, q.is_required, q.display_order,
+                q.help_text or "", q.placeholder or "")
+            local row = db.select("id FROM profile_questions WHERE question_key = ?", q.question_key)
+            return row and row[1] and row[1].id or nil
+        end
+
+        local function ensure_rule(target_key, source_key, rule_name, operator, expected_value)
+            local tgt = db.select("id FROM profile_questions WHERE question_key = ?", target_key)
+            local src = db.select("id FROM profile_questions WHERE question_key = ?", source_key)
+            if not tgt or #tgt == 0 or not src or #src == 0 then return end
+            local exists = db.select(
+                "id FROM profile_question_rules WHERE question_id = ? AND source_question_id = ?",
+                tgt[1].id, src[1].id)
+            if exists and #exists > 0 then return end
+            db.query([[
+                INSERT INTO profile_question_rules
+                    (uuid, question_id, rule_name, rule_type, operator,
+                     source_question_id, expected_value, logic_group,
+                     is_active, created_at, updated_at)
+                VALUES (?, ?, ?, 'visibility', ?, ?, ?, 'AND', true, NOW(), NOW())
+            ]], MigrationUtils.generateUUID(), tgt[1].id, rule_name, operator,
+                src[1].id, expected_value)
+        end
+
+        -- ── Category 1: Employment details ──────────────────────────
+        -- Mirrors tax_form_sections.employment_details. Includes the
+        -- title + subtitle fields the list view uses (employer_name,
+        -- paye_reference) — the frontend's list card reads the answers
+        -- to these two questions by their known question_keys.
+        local ed_id = ensure_category(
+            "employment-details", "Employment details",
+            "Who you worked for — from your P60, P45 or payslips.",
+            "briefcase", 1, "employment")
+        if ed_id then
+            ensure_question(ed_id, { question_key = "emp_employer_name",
+                label = "Employer's name", question_type = "short_text",
+                is_required = true, display_order = 1 })
+            ensure_question(ed_id, { question_key = "emp_paye_reference",
+                label = "Employer's PAYE tax reference (NNN/XXXXXX)",
+                question_type = "short_text", is_required = true, display_order = 2,
+                help_text = "On your P60 or P45 — three numbers, a slash, then letters and numbers." })
+            ensure_question(ed_id, { question_key = "emp_start_date",
+                label = "Date employment started", question_type = "date",
+                is_required = false, display_order = 3 })
+            ensure_question(ed_id, { question_key = "emp_end_date",
+                label = "Date employment ceased", question_type = "date",
+                is_required = false, display_order = 4 })
+            ensure_question(ed_id, { question_key = "emp_is_director",
+                label = "Were you a company director?", question_type = "boolean",
+                is_required = false, display_order = 5 })
+            ensure_question(ed_id, { question_key = "emp_director_ceased_date",
+                label = "Date ceased being a director", question_type = "date",
+                is_required = false, display_order = 6 })
+            ensure_question(ed_id, { question_key = "emp_is_close_company",
+                label = "Is this a close company?", question_type = "boolean",
+                is_required = false, display_order = 7,
+                help_text = "A company controlled by 5 or fewer people (or by its directors)." })
+        end
+        ensure_rule("emp_director_ceased_date", "emp_is_director",
+            "Show when user was a director", "equals", "true")
+
+        -- ── Category 2: Close company details ───────────────────────
+        local cc_id = ensure_category(
+            "employment-close-company", "Close company details",
+            nil, "briefcase", 2, "employment")
+        if cc_id then
+            ensure_question(cc_id, { question_key = "emp_cc_registered_number",
+                label = "Registered number", question_type = "short_text",
+                is_required = false, display_order = 1 })
+            ensure_question(cc_id, { question_key = "emp_cc_dividends",
+                label = "Dividends you received from this close company",
+                question_type = "currency", is_required = false, display_order = 2 })
+            ensure_question(cc_id, { question_key = "emp_cc_shareholding_percent",
+                label = "Percentage shareholding in this close company",
+                question_type = "percentage", is_required = false, display_order = 3 })
+        end
+        ensure_rule("emp_cc_registered_number", "emp_is_close_company",
+            "Show when close company", "equals", "true")
+        ensure_rule("emp_cc_dividends", "emp_is_close_company",
+            "Show when close company", "equals", "true")
+        ensure_rule("emp_cc_shareholding_percent", "emp_is_close_company",
+            "Show when close company", "equals", "true")
+
+        -- ── Category 3: Income ───────────────────────────────────────
+        local inc_id = ensure_category(
+            "employment-income", "Income",
+            "From your P60 (or P45 if you left during the year).",
+            "briefcase", 3, "employment")
+        if inc_id then
+            ensure_question(inc_id, { question_key = "emp_pay_before_tax",
+                label = "Pay from this employment before tax was taken off",
+                question_type = "currency", is_required = false, display_order = 1 })
+            ensure_question(inc_id, { question_key = "emp_payrolled_benefits",
+                label = "Payrolled benefits included above which affect your student loan repayments",
+                question_type = "currency", is_required = false, display_order = 2 })
+            ensure_question(inc_id, { question_key = "emp_uk_tax_taken_off",
+                label = "UK tax taken off", question_type = "currency",
+                is_required = false, display_order = 3 })
+            ensure_question(inc_id, { question_key = "emp_tips_not_on_p60",
+                label = "Tips and other payments not on your P60",
+                question_type = "currency", is_required = false, display_order = 4 })
+        end
+
+        -- ── Category 4: Benefits ─────────────────────────────────────
+        local ben_id = ensure_category(
+            "employment-benefits", "Benefits",
+            "These amounts will be on form P11D from your employer.",
+            "briefcase", 4, "employment")
+        if ben_id then
+            local benefits = {
+                { "emp_ben_company_cars",          "Company cars",                                            1 },
+                { "emp_ben_fuel_company_cars",     "Fuel for company cars",                                   2 },
+                { "emp_ben_company_vans",          "Company vans",                                            3 },
+                { "emp_ben_fuel_company_vans",     "Fuel for company vans",                                   4 },
+                { "emp_ben_travel_subsistence",    "Travel and subsistence",                                  5 },
+                { "emp_ben_entertaining",          "Entertaining",                                            6 },
+                { "emp_ben_private_medical",       "Private medical and dental insurance",                    7 },
+                { "emp_ben_telephone",             "Telephone",                                               8 },
+                { "emp_ben_professional_fees",     "Professional fees & subscriptions paid by employer",      9 },
+                { "emp_ben_vouchers_credit_cards", "Vouchers and credit cards",                              10 },
+                { "emp_ben_excess_mileage",        "Excess mileage allowance",                               11 },
+                { "emp_ben_goods_assets",          "Goods and other assets provided by employer",            12 },
+                { "emp_ben_accommodation",         "Accommodation provided by employer",                     13 },
+                { "emp_ben_other",                 "Other benefits",                                         14 },
+                { "emp_ben_expenses_payments",     "Expenses payments received",                             15 },
+            }
+            for _, b in ipairs(benefits) do
+                ensure_question(ben_id, { question_key = b[1], label = b[2],
+                    question_type = "currency", is_required = false, display_order = b[3] })
+            end
+        end
+
+        -- ── Category 5: Expenses ─────────────────────────────────────
+        local exp_id = ensure_category(
+            "employment-expenses", "Expenses",
+            "Costs of doing your job that your employer didn't reimburse.",
+            "briefcase", 5, "employment")
+        if exp_id then
+            local expenses = {
+                { "emp_exp_business_travel",     "Business travel",                            1 },
+                { "emp_exp_hotel_meal",          "Hotel and meal expenses",                    2 },
+                { "emp_exp_fixed_deductions",    "Fixed deductions for expenses",              3 },
+                { "emp_exp_professional_fees",   "Professional fees and subscriptions",        4 },
+                { "emp_exp_tools_clothes",       "Cost of tools and work clothes",             5 },
+                { "emp_exp_vehicle",             "Vehicle expenses",                           6 },
+                { "emp_exp_mileage_shortfall",   "Mileage allowance shortfall",                7 },
+                { "emp_exp_other_capital",       "Other expenses and capital allowances",      8 },
+            }
+            for _, e in ipairs(expenses) do
+                ensure_question(exp_id, { question_key = e[1], label = e[2],
+                    question_type = "currency", is_required = false, display_order = e[3] })
+            end
+        end
+
+        -- ── Category 6: Foreign earnings ─────────────────────────────
+        local for_id = ensure_category(
+            "employment-foreign", "Foreign earnings and deductions",
+            nil, "briefcase", 6, "employment")
+        if for_id then
+            ensure_question(for_id, { question_key = "emp_foreign_seafarers",
+                label = "Seafarers' earnings deduction", question_type = "currency",
+                is_required = false, display_order = 1 })
+            ensure_question(for_id, { question_key = "emp_foreign_not_taxable",
+                label = "Foreign earnings not taxable in the UK",
+                question_type = "currency", is_required = false, display_order = 2 })
+            ensure_question(for_id, { question_key = "emp_foreign_tax_no_credit",
+                label = "Foreign tax for which tax credit relief not claimed",
+                question_type = "currency", is_required = false, display_order = 3 })
+            ensure_question(for_id, { question_key = "emp_foreign_exempt_pension",
+                label = "Exempt employers' contributions to an overseas pension scheme",
+                question_type = "currency", is_required = false, display_order = 4 })
+        end
+
+        -- ── Category 7: Notes ────────────────────────────────────────
+        local notes_id = ensure_category(
+            "employment-notes", "Additional information",
+            nil, "briefcase", 7, "employment")
+        if notes_id then
+            ensure_question(notes_id, { question_key = "emp_tax_return_note",
+                label = "Additional text note for your tax return",
+                question_type = "long_text", is_required = false, display_order = 1,
+                help_text = "Anything HMRC should know about this employment — goes in the 'any other information' box." })
+        end
+
+        print("[Salary → Profile Builder] Seeded 7 categories, 42 questions, 4 visibility rules under entity_type='employment'")
+    end,
+}

--- a/lapis/queries/EmploymentQueries.lua
+++ b/lapis/queries/EmploymentQueries.lua
@@ -58,10 +58,31 @@ local function present(row)
 end
 
 -- ────────────────────────────────────────────────────────────────────────────
--- List — used by the hub. tax_year is accepted for API symmetry with the
--- other hubs but is ignored today: employments carry no per-year derived
--- totals (all figures are Profile Builder answers, not line-item sums).
+-- List — used by the hub.
+--
+-- When `params.tax_year` is provided (YYYY-YY), each row is decorated
+-- with derived totals for the employment:
+--
+--   pay_total     SUM of emp_pay_before_tax + emp_tips_not_on_p60
+--                 (matches salary-employment-system.lua's `summary=true`
+--                 flag on those two SA102 boxes — the classic "salary
+--                 income" figure the /my-income overview cares about).
+--   benefits_total  SUM of every emp_ben_* field (BIK on P11D)
+--   expenses_total  SUM of every emp_exp_* field
+--   income_total  pay + benefits (the taxable side of the employment)
+--   net_total     income_total - expenses_total  (what actually gets
+--                 taxed for this employment after allowable expenses)
+--
+-- One aggregated SQL query pulls every relevant row for every listed
+-- employment in a single round-trip; no N+1 per employment. Rows are
+-- keyed on (entity_uuid, question_key) so the frontend can also
+-- render a per-employment card without a second call.
+--
+-- If tax_year is omitted, totals are omitted too — some callers only
+-- want the identifiers.
 -- ────────────────────────────────────────────────────────────────────────────
+local SALARY_PAY_KEYS = { "emp_pay_before_tax", "emp_tips_not_on_p60" }
+
 function EmploymentQueries.all(params, user)
     local internal_user_id, err = resolveUserId(user)
     if not internal_user_id then return nil, err end
@@ -77,8 +98,112 @@ function EmploymentQueries.all(params, user)
         .. " ORDER BY display_order ASC, created_at ASC",
         unpack(args)) or {}
 
-    for _, r in ipairs(rows) do present(r) end
+    -- Zero out the totals slot on every row up-front so the frontend
+    -- doesn't have to distinguish "not requested" from "requested but
+    -- empty". Whether we populate them depends on tax_year being set.
+    for _, r in ipairs(rows) do
+        r.pay_total = 0
+        r.benefits_total = 0
+        r.expenses_total = 0
+        r.income_total = 0
+        r.net_total = 0
+        present(r)
+    end
+
+    -- Derived totals only when a tax_year is requested. Some scopes on
+    -- the employment questions are per-entity (evergreen — e.g. employer
+    -- name), others are per-entity per-year (e.g. pay figures) — the
+    -- year-scoped ones are the ones that sum to a total. We filter the
+    -- answer set on (entity_uuid IN listed, question_key LIKE 'emp_%')
+    -- and let PostgreSQL do the grouping.
+    if params.tax_year and params.tax_year ~= "" and #rows > 0 then
+        local uuid_list = {}
+        for _, r in ipairs(rows) do uuid_list[#uuid_list + 1] = r.uuid end
+        local ans = db.query([[
+            SELECT a.entity_uuid, q.question_key,
+                   COALESCE(a.answer_number, 0) AS amount
+            FROM user_profile_answers a
+            JOIN profile_questions q ON q.id = a.question_id
+            WHERE a.user_id = ?
+              AND a.entity_uuid = ANY(?)
+              AND (a.tax_year = ? OR a.tax_year IS NULL)
+              AND (q.question_key LIKE 'emp_pay_%'
+                   OR q.question_key = 'emp_tips_not_on_p60'
+                   OR q.question_key LIKE 'emp_ben_%'
+                   OR q.question_key LIKE 'emp_exp_%')
+              AND a.answer_number IS NOT NULL
+        ]], internal_user_id, db.array(uuid_list), params.tax_year) or {}
+
+        local by_uuid = {}
+        for _, r in ipairs(rows) do by_uuid[r.uuid] = r end
+
+        for _, a in ipairs(ans) do
+            local entity = by_uuid[a.entity_uuid]
+            if entity then
+                local amount = tonumber(a.amount) or 0
+                local qk = a.question_key
+                if qk == "emp_pay_before_tax" or qk == "emp_tips_not_on_p60" then
+                    entity.pay_total = entity.pay_total + amount
+                elseif qk:sub(1, 8) == "emp_ben_" then
+                    entity.benefits_total = entity.benefits_total + amount
+                elseif qk:sub(1, 8) == "emp_exp_" then
+                    entity.expenses_total = entity.expenses_total + amount
+                end
+            end
+        end
+
+        for _, r in ipairs(rows) do
+            r.income_total = r.pay_total + r.benefits_total
+            r.net_total = r.income_total - r.expenses_total
+        end
+    end
+
     return { data = rows, total = #rows }
+end
+
+-- Aggregate across every non-archived employment for a user + tax year.
+-- Used by /my-income to swap the legacy tax_form_records-based salary
+-- total with the profile-builder-sourced one for migrated envs. Same
+-- key set as EmploymentQueries.all's total decoration — kept in step
+-- via SALARY_PAY_KEYS + the emp_ben_/emp_exp_ prefixes below.
+function EmploymentQueries.aggregate_income_total(user, tax_year)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    -- Two SUMs: pay (pay_before_tax + tips) and benefits (emp_ben_*).
+    -- Matches the "summary=true" fields in the legacy salary-employment-
+    -- system.lua catalog + BIK. Expenses are DEDUCTIONS, tracked
+    -- separately so /my-income can show gross income (matches the
+    -- pre-Phase-1 card total).
+    local pay_placeholders = "'" .. table.concat(SALARY_PAY_KEYS, "','") .. "'"
+    local rows = db.query([[
+        SELECT
+          COALESCE(SUM(CASE
+            WHEN q.question_key IN (]] .. pay_placeholders .. [[)
+            THEN a.answer_number ELSE 0 END), 0) AS pay_total,
+          COALESCE(SUM(CASE
+            WHEN q.question_key LIKE 'emp_ben_%'
+            THEN a.answer_number ELSE 0 END), 0) AS benefits_total,
+          COUNT(DISTINCT a.entity_uuid) AS employment_count
+        FROM user_profile_answers a
+        JOIN profile_questions q ON q.id = a.question_id
+        JOIN user_profile_entities e ON e.uuid = a.entity_uuid
+        WHERE a.user_id = ?
+          AND e.entity_type = ?
+          AND e.is_archived = false
+          AND (a.tax_year = ? OR a.tax_year IS NULL)
+          AND a.answer_number IS NOT NULL
+    ]], internal_user_id, ENTITY_TYPE, tax_year or "") or {}
+
+    local r = rows[1] or {}
+    local pay = tonumber(r.pay_total) or 0
+    local benefits = tonumber(r.benefits_total) or 0
+    return {
+        pay_total = pay,
+        benefits_total = benefits,
+        income_total = pay + benefits,
+        employment_count = tonumber(r.employment_count) or 0,
+    }
 end
 
 function EmploymentQueries.show(employment_uuid, user)

--- a/lapis/queries/EmploymentQueries.lua
+++ b/lapis/queries/EmploymentQueries.lua
@@ -1,0 +1,208 @@
+--[[
+    Employment Queries — user_profile_entities rows of entity_type 'employment'.
+
+    An "employment" is the drill-down unit of the Salary income hub — one
+    row per PAYE job the taxpayer held during the year. Each carries:
+      * a user-facing label (nickname / employer name shown in the hub list)
+      * entity-scoped Profile Builder answers via user_profile_answers.entity_uuid
+        (the 42 fields seeded by migration 758)
+
+    Unlike properties and businesses, employments have NO line items — every
+    figure is one answer against a Profile Builder question, so there's no
+    parallel to property_line_items / business_line_values here. Deliberately
+    kept separate from PropertyQueries so this module never grows a
+    "if entity_type == 'employment' then skip line items" shim.
+
+    Every read/write is user-scoped. Soft-delete via is_archived so
+    entity-scoped answers keep a resolvable parent for historical
+    calculations.
+]]
+
+local Global = require "helper.global"
+local TaxAuditLogQueries = require "queries.TaxAuditLogQueries"
+local db = require("lapis.db")
+local cjson = require("cjson")
+
+local EmploymentQueries = {}
+local ENTITY_TYPE = "employment"
+local AUDIT_LABEL = "EMPLOYMENT"
+
+local function resolveUserId(user)
+    if not user then return nil, "User not authenticated" end
+    local user_uuid = user.uuid or user.id
+    local rows
+    if user.uuid then
+        rows = db.query("SELECT id FROM users WHERE uuid = ? LIMIT 1", user_uuid)
+    else
+        rows = db.query("SELECT id FROM users WHERE id = ? LIMIT 1", user_uuid)
+    end
+    if not rows or #rows == 0 then return nil, "User not found" end
+    return rows[1].id
+end
+
+local function resolveNamespaceId(internal_user_id)
+    local rows = db.query([[
+        SELECT default_namespace_id FROM user_namespace_settings
+        WHERE user_id = ? LIMIT 1
+    ]], internal_user_id)
+    if rows and #rows > 0 and rows[1].default_namespace_id then
+        return tonumber(rows[1].default_namespace_id)
+    end
+    return nil
+end
+
+local function present(row)
+    row.id = row.uuid
+    row.user_id = nil
+    return row
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- List — used by the hub. tax_year is accepted for API symmetry with the
+-- other hubs but is ignored today: employments carry no per-year derived
+-- totals (all figures are Profile Builder answers, not line-item sums).
+-- ────────────────────────────────────────────────────────────────────────────
+function EmploymentQueries.all(params, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local where = { "user_id = ?", "entity_type = ?" }
+    local args = { internal_user_id, ENTITY_TYPE }
+    if params.include_archived ~= "true" and params.include_archived ~= true then
+        table.insert(where, "is_archived = false")
+    end
+
+    local rows = db.query(
+        "SELECT * FROM user_profile_entities WHERE " .. table.concat(where, " AND ")
+        .. " ORDER BY display_order ASC, created_at ASC",
+        unpack(args)) or {}
+
+    for _, r in ipairs(rows) do present(r) end
+    return { data = rows, total = #rows }
+end
+
+function EmploymentQueries.show(employment_uuid, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local rows = db.query([[
+        SELECT * FROM user_profile_entities
+        WHERE uuid = ? AND user_id = ? AND entity_type = ?
+        LIMIT 1
+    ]], employment_uuid, internal_user_id, ENTITY_TYPE)
+    if not rows or #rows == 0 then return nil end
+    return present(rows[1])
+end
+
+function EmploymentQueries.create(data, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    if not data.label or data.label == "" then
+        return nil, "label is required"
+    end
+
+    local uuid = Global.generateUUID()
+    db.query([[
+        INSERT INTO user_profile_entities
+            (uuid, user_id, user_uuid, namespace_id, entity_type, label, metadata_json, display_order, is_archived, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, false, NOW(), NOW())
+    ]],
+        uuid,
+        internal_user_id,
+        tostring(user.uuid or user.id),
+        resolveNamespaceId(internal_user_id) or db.NULL,
+        ENTITY_TYPE,
+        tostring(data.label),
+        data.metadata_json or db.NULL,
+        tonumber(data.display_order) or 0
+    )
+    local row = db.query("SELECT * FROM user_profile_entities WHERE uuid = ? LIMIT 1", uuid)[1]
+
+    TaxAuditLogQueries.log({
+        user_id = internal_user_id,
+        user_email = user.email,
+        entity_type = AUDIT_LABEL,
+        entity_id = uuid,
+        action = "CREATE",
+        new_values = cjson.encode(row),
+    })
+    return present(row)
+end
+
+function EmploymentQueries.update(employment_uuid, data, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local existing = db.query([[
+        SELECT * FROM user_profile_entities
+        WHERE uuid = ? AND user_id = ? AND entity_type = ? LIMIT 1
+    ]], employment_uuid, internal_user_id, ENTITY_TYPE)
+    if not existing or #existing == 0 then return nil end
+    local old = existing[1]
+
+    local updates, args = {}, {}
+    if data.label ~= nil then
+        if data.label == "" then return nil, "label cannot be empty" end
+        table.insert(updates, "label = ?"); table.insert(args, tostring(data.label))
+    end
+    if data.metadata_json ~= nil then
+        table.insert(updates, "metadata_json = ?")
+        table.insert(args, data.metadata_json ~= "" and data.metadata_json or db.NULL)
+    end
+    if data.display_order ~= nil then
+        table.insert(updates, "display_order = ?"); table.insert(args, tonumber(data.display_order) or 0)
+    end
+    if #updates == 0 then return present(old) end
+
+    table.insert(updates, "updated_at = NOW()")
+    table.insert(args, employment_uuid)
+    table.insert(args, internal_user_id)
+    db.query("UPDATE user_profile_entities SET " .. table.concat(updates, ", ")
+        .. " WHERE uuid = ? AND user_id = ?", unpack(args))
+
+    local refreshed = db.query("SELECT * FROM user_profile_entities WHERE uuid = ? LIMIT 1", employment_uuid)[1]
+
+    TaxAuditLogQueries.log({
+        user_id = internal_user_id,
+        user_email = user.email,
+        entity_type = AUDIT_LABEL,
+        entity_id = employment_uuid,
+        action = "UPDATE",
+        old_values = cjson.encode(old),
+        new_values = cjson.encode(refreshed),
+    })
+    return present(refreshed)
+end
+
+-- Soft-delete. Entity-scoped answers are LEFT in place so historical
+-- calculations for prior tax years remain reproducible (matches the
+-- Property / Business archive contract).
+function EmploymentQueries.archive(employment_uuid, user)
+    local internal_user_id, err = resolveUserId(user)
+    if not internal_user_id then return nil, err end
+
+    local existing = db.query([[
+        SELECT * FROM user_profile_entities
+        WHERE uuid = ? AND user_id = ? AND entity_type = ? LIMIT 1
+    ]], employment_uuid, internal_user_id, ENTITY_TYPE)
+    if not existing or #existing == 0 then return nil end
+
+    db.query([[
+        UPDATE user_profile_entities
+           SET is_archived = true, archived_at = NOW(), updated_at = NOW()
+         WHERE uuid = ? AND user_id = ?
+    ]], employment_uuid, internal_user_id)
+
+    TaxAuditLogQueries.log({
+        user_id = internal_user_id,
+        user_email = user.email,
+        entity_type = AUDIT_LABEL,
+        entity_id = employment_uuid,
+        action = "DELETE",
+        old_values = cjson.encode(existing[1]),
+    })
+    return true
+end
+
+return EmploymentQueries

--- a/lapis/queries/FormSectionQueries.lua
+++ b/lapis/queries/FormSectionQueries.lua
@@ -768,19 +768,36 @@ function FormSectionQueries.card_summary(user)
         entry.row_count = entry.row_count + (tonumber(r.row_count) or 0)
     end
 
-    -- Migrated types (salary, pension_payments) — REPLACE the tax_form_*
-    -- total with the profile-builder-sourced total. After the Phase 1/2
-    -- default flip, new writes for these types land only in
-    -- user_profile_answers, so continuing to read from tax_form_records/
-    -- tax_form_items would silently under-count them on the /my-income
-    -- overview. The row_count from the tax_form_* side is kept so the
-    -- overview card still knows the type "has data" (Phase 3 will drop
-    -- the tax_form_* rows entirely and this branch becomes the only
-    -- source).
+    -- Profile-builder-sourced totals for types whose data lives in
+    -- user_profile_answers rather than tax_form_*. Three cases today:
+    --
+    --   salary            entity-scoped answers under emp_pay_*,
+    --                     emp_tips_*, emp_ben_*  (Phase 1 migration)
+    --   pension_payments  year-scoped repeating_group JSON arrays
+    --                     (Phase 2 migration)
+    --   dividends         year-scoped currency answers (never used the
+    --                     Form Sections engine — always inline via the
+    --                     [type]/page.tsx PROFILE_BUILDER_CONTEXTS
+    --                     map, so card_summary never saw them until
+    --                     this branch existed).
+    --
+    -- Both `total` AND `row_count` need to be set — the /my-income
+    -- overview card renders "Nothing recorded yet" when row_count = 0
+    -- regardless of what total says. Post-cutover for salary/pension
+    -- there are no tax_form_* rows to source row_count from, so
+    -- reading it from the pb store's natural row concept (entities
+    -- for salary, array-element count for pension, answered-question
+    -- count for dividends) is the only way to make hasEntries true.
     --
     -- Kept in this function rather than the route so every caller of
     -- card_summary (route, future scheduled jobs, integration tests)
     -- gets consistent totals — one source of truth for the aggregate.
+
+    -- ── Salary ──────────────────────────────────────────────────────
+    -- Total = pay + tips + benefits across every non-archived
+    -- employment. Count = number of employments (matches the
+    -- "N entries" concept from the legacy FormRecordsPage — one
+    -- record was one employment there too).
     local salary_row = db.query([[
         SELECT
           COALESCE(SUM(CASE
@@ -795,6 +812,10 @@ function FormSectionQueries.card_summary(user)
           AND e.is_archived = false
           AND a.answer_number IS NOT NULL
     ]], internal_user_id)
+    local salary_count = db.query([[
+        SELECT COUNT(*) AS n FROM user_profile_entities
+        WHERE user_id = ? AND entity_type = 'employment' AND is_archived = false
+    ]], internal_user_id)
     if salary_row and salary_row[1] then
         local salary_entry = by_type["salary"]
         if not salary_entry then
@@ -803,19 +824,20 @@ function FormSectionQueries.card_summary(user)
             by_type["salary"] = salary_entry
         end
         salary_entry.total = tonumber(salary_row[1].total) or 0
+        salary_entry.row_count = tonumber((salary_count[1] or {}).n) or 0
     end
 
-    -- Pension: SUM the `amount` field across every element of every
-    -- answer_json array for the three pp_*_payments questions. JSON
-    -- aggregation happens in-database via jsonb_array_elements — one
-    -- round-trip regardless of how many rows the user has entered.
+    -- ── Pension payments ────────────────────────────────────────────
+    -- Total = SUM amount across every element of every answer_json
+    -- array for the three pp_*_payments questions.
+    -- Count = total number of individual payment rows the user has
+    -- entered (SUM of array lengths across all 3 sections × all years).
     -- jsonb_typeof guard: other question types can store objects in
-    -- answer_json (e.g. multi-select choices as {selected: [...]}),
-    -- and jsonb_array_elements throws on non-arrays. Filtering out
-    -- non-arrays at the WHERE stage keeps this SUM safe if pension
-    -- question_keys ever collide with a non-array-shaped question.
+    -- answer_json; jsonb_array_elements throws on non-arrays.
     local pension_row = db.query([[
-        SELECT COALESCE(SUM((elem->>'amount')::numeric), 0) AS total
+        SELECT
+          COALESCE(SUM((elem->>'amount')::numeric), 0) AS total,
+          COUNT(*)                                    AS row_count
         FROM user_profile_answers a
         JOIN profile_questions q ON q.id = a.question_id
         CROSS JOIN LATERAL jsonb_array_elements(a.answer_json::jsonb) elem
@@ -834,6 +856,46 @@ function FormSectionQueries.card_summary(user)
             by_type["pension_payments"] = pension_entry
         end
         pension_entry.total = tonumber(pension_row[1].total) or 0
+        pension_entry.row_count = tonumber(pension_row[1].row_count) or 0
+    end
+
+    -- ── Dividends ───────────────────────────────────────────────────
+    -- Dividends never had tax_form_* rows — it's inline in the
+    -- /my-income/[type] dispatcher's PROFILE_BUILDER_CONTEXTS map, so
+    -- card_summary NEVER surfaced it before this branch existed. Users
+    -- had figures on /my-income/dividends but /my-income showed
+    -- "Nothing recorded yet" for the type — exactly the same symptom
+    -- salary just hit.
+    --
+    -- Total = SUM currency answers for questions in category
+    -- context='dividends' (avoids hardcoding the sa100_* question_key
+    -- list — admin can add a new dividends field via the admin UI and
+    -- the total picks it up next call).
+    -- Count = number of question_keys with a non-null numeric answer.
+    -- One row means "this type has SOMETHING recorded"; the number
+    -- itself isn't user-surfaced beyond the hasEntries threshold.
+    local dividends_row = db.query([[
+        SELECT
+          COALESCE(SUM(a.answer_number), 0) AS total,
+          COUNT(a.id)                       AS row_count
+        FROM user_profile_answers a
+        JOIN profile_questions q  ON q.id = a.question_id
+        JOIN profile_categories c ON c.id = q.category_id
+        WHERE a.user_id = ?
+          AND c.context = 'dividends'
+          AND c.is_active = true
+          AND c.is_archived = false
+          AND a.answer_number IS NOT NULL
+    ]], internal_user_id)
+    if dividends_row and dividends_row[1] then
+        local dividends_entry = by_type["dividends"]
+        if not dividends_entry then
+            dividends_entry = { income_type_key = "dividends", total = 0, row_count = 0 }
+            out[#out + 1] = dividends_entry
+            by_type["dividends"] = dividends_entry
+        end
+        dividends_entry.total = tonumber(dividends_row[1].total) or 0
+        dividends_entry.row_count = tonumber(dividends_row[1].row_count) or 0
     end
 
     return out

--- a/lapis/queries/FormSectionQueries.lua
+++ b/lapis/queries/FormSectionQueries.lua
@@ -767,6 +767,75 @@ function FormSectionQueries.card_summary(user)
         entry.total = entry.total + (tonumber(r.total) or 0)
         entry.row_count = entry.row_count + (tonumber(r.row_count) or 0)
     end
+
+    -- Migrated types (salary, pension_payments) — REPLACE the tax_form_*
+    -- total with the profile-builder-sourced total. After the Phase 1/2
+    -- default flip, new writes for these types land only in
+    -- user_profile_answers, so continuing to read from tax_form_records/
+    -- tax_form_items would silently under-count them on the /my-income
+    -- overview. The row_count from the tax_form_* side is kept so the
+    -- overview card still knows the type "has data" (Phase 3 will drop
+    -- the tax_form_* rows entirely and this branch becomes the only
+    -- source).
+    --
+    -- Kept in this function rather than the route so every caller of
+    -- card_summary (route, future scheduled jobs, integration tests)
+    -- gets consistent totals — one source of truth for the aggregate.
+    local salary_row = db.query([[
+        SELECT
+          COALESCE(SUM(CASE
+            WHEN q.question_key IN ('emp_pay_before_tax','emp_tips_not_on_p60')
+              OR q.question_key LIKE 'emp_ben_%'
+            THEN a.answer_number ELSE 0 END), 0) AS total
+        FROM user_profile_answers a
+        JOIN profile_questions q ON q.id = a.question_id
+        JOIN user_profile_entities e ON e.uuid = a.entity_uuid
+        WHERE a.user_id = ?
+          AND e.entity_type = 'employment'
+          AND e.is_archived = false
+          AND a.answer_number IS NOT NULL
+    ]], internal_user_id)
+    if salary_row and salary_row[1] then
+        local salary_entry = by_type["salary"]
+        if not salary_entry then
+            salary_entry = { income_type_key = "salary", total = 0, row_count = 0 }
+            out[#out + 1] = salary_entry
+            by_type["salary"] = salary_entry
+        end
+        salary_entry.total = tonumber(salary_row[1].total) or 0
+    end
+
+    -- Pension: SUM the `amount` field across every element of every
+    -- answer_json array for the three pp_*_payments questions. JSON
+    -- aggregation happens in-database via jsonb_array_elements — one
+    -- round-trip regardless of how many rows the user has entered.
+    -- jsonb_typeof guard: other question types can store objects in
+    -- answer_json (e.g. multi-select choices as {selected: [...]}),
+    -- and jsonb_array_elements throws on non-arrays. Filtering out
+    -- non-arrays at the WHERE stage keeps this SUM safe if pension
+    -- question_keys ever collide with a non-array-shaped question.
+    local pension_row = db.query([[
+        SELECT COALESCE(SUM((elem->>'amount')::numeric), 0) AS total
+        FROM user_profile_answers a
+        JOIN profile_questions q ON q.id = a.question_id
+        CROSS JOIN LATERAL jsonb_array_elements(a.answer_json::jsonb) elem
+        WHERE a.user_id = ?
+          AND q.question_key IN
+              ('pp_registered_payments','pp_employer_payments','pp_overseas_payments')
+          AND a.answer_json IS NOT NULL
+          AND a.answer_json <> ''
+          AND jsonb_typeof(a.answer_json::jsonb) = 'array'
+    ]], internal_user_id)
+    if pension_row and pension_row[1] then
+        local pension_entry = by_type["pension_payments"]
+        if not pension_entry then
+            pension_entry = { income_type_key = "pension_payments", total = 0, row_count = 0 }
+            out[#out + 1] = pension_entry
+            by_type["pension_payments"] = pension_entry
+        end
+        pension_entry.total = tonumber(pension_row[1].total) or 0
+    end
+
     return out
 end
 

--- a/lapis/routes/tax-employments.lua
+++ b/lapis/routes/tax-employments.lua
@@ -66,6 +66,10 @@ end
 
 return function(app)
     app:get("/api/v2/tax/employments", AuthMiddleware.requireAuth(function(self)
+        -- tax_year is optional. When present it decorates every row
+        -- with pay/benefits/expenses/income/net totals derived from
+        -- user_profile_answers — see EmploymentQueries.all's docstring
+        -- for the key-set and grouping.
         local result, err = EmploymentQueries.all(self.params, self.current_user)
         if not result then
             return { json = { error = err or "Failed to list employments" }, status = 400 }

--- a/lapis/routes/tax-employments.lua
+++ b/lapis/routes/tax-employments.lua
@@ -1,0 +1,111 @@
+--[[
+    Employment Routes — the Salary hub's backend surface (Phase 1 of the
+    profile-builder unification, see
+    docs/PROFILE_BUILDER_UNIFICATION_PLAN.md).
+
+    Endpoints (all auth-required):
+      GET    /api/v2/tax/employments                     list (hub)
+      POST   /api/v2/tax/employments                     { label }
+      GET    /api/v2/tax/employments/:uuid
+      PUT    /api/v2/tax/employments/:uuid               { label?, metadata_json?, display_order? }
+      DELETE /api/v2/tax/employments/:uuid               soft archive
+
+    Employment-scope QUESTIONS are not served here — they come from the
+    Profile Builder (?context=employment&entity=<uuid>) so admins keep
+    full control of what's asked per employment without shipping code.
+
+    Wire-up: added under load_if("tax_copilot", ...) in app.lua alongside
+    tax-properties / tax-businesses. Off by default outside tax_copilot.
+]]
+
+local cjson = require("cjson")
+local EmploymentQueries = require "queries.EmploymentQueries"
+local AuthMiddleware = require("middleware.auth")
+
+-- Parse JSON or form body — same helper shape as tax-properties.lua:
+-- cjson.null stripped at the boundary so a JSON null behaves like an
+-- absent key; body-file fallback for spooled bodies.
+local function parse_request_body()
+    ngx.req.read_body()
+    local content_type = ngx.var.content_type or ""
+    if content_type:find("application/json", 1, true) then
+        local ok, result = pcall(function()
+            local body = ngx.req.get_body_data()
+            if not body or body == "" then
+                local path = ngx.req.get_body_file()
+                if path then
+                    local f = io.open(path, "rb")
+                    if f then
+                        body = f:read("*a")
+                        f:close()
+                    end
+                end
+            end
+            if not body or body == "" then return {} end
+            return cjson.decode(body)
+        end)
+        if ok and type(result) == "table" then
+            for k, v in pairs(result) do
+                if v == cjson.null then result[k] = nil end
+            end
+            return result
+        end
+        return {}
+    end
+    local post_args = ngx.req.get_post_args()
+    if post_args and next(post_args) then return post_args end
+    return {}
+end
+
+local function merge_params(self)
+    local body_params = parse_request_body()
+    for k, v in pairs(body_params) do
+        if self.params[k] == nil then self.params[k] = v end
+    end
+end
+
+return function(app)
+    app:get("/api/v2/tax/employments", AuthMiddleware.requireAuth(function(self)
+        local result, err = EmploymentQueries.all(self.params, self.current_user)
+        if not result then
+            return { json = { error = err or "Failed to list employments" }, status = 400 }
+        end
+        if #result.data == 0 then result.data = cjson.empty_array end
+        return { json = result, status = 200 }
+    end))
+
+    app:post("/api/v2/tax/employments", AuthMiddleware.requireAuth(function(self)
+        merge_params(self)
+        if not self.params.label or tostring(self.params.label):gsub("%s", "") == "" then
+            return { json = { error = "label is required" }, status = 400 }
+        end
+        if #tostring(self.params.label) > 120 then
+            return { json = { error = "label must be 120 characters or fewer" }, status = 400 }
+        end
+        local row, err = EmploymentQueries.create(self.params, self.current_user)
+        if not row then return { json = { error = err or "Failed to create employment" }, status = 400 } end
+        return { json = { data = row }, status = 201 }
+    end))
+
+    app:get("/api/v2/tax/employments/:uuid", AuthMiddleware.requireAuth(function(self)
+        local row = EmploymentQueries.show(tostring(self.params.uuid), self.current_user)
+        if not row then return { json = { error = "Employment not found" }, status = 404 } end
+        return { json = { data = row }, status = 200 }
+    end))
+
+    app:put("/api/v2/tax/employments/:uuid", AuthMiddleware.requireAuth(function(self)
+        merge_params(self)
+        if self.params.label ~= nil and #tostring(self.params.label) > 120 then
+            return { json = { error = "label must be 120 characters or fewer" }, status = 400 }
+        end
+        local row, err = EmploymentQueries.update(tostring(self.params.uuid), self.params, self.current_user)
+        if not row then return { json = { error = err or "Employment not found" }, status = err and 400 or 404 } end
+        return { json = { data = row }, status = 200 }
+    end))
+
+    app:delete("/api/v2/tax/employments/:uuid", AuthMiddleware.requireAuth(function(self)
+        local ok = EmploymentQueries.archive(tostring(self.params.uuid), self.current_user)
+        if not ok then return { json = { error = "Employment not found" }, status = 404 } end
+        return { json = { message = "Employment archived" }, status = 200 }
+    end))
+end

--- a/lapis/routes/tax-form-sections.lua
+++ b/lapis/routes/tax-form-sections.lua
@@ -43,6 +43,7 @@ local AuthMiddleware = require("middleware.auth")
 -- shadow writes. See docs/PROFILE_BUILDER_UNIFICATION_PLAN.md §4-5 in
 -- the diy-tax-return-uk repo.
 local SalaryFork = require("helper.salary-profile-builder-fork")
+local PensionFork = require("helper.pension-profile-builder-fork")
 
 -- YYYY-YY (e.g. 2026-27) — same contract as my-incomes / tax-properties.
 local function valid_tax_year(s)
@@ -188,6 +189,15 @@ return function(app)
         self.params.extra_json = encode_extra(self.params.extra, section)
         local row, err = FormSectionQueries.create_item(self.params, self.current_user)
         if not row then return { json = { error = err or "Failed to save the entry" }, status = 400 } end
+        -- Fork write. No-op when the pension_payments flag is off (default)
+        -- or when this row is a different income type. Any failure is
+        -- pcall-swallowed inside the helper — primary create stays
+        -- authoritative. Passes the identifying triple; the helper
+        -- reads current bucket state itself so we don't have to
+        -- serialise the row here.
+        if row.income_type_key == "pension_payments" then
+            PensionFork.on_change(row.user_id, row.tax_year, row.section_key)
+        end
         return { json = { data = row }, status = 201 }
     end))
 
@@ -214,12 +224,24 @@ return function(app)
         end
         local row, err = FormSectionQueries.update_item(tostring(self.params.uuid), data, self.current_user)
         if not row then return { json = { error = err or "Entry not found" }, status = err and 400 or 404 } end
+        if row.income_type_key == "pension_payments" then
+            PensionFork.on_change(row.user_id, row.tax_year, row.section_key)
+        end
         return { json = { data = row }, status = 200 }
     end))
 
     app:delete("/api/v2/tax/form-items/:uuid", AuthMiddleware.requireAuth(function(self)
+        -- Look up before archiving so the fork's on_change has the row's
+        -- bucket identity (user + year + section) — the row itself is
+        -- about to become is_archived=true and rebuild_bucket filters
+        -- those out. show_item enforces user-owned-only, same guard
+        -- archive_item runs; nil here means archive would also 404.
+        local existing = FormSectionQueries.show_item(tostring(self.params.uuid), self.current_user)
         local ok = FormSectionQueries.archive_item(tostring(self.params.uuid), self.current_user)
         if not ok then return { json = { error = "Entry not found" }, status = 404 } end
+        if existing and existing.income_type_key == "pension_payments" then
+            PensionFork.on_change(existing.user_id, existing.tax_year, existing.section_key)
+        end
         return { json = { message = "Entry removed" }, status = 200 }
     end))
 

--- a/lapis/routes/tax-form-sections.lua
+++ b/lapis/routes/tax-form-sections.lua
@@ -34,6 +34,15 @@
 local cjson = require("cjson")
 local FormSectionQueries = require "queries.FormSectionQueries"
 local AuthMiddleware = require("middleware.auth")
+-- Phase 1 salary → profile-builder dual-write fork. Every entry point
+-- is safe to call unconditionally (feature-flag check + pcall guard
+-- are inside the helper), so we hang the fork onto every successful
+-- primary write without gating in this file. Turning dual-write off
+-- (INCOME_ENGINE_SALARY_DUAL_WRITE unset) makes the helper a no-op
+-- immediately — no route change or redeploy needed to disable the
+-- shadow writes. See docs/PROFILE_BUILDER_UNIFICATION_PLAN.md §4-5 in
+-- the diy-tax-return-uk repo.
+local SalaryFork = require("helper.salary-profile-builder-fork")
 
 -- YYYY-YY (e.g. 2026-27) — same contract as my-incomes / tax-properties.
 local function valid_tax_year(s)
@@ -246,6 +255,10 @@ return function(app)
             total = total,
         }, self.current_user)
         if not row then return { json = { error = err or "Failed to save" }, status = 400 } end
+        -- Fork write. No-op when INCOME_ENGINE_SALARY_DUAL_WRITE is
+        -- unset (default). Any failure is pcall-swallowed inside the
+        -- helper — the primary create stays authoritative.
+        SalaryFork.on_create(row)
         return { json = { data = row }, status = 201 }
     end))
 
@@ -269,12 +282,20 @@ return function(app)
             total = total,
         }, self.current_user)
         if not row then return { json = { error = err or "Record not found" }, status = err and 400 or 404 } end
+        SalaryFork.on_update(row)
         return { json = { data = row }, status = 200 }
     end))
 
     app:delete("/api/v2/tax/form-records/:uuid", AuthMiddleware.requireAuth(function(self)
+        -- Look up before archiving so the fork's on_delete has the row's
+        -- uuid + income_type_key (needed to derive the shadow entity
+        -- uuid + to gate on the income_type flag). show_record enforces
+        -- the same user-owned-only check archive_record does; a not-owned
+        -- record returns nil here and the archive would also 404 below.
+        local existing = FormSectionQueries.show_record(tostring(self.params.uuid), self.current_user)
         local ok = FormSectionQueries.archive_record(tostring(self.params.uuid), self.current_user)
         if not ok then return { json = { error = "Record not found" }, status = 404 } end
+        if existing then SalaryFork.on_delete(existing) end
         return { json = { message = "Record removed" }, status = 200 }
     end))
 


### PR DESCRIPTION
## Summary

**Phase 1 backend** of the profile-builder unification (see the diy-tax-return-uk repo's [PROFILE_BUILDER_UNIFICATION_PLAN.md](https://github.com/bwalia/diy-tax-return-uk/blob/main/docs/PROFILE_BUILDER_UNIFICATION_PLAN.md) §5-6). Migrates \`/my-income/salary\` from the legacy Form Sections engine onto the unified Profile Builder store, feature-flagged per env, dual-write for safety.

## What ships (4 commits)

1. **Catalog seed** (\`lapis/migrations/salary-profile-builder-catalog.lua\`)
   - 7 profile_categories under \`context='employment'\`, \`answer_scope='entity'\`, \`entity_type='employment'\`
   - 42 profile_questions (all keyed \`emp_*\` to prevent collision)
   - 4 profile_question_rules for the \`show_if\` visibility gates

2. **Backfill** (\`lapis/migrations/salary-profile-builder-backfill.lua\`)
   - Walks every non-archived \`tax_form_records\` salary row → materialises \`user_profile_entities\` + \`user_profile_answers\`
   - Deterministic hashed entity UUID (md5-based) → idempotent, safe to re-run
   - Full 42-field FIELD_MAP with typed coercion; unknown fields silently dropped
   - Source rows LEFT IN PLACE (Phase 3's cleanup)

3. **Dual-write fork** (\`lapis/helper/salary-profile-builder-fork.lua\`)
   - \`on_create\` / \`on_update\` / \`on_delete\` — hangs off the existing form-records handlers
   - Gated by \`IncomeEngine.dual_write_enabled("salary")\` — default off
   - Every entry point pcalls; primary write NEVER breaks
   - Failure logged as \`INCOME_ENGINE_DUAL_WRITE_MISMATCH\` for the cutover gate
   - ON CONFLICT DO UPDATE (not DO NOTHING like backfill) — the primary user write is authoritative

4. **Migration registration** (\`lapis/migrations.lua\`)
   - Slots \`758_seed_salary_profile_builder_catalog\` and \`759_backfill_salary_to_profile_builder\` after the existing salary content migrations
   - Both feature-gated on TAX_COPILOT
   - Prefix ordering load-bearing (catalog → backfill; backfill is safe on empty catalog, just early-returns)

## Deployment sequence

Zero user-facing behavior change from merging this PR alone. Follows the plan §6 cutover schedule:

1. Merge + deploy opsapi to int. Migrations 758-759 run automatically at pod start. Backfill copies existing rows. **Nothing else changes** — form-records API stays authoritative, frontend still reads via it.
2. Set \`INCOME_ENGINE_SALARY_DUAL_WRITE=true\` in int env (Vault → pod env → restart). New writes now fork into both stores. Log for the mismatch marker.
3. Wait for the discrepancy log to be clean for 48h.
4. When the frontend PR (in diy-tax-return-uk) is merged and deployed, flip \`NEXT_PUBLIC_INCOME_ENGINE_SALARY=profile_builder\` in int env. Reads now come from the unified store.
5. Soak int for 5 days (per §4.3). Then test → acc → prod.
6. Post-prod: 14-day dual-write window. Then Phase 3 archives and drops the legacy rows.

Rollback at any point: unset the frontend flag → redeploy frontend → ~2 min. Backfill is reversible (metadata_json.origin marker).

## Feature-flag env vars this PR consumes

- \`INCOME_ENGINE_SALARY_DUAL_WRITE\` — when \`true\`, salary form-records writes fork into the Profile Builder store
- (backend does NOT read \`INCOME_ENGINE_SALARY\` yet — the frontend flag is the read switch; the backend just services whichever API the frontend calls)

Both defined by the Phase 0 helper (\`lapis/helper/income-engine.lua\`, PR #496).

## Non-goals for this PR

- No read-side route for the salary Profile Builder engine (the profile-builder \`/schema\` and \`/answers\` endpoints already serve \`entity_type='employment'\` for free — they're generic on entity_type)
- No frontend changes (sibling PR in diy-tax-return-uk)
- No retirement of legacy salary code paths (Phase 3)
- No archive / drop of \`tax_form_records\` (Phase 3)
- No pension migration (Phase 2, next week)

## Test plan

- [ ] Fresh DB — run migrations end-to-end → confirm 7 categories, 42 questions, 4 rules seeded correctly
- [ ] Existing int DB — run migrations → confirm all existing salary records have shadow entities + answers matching data_json
- [ ] Re-run the seed migration → confirm zero duplicates, labels updated
- [ ] Re-run the backfill → confirm zero duplicates, no user edits overwritten
- [ ] With \`INCOME_ENGINE_SALARY_DUAL_WRITE=true\`:
  - POST /form-records → confirm both stores have the row
  - PUT /form-records/:uuid → confirm both stores updated
  - DELETE /form-records/:uuid → confirm shadow entity archived
- [ ] Simulate a fork failure (e.g. drop the profile_questions row for one question, then PUT) → confirm primary write succeeds + mismatch log line fires
- [ ] With flag OFF → confirm zero fork writes, existing behavior unchanged

## Refs

- diy-tax-return-uk [docs/PROFILE_BUILDER_UNIFICATION_PLAN.md](https://github.com/bwalia/diy-tax-return-uk/blob/main/docs/PROFILE_BUILDER_UNIFICATION_PLAN.md)
- opsapi PR #496 — Phase 0 backend flag helper
- diy-tax-return-uk PR #797 — Phase 0 frontend flag + CI guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)