### PR TITLE
feat(academy-dashboard): approval-gate UI — honest submit + admin review queue

### DIFF
--- a/opsapi-dashboard/app/dashboard/academy/page.tsx
+++ b/opsapi-dashboard/app/dashboard/academy/page.tsx
@@ -2,13 +2,15 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
-import { Search, Plus, Trash2, Edit, BookOpen, RefreshCw, Layers, CreditCard, Banknote, GraduationCap, ArrowRight, User, X } from 'lucide-react';
+import { Search, Plus, Trash2, Edit, BookOpen, RefreshCw, Layers, CreditCard, Banknote, GraduationCap, ArrowRight, User, X, ClipboardCheck, CheckCircle2, XCircle } from 'lucide-react';
 import { Table, Badge, Pagination, Modal, Button, ConfirmDialog, Select } from '@/components/ui';
 import { ProtectedPage } from '@/components/permissions';
 import { usePermissions } from '@/contexts/PermissionsContext';
 import {
   academyService,
   getCourseStatusVariant,
+  getCourseStatusLabel,
+  academyErrorMessage,
   formatCourseDuration,
   type AcademyCourse,
   type CourseInput,
@@ -31,6 +33,7 @@ const LEVEL_OPTIONS: { value: string; label: string }[] = [
 const STATUS_OPTIONS: { value: string; label: string }[] = [
   { value: 'all', label: 'All Status' },
   { value: 'draft', label: 'Draft' },
+  { value: 'pending_review', label: 'Pending review' },
   { value: 'published', label: 'Published' },
   { value: 'archived', label: 'Archived' },
 ];
@@ -57,11 +60,14 @@ const EMPTY_FORM: CourseInput = {
 interface CourseModalProps {
   isOpen: boolean;
   course: AcademyCourse | null;
+  // Reviewers (platform admin / namespace owner) may publish directly; everyone
+  // else can only submit for review, so the status control adapts to the role.
+  canPublishDirectly: boolean;
   onClose: () => void;
   onSuccess: () => void;
 }
 
-const CourseModal: React.FC<CourseModalProps> = ({ isOpen, course, onClose, onSuccess }) => {
+const CourseModal: React.FC<CourseModalProps> = ({ isOpen, course, canPublishDirectly, onClose, onSuccess }) => {
   const [form, setForm] = useState<CourseInput>(EMPTY_FORM);
   const [submitting, setSubmitting] = useState(false);
   const [categories, setCategories] = useState<string[]>([]);
@@ -147,18 +153,22 @@ const CourseModal: React.FC<CourseModalProps> = ({ isOpen, course, onClose, onSu
         // Convert major units (what the user typed) back to minor units for the API.
         price: form.is_free ? 0 : Math.round((Number(form.price) || 0) * 100),
       };
-      if (course) {
-        await academyService.updateCourse(course.uuid, payload);
-        toast.success('Course updated');
+      const saved = course
+        ? await academyService.updateCourse(course.uuid, payload)
+        : await academyService.createCourse(payload);
+      // The backend gate silently turns an instructor's `published` into
+      // `pending_review`. Tell the truth: if that happened, say it's awaiting
+      // review, not that it was published.
+      if (saved.status === 'pending_review') {
+        toast.success('Submitted for review — an admin will approve it before it goes live');
       } else {
-        await academyService.createCourse(payload);
-        toast.success('Course created');
+        toast.success(course ? 'Course updated' : 'Course created');
       }
       onSuccess();
       onClose();
     } catch (err) {
       console.error('Save course failed:', err);
-      toast.error('Failed to save course');
+      toast.error(academyErrorMessage(err, 'Failed to save course'));
     } finally {
       setSubmitting(false);
     }
@@ -206,11 +216,36 @@ const CourseModal: React.FC<CourseModalProps> = ({ isOpen, course, onClose, onSu
           </div>
           <div>
             <label className="block text-sm font-medium text-secondary-700 mb-1">Status</label>
-            <select className={inputClass} value={form.status} onChange={(e) => set('status', e.target.value as CourseStatus)}>
-              <option value="draft">Draft</option>
-              <option value="published">Published</option>
-              <option value="archived">Archived</option>
-            </select>
+            {canPublishDirectly ? (
+              // Reviewers (admin / owner) publish directly.
+              <select className={inputClass} value={form.status} onChange={(e) => set('status', e.target.value as CourseStatus)}>
+                <option value="draft">Draft</option>
+                {form.status === 'pending_review' && <option value="pending_review">Pending review</option>}
+                <option value="published">Published</option>
+                <option value="archived">Archived</option>
+              </select>
+            ) : (
+              // Instructors cannot self-publish. The publish choice is honestly
+              // labelled "Submit for review" and carries value `published`, which
+              // the backend gate converts to `pending_review`. A course already
+              // pending review maps onto this same option so it reads truthfully.
+              <>
+                <select
+                  className={inputClass}
+                  value={form.status === 'pending_review' ? 'published' : form.status}
+                  onChange={(e) => set('status', e.target.value as CourseStatus)}
+                >
+                  <option value="draft">Save as draft</option>
+                  <option value="published">Submit for review</option>
+                  <option value="archived">Archived</option>
+                </select>
+                {form.status === 'pending_review' ? (
+                  <p className="mt-1 text-xs text-warning-600">Awaiting admin review. Resubmitting keeps it in the queue.</p>
+                ) : form.status === 'published' ? (
+                  <p className="mt-1 text-xs text-secondary-500">An admin approves it before it appears on the public site.</p>
+                ) : null}
+              </>
+            )}
           </div>
           <div className="col-span-2">
             <label className="block text-sm font-medium text-secondary-700 mb-1">Thumbnail URL</label>
@@ -279,6 +314,139 @@ const CourseModal: React.FC<CourseModalProps> = ({ isOpen, course, onClose, onSu
 };
 
 // ============================================================
+// Admin review queue — the approval gate's front end.
+// Only rendered for reviewers (platform admin / namespace owner). Lists every
+// course an instructor submitted, with Approve (→ published) and Reject
+// (→ draft) actions, each confirmed before it fires.
+// ============================================================
+
+interface PendingReviewPanelProps {
+  // Bumped by the parent whenever the main list changes, to keep the queue fresh
+  // (e.g. after a course is edited into pending_review elsewhere).
+  refreshKey: number;
+  onReviewed: () => void;
+}
+
+type ReviewAction = { course: AcademyCourse; kind: 'approve' | 'reject' };
+
+const PendingReviewPanel: React.FC<PendingReviewPanelProps> = ({ refreshKey, onReviewed }) => {
+  const router = useRouter();
+  const [pending, setPending] = useState<AcademyCourse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [action, setAction] = useState<ReviewAction | null>(null);
+  const [working, setWorking] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      setPending(await academyService.getPendingCourses());
+    } catch (err) {
+      console.error('Load pending courses failed:', err);
+      toast.error(academyErrorMessage(err, 'Failed to load pending courses'));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load, refreshKey]);
+
+  const runAction = async () => {
+    if (!action) return;
+    setWorking(true);
+    try {
+      if (action.kind === 'approve') {
+        await academyService.approveCourse(action.course.uuid);
+        toast.success(`"${action.course.title}" approved and published`);
+      } else {
+        await academyService.rejectCourse(action.course.uuid);
+        toast.success(`"${action.course.title}" sent back to the instructor as a draft`);
+      }
+      setAction(null);
+      await load();
+      onReviewed();
+    } catch (err) {
+      console.error('Review action failed:', err);
+      toast.error(academyErrorMessage(err, 'Failed to update course'));
+    } finally {
+      setWorking(false);
+    }
+  };
+
+  return (
+    <div className="bg-surface rounded-xl border border-warning-200 overflow-hidden">
+      <div className="flex items-center gap-2 px-4 py-3 border-b border-secondary-200 bg-warning-500/5">
+        <ClipboardCheck size={18} className="text-warning-600" />
+        <h2 className="text-sm font-semibold text-secondary-800">Pending review</h2>
+        {!loading && (
+          <Badge variant="warning">{pending.length}</Badge>
+        )}
+        <span className="text-xs text-secondary-500 ml-1">Courses instructors submitted, awaiting your approval.</span>
+      </div>
+
+      {loading ? (
+        <div className="p-4"><div className="h-16 animate-pulse rounded bg-secondary-100" /></div>
+      ) : pending.length === 0 ? (
+        <p className="px-4 py-6 text-sm text-secondary-500">Nothing waiting for review right now.</p>
+      ) : (
+        <ul className="divide-y divide-secondary-100">
+          {pending.map((c) => (
+            <li key={c.uuid} className="flex flex-col sm:flex-row sm:items-center gap-3 px-4 py-3">
+              <div className="min-w-0 flex-1">
+                <button
+                  onClick={() => router.push(`/dashboard/academy/${c.uuid}`)}
+                  className="font-medium text-secondary-900 truncate hover:text-primary-600 text-left"
+                >
+                  {c.title}
+                </button>
+                <p className="text-xs text-secondary-500 truncate">
+                  /{c.slug}
+                  {c.instructor ? ` · ${c.instructor}` : ''}
+                  {` · ${c.lesson_count ?? 0} lesson${(c.lesson_count ?? 0) === 1 ? '' : 's'}`}
+                </p>
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  leftIcon={<XCircle size={16} />}
+                  onClick={() => setAction({ course: c, kind: 'reject' })}
+                >
+                  Reject
+                </Button>
+                <Button
+                  size="sm"
+                  leftIcon={<CheckCircle2 size={16} />}
+                  onClick={() => setAction({ course: c, kind: 'approve' })}
+                >
+                  Approve
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <ConfirmDialog
+        isOpen={!!action}
+        onClose={() => setAction(null)}
+        onConfirm={runAction}
+        title={action?.kind === 'approve' ? 'Approve course' : 'Reject course'}
+        message={
+          action?.kind === 'approve'
+            ? `Publish "${action?.course.title}"? It will become visible on the public site immediately.`
+            : `Send "${action?.course.title}" back to draft? The instructor can revise and resubmit it.`
+        }
+        confirmText={action?.kind === 'approve' ? 'Approve & publish' : 'Reject'}
+        variant={action?.kind === 'approve' ? 'info' : 'danger'}
+        isLoading={working}
+      />
+    </div>
+  );
+};
+
+// ============================================================
 // Page
 // ============================================================
 
@@ -298,6 +466,22 @@ function AcademyCoursesPage() {
   const [editing, setEditing] = useState<AcademyCourse | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<AcademyCourse | null>(null);
   const [deleting, setDeleting] = useState(false);
+
+  // A reviewer (platform admin OR namespace owner) may publish directly and sees
+  // the approval queue. `isAdmin` covers the platform admin; ownership comes from
+  // the instructor-status endpoint, mirroring the backend's can_manage_all.
+  const [isOwner, setIsOwner] = useState(false);
+  const [reviewRefresh, setReviewRefresh] = useState(0);
+  const isReviewer = isAdmin || isOwner;
+
+  useEffect(() => {
+    let active = true;
+    academyService
+      .getInstructorStatus()
+      .then((s) => { if (active) setIsOwner(!!s.is_owner); })
+      .catch(() => { if (active) setIsOwner(false); });
+    return () => { active = false; };
+  }, []);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -383,7 +567,7 @@ function AcademyCoursesPage() {
     {
       key: 'status',
       header: 'Status',
-      render: (c) => <Badge variant={getCourseStatusVariant(c.status)} className="capitalize">{c.status}</Badge>,
+      render: (c) => <Badge variant={getCourseStatusVariant(c.status)}>{getCourseStatusLabel(c.status)}</Badge>,
     },
     {
       key: 'updated_at',
@@ -461,6 +645,14 @@ function AcademyCoursesPage() {
         </div>
       </div>
 
+      {/* Approval queue — reviewers only (platform admin / namespace owner) */}
+      {isReviewer && (
+        <PendingReviewPanel
+          refreshKey={reviewRefresh}
+          onReviewed={load}
+        />
+      )}
+
       {/* Table */}
       <div className="bg-surface rounded-xl border border-secondary-200 overflow-hidden">
         <Table
@@ -481,8 +673,9 @@ function AcademyCoursesPage() {
       <CourseModal
         isOpen={modalOpen}
         course={editing}
+        canPublishDirectly={isReviewer}
         onClose={() => setModalOpen(false)}
-        onSuccess={load}
+        onSuccess={() => { load(); setReviewRefresh((n) => n + 1); }}
       />
 
       <ConfirmDialog

--- a/opsapi-dashboard/services/academy.service.ts
+++ b/opsapi-dashboard/services/academy.service.ts
@@ -5,7 +5,10 @@ import apiClient, { toFormData, buildQueryString } from '@/lib/api-client';
 // ============================================================
 
 export type CourseLevel = 'beginner' | 'intermediate' | 'advanced';
-export type CourseStatus = 'draft' | 'published' | 'archived';
+// `pending_review` is the admin-approval gate: an instructor who submits
+// `published` is downgraded to `pending_review` server-side (gate_publish) and
+// the course stays invisible on the public site until an admin approves it.
+export type CourseStatus = 'draft' | 'pending_review' | 'published' | 'archived';
 export type LessonStatus = 'draft' | 'published';
 
 export interface AcademyCourse {
@@ -283,6 +286,33 @@ export const academyService = {
   },
 
   // ----------------------------------------------------------
+  // Admin course-approval gate (platform admin / namespace owner only).
+  // These are the only way a course reaches `published`: an instructor's
+  // publish attempt lands in `pending_review`, and a reviewer approves or
+  // rejects it here. 403 for anyone who is not an admin.
+  // ----------------------------------------------------------
+
+  // Every course awaiting approval, for the reviewer's queue.
+  async getPendingCourses(): Promise<AcademyCourse[]> {
+    const response = await apiClient.get('/api/v2/academy/pending-courses');
+    const data = unwrap<{ data?: AcademyCourse[] } | AcademyCourse[]>(response);
+    if (Array.isArray(data)) return data;
+    return Array.isArray(data?.data) ? data.data : [];
+  },
+
+  // Approve → the course goes live (`published`).
+  async approveCourse(uuid: string): Promise<AcademyCourse> {
+    const response = await apiClient.post(`/api/v2/academy/courses/${uuid}/approve`);
+    return unwrap<AcademyCourse>(response);
+  },
+
+  // Reject → back to `draft` so the instructor can revise and resubmit.
+  async rejectCourse(uuid: string): Promise<AcademyCourse> {
+    const response = await apiClient.post(`/api/v2/academy/courses/${uuid}/reject`);
+    return unwrap<AcademyCourse>(response);
+  },
+
+  // ----------------------------------------------------------
   // Lessons
   // ----------------------------------------------------------
 
@@ -436,15 +466,42 @@ export const academyService = {
 
 export function getCourseStatusVariant(
   status: CourseStatus
-): 'success' | 'warning' | 'secondary' {
+): 'success' | 'warning' | 'info' | 'secondary' {
   switch (status) {
     case 'published':
       return 'success';
-    case 'draft':
+    case 'pending_review':
+      // Amber "awaiting action" — distinct from the neutral draft state.
       return 'warning';
+    case 'draft':
+      return 'info';
     default:
       return 'secondary';
   }
+}
+
+// Human label for a course status. Critically maps `pending_review` to a clean
+// "Pending review" rather than the raw, underscored enum value.
+export function getCourseStatusLabel(status: CourseStatus): string {
+  switch (status) {
+    case 'pending_review':
+      return 'Pending review';
+    case 'published':
+      return 'Published';
+    case 'archived':
+      return 'Archived';
+    case 'draft':
+    default:
+      return 'Draft';
+  }
+}
+
+// Pull the backend's `{ error }` message out of an axios error so toasts show the
+// real reason (e.g. "Course is not pending review") instead of a generic string.
+export function academyErrorMessage(err: unknown, fallback: string): string {
+  const e = err as { response?: { data?: { error?: string } } } | undefined;
+  const msg = e?.response?.data?.error;
+  return typeof msg === 'string' && msg.trim() !== '' ? msg : fallback;
 }
 
 export function formatCourseDuration(minutes?: number): string {


### PR DESCRIPTION
## Why
The backend approval gate shipped (status `pending_review`, `gate_publish` downgrade, admin-only `pending-courses` / `approve` / `reject` routes) but the **dashboard had none of the matching UI**. Worse, the course modal still offered instructors a **"Published"** option while the backend silently stored `pending_review`, and the toast said **"Course created"** — so a teacher would "publish", the course would never appear on the public site, and they'd get zero explanation. This PR builds the missing front-end half.

Stacked on `feat/academy-course-categories-tags` (keeps the categories/tags UI intact).

## What changed (opsapi-dashboard only)
**`services/academy.service.ts`**
- `CourseStatus` gains `'pending_review'`.
- `getCourseStatusVariant()` returns amber **`warning`** for `pending_review`.
- New `getCourseStatusLabel()` → clean **"Pending review"** (never the raw `Pending_review`).
- New service methods: `getPendingCourses()`, `approveCourse(uuid)`, `rejectCourse(uuid)`.
- New `academyErrorMessage()` surfaces the backend's `{ error }` message in toasts (the audit flagged generic messages).

**`app/dashboard/academy/page.tsx`**
- **Honest submit UX:** non-admin instructors no longer see a lying "Published" option — they get **"Save as draft" / "Submit for review"**. A save that returns `pending_review` toasts **"Submitted for review …"**, not "Course created". Reviewers (platform admin / namespace owner) still publish directly.
- **Review queue:** reviewers get a **"Pending review"** panel listing submitted courses with **Approve** (→ published) and **Reject** (→ draft), each behind a confirm dialog, with toast + list refresh. Rendered only for `isAdmin || is_owner` (mirrors the backend's `can_manage_all`).
- **"Pending review"** added to the status filter; status badge now uses the label helper.

## Verification
- `npx tsc --noEmit` clean; `npm run build` succeeds (academy pages generated); `next dev` compiles `/dashboard/academy` → HTTP 200.
- **Drove the exact endpoints the UI calls against the running backend** (localhost:4010, `X-Namespace-Slug: academy`) as a real non-owner instructor vs. the namespace owner:
  - instructor creates a course with `status=published` → backend stores **`pending_review`** ✓
  - owner `GET /pending-courses` lists it ✓
  - owner **approve** → `published` ✓
  - owner **reject** (second course) → `draft` ✓
  - non-owner `GET /pending-courses` → **403** ✓ ; unauth'd gate routes → **401** ✓
  - test courses cleaned up afterward.

Browser click-through was **not** performed (the page is client-gated on a localStorage auth token, not feasible headless) — verification is tsc + build + `next dev` compile + the driven API evidence above.

## Scope / safety
Dashboard-only. **No backend Lua touched**, nothing diy-tax-return depends on is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)