### PR TITLE
feat(academy): admin-approval gate + webhook idempotency + content-type-aware parse_body

### DIFF
--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -2203,6 +2203,8 @@ local _migrations = {
     -- progress migrations and 819/820/821 are tax identity-lock — distinct features,
     -- but 822 is free everywhere, avoiding any numeric-prefix dedup in the `all` preset.
     ['822_seed_academy_namespace'] = conditional_array(ProjectConfig.FEATURES.ACADEMY, academy_migrations, 6),
+    -- Admin-approval gate: widen the course status CHECK to allow pending_review.
+    ['823_academy_course_pending_review'] = conditional_array(ProjectConfig.FEATURES.ACADEMY, academy_migrations, 7),
     -- Academy sidebar menu item + RBAC module ("courses") + role grants
     ['804_seed_academy_menu_items'] = conditional_array(ProjectConfig.FEATURES.ACADEMY, academy_menu_migrations, 1),
     ['805_register_academy_modules'] = conditional_array(ProjectConfig.FEATURES.ACADEMY, academy_menu_migrations, 2),

--- a/lapis/migrations/academy-system.lua
+++ b/lapis/migrations/academy-system.lua
@@ -372,4 +372,32 @@ return {
             end
         end
     end,
+
+    -- ========================================================================
+    -- [7] Admin-approval gate: allow the `pending_review` course status.
+    --
+    -- Instructors submit into pending_review and only an admin can move a course
+    -- on to `published` (enforced in routes/academy.lua). The public endpoints
+    -- already show only `published`, so this state is invisible to learners.
+    --
+    -- The original CHECK constraint (created in [1]) forbids the new value, so it
+    -- must be dropped and recreated. Idempotent and safe to re-run: DROP uses IF
+    -- EXISTS, the constraint name is stable, and it only WIDENS the allowed set,
+    -- never rewriting a row.
+    -- ========================================================================
+    [7] = function()
+        pcall(function()
+            db.query([[
+                ALTER TABLE academy_courses
+                DROP CONSTRAINT IF EXISTS academy_courses_status_check
+            ]])
+        end)
+        pcall(function()
+            db.query([[
+                ALTER TABLE academy_courses
+                ADD CONSTRAINT academy_courses_status_check
+                CHECK (status IN ('draft', 'pending_review', 'published', 'archived'))
+            ]])
+        end)
+    end,
 }

--- a/lapis/routes/academy-admin.lua
+++ b/lapis/routes/academy-admin.lua
@@ -16,14 +16,35 @@ local PayoutQueries = require("queries.PayoutQueries")
 local AuthMiddleware = require("middleware.auth")
 
 return function(app)
+    -- Parse a JSON or form-encoded body into a table.
+    -- get_post_args() parses ANY body as urlencoded, which turns a JSON body into
+    -- a single bogus key (silently dropping the real fields). Only take the form
+    -- fast path when the client didn't declare JSON. Large bodies spill to a temp
+    -- file, so we fall back to reading the body file and parsing it ourselves.
     local function parse_body()
         ngx.req.read_body()
-        local post_args = ngx.req.get_post_args()
-        if post_args and next(post_args) then return post_args end
+
+        local ctype = ngx.var.content_type or ""
+        local is_json = ctype:find("application/json", 1, true) ~= nil
+
+        if not is_json then
+            local post_args = ngx.req.get_post_args()
+            if post_args and next(post_args) then return post_args end
+        end
+
         local body = ngx.req.get_body_data()
+        if not body or body == "" then
+            local path = ngx.req.get_body_file()
+            if path then
+                local f = io.open(path, "rb")
+                if f then body = f:read("*a"); f:close() end
+            end
+        end
         if not body or body == "" then return {} end
+
         local ok, decoded = pcall(cJson.decode, body)
         if ok and type(decoded) == "table" then return decoded end
+
         local args = ngx.decode_args(body)
         return type(args) == "table" and args or {}
     end

--- a/lapis/routes/academy-billing.lua
+++ b/lapis/routes/academy-billing.lua
@@ -64,10 +64,22 @@ local BANK_OUT_FIELDS = {
 }
 
 return function(app)
+    -- Parse a JSON or form-encoded body into a table.
+    -- get_post_args() parses ANY body as urlencoded, which turns a JSON body into
+    -- a single bogus key (silently dropping the real fields). Only take the form
+    -- fast path when the client didn't declare JSON. Large bodies spill to a temp
+    -- file, so we fall back to reading the body file and parsing it ourselves.
     local function parse_body()
         ngx.req.read_body()
-        local post_args = ngx.req.get_post_args()
-        if post_args and next(post_args) then return post_args end
+
+        local ctype = ngx.var.content_type or ""
+        local is_json = ctype:find("application/json", 1, true) ~= nil
+
+        if not is_json then
+            local post_args = ngx.req.get_post_args()
+            if post_args and next(post_args) then return post_args end
+        end
+
         local body = ngx.req.get_body_data()
         if not body or body == "" then
             local path = ngx.req.get_body_file()
@@ -77,8 +89,10 @@ return function(app)
             end
         end
         if not body or body == "" then return {} end
+
         local ok, decoded = pcall(cJson.decode, body)
         if ok and type(decoded) == "table" then return decoded end
+
         local args = ngx.decode_args(body)
         return type(args) == "table" and args or {}
     end

--- a/lapis/routes/academy-stripe-webhook.lua
+++ b/lapis/routes/academy-stripe-webhook.lua
@@ -21,16 +21,40 @@ local PayoutQueries = require("queries.PayoutQueries")
 local CourseQueries = require("queries.CourseQueries")
 
 return function(app)
-    -- Idempotency: true if already handled. Inserts the marker; a unique-violation
-    -- race also counts as "already processed".
-    local function already_processed(event_id, etype)
+    -- Idempotency, part 1 (read-only): has this event already been fully
+    -- processed and committed? The marker is written LAST, inside the same
+    -- transaction as the side effects (see below), so its presence guarantees
+    -- the side effects landed. A missing marker means genuine reprocessing is
+    -- safe — which is exactly what we want after a mid-handler failure.
+    local function is_processed(event_id)
         local rows = db.query("SELECT 1 FROM processed_stripe_events WHERE event_id = ? LIMIT 1", event_id)
-        if rows and #rows > 0 then return true end
-        local ok = pcall(function()
-            db.query("INSERT INTO processed_stripe_events (event_id, type, created_at) VALUES (?, ?, NOW())",
-                event_id, etype)
-        end)
-        return not ok
+        return rows ~= nil and #rows > 0
+    end
+
+    -- Idempotency, part 2 (write): mark the event processed. Called as the FINAL
+    -- statement inside the side-effect transaction. The unique index on event_id
+    -- doubles as the concurrency guard: if two deliveries of the same event race,
+    -- one INSERT blocks then raises a unique violation, aborting that whole
+    -- transaction (rolling back its partial side effects) — so a duplicate can
+    -- never write the ledger twice.
+    local function mark_processed(event_id, etype)
+        db.query("INSERT INTO processed_stripe_events (event_id, type, created_at) VALUES (?, ?, NOW())",
+            event_id, etype)
+    end
+
+    -- Run fn inside a DB transaction. Any error (from a side effect OR the marker
+    -- INSERT) rolls back EVERYTHING — including the idempotency marker — so the
+    -- event stays un-marked and Stripe's retry genuinely reprocesses it. Returns
+    -- (true) on commit, or (false, err) on rollback.
+    local function in_transaction(fn)
+        db.query("BEGIN")
+        local ok, err = pcall(fn)
+        if ok then
+            db.query("COMMIT")
+            return true
+        end
+        pcall(function() db.query("ROLLBACK") end)
+        return false, err
     end
 
     local function raw_body()
@@ -59,61 +83,95 @@ return function(app)
             return { status = 400, json = { error = "invalid signature" } }
         end
 
-        if already_processed(event.id, event.type) then
+        -- Genuine duplicate (already committed) — short-circuit. A missing marker
+        -- after an earlier failure is NOT a duplicate: we fall through and reprocess.
+        if is_processed(event.id) then
             return { status = 200, json = { received = true, duplicate = true } }
         end
 
         local obj = (event.data and event.data.object) or {}
         local t = event.type
 
-        if t == "checkout.session.completed" then
-            local md = obj.metadata or {}
-            local ns_id = tonumber(md.namespace_id)
-            if md.kind == "course" and ns_id and tonumber(md.course_id) and md.user_uuid then
-                pcall(EnrollmentQueries.enroll, ns_id, tonumber(md.course_id), md.user_uuid)
-                -- Attribute the sale to the course owner (the instructor). Legacy /
-                -- admin-owned courses may have no owner -> platform revenue.
-                local course = CourseQueries.findById(ns_id, tonumber(md.course_id))
-                PayoutQueries.recordSale({
-                    user_uuid = md.user_uuid, namespace_id = ns_id, course_id = tonumber(md.course_id),
-                    seller_user_uuid = course and course.owner_user_uuid or nil,
-                    kind = "course", stripe_ref = obj.payment_intent, amount = obj.amount_total, currency = obj.currency,
-                })
-            elseif md.kind == "subscription" and ns_id and md.user_uuid and obj.subscription then
-                local subobj = Stripe.new():retrieve_subscription(obj.subscription)
-                SubscriptionQueries.upsert({
-                    user_uuid = md.user_uuid, namespace_id = ns_id,
-                    stripe_subscription_id = obj.subscription, stripe_customer_id = obj.customer,
-                    status = subobj and subobj.status or "active",
-                    current_period_end_unix = subobj and subobj.current_period_end or nil,
-                })
-                -- First payment: record the ledger entry here (renewals come via invoice.paid).
-                PayoutQueries.recordSale({
-                    user_uuid = md.user_uuid, namespace_id = ns_id, kind = "subscription",
-                    stripe_ref = obj.subscription, amount = obj.amount_total, currency = obj.currency,
-                })
-            end
+        -- Fetch any external Stripe data BEFORE opening the transaction: a Stripe
+        -- HTTP round-trip must not hold a DB transaction (and its row locks) open.
+        -- A failed fetch here just means the sub object stays nil; we degrade the
+        -- same way the original code did (default status "active", no period end).
+        local subobj = nil
+        local need_sub =
+            (t == "checkout.session.completed" and (obj.metadata or {}).kind == "subscription" and obj.subscription) or
+            (t == "invoice.paid" and obj.subscription)
+        if need_sub then
+            local ok_fetch, res = pcall(function() return Stripe.new():retrieve_subscription(obj.subscription) end)
+            if ok_fetch then subobj = res end
+        end
 
-        elseif t == "invoice.paid" then
-            if obj.subscription then
-                local subobj = Stripe.new():retrieve_subscription(obj.subscription)
-                if subobj then
-                    SubscriptionQueries.updateStatusByStripeId(obj.subscription, subobj.status, subobj.current_period_end)
+        -- All persistent side effects run inside ONE transaction, and the
+        -- idempotency marker is written as its LAST statement. Any failure rolls
+        -- back the marker together with the partial side effects, so nothing is
+        -- half-written and Stripe's retry reprocesses the whole event cleanly.
+        local ok, err = in_transaction(function()
+            if t == "checkout.session.completed" then
+                local md = obj.metadata or {}
+                local ns_id = tonumber(md.namespace_id)
+                if md.kind == "course" and ns_id and tonumber(md.course_id) and md.user_uuid then
+                    -- Enroll + ledger are now atomic: if the ledger write fails the
+                    -- enrollment rolls back too, so the buyer is never granted access
+                    -- without the instructor's earnings row being recorded.
+                    EnrollmentQueries.enroll(ns_id, tonumber(md.course_id), md.user_uuid)
+                    -- Attribute the sale to the course owner (the instructor). Legacy /
+                    -- admin-owned courses may have no owner -> platform revenue.
+                    local course = CourseQueries.findById(ns_id, tonumber(md.course_id))
+                    PayoutQueries.recordSale({
+                        user_uuid = md.user_uuid, namespace_id = ns_id, course_id = tonumber(md.course_id),
+                        seller_user_uuid = course and course.owner_user_uuid or nil,
+                        kind = "course", stripe_ref = obj.payment_intent, amount = obj.amount_total, currency = obj.currency,
+                    })
+                elseif md.kind == "subscription" and ns_id and md.user_uuid and obj.subscription then
+                    SubscriptionQueries.upsert({
+                        user_uuid = md.user_uuid, namespace_id = ns_id,
+                        stripe_subscription_id = obj.subscription, stripe_customer_id = obj.customer,
+                        status = subobj and subobj.status or "active",
+                        current_period_end_unix = subobj and subobj.current_period_end or nil,
+                    })
+                    -- First payment: record the ledger entry here (renewals come via invoice.paid).
+                    PayoutQueries.recordSale({
+                        user_uuid = md.user_uuid, namespace_id = ns_id, kind = "subscription",
+                        stripe_ref = obj.subscription, amount = obj.amount_total, currency = obj.currency,
+                    })
                 end
-                -- Renewals only — the first invoice is already recorded at checkout.
-                if obj.billing_reason == "subscription_cycle" then
-                    local sub = SubscriptionQueries.findByStripeId(obj.subscription)
-                    if sub then
-                        PayoutQueries.recordSale({
-                            user_uuid = sub.user_uuid, namespace_id = sub.namespace_id, kind = "subscription",
-                            stripe_ref = obj.id, amount = obj.amount_paid or obj.amount_due, currency = obj.currency,
-                        })
+
+            elseif t == "invoice.paid" then
+                if obj.subscription then
+                    if subobj then
+                        SubscriptionQueries.updateStatusByStripeId(obj.subscription, subobj.status, subobj.current_period_end)
+                    end
+                    -- Renewals only — the first invoice is already recorded at checkout.
+                    if obj.billing_reason == "subscription_cycle" then
+                        local sub = SubscriptionQueries.findByStripeId(obj.subscription)
+                        if sub then
+                            PayoutQueries.recordSale({
+                                user_uuid = sub.user_uuid, namespace_id = sub.namespace_id, kind = "subscription",
+                                stripe_ref = obj.id, amount = obj.amount_paid or obj.amount_due, currency = obj.currency,
+                            })
+                        end
                     end
                 end
+
+            elseif t == "customer.subscription.updated" or t == "customer.subscription.deleted" then
+                SubscriptionQueries.updateStatusByStripeId(obj.id, obj.status, obj.current_period_end)
             end
 
-        elseif t == "customer.subscription.updated" or t == "customer.subscription.deleted" then
-            SubscriptionQueries.updateStatusByStripeId(obj.id, obj.status, obj.current_period_end)
+            -- Idempotency marker LAST — same transaction as the side effects above.
+            mark_processed(event.id, t)
+        end)
+
+        if not ok then
+            -- Marker was rolled back with the side effects: return non-2xx so Stripe
+            -- retries and genuinely reprocesses (no silent revenue loss).
+            ngx.log(ngx.ERR, "[academy webhook] processing FAILED for event " ..
+                tostring(event.id) .. " (" .. tostring(t) .. "): " .. tostring(err) ..
+                " — marker NOT written, Stripe will retry")
+            return { status = 500, json = { error = "processing failed" } }
         end
 
         return { status = 200, json = { received = true } }

--- a/lapis/routes/academy.lua
+++ b/lapis/routes/academy.lua
@@ -37,7 +37,11 @@ local AuthMiddleware = require("middleware.auth")
 local NamespaceMiddleware = require("middleware.namespace")
 
 local LEVELS = { beginner = true, intermediate = true, advanced = true }
-local COURSE_STATUS = { draft = true, published = true, archived = true }
+-- pending_review is the admin-approval gate: an instructor submits a course into
+-- it, and only an admin can move it on to `published`. The public endpoints
+-- already show ONLY `published`, so a pending_review course is invisible to
+-- learners for free — the gate is entirely about who may set `published`.
+local COURSE_STATUS = { draft = true, pending_review = true, published = true, archived = true }
 local LESSON_STATUS = { draft = true, published = true }
 
 -- The single academy tenant. Instructors are a ROLE inside this one namespace —
@@ -228,6 +232,21 @@ return function(app)
         return self.is_platform_admin == true or self.is_namespace_owner == true
     end
 
+    -- The admin-approval gate. Only an admin (platform admin / namespace owner)
+    -- may put a course live. An instructor asking for `published` gets
+    -- `pending_review` instead — their submission, awaiting approval — rather than
+    -- an error, so the dashboard's "publish" button becomes "submit for review"
+    -- with no client change. Admins pass through unchanged.
+    --
+    -- Returns the status to actually persist. Applied on BOTH create and update,
+    -- because either can carry status=published.
+    local function gate_publish(self, requested)
+        if requested == "published" and not can_manage_all(self) then
+            return "pending_review"
+        end
+        return requested
+    end
+
     -- Owner filter to hand CourseQueries.list: nil for admins/owners (see all),
     -- else the caller's uuid so instructors see only their own courses.
     local function owner_scope(self)
@@ -312,8 +331,10 @@ return function(app)
             end
             local status = body.status or "draft"
             if not COURSE_STATUS[status] then
-                return api_response(400, nil, "Invalid status (draft|published|archived)")
+                return api_response(400, nil, "Invalid status (draft|pending_review|published|archived)")
             end
+            -- An instructor cannot self-publish: publish requires admin approval.
+            status = gate_publish(self, status)
 
             local is_free = to_bool(body.is_free, true)
             local price = tonumber(body.price) or 0
@@ -362,6 +383,9 @@ return function(app)
             if body.status and not COURSE_STATUS[body.status] then
                 return api_response(400, nil, "Invalid status")
             end
+            -- Same gate as create: an instructor editing status to `published`
+            -- gets `pending_review` instead. Only approve/reject (admin) sets live.
+            if body.status then body.status = gate_publish(self, body.status) end
 
             local fields = {}
             for _, k in ipairs({ "title", "slug", "description", "instructor", "thumbnail_url",
@@ -407,6 +431,60 @@ return function(app)
             local ok = CourseQueries.softDelete(self.namespace.id, self.params.uuid)
             if not ok then return api_response(404, nil, "Course not found") end
             return api_response(200, { deleted = true })
+        end)))
+
+    ---------------------------------------------------------------------------
+    -- ADMIN: COURSE REVIEW (approval gate)
+    --
+    -- Instructors submit into `pending_review` (they cannot self-publish — see
+    -- gate_publish). These two endpoints are the ONLY way a course reaches
+    -- `published`, and both are restricted to an admin (platform admin /
+    -- namespace owner) via can_manage_all — the RBAC "courses" permission an
+    -- instructor holds is NOT enough. That is the whole point of the gate: the
+    -- people who can author are deliberately not the people who can publish.
+    ---------------------------------------------------------------------------
+
+    -- Everything awaiting approval, for the admin's review queue.
+    -- NOT under /courses/:uuid — that route would capture "pending" as a uuid and
+    -- 404. A distinct path sidesteps the collision regardless of router ordering.
+    app:get("/api/v2/academy/pending-courses", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("courses", "read", function(self)
+            if not can_manage_all(self) then
+                return api_response(403, nil, "Only an admin can review course submissions")
+            end
+            local res = CourseQueries.list(self.namespace.id, { status = "pending_review", perPage = 200 })
+            return api_response(200, res)
+        end)))
+
+    app:post("/api/v2/academy/courses/:uuid/approve", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("courses", "update", function(self)
+            if not can_manage_all(self) then
+                return api_response(403, nil, "Only an admin can approve a course")
+            end
+            local course = CourseQueries.getByUuid(self.namespace.id, self.params.uuid)
+            if not course then return api_response(404, nil, "Course not found") end
+            -- Approving a course that is not awaiting review is a no-op mistake
+            -- worth naming, so the admin knows nothing changed.
+            if course.status ~= "pending_review" then
+                return api_response(409, nil, "Course is not pending review (status: " .. tostring(course.status) .. ")")
+            end
+            local updated = CourseQueries.update(self.namespace.id, self.params.uuid, { status = "published" })
+            if not updated then return api_response(404, nil, "Course not found") end
+            return api_response(200, updated)
+        end)))
+
+    app:post("/api/v2/academy/courses/:uuid/reject", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("courses", "update", function(self)
+            if not can_manage_all(self) then
+                return api_response(403, nil, "Only an admin can reject a course")
+            end
+            local course = CourseQueries.getByUuid(self.namespace.id, self.params.uuid)
+            if not course then return api_response(404, nil, "Course not found") end
+            -- Rejection sends it back to draft so the instructor can revise and
+            -- resubmit — a rejected course is not archived, it is "not yet good".
+            local updated = CourseQueries.update(self.namespace.id, self.params.uuid, { status = "draft" })
+            if not updated then return api_response(404, nil, "Course not found") end
+            return api_response(200, updated)
         end)))
 
     ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this is

