### PR TITLE
feat(academy): course category create-or-select + tags

### DIFF
--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -2205,6 +2205,8 @@ local _migrations = {
     ['822_seed_academy_namespace'] = conditional_array(ProjectConfig.FEATURES.ACADEMY, academy_migrations, 6),
     -- Admin-approval gate: widen the course status CHECK to allow pending_review.
     ['823_academy_course_pending_review'] = conditional_array(ProjectConfig.FEATURES.ACADEMY, academy_migrations, 7),
+    -- Add a jsonb `tags` array to courses (create-or-select category + multi-tags).
+    ['824_academy_course_tags'] = conditional_array(ProjectConfig.FEATURES.ACADEMY, academy_migrations, 8),
     -- Academy sidebar menu item + RBAC module ("courses") + role grants
     ['804_seed_academy_menu_items'] = conditional_array(ProjectConfig.FEATURES.ACADEMY, academy_menu_migrations, 1),
     ['805_register_academy_modules'] = conditional_array(ProjectConfig.FEATURES.ACADEMY, academy_menu_migrations, 2),

--- a/lapis/migrations/academy-system.lua
+++ b/lapis/migrations/academy-system.lua
@@ -400,4 +400,26 @@ return {
             ]])
         end)
     end,
+
+    -- ========================================================================
+    -- [8] Add a free-form `tags` array to courses.
+    --
+    -- A course already carries one `category` string; `tags` is the multi-value
+    -- counterpart (stored as a jsonb array of strings) so the catalogue can be
+    -- sorted/filtered by tag as well as category. Defaults to an empty array and
+    -- is NOT NULL, so every existing row gets `[]` and the filter (tags @> ...)
+    -- never trips over a null.
+    --
+    -- Idempotent (ADD COLUMN IF NOT EXISTS) and wrapped in pcall like the other
+    -- ALTERs above, so a re-run — or a column that somehow already exists — is a
+    -- no-op rather than an error. Academy-feature-gated in migrations.lua.
+    -- ========================================================================
+    [8] = function()
+        pcall(function()
+            db.query([[
+                ALTER TABLE academy_courses
+                ADD COLUMN IF NOT EXISTS tags jsonb NOT NULL DEFAULT '[]'::jsonb
+            ]])
+        end)
+    end,
 }

--- a/lapis/queries/CourseQueries.lua
+++ b/lapis/queries/CourseQueries.lua
@@ -7,6 +7,7 @@
 local AcademyCourseModel = require "models.AcademyCourseModel"
 local Global = require "helper.global"
 local db = require("lapis.db")
+local cjson = require("cjson")
 
 local CourseQueries = {}
 
@@ -15,6 +16,20 @@ local function slugify(text)
     return (text:lower():gsub("%s+", "-"):gsub("[^%w%-]", ""):gsub("%-+", "-"):gsub("^%-", ""):gsub("%-$", ""))
 end
 CourseQueries.slugify = slugify
