### PR TITLE
feat(income-types): return admin-configured description from /types

### DIFF
--- a/lapis/routes/my-incomes.lua
+++ b/lapis/routes/my-incomes.lua
@@ -119,6 +119,12 @@ return function(app)
             data[#data + 1] = {
                 key = r.income_type_key,
                 label = r.display_name,
+                -- Admin-configured plain-English description shown under the
+                -- H1 on the income type's page. Optional in the schema (text
+                -- null=true) — pass through as-is, incl. the empty string,
+                -- so the frontend can distinguish "admin left it blank" from
+                -- "backend forgot to send it".
+                description = r.description,
                 required_documents = docs,
                 allows_manual_entry = r.allows_manual_entry,
             }


### PR DESCRIPTION
## Summary

6-line addition to \`routes/my-incomes.lua\` so the \`/api/v2/tax/my-incomes/types\` response includes each type's admin-configured \`description\`. The column already exists on \`income_types\` and \`IncomeTypeQueries.list_active()\` already selects it (via \`SELECT *\`) — the route mapping was just dropping it before building the payload.

## Why

Frontend PR (opened separately against the diy-tax-return-uk repo) wires this description into the H1 subtitle on \`/my-income/[type]\`, \`/my-income/salary\` and \`/my-income/pension_payments\`. Without this backend change, the frontend correctly falls back to a hardcoded string — meaning an admin editing \`/admin/income-types\` sees zero effect on end-user pages.

Reporter confirmed the symptom: they set salary description to \"Wages or salary from employment, taxed through PAYE..\" via the admin dashboard, but \`/my-income/salary\` continued to show the hardcoded fallback because the API wasn't returning \`description\`.

## Missed original merge

This commit was pushed to \`feat/phase-1-salary-migration-to-profile-builder\` shortly AFTER PR #497 squash-merged, so it never made it into main. This PR carries just that one commit on a fresh branch off main.

## Non-goals

- No schema change (column already exists).
- No admin route change (\`/api/v2/tax/admin/income-types\` PUT already writes to the column).
- No frontend change (handled in the sibling PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)