Consolidates three local academy-only backend fixes onto one branch, rebased on current `main`:

1. **Admin-approval gate** (`179afe4`) — instructors can no longer publish a course directly. Setting `status=published` on create/update is rewritten to a new `pending_review` status via `gate_publish()`; only admins (`can_manage_all`) may move a course to `published`. Adds admin-only `GET /pending-courses`, `POST /courses/:uuid/approve` (→ published), `POST /courses/:uuid/reject` (→ draft). Migration `823_academy_course_pending_review` widens the `academy_courses` status CHECK to allow `pending_review` (DROP … IF EXISTS + re-ADD; idempotent, only widens the allowed set, never rewrites a row).
   - *Verified:* `luac -p` clean; migration applies on the academy DB and is idempotent on re-run; the three new routes are auth-gated.
2. **Stripe webhook idempotency made atomic** (`49b698d`) — the processed-event marker is now written **last**, inside the same transaction as its side effects, so a failure leaves the event un-marked and Stripe's retry genuinely reprocesses. External Stripe calls moved out of the transaction so a round-trip never holds row locks. The `event_id` unique index doubles as the concurrency guard.
3. **Content-type-aware `parse_body`** (`1087b2f`) — `academy-billing.lua` and `academy-admin.lua` now use the same JSON-aware body parsing already in `routes/academy.lua`: take the form fast-path only when the client did not declare `application/json`, otherwise decode the raw body (incl. temp-file spill).