+
+-- Convert a Lua array of tag strings into a db.raw jsonb literal for the
+-- `tags` column. The value is JSON-encoded and cast with an explicit ?::jsonb
+-- (via interpolate_query, so the payload is escaped) — this mirrors
+-- IncomeTypeQueries and never relies on an implicit text→jsonb coercion. An
+-- empty/nil list becomes the `[]` literal, matching the column default.
+local function tags_to_jsonb(tags)
+    local arr = {}
+    if type(tags) == "table" then
+        for _, v in ipairs(tags) do arr[#arr + 1] = v end
+    end
+    local json = #arr > 0 and cjson.encode(arr) or "[]"
+    return db.raw(db.interpolate_query("?::jsonb", json))
+end
 
 --- Find a single non-deleted course scoped to a namespace.
 local function findScoped(namespace_id, uuid)
@@ -31,6 +46,9 @@ function CourseQueries.create(namespace_id, params)
     if (not params.slug or params.slug == "") and params.title then
         params.slug = slugify(params.title)
     end
+    -- The route hands us an already-coerced Lua array; encode it for the jsonb
+    -- column. When omitted, the column default ('[]') applies.
+    if params.tags ~= nil then params.tags = tags_to_jsonb(params.tags) end
     params.created_at = db.raw("NOW()")
     params.updated_at = db.raw("NOW()")
     return AcademyCourseModel:create(params, { returning = "*" })
@@ -54,6 +72,12 @@ function CourseQueries.list(namespace_id, params)
     end
     if params.level and params.level ~= "" then
         table.insert(where, "level = ?"); table.insert(values, params.level)
+    end
+    -- Filter by a single tag via jsonb containment: tags @> '["<t>"]'. The tag is
+    -- embedded as a JSON array literal (quotes stripped) and cast to jsonb.
+    if params.tag and params.tag ~= "" then
+        table.insert(where, "tags @> ?::jsonb")
+        table.insert(values, '["' .. tostring(params.tag):gsub('"', '') .. '"]')
     end
     if params.is_free ~= nil then
         table.insert(where, "is_free = ?"); table.insert(values, params.is_free)
@@ -93,6 +117,22 @@ function CourseQueries.getByUuid(namespace_id, uuid)
     return findScoped(namespace_id, uuid)
 end
 
+--- Distinct, non-empty, sorted `category` values in a namespace (excluding
+--- soft-deleted courses). There is no categories table — a "category" is just
+--- the string on a course, so the create-or-select control offers the existing
+--- distinct values while still letting the teacher type a brand-new one.
+function CourseQueries.distinctCategories(namespace_id)
+    local rows = db.query([[
+        SELECT DISTINCT category FROM academy_courses
+        WHERE namespace_id = ? AND deleted_at IS NULL
+          AND category IS NOT NULL AND category <> ''
+        ORDER BY category ASC
+    ]], namespace_id)
+    local out = {}
+    for _, r in ipairs(rows or {}) do out[#out + 1] = r.category end
+    return out
+end
+
 --- Find a non-deleted course by numeric id, scoped to a namespace.
 -- Used for lesson ownership checks (lessons reference course_id, not uuid).
 function CourseQueries.findById(namespace_id, id)
@@ -115,9 +155,13 @@ function CourseQueries.update(namespace_id, uuid, params)
     params.namespace_id = nil   -- never allow reassigning tenant
     params.id = nil
     params.uuid = nil
+    if params.tags ~= nil then params.tags = tags_to_jsonb(params.tags) end
     params.updated_at = db.raw("NOW()")
     course:update(params)
-    return course
+    -- Re-read: fields written via db.raw (the jsonb `tags`, NOW()) are left on the
+    -- model as raw SQL fragments after :update, so a fresh find returns the actual
+    -- stored values for the response shape.
+    return findScoped(namespace_id, uuid)
 end
 
 function CourseQueries.softDelete(namespace_id, uuid)

--- a/lapis/routes/academy.lua
+++ b/lapis/routes/academy.lua
@@ -114,6 +114,66 @@ return function(app)
         return s == "true" or s == "1" or s == "yes"
     end
 
+    -- Tags come in three shapes depending on the transport: a JSON body sends a
+    -- real array; a form body sends either a single string (one tag) or, if the
+    -- client JSON-stringified the list, a JSON-array string. coerce_tags accepts
+    -- all three and returns a clean Lua array: each tag trimmed, capped at 40
+    -- chars, empties dropped, case-insensitively de-duped, at most 20 total.
+    -- Returns nil ONLY when the field was absent, so update can tell "clear the
+    -- tags" (an explicit []) apart from "leave them untouched" (omitted).
+    local MAX_TAGS, MAX_TAG_LEN = 20, 40
+    local function coerce_tags(raw)
+        if raw == nil then return nil end
+        local list = raw
+        if type(raw) == "string" then
+            local ok, decoded = pcall(cJson.decode, raw)
+            if ok and type(decoded) == "table" then
+                list = decoded
+            else
+                list = { raw }
+            end
+        end
+        if type(list) ~= "table" then return {} end
+        local seen, out = {}, {}
+        for _, v in ipairs(list) do
+            if type(v) == "string" or type(v) == "number" then
+                local s = tostring(v):gsub("^%s+", ""):gsub("%s+$", "")
+                if #s > MAX_TAG_LEN then s = s:sub(1, MAX_TAG_LEN) end
+                local key = s:lower()
+                if s ~= "" and not seen[key] then
+                    seen[key] = true
+                    out[#out + 1] = s
+                    if #out >= MAX_TAGS then break end
+                end
+            end
+        end
+        return out
+    end
+
+    -- Postgres returns a jsonb column to us as its TEXT form, so a course row's
+    -- `tags` arrives as the string '["a","b"]'. Decode it to an array for output
+    -- (empty → the JSON `[]` sentinel, so it never serializes as `{}`). Tolerant
+    -- of an already-decoded table and of a null/blank column.
+    local function tags_out(v)
+        local arr
+        if type(v) == "table" then
+            arr = v
+        elseif type(v) == "string" and v ~= "" then
+            local ok, decoded = pcall(cJson.decode, v)
+            arr = (ok and type(decoded) == "table") and decoded or {}
+        else
+            arr = {}
+        end
+        return #arr > 0 and arr or cJson.empty_array
+    end
+
+    -- Attach the decoded `tags` to an admin course row/model in place, so the
+    -- admin course shape returns tags as an array (matching public_course).
+    local function with_tags(course)
+        if course then course.tags = tags_out(course.tags) end
+        return course
+    end
+
     -- Postgres booleans reach us either as a real boolean or as the string "t",
     -- depending on the driver path — EntitlementQueries.hasCourseAccess checks
     -- for both, which is why this cannot use to_bool(): that maps "t" to FALSE
@@ -208,6 +268,7 @@ return function(app)
             instructor_id = (instructor_info and instructor_info.id) or row.owner_user_uuid,
             thumbnail_url = row.thumbnail_url,
             category = row.category,
+            tags = tags_out(row.tags),
             level = row.level,
             is_free = row.is_free,
             price = row.price,
@@ -294,10 +355,12 @@ return function(app)
                 perPage = self.params.perPage,
                 status = self.params.status,
                 category = self.params.category,
+                tag = self.params.tag,
                 level = self.params.level,
                 search = self.params.search,
                 owner_user_uuid = owner_scope(self),
             })
+            for _, row in ipairs(result.data) do with_tags(row) end
             return {
                 status = 200,
                 json = {
@@ -306,6 +369,17 @@ return function(app)
                     pagination = { page = result.page, perPage = result.perPage, total = result.total },
                 }
             }
+        end)))
+
+    -- Distinct category strings used in this namespace, for the dashboard's
+    -- "create or select" category control. There is no categories table — this
+    -- just returns the existing values so the teacher can pick one or type a new.
+    app:get("/api/v2/academy/categories", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("courses", "read", function(self)
+            local categories = CourseQueries.distinctCategories(self.namespace.id)
+            return api_response(200, {
+                categories = #categories > 0 and categories or cJson.empty_array,
+            })
         end)))
 
     -- A paid course with no price cannot be bought: Stripe rejects a zero amount,
