### PR TITLE
feat(income-types): admin-configurable linked HMRC form metadata

### DIFF
--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -252,6 +252,15 @@ local sa110_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "mi
 -- so there is no backfill/fork pair. Gated on TAX_COPILOT.
 local sa108_capital_gains_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.sa108-capital-gains-questions") or {}
 
+-- Adds admin-configurable linked-form metadata columns to income_types
+-- (linked_form_title / linked_form_description / linked_form_weblink)
+-- so the "SA100 boxes — {year}" card header on /my-income/[type] stops
+-- being hardcoded and starts naming the actual reference form the
+-- admin has associated with the type. Step 1 = ALTER TABLE, step 2 =
+-- seed sensible defaults for the 8 known income types (COALESCE — never
+-- overwrites admin edits).
+local income_types_linked_form_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.income-types-linked-form-metadata") or {}
+
 -- Billing / payments (Stripe Connect: subscriptions + one-time). Gated on
 -- tax_copilot for now; broaden to a feature list (e.g. {ECOMMERCE, TAX_COPILOT})
 -- once multiple project codes need it. See migrations/billing-system.lua.
@@ -2090,6 +2099,11 @@ local _migrations = {
     -- No backfill step: capital gains never had a legacy engine store.
     ['768_seed_sa108_capital_gains_categories'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, sa108_capital_gains_migrations, 1),
     ['769_seed_sa108_capital_gains_questions'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, sa108_capital_gains_migrations, 2),
+    -- 770/771 — linked-form metadata columns on income_types + seed
+    -- defaults for the 8 known types. Retires the hardcoded
+    -- "SA100 boxes" card header on /my-income/[type]. Both idempotent.
+    ['770_add_income_types_linked_form_columns'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, income_types_linked_form_migrations, 1),
+    ['771_seed_income_types_linked_form_defaults'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, income_types_linked_form_migrations, 2),
 
     -- =========================================================================
     -- Academy (LMS): courses + lessons (namespace-scoped). Feature-gated, so

--- a/lapis/migrations/income-types-linked-form-metadata.lua
+++ b/lapis/migrations/income-types-linked-form-metadata.lua
@@ -1,0 +1,130 @@
+--[[
+  Adds admin-configurable "linked HMRC form" metadata to income_types.
+
+  Motivation: /my-income/[type] rendered a HARDCODED "SA100 boxes —
+  {year}" header above the profile-builder ContextSections region.
+  The label was accurate for dividends (SA100) but wrong for anything
+  else — SA110 users saw the SA100 label above SA110 boxes, SA108
+  users saw it above SA108 boxes, and every future income type would
+  either have to accept the misleading header or force a
+  per-type code change to the frontend.
+
+  Solution: three optional metadata columns on income_types that let
+  admins name the reference form themselves, describe what the fields
+  map to, and link the HMRC PDF as an external reference.
+
+    linked_form_title       varchar(120)  e.g. "SA100" / "SA110" / "SA108"
+    linked_form_description text          e.g. "These fields map directly
+                                               to the SA100 form."
+    linked_form_weblink     text          e.g. https://assets.publishing
+                                               .service.gov.uk/.../SA110-2026.pdf
+
+  Rendered by the frontend as: card header showing the title (when
+  set), the description below it, and — when weblink is set — an
+  "Open reference form ↗" link that opens the PDF in a new tab
+  (target="_blank" rel="noopener noreferrer" — the noreferrer half
+  strips Referer so HMRC's server doesn't get a trail of who
+  opened it from where).
+
+  All three columns nullable — a type without them still renders,
+  just without the reference-form card. Empty string treated as
+  "not set" on the frontend (matches how income_types.description
+  is already handled).
+
+  IF NOT EXISTS on every ADD COLUMN so a re-run on an env where
+  the columns already exist is a no-op. Only executed when
+  PROJECT_CODE includes 'tax_copilot'.
+]]
+
+local db = require("lapis.db")
+
+return {
+    -- =========================================================================
+    -- 1. Add the three linked-form columns to income_types. All nullable
+    --    — a type without them renders unchanged.
+    -- =========================================================================
+    [1] = function()
+        db.query([[
+            ALTER TABLE income_types
+              ADD COLUMN IF NOT EXISTS linked_form_title       VARCHAR(120),
+              ADD COLUMN IF NOT EXISTS linked_form_description TEXT,
+              ADD COLUMN IF NOT EXISTS linked_form_weblink     TEXT
+        ]])
+        print("[income_types] Added linked_form_title / linked_form_description / linked_form_weblink columns")
+    end,
+
+    -- =========================================================================
+    -- 2. Seed the initial known types with sensible defaults so admins
+    --    see the reference-form card without having to fill in every
+    --    type by hand. Admin can edit any of these values via
+    --    /admin/income-types afterwards. Idempotent — UPDATE with a
+    --    WHERE guard so a row where the admin has already customised
+    --    the copy isn't clobbered on re-run.
+    -- =========================================================================
+    [2] = function()
+        local seeds = {
+            {
+                key = "dividends",
+                title = "SA100",
+                description = "These fields map directly to the SA100 form.",
+                weblink = "https://assets.publishing.service.gov.uk/media/6874c86d4c1a4020117e9d68/SA100-2025.pdf",
+            },
+            {
+                key = "salary",
+                title = "SA102",
+                description = "These fields map directly to the SA102 Employment supplementary form.",
+                weblink = "https://assets.publishing.service.gov.uk/media/6874ca9c66bef7d5e5b60fc7/SA102-2025.pdf",
+            },
+            {
+                key = "pension_payments",
+                title = "SA100 TR4",
+                description = "These fields map to the 'Tax reliefs' section on page TR4 of the SA100 form.",
+                weblink = "https://assets.publishing.service.gov.uk/media/6874c86d4c1a4020117e9d68/SA100-2025.pdf",
+            },
+            {
+                key = "sa110",
+                title = "SA110",
+                description = "These fields map directly to the SA110 Tax calculation summary form.",
+                weblink = "https://assets.publishing.service.gov.uk/media/68af7c2fe1055f748d55c184/SA110-2026.pdf",
+            },
+            {
+                key = "sa108",
+                title = "SA108",
+                description = "These fields map directly to the SA108 Capital Gains Tax summary form.",
+                weblink = "https://assets.publishing.service.gov.uk/media/6874ca08d24a86df80b8ceac/SA108-2025.pdf",
+            },
+            {
+                key = "rental",
+                title = "SA105",
+                description = "These fields map directly to the SA105 UK property supplementary form.",
+                weblink = "https://assets.publishing.service.gov.uk/media/6874c94af6a03e18e2ca4a3d/SA105-2025.pdf",
+            },
+            {
+                key = "self_employment",
+                title = "SA103",
+                description = "These fields map to the SA103 Self-employment supplementary form.",
+                weblink = "https://assets.publishing.service.gov.uk/media/6874c8cd63b78ce8bc3c2f5b/SA103F-2025.pdf",
+            },
+            {
+                key = "overseas_property",
+                title = "SA106",
+                description = "These fields map to the SA106 Foreign income supplementary form.",
+                weblink = "https://assets.publishing.service.gov.uk/media/6874c9e963b78ce8bc3c2f78/SA106-2025.pdf",
+            },
+        }
+        for _, s in ipairs(seeds) do
+            -- Only fill columns that are still NULL — never overwrite
+            -- an admin's manual edit. COALESCE keeps existing values
+            -- intact while filling the blanks.
+            db.query([[
+                UPDATE income_types
+                   SET linked_form_title       = COALESCE(linked_form_title, ?),
+                       linked_form_description = COALESCE(linked_form_description, ?),
+                       linked_form_weblink     = COALESCE(linked_form_weblink, ?),
+                       updated_at              = NOW()
+                 WHERE income_type_key = ?
+            ]], s.title, s.description, s.weblink, s.key)
+        end
+        print("[income_types] Seeded linked-form defaults for 8 known income types (COALESCE — never overwrites admin edits)")
+    end,
+}

--- a/lapis/queries/IncomeTypeQueries.lua
+++ b/lapis/queries/IncomeTypeQueries.lua
@@ -134,14 +134,19 @@ function IncomeTypeQueries.create(body)
     end
 
     local uuid = Global.generateUUID()
+    -- linked_form_* columns are admin-configurable metadata pointing at
+    -- the HMRC reference form for this income type (SA100/SA110/SA108/
+    -- etc). All three optional — nil coerces to db.NULL. Rendered by
+    -- the frontend as a small reference card on /my-income/[type].
     db.query([[
         INSERT INTO income_types
             (uuid, income_type_key, display_name, description,
              required_documents, allows_manual_entry,
              keyword_rules, category_affinity, rules_markdown,
              hmrc_mapping, display_order, is_active, namespace_id,
+             linked_form_title, linked_form_description, linked_form_weblink,
              created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?::jsonb, ?, ?::jsonb, ?::jsonb, ?, ?::jsonb, ?, ?, ?, NOW(), NOW())
+        VALUES (?, ?, ?, ?, ?::jsonb, ?, ?::jsonb, ?::jsonb, ?, ?::jsonb, ?, ?, ?, ?, ?, ?, NOW(), NOW())
     ]],
         uuid,
         body.income_type_key,
@@ -155,7 +160,10 @@ function IncomeTypeQueries.create(body)
         enc_json(body.hmrc_mapping, false),
         body.display_order or 100,
         body.is_active ~= false,                     -- default true
-        body.namespace_id or db.NULL
+        body.namespace_id or db.NULL,
+        body.linked_form_title or db.NULL,
+        body.linked_form_description or db.NULL,
+        body.linked_form_weblink or db.NULL
     )
 
     local created = db.query("SELECT * FROM income_types WHERE uuid = ?", uuid)
@@ -188,6 +196,14 @@ function IncomeTypeQueries.update(uuid, body)
     add("hmrc_mapping", body.hmrc_mapping, "object")
     add("rules_markdown", body.rules_markdown)
     add("display_order", body.display_order)
+    -- Linked-form metadata — admin renames the reference form (SA110 →
+    -- SA103) via the /admin/income-types edit modal and this catches
+    -- it. Empty string is a valid "clear" operation (add() only skips
+    -- when the field is nil, not when it's ""), so a partial payload
+    -- doesn't accidentally wipe a value the admin didn't touch.
+    add("linked_form_title", body.linked_form_title)
+    add("linked_form_description", body.linked_form_description)
+    add("linked_form_weblink", body.linked_form_weblink)
     -- Booleans handled explicitly: Lua truthiness would coerce a JSON false.
     if body.allows_manual_entry ~= nil then
         table.insert(sets, "allows_manual_entry = " ..

--- a/lapis/routes/my-incomes.lua
+++ b/lapis/routes/my-incomes.lua
@@ -127,6 +127,16 @@ return function(app)
                 description = r.description,
                 required_documents = docs,
                 allows_manual_entry = r.allows_manual_entry,
+                -- Admin-configured "linked HMRC form" metadata (SA100 /
+                -- SA110 / SA108 / etc). Rendered as a small reference card
+                -- above the profile-builder ContextSections on
+                -- /my-income/[type]. All three optional — omit or blank
+                -- either field and the frontend renders the fallback layout.
+                -- See migration income-types-linked-form-metadata for the
+                -- column semantics + initial seed defaults.
+                linked_form_title = r.linked_form_title,
+                linked_form_description = r.linked_form_description,
+                linked_form_weblink = r.linked_form_weblink,
             }
         end
         -- Force [] (not {}) when empty so JSON consumers that do


### PR DESCRIPTION
## Summary

Retires the hardcoded \"SA100 boxes — {year}\" card header on \`/my-income/[type]\`. Three new nullable columns on \`income_types\` plus pass-through wiring on read + write endpoints so admins name the reference form for each income type themselves — SA100 for dividends, SA110 for tax calc summary, SA108 for CGT, and any future type an admin adds.

## What ships

- **Migration 770/771** — new file \`income-types-linked-form-metadata.lua\`:
  - Step 1: \`ALTER TABLE income_types ADD COLUMN IF NOT EXISTS\` for \`linked_form_title\` (varchar 120), \`linked_form_description\` (text), \`linked_form_weblink\` (text). All nullable.
  - Step 2: seed sensible defaults for the 8 known income types (dividends → SA100, salary → SA102, pension → SA100 TR4, sa110 → SA110, sa108 → SA108, rental → SA105, self_employment → SA103, overseas_property → SA106). Uses COALESCE so admin edits that land before the seed run aren't overwritten.

- \`GET /api/v2/tax/my-incomes/types\` — 3 new fields in each row.
- \`POST /api/v2/tax/admin/income-types\` — INSERT now includes the 3 columns.
- \`PUT /api/v2/tax/admin/income-types/:uuid\` — UPDATE via existing add() helper; empty string is a valid \"clear\" operation (add skips only on nil), so a partial payload can't accidentally wipe untouched values.

## Companion frontend PR

Sibling PR on \`bwalia/diy-tax-return-uk\` consumes these fields (renders the reference-form card + adds the 3 fields to the admin edit modal). Should merge together — this backend alone is inert without the frontend consumer.

## Non-goals

- No URL validation on the weblink. Trust the admin — HMRC URLs change format occasionally and hardcoding a regex would make failures less obvious.
- No new admin endpoint — the existing create + update paths already exist; this just adds three optional fields to the payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)