## diy-tax-return (tax_copilot) safety — this is SHARED PRODUCTION opsapi

Full diff vs `origin/main` is six files:

```
lapis/migrations.lua                    |   2 +
lapis/migrations/academy-system.lua     |  28 ++
lapis/routes/academy-admin.lua          |  25 +-
lapis/routes/academy-billing.lua        |  18 +-
lapis/routes/academy-stripe-webhook.lua | 162 +++++---
lapis/routes/academy.lua                |  82 +++-
```

- **The four route files + `academy-system.lua` are academy-only.** All four routes load exclusively via `load_if("academy", …)` in `app.lua`, which does not even `require` the module when the feature is off — so they are physically absent for `PROJECT_CODE=tax_copilot`. No non-academy path references them (grep confirms only comments mention `routes.academy*`).
- **`migrations.lua` is the only shared file, and its entire change is one gated line:**
  ```lua
  ['823_academy_course_pending_review'] = conditional_array(ProjectConfig.FEATURES.ACADEMY, academy_migrations, 7),
  ```
  `conditional_array` returns an unregistered no-op (`skip_unregistered` → nil) whenever the feature is off, and the `tax_copilot` preset is `{CORE, TAX_COPILOT, NOTIFICATIONS, MENU, THEMES}` — it does **not** include `ACADEMY`.
- **Every tax SA10x registration is intact.** All `TAX_COPILOT` migration registrations in `migrations.lua` are byte-identical between `origin/main` and this branch (verified with `diff`); nothing was dropped resolving the insertion.
- **Runtime proof (non-destructive).** `MIGRATION_DRY_RUN=1 PROJECT_CODE=tax_copilot lapis migrate` (no DB changes) reports `Enabled features: core, tax_copilot, notifications, menu, themes` and logs `[Migration] SKIP academy[7] -- feature 'academy' not enabled for PROJECT_CODE=tax_copilot` — `academy[7]` is exactly migration 823. All 23 academy migrations are skipped for tax. On the academy container's own code path, `lapis migrate` applies 823 cleanly and is idempotent on a second run.

Conclusion: no shared behaviour changes for `tax_copilot`.

## ⚠️ WARNING — do NOT deploy to production yet

**The instructor DASHBOARD UI for this gate (the approve/reject review queue and the `pending_review` status labels) is NOT in this PR.** Merging/deploying the backend gate alone means an instructor clicking "publish" will silently have their course moved to `pending_review` **with no UI anywhere to approve it** — the course simply never goes live. **Do not deploy to production until the dashboard approval UI lands.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
