### PR TITLE
feat(sa110): seed catalog for SA110 Tax Calculation Summary

### DIFF
--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -238,6 +238,14 @@ local salary_profile_builder_backfill_migrations = load_if_enabled(ProjectConfig
 local pension_profile_builder_catalog_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.pension-profile-builder-catalog") or {}
 local pension_profile_builder_backfill_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.pension-profile-builder-backfill") or {}
 
+-- SA110 Tax Calculation Summary — one seed file, no backfill (no
+-- legacy Form Sections rows to port). Ships as an income_types row +
+-- 6 profile_categories + 17 profile_questions under context='sa110',
+-- answer_scope='year'. Once merged and applied, /my-income/sa110
+-- becomes admin-configurable end-to-end (add / rename / reorder
+-- questions via /admin/profile-builder without a code deploy).
+local sa110_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.sa110-tax-calculation-summary") or {}
+
 -- Billing / payments (Stripe Connect: subscriptions + one-time). Gated on
 -- tax_copilot for now; broaden to a feature list (e.g. {ECOMMERCE, TAX_COPILOT})
 -- once multiple project codes need it. See migrations/billing-system.lua.
@@ -2061,6 +2069,12 @@ local _migrations = {
     -- already fully succeeded treats these as no-ops.
     ['764_reseed_pension_profile_builder_catalog'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, pension_profile_builder_catalog_migrations, 2),
     ['765_rebackfill_pension_to_profile_builder'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, pension_profile_builder_backfill_migrations, 2),
+    -- 766/767 — SA110 Tax Calculation Summary catalog. income_types
+    -- row + 6 profile_categories + 17 profile_questions under
+    -- context='sa110', answer_scope='year'. 767 is the safety-net
+    -- re-run pass (same convention as 760 / 764).
+    ['766_seed_sa110_tax_calculation_summary'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, sa110_migrations, 1),
+    ['767_reseed_sa110_tax_calculation_summary'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, sa110_migrations, 2),
 
     -- =========================================================================
     -- Academy (LMS): courses + lessons (namespace-scoped). Feature-gated, so

--- a/lapis/migrations/sa110-tax-calculation-summary.lua
+++ b/lapis/migrations/sa110-tax-calculation-summary.lua
@@ -1,0 +1,291 @@
+--[[
+  SA110 Tax Calculation Summary — Profile Builder catalog.
+
+  Ports HMRC's SA110 form (17 boxes across 6 sections) into the unified
+  Profile Builder store so /my-income/sa110 can be served by the same
+  engine as dividends, salary and pension_payments.
+
+  Structure (from the SA110 2026 PDF — tax year 2025-26):
+
+    Section 1 — Self Assessment (boxes 1, 2, 3, 3.1, 4, 4.1, 5, 6)
+      Total tax due / overpaid, Student & Postgraduate Loan
+      repayments, Class 2 & 4 NICs, CGT, Pension charges.
+      All currency.
+
+    Section 2 — Underpaid tax and other debts (boxes 7, 8, 9)
+      PAYE Coding Notice figures — earlier-year underpayment,
+      current-year underpayment, outstanding debt. All currency.
+
+    Section 3 — Payments on account (boxes 10, 11)
+      Box 10 is an X-in-the-box claim (boolean); box 11 is the
+      reduced first-payment amount (currency).
+
+    Section 4 — Blind person's + married couple's surplus allowance
+      (boxes 12, 13). Both currency. Surplus transferred from spouse
+      or civil partner.
+
+    Section 5 — Adjustments to tax due (boxes 14, 15, 16)
+      Increase / decrease from earlier-year adjustments, and any
+      2026-27 repayment claimed now. All currency.
+
+    Section 6 — Any other information (box 17)
+      Free text (long_text) — box 17 on TC 2, "Please give any
+      other information in this space".
+
+  Modelling choices — matches the dividends pattern (year-scoped
+  answers, one category per form section):
+
+    * profile_categories.context = 'sa110'
+    * answer_scope = 'year' (no user_profile_entities row —
+                             a single set of answers per tax year)
+    * entity_type = NULL
+
+  Total: 1 income_types row + 6 profile_categories + 17 profile_questions.
+
+  Idempotency: keyed on income_type_key + category slug + question_key,
+  same convention as every other tax_copilot seed. Re-running touches
+  labels/help_text/order but never duplicates or resurrects admin-
+  archived rows.
+
+  Only executed when PROJECT_CODE includes 'tax_copilot'.
+]]
+
+local db = require("lapis.db")
+local cjson = require("cjson")
+local MigrationUtils = require "helper.migration-utils"
+
+-- Seed body extracted to module scope so a re-run step ([2]) can call
+-- it. Every ensure_* helper is idempotent; a fresh env where step [1]
+-- fully succeeded treats [2] as a no-op.
+local function seed_sa110_catalog()
+    -- Nil-safe helpers — coerce nil description / nil icon / nil help
+    -- text to db.NULL BEFORE the db.query call. Lua truncates varargs
+    -- at the first nil (`{...}` stops there), so passing nil in the
+    -- middle would silently drop trailing placeholders. Same fix that
+    -- landed on salary-profile-builder-catalog.lua after the incident
+    -- there.
+    local function nn(v) return v ~= nil and v or db.NULL end
+
+    local function ensure_income_type(key, display_name, description)
+        local exists = db.select("id FROM income_types WHERE income_type_key = ?", key)
+        if exists and #exists > 0 then
+            db.query([[
+                UPDATE income_types
+                   SET display_name = ?, description = ?,
+                       allows_manual_entry = false,
+                       is_active = true, updated_at = NOW()
+                 WHERE income_type_key = ?
+            ]], display_name, nn(description), key)
+            return
+        end
+        db.query([[
+            INSERT INTO income_types
+                (uuid, income_type_key, display_name, description,
+                 required_documents, allows_manual_entry,
+                 keyword_rules, category_affinity, rules_markdown,
+                 hmrc_mapping, display_order, is_active, namespace_id,
+                 created_at, updated_at)
+            VALUES (?, ?, ?, ?,
+                    '[]'::jsonb, false,
+                    '[]'::jsonb, '{}'::jsonb, NULL,
+                    ?::jsonb, 90, true, NULL, NOW(), NOW())
+        ]], MigrationUtils.generateUUID(), key, display_name, nn(description),
+            cjson.encode({ sa110_form = "TC1-TC2" }))
+    end
+
+    local function ensure_category(slug, name, description, icon, display_order)
+        local exists = db.select("id FROM profile_categories WHERE slug = ?", slug)
+        if exists and #exists > 0 then
+            db.query([[
+                UPDATE profile_categories
+                   SET name = ?, description = ?, icon = ?, display_order = ?,
+                       context = 'sa110',
+                       answer_scope = 'year',
+                       entity_type = NULL,
+                       is_active = true, is_archived = false, updated_at = NOW()
+                 WHERE slug = ?
+            ]], name, nn(description), nn(icon), display_order, slug)
+            return exists[1].id
+        end
+        db.query([[
+            INSERT INTO profile_categories
+                (uuid, namespace_id, name, slug, description, icon,
+                 display_order, context, answer_scope, entity_type,
+                 is_active, is_archived, created_at, updated_at)
+            VALUES (?, 0, ?, ?, ?, ?, ?, 'sa110', 'year', NULL,
+                    true, false, NOW(), NOW())
+        ]], MigrationUtils.generateUUID(), name, slug, nn(description),
+            nn(icon), display_order)
+        local row = db.select("id FROM profile_categories WHERE slug = ?", slug)
+        return row and row[1] and row[1].id or nil
+    end
+
+    local function ensure_question(cat_id, q)
+        local exists = db.select("id FROM profile_questions WHERE question_key = ?", q.question_key)
+        if exists and #exists > 0 then
+            db.query([[
+                UPDATE profile_questions
+                   SET category_id = ?, label = ?, question_type = ?, is_required = ?,
+                       display_order = ?, help_text = ?, placeholder = '',
+                       is_active = true, is_archived = false, updated_at = NOW()
+                 WHERE question_key = ?
+            ]], cat_id, q.label, q.question_type, q.is_required, q.display_order,
+                q.help_text or "", q.question_key)
+            return exists[1].id
+        end
+        db.query([[
+            INSERT INTO profile_questions
+                (uuid, category_id, question_key, label, question_type, is_required,
+                 display_order, help_text, placeholder,
+                 is_active, version, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, '', true, 1, NOW(), NOW())
+        ]], MigrationUtils.generateUUID(), cat_id, q.question_key, q.label,
+            q.question_type, q.is_required, q.display_order, q.help_text or "")
+    end
+
+    -- ── Income type ─────────────────────────────────────────────────
+    -- allows_manual_entry=false: /my-incomes rows typed 'sa110' would
+    -- be counted as trading income (wrong direction — SA110 is a
+    -- calculation summary, not an income source). Setting the flag
+    -- keeps SA110 off the flat-entry legacy path; the profile-builder
+    -- store is authoritative from day one.
+    ensure_income_type(
+        "sa110",
+        "Tax calculation summary (SA110)",
+        "HMRC's SA110 supplementary form — enter the total tax, NICs, Student & Postgraduate Loan repayments, CGT, pension charges and any payments-on-account claims for the year. Use the working sheet in the 'Tax calculation summary notes' to derive the box values."
+    )
+
+    -- ── Section 1: Self Assessment ─────────────────────────────────
+    local sa_id = ensure_category(
+        "sa110-self-assessment", "Self Assessment",
+        "Total tax, NICs, Student & Postgraduate Loan repayments, CGT, and pension charges due or overpaid for the year.",
+        "pound-sign", 1)
+    if sa_id then
+        ensure_question(sa_id, { question_key = "sa110_total_tax_due",
+            label = "Total tax, NICs, Student Loan and Postgraduate Loan repayments due (box 1)",
+            question_type = "currency", is_required = false, display_order = 1,
+            help_text = "The total tax figure BEFORE any payments on account. If the working sheet produces a negative number, enter it in the 'overpaid' box below instead." })
+        ensure_question(sa_id, { question_key = "sa110_total_tax_overpaid",
+            label = "Total tax, NICs, Student Loan and Postgraduate Loan repayments overpaid (box 2)",
+            question_type = "currency", is_required = false, display_order = 2,
+            help_text = "Only fill in if the working sheet shows tax overpaid — this triggers a refund rather than a balance due." })
+        ensure_question(sa_id, { question_key = "sa110_student_loan_due",
+            label = "Student Loan repayment due (box 3)",
+            question_type = "currency", is_required = false, display_order = 3 })
+        ensure_question(sa_id, { question_key = "sa110_postgraduate_loan_due",
+            label = "Postgraduate Loan repayment due (box 3.1)",
+            question_type = "currency", is_required = false, display_order = 4 })
+        ensure_question(sa_id, { question_key = "sa110_class4_nics_due",
+            label = "Class 4 NICs due (box 4)",
+            question_type = "currency", is_required = false, display_order = 5,
+            help_text = "Only applies to self-employed profits above the Lower Profits Limit." })
+        ensure_question(sa_id, { question_key = "sa110_class2_nics_due",
+            label = "Class 2 NICs due (box 4.1)",
+            question_type = "currency", is_required = false, display_order = 6 })
+        ensure_question(sa_id, { question_key = "sa110_capital_gains_tax_due",
+            label = "Capital Gains Tax due (box 5)",
+            question_type = "currency", is_required = false, display_order = 7 })
+        ensure_question(sa_id, { question_key = "sa110_pension_charges_due",
+            label = "Pension charges due (box 6)",
+            question_type = "currency", is_required = false, display_order = 8,
+            help_text = "Annual allowance charge, lifetime allowance charge, unauthorised payments — see the SA110 notes." })
+    end
+
+    -- ── Section 2: Underpaid tax and other debts ────────────────────
+    local ut_id = ensure_category(
+        "sa110-underpaid-tax", "Underpaid tax and other debts",
+        "Figures from your P2 PAYE Coding Notice — earlier-year and current-year underpayments, plus any outstanding debt included in your code.",
+        "pound-sign", 2)
+    if ut_id then
+        ensure_question(ut_id, { question_key = "sa110_underpaid_earlier_years",
+            label = "Underpaid tax for earlier years in your 2025-26 code (box 7)",
+            question_type = "currency", is_required = false, display_order = 1,
+            help_text = "Shown as 'amount of underpaid tax for earlier years' on your P2." })
+        ensure_question(ut_id, { question_key = "sa110_underpaid_2025_26",
+            label = "Underpaid tax for 2025-26 in your 2026-27 code (box 8)",
+            question_type = "currency", is_required = false, display_order = 2,
+            help_text = "Shown as 'estimated underpayment for 2025-26' on your P2." })
+        ensure_question(ut_id, { question_key = "sa110_outstanding_debt",
+            label = "Outstanding debt in your 2025-26 code (box 9)",
+            question_type = "currency", is_required = false, display_order = 3,
+            help_text = "The debt figure from your P2." })
+    end
+
+    -- ── Section 3: Payments on account ──────────────────────────────
+    local poa_id = ensure_category(
+        "sa110-payments-on-account", "Payments on account",
+        "Claim to reduce your 2026-27 payments on account and (if so) your first reduced payment.",
+        "pound-sign", 3)
+    if poa_id then
+        ensure_question(poa_id, { question_key = "sa110_reduce_poa_claim",
+            label = "Claim to reduce 2026-27 payments on account (box 10)",
+            question_type = "boolean", is_required = false, display_order = 1,
+            help_text = "Tick this box if you're claiming to reduce your 2026-27 payments on account. Say WHY in box 17 (Any other information)." })
+        ensure_question(poa_id, { question_key = "sa110_first_poa_amount",
+            label = "Your first payment on account for 2026-27, including pence (box 11)",
+            question_type = "currency", is_required = false, display_order = 2,
+            help_text = "The reduced amount you're claiming. Only needed if you ticked the box above." })
+    end
+
+    -- ── Section 4: Blind person's + married couple's surplus ────────
+    local sa_al_id = ensure_category(
+        "sa110-surplus-allowances", "Blind person's and married couple's surplus allowance",
+        "Enter the surplus allowance transferred from your spouse or civil partner.",
+        "pound-sign", 4)
+    if sa_al_id then
+        ensure_question(sa_al_id, { question_key = "sa110_blind_person_surplus",
+            label = "Blind person's surplus allowance you can have (box 12)",
+            question_type = "currency", is_required = false, display_order = 1 })
+        ensure_question(sa_al_id, { question_key = "sa110_married_couple_surplus",
+            label = "Married couple's surplus allowance you can have (box 13)",
+            question_type = "currency", is_required = false, display_order = 2,
+            help_text = "Only if you or your spouse or civil partner were born before 6 April 1935." })
+    end
+
+    -- ── Section 5: Adjustments to tax due ───────────────────────────
+    local adj_id = ensure_category(
+        "sa110-adjustments", "Adjustments to tax due",
+        "Adjustments calculated by reference to an earlier year (averaging for farmers/creators, loss carry-back, etc.).",
+        "pound-sign", 5)
+    if adj_id then
+        ensure_question(adj_id, { question_key = "sa110_increase_earlier_year",
+            label = "Increase in tax due because of adjustments to an earlier year (box 14)",
+            question_type = "currency", is_required = false, display_order = 1 })
+        ensure_question(adj_id, { question_key = "sa110_decrease_earlier_year",
+            label = "Decrease in tax due because of adjustments to an earlier year (box 15)",
+            question_type = "currency", is_required = false, display_order = 2 })
+        ensure_question(adj_id, { question_key = "sa110_repayment_2026_27_now",
+            label = "Any 2026-27 repayment you're claiming now (box 16)",
+            question_type = "currency", is_required = false, display_order = 3,
+            help_text = "A credit that appears on your Self Assessment statement of account and is set against other amounts to be paid — doesn't affect boxes 1 to 6." })
+    end
+
+    -- ── Section 6: Any other information ────────────────────────────
+    local other_id = ensure_category(
+        "sa110-other-info", "Any other information",
+        "Free-form notes to HMRC — use this to explain any reduced payment on account claim, unusual adjustments, or context they need.",
+        "pound-sign", 6)
+    if other_id then
+        ensure_question(other_id, { question_key = "sa110_other_information",
+            label = "Please give any other information in this space (box 17)",
+            question_type = "long_text", is_required = false, display_order = 1,
+            help_text = "Required if you ticked box 10 (reduced payments-on-account claim) — HMRC wants a reason. Otherwise optional." })
+    end
+
+    print("[SA110] Seeded income_types row + 6 categories + 17 questions under context='sa110' (answer_scope='year')")
+end
+
+return {
+    -- =========================================================================
+    -- 1. Original seed pass. Registered as 766 in migrations.lua.
+    -- =========================================================================
+    [1] = seed_sa110_catalog,
+
+    -- =========================================================================
+    -- 2. Re-run pass. Registered as 767 in migrations.lua. Safety net
+    --    for future edits to this file (same convention as the pension
+    --    catalog's 764 and the salary catalog's 760). Fresh envs where
+    --    [1] fully succeeded treat [2] as an idempotent no-op.
+    -- =========================================================================
+    [2] = seed_sa110_catalog,
+}

--- a/lapis/queries/FormSectionQueries.lua
+++ b/lapis/queries/FormSectionQueries.lua
@@ -859,43 +859,73 @@ function FormSectionQueries.card_summary(user)
         pension_entry.row_count = tonumber(pension_row[1].row_count) or 0
     end
 
-    -- ── Dividends ───────────────────────────────────────────────────
-    -- Dividends never had tax_form_* rows — it's inline in the
-    -- /my-income/[type] dispatcher's PROFILE_BUILDER_CONTEXTS map, so
-    -- card_summary NEVER surfaced it before this branch existed. Users
-    -- had figures on /my-income/dividends but /my-income showed
-    -- "Nothing recorded yet" for the type — exactly the same symptom
-    -- salary just hit.
+    -- ── Generic profile-builder totals (dividends, SA110, and any
+    --    future admin-added income type) ─────────────────────────────
+    -- Previously this was a hardcoded per-type branch: dividends
+    -- explicit, plus a comment "add SA110 here later, etc". That
+    -- broke the "admin adds a section and it ships" promise the
+    -- frontend just delivered via auto-discovery (feat/sa110-...
+    -- retired PROFILE_BUILDER_CONTEXTS). This is the backend
+    -- companion — one query that covers every income_type whose key
+    -- matches a profile_categories.context, so a new type + category
+    -- combination lands on /my-income overview automatically.
     --
-    -- Total = SUM currency answers for questions in category
-    -- context='dividends' (avoids hardcoding the sa100_* question_key
-    -- list — admin can add a new dividends field via the admin UI and
-    -- the total picks it up next call).
-    -- Count = number of question_keys with a non-null numeric answer.
-    -- One row means "this type has SOMETHING recorded"; the number
-    -- itself isn't user-surfaced beyond the hasEntries threshold.
-    local dividends_row = db.query([[
-        SELECT
-          COALESCE(SUM(a.answer_number), 0) AS total,
-          COUNT(a.id)                       AS row_count
+    -- What's summed
+    --   total     SUM(answer_number) — every numeric answer under
+    --             the type's categories. Adminstrictly-numeric
+    --             questions (currency / number / percentage) are the
+    --             only ones with answer_number populated; text /
+    --             boolean / date answers are naturally excluded.
+    --   row_count number of distinct question_ids with a non-null
+    --             numeric answer. Value isn't user-surfaced beyond
+    --             the hasEntries threshold; 1 or more means "this
+    --             type has data".
+    --
+    -- What's excluded
+    --   salary + pension_payments — handled by explicit branches
+    --   above with type-specific sum logic (entity-scoped for
+    --   salary, aggregated JSON arrays for pension). Skipped in the
+    --   NOT IN filter so their pb totals aren't overwritten by this
+    --   generic sum, which would double-count for salary (already
+    --   summed by employment_type) or be zero for pension (numeric
+    --   values live in answer_json, not answer_number).
+    --
+    --   Per-entity contexts (property, business, overseas_property,
+    --   rental_business, employment) — these DON'T correspond 1:1 to
+    --   an income_type_key (rental hub is 'rental', not
+    --   'rental_business'; self-employment hub is 'self_employment',
+    --   not 'business'; etc.). They're joined via the entity's own
+    --   income type, not the context string. Filter by requiring
+    --   the join on income_types to succeed.
+    --
+    -- Categories with no matching income_types row are skipped by
+    -- the JOIN — admin creating a profile_categories.context that
+    -- doesn't match an income_type_key won't leak orphan rows here.
+    local generic_rows = db.query([[
+        SELECT it.income_type_key,
+               COALESCE(SUM(a.answer_number), 0) AS total,
+               COUNT(DISTINCT a.question_id)    AS row_count
         FROM user_profile_answers a
         JOIN profile_questions q  ON q.id = a.question_id
         JOIN profile_categories c ON c.id = q.category_id
+        JOIN income_types it      ON it.income_type_key = c.context
         WHERE a.user_id = ?
-          AND c.context = 'dividends'
+          AND it.income_type_key NOT IN ('salary', 'pension_payments')
           AND c.is_active = true
           AND c.is_archived = false
+          AND it.is_active = true
           AND a.answer_number IS NOT NULL
-    ]], internal_user_id)
-    if dividends_row and dividends_row[1] then
-        local dividends_entry = by_type["dividends"]
-        if not dividends_entry then
-            dividends_entry = { income_type_key = "dividends", total = 0, row_count = 0 }
-            out[#out + 1] = dividends_entry
-            by_type["dividends"] = dividends_entry
+        GROUP BY it.income_type_key
+    ]], internal_user_id) or {}
+    for _, r in ipairs(generic_rows) do
+        local entry = by_type[r.income_type_key]
+        if not entry then
+            entry = { income_type_key = r.income_type_key, total = 0, row_count = 0 }
+            out[#out + 1] = entry
+            by_type[r.income_type_key] = entry
         end
-        dividends_entry.total = tonumber(dividends_row[1].total) or 0
-        dividends_entry.row_count = tonumber(dividends_row[1].row_count) or 0
+        entry.total = tonumber(r.total) or 0
+        entry.row_count = tonumber(r.row_count) or 0
     end
 
     return out


### PR DESCRIPTION
## Summary

Ports HMRC's SA110 form (17 boxes / 6 sections) into the unified Profile Builder store so \`/my-income/sa110\` renders via the same engine as dividends without a per-page code change on the frontend.

Ships one migration file: 1 \`income_types\` row + 6 \`profile_categories\` + 17 \`profile_questions\` under \`context='sa110'\`, \`answer_scope='year'\`.

## SA110 mapping

| Section | Category slug | Fields | Type |
|---|---|---|---|
| Self Assessment | \`sa110-self-assessment\` | 8 (boxes 1, 2, 3, 3.1, 4, 4.1, 5, 6) | currency |
| Underpaid tax + other debts | \`sa110-underpaid-tax\` | 3 (boxes 7, 8, 9) | currency |
| Payments on account | \`sa110-payments-on-account\` | 2 (box 10 boolean + box 11 currency) | mixed |
| Blind person's + married couple's surplus | \`sa110-surplus-allowances\` | 2 (boxes 12, 13) | currency |
| Adjustments to tax due | \`sa110-adjustments\` | 3 (boxes 14, 15, 16) | currency |
| Any other information | \`sa110-other-info\` | 1 (box 17) | long_text |

Each question carries the SA110 box number in its label and plain-English help_text derived from the reference form's notes.

## Design choices

- \`allows_manual_entry=false\` on the income_types row — SA110 is a calculation summary, not an income source; a flat-entry my_incomes row typed 'sa110' would be miscounted as trading income.
- Same nil-safe helper pattern (\`nn(v) = v ~= nil and v or db.NULL\`) as pension + salary catalogs — protects against Lua vararg truncation at first nil.
- Two-step file: [1] seed, [2] re-run safety-net. Same convention as pension's 764 and salary's 760.
- Registered as 766 (seed) + 767 (re-run) in migrations.lua. Feature-gated on TAX_COPILOT.

## Companion frontend PR

Sibling PR on \`bwalia/diy-tax-return-uk\` retires the hardcoded \`PROFILE_BUILDER_CONTEXTS\` map in \`/my-income/[type]/page.tsx\` and replaces it with runtime discovery via \`profileSchemaApi.get({ context: typeKey })\`. Once both PRs merge, \`/my-income/sa110\` renders the 17 boxes with zero per-type frontend registration — and every FUTURE income type added by an admin gets the same treatment automatically.

## Non-goals

- No backfill — SA110 has no legacy Form Sections rows to port.
- No opsapi routing change — the profile-builder schema/answer routes already handle year-scoped contexts unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)