@@ -348,6 +422,7 @@ return function(app)
                 instructor = body.instructor,
                 thumbnail_url = body.thumbnail_url,
                 category = body.category or "general",
+                tags = coerce_tags(body.tags) or {},
                 level = level,
                 is_free = is_free,
                 price = price,
@@ -359,7 +434,7 @@ return function(app)
                 ngx.log(ngx.ERR, "[academy] create course failed: ", tostring(course_or_err))
                 return api_response(409, nil, "Could not create course (slug may already exist)")
             end
-            return api_response(201, course_or_err)
+            return api_response(201, with_tags(course_or_err))
         end)))
 
     app:get("/api/v2/academy/courses/:uuid", AuthMiddleware.requireAuth(
@@ -370,7 +445,7 @@ return function(app)
                 return api_response(403, nil, "You can only view your own courses")
             end
             local lessons = LessonQueries.listByCourse(course.id, { published_only = false })
-            local data = { course = course, lessons = lessons }
+            local data = { course = with_tags(course), lessons = lessons }
             return api_response(200, data)
         end)))
 
@@ -394,6 +469,8 @@ return function(app)
             end
             if body.is_free ~= nil then fields.is_free = to_bool(body.is_free, true) end
             if body.price ~= nil then fields.price = tonumber(body.price) or 0 end
+            -- Present-but-empty ([]) clears the tags; absent leaves them untouched.
+            if body.tags ~= nil then fields.tags = coerce_tags(body.tags) end
 
             local existing = CourseQueries.getByUuid(self.namespace.id, self.params.uuid)
             if not existing then return api_response(404, nil, "Course not found") end
@@ -416,7 +493,7 @@ return function(app)
 
             local updated = CourseQueries.update(self.namespace.id, self.params.uuid, fields)
             if not updated then return api_response(404, nil, "Course not found") end
-            return api_response(200, updated)
+            return api_response(200, with_tags(updated))
         end)))
 
     app:delete("/api/v2/academy/courses/:uuid", AuthMiddleware.requireAuth(

--- a/opsapi-dashboard/app/dashboard/academy/page.tsx
+++ b/opsapi-dashboard/app/dashboard/academy/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
-import { Search, Plus, Trash2, Edit, BookOpen, RefreshCw, Layers, CreditCard, Banknote, GraduationCap, ArrowRight, User } from 'lucide-react';
+import { Search, Plus, Trash2, Edit, BookOpen, RefreshCw, Layers, CreditCard, Banknote, GraduationCap, ArrowRight, User, X } from 'lucide-react';
 import { Table, Badge, Pagination, Modal, Button, ConfirmDialog, Select } from '@/components/ui';
 import { ProtectedPage } from '@/components/permissions';
 import { usePermissions } from '@/contexts/PermissionsContext';
@@ -42,6 +42,7 @@ const EMPTY_FORM: CourseInput = {
   instructor: '',
   thumbnail_url: '',
   category: 'general',
+  tags: [],
   level: 'beginner',
   is_free: true,
   price: 0,
@@ -63,6 +64,8 @@ interface CourseModalProps {
 const CourseModal: React.FC<CourseModalProps> = ({ isOpen, course, onClose, onSuccess }) => {
   const [form, setForm] = useState<CourseInput>(EMPTY_FORM);
   const [submitting, setSubmitting] = useState(false);
+  const [categories, setCategories] = useState<string[]>([]);
+  const [tagDraft, setTagDraft] = useState('');
 
   useEffect(() => {
     if (course) {
@@ -73,6 +76,7 @@ const CourseModal: React.FC<CourseModalProps> = ({ isOpen, course, onClose, onSu
         instructor: course.instructor ?? '',
         thumbnail_url: course.thumbnail_url ?? '',
         category: course.category ?? 'general',
+        tags: course.tags ?? [],
         level: course.level,
         is_free: course.is_free,
         // Stored in minor units (pence/cents); edit in major units.
@@ -83,10 +87,49 @@ const CourseModal: React.FC<CourseModalProps> = ({ isOpen, course, onClose, onSu
     } else {
       setForm(EMPTY_FORM);
     }
+    setTagDraft('');
   }, [course, isOpen]);
+
+  // Fetch the existing category values whenever the modal opens, so the
+  // create-or-select control can offer them (falls back to none on error).
+  useEffect(() => {
+    if (!isOpen) return;
+    let active = true;
+    academyService
+      .getCategories()
+      .then((cats) => { if (active) setCategories(cats); })
+      .catch(() => { if (active) setCategories([]); });
+    return () => { active = false; };
+  }, [isOpen]);
 
   const set = <K extends keyof CourseInput>(key: K, value: CourseInput[K]) =>
     setForm((prev) => ({ ...prev, [key]: value }));
+
+  // Tag chips: add on Enter or comma, de-duped case-insensitively, capped and
+  // trimmed to match the backend (max 20 tags, <= 40 chars each).
+  const addTag = (raw: string) => {
+    const value = raw.trim().slice(0, 40);
+    if (!value) return;
+    setForm((prev) => {
+      const existing = prev.tags ?? [];
+      if (existing.length >= 20) return prev;
+      if (existing.some((t) => t.toLowerCase() === value.toLowerCase())) return prev;
+      return { ...prev, tags: [...existing, value] };
+    });
+    setTagDraft('');
+  };
+
+  const removeTag = (tag: string) =>
+    setForm((prev) => ({ ...prev, tags: (prev.tags ?? []).filter((t) => t !== tag) }));
+
+  const handleTagKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      addTag(tagDraft);
+    } else if (e.key === 'Backspace' && tagDraft === '' && (form.tags ?? []).length > 0) {
+      removeTag((form.tags ?? [])[(form.tags ?? []).length - 1]);
+    }
+  };
 
   const inputClass =
     'w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500';
@@ -139,7 +182,19 @@ const CourseModal: React.FC<CourseModalProps> = ({ isOpen, course, onClose, onSu
           </div>
           <div>
             <label className="block text-sm font-medium text-secondary-700 mb-1">Category</label>
-            <input className={inputClass} value={form.category} onChange={(e) => set('category', e.target.value)} placeholder="e.g. programming" />
+            {/* Create-or-select: pick an existing category or type a brand-new one. */}
+            <input
+              className={inputClass}
+              list="course-category-options"
+              value={form.category}
+              onChange={(e) => set('category', e.target.value)}
+              placeholder="Pick existing or type a new one"
+            />
+            <datalist id="course-category-options">
+              {categories.map((c) => (
+                <option key={c} value={c} />
+              ))}
+            </datalist>
           </div>
           <div>
             <label className="block text-sm font-medium text-secondary-700 mb-1">Level</label>
@@ -160,6 +215,36 @@ const CourseModal: React.FC<CourseModalProps> = ({ isOpen, course, onClose, onSu
           <div className="col-span-2">
             <label className="block text-sm font-medium text-secondary-700 mb-1">Thumbnail URL</label>
             <input className={inputClass} value={form.thumbnail_url} onChange={(e) => set('thumbnail_url', e.target.value)} placeholder="https://…/thumb.jpg" />
+          </div>
+          <div className="col-span-2">
+            <label className="block text-sm font-medium text-secondary-700 mb-1">Tags</label>
+            <div className={`${inputClass} flex flex-wrap items-center gap-1.5 min-h-[42px] h-auto`}>
+              {(form.tags ?? []).map((tag) => (
+                <span
+                  key={tag}
+                  className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-primary-50 text-primary-700 text-xs font-medium"
+                >
+                  {tag}
+                  <button
+                    type="button"
+                    onClick={() => removeTag(tag)}
+                    className="text-primary-500 hover:text-primary-700"
+                    aria-label={`Remove ${tag}`}
+                  >
+                    <X className="w-3 h-3" />
+                  </button>
+                </span>
+              ))}
+              <input
+                className="flex-1 min-w-[8rem] border-none outline-none bg-transparent text-sm p-0 focus:ring-0"
+                value={tagDraft}
+                onChange={(e) => setTagDraft(e.target.value)}
+                onKeyDown={handleTagKeyDown}
+                onBlur={() => addTag(tagDraft)}
+                placeholder={(form.tags ?? []).length === 0 ? 'Add tags (Enter or comma)…' : ''}
+              />
+            </div>
+            <p className="mt-1 text-xs text-secondary-500">Press Enter or comma to add. Used for sorting and filtering. Up to 20 tags.</p>
           </div>
           <div className="col-span-2 flex items-center gap-3">
             <input id="is_free" type="checkbox" checked={form.is_free} onChange={(e) => set('is_free', e.target.checked)} className="w-4 h-4 rounded border-secondary-300 text-primary-600 focus:ring-primary-500" />

--- a/opsapi-dashboard/services/academy.service.ts
+++ b/opsapi-dashboard/services/academy.service.ts
@@ -16,6 +16,7 @@ export interface AcademyCourse {
   instructor?: string;
   thumbnail_url?: string;
   category?: string;
+  tags?: string[];
   level: CourseLevel;
   is_free: boolean;
   price: number;
@@ -123,6 +124,7 @@ export interface CourseInput {
   instructor?: string;
   thumbnail_url?: string;
   category?: string;
+  tags?: string[];
   level?: CourseLevel;
   is_free?: boolean;
   price?: number;
@@ -201,6 +203,15 @@ function unwrap<T>(response: { data: unknown }): T {
   return (d?.data ?? d) as T;
 }
 
+// Serialize a course payload for the form-encoded body. `tags` is JSON-encoded
+// into a single field (rather than repeated keys) so an empty list travels as
+// "[]" and clears the tags server-side; the backend accepts the JSON string.
+function serializeCourse(data: Partial<CourseInput>): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...data };
+  if (data.tags !== undefined) out.tags = JSON.stringify(data.tags ?? []);
+  return out;
+}
+
 function buildCourseParams(params: CourseListParams): Record<string, unknown> {
   const q: Record<string, unknown> = {};
   if (params.page) q.page = params.page;
@@ -244,7 +255,7 @@ export const academyService = {
   async createCourse(data: CourseInput): Promise<AcademyCourse> {
     const response = await apiClient.post(
       '/api/v2/academy/courses',
-      toFormData(data as unknown as Record<string, unknown>)
+      toFormData(serializeCourse(data))
     );
     return unwrap<AcademyCourse>(response);
   },
@@ -252,9 +263,19 @@ export const academyService = {
   async updateCourse(uuid: string, data: Partial<CourseInput>): Promise<AcademyCourse> {
     const response = await apiClient.put(
       `/api/v2/academy/courses/${uuid}`,
-      toFormData(data as unknown as Record<string, unknown>)
+      toFormData(serializeCourse(data))
     );
     return unwrap<AcademyCourse>(response);
+  },
+
+  // Distinct category strings used in this namespace, for the create-or-select
+  // category control. Returns [] if the backend is unreachable or empty.
+  async getCategories(): Promise<string[]> {
+    const response = await apiClient.get('/api/v2/academy/categories');
+    const body = response.data as Record<string, unknown>;
+    const inner = (body?.data ?? body) as Record<string, unknown>;
+    const cats = inner?.categories;
+    return Array.isArray(cats) ? (cats as string[]) : [];
   },
 
   async deleteCourse(uuid: string): Promise<void> {


### PR DESCRIPTION
Stacked on #505. Base is `feat/academy-approval-gate-consolidated` so this PR's
diff is JUST the one categories/tags commit. **Merge #505 first**, then this
retargets cleanly to `main` (or retarget the base to `main` now and it'll show
only these changes once #505 lands).

## What this adds
A teacher creating/editing a course can now pick an **existing category or type a
new one**, and attach **tags** — both to drive catalogue sorting/filtering.

- **Category → create-or-select.** New `GET /api/v2/academy/categories` returns
  the distinct categories used in the namespace; the dashboard offers them via a
  `<datalist>`-backed input so the teacher selects an existing one or types a new
  one. No categories table — a category is just the value on a course.
- **Tags.** New `tags jsonb NOT NULL DEFAULT '[]'` column (migration `824`,
  academy-gated). Accepted on create/update, normalized server-side (trim, drop
  empties, dedupe case-insensitively, ≤40 chars, ≤20 tags), returned in both the
  admin course shape and `public_course`. Dashboard has a chip input
  (Enter/comma to add, removable).
- **Filtering.** Course list gains an optional `?tag=` filter (`tags @> ?::jsonb`);
  category filtering already existed.

## Verified by driving the running stack
- Migration `824` applied; created a course `tags:["a","b","a"," c ",""]` →
  stored `["a","b","c"]`; `GET /categories` then included the new category; the
  course returned its tags; `?tag=a` matched, a nonsense tag returned 0. Both the
  JSON and form-encoded paths work; clearing tags works.
- Dashboard `tsc --noEmit` clean, `npm run build` ✓. `luac -p` clean on all Lua
  files.

## diy-tax-return safety
Only shared file touched is `migrations.lua` — one academy-gated line. A dry-run
`PROJECT_CODE=tax_copilot lapis migrate` prints `SKIP academy[8]`, so the tax
build never runs it. Everything else is academy-only.

## Note
Learner-site tag-filtering UI is not included — the backend returns `tags` so the
catalogue can filter later, but the student-facing filter controls are a
follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)