### PR TITLE
feat(interest): itemised bank interest and a foreign interest tab

### DIFF
--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -308,6 +308,14 @@ local sa103f_completion_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_
 -- the table layout mode.
 local dividend_panels_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.dividend-panels") or {}
 
+-- Interest panels: /my-income/interest (UK banks, untaxed + taxed
+-- tables) and a new foreign_interest income type, each an itemised
+-- table rendered by the repeating_group widget's table layout. The
+-- follow-on dividend-panels.lua flagged: the flat interest boxes it
+-- deactivated (old boxes 1-3) get their itemised home here. SA106
+-- foreign_income is untouched.
+local interest_panels_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.interest-panels") or {}
+
 -- Billing / payments (Stripe Connect: subscriptions + one-time). Gated on
 -- tax_copilot for now; broaden to a feature list (e.g. {ECOMMERCE, TAX_COPILOT})
 -- once multiple project codes need it. See migrations/billing-system.lua.
@@ -2223,6 +2231,17 @@ local _migrations = {
     -- 764 / 767).
     ['791_seed_dividend_panels'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, dividend_panels_migrations, 1),
     ['792_reseed_dividend_panels'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, dividend_panels_migrations, 2),
+
+    -- 793/794 — Interest panels. Seeds the foreign_interest income
+    -- type and four itemised categories: untaxed UK / taxed UK /
+    -- notes under context='interest', and foreign savings interest
+    -- under context='foreign_interest'. Adding a context to
+    -- 'interest' also switches /my-income/interest out of flat-entry
+    -- mode (my_incomes rows stay in the DB, the Add-income surface
+    -- stops rendering) — same trade 791 made for dividends. 794 is
+    -- the re-run safety net (convention: 760 / 764 / 767 / 792).
+    ['793_seed_interest_panels'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, interest_panels_migrations, 1),
+    ['794_reseed_interest_panels'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, interest_panels_migrations, 2),
 
     -- =========================================================================
     -- Academy (LMS): courses + lessons (namespace-scoped). Feature-gated, so

--- a/lapis/migrations/interest-panels.lua
+++ b/lapis/migrations/interest-panels.lua
@@ -1,0 +1,401 @@
+--[[
+  Interest panels — two income-type tabs, each an itemised table.
+
+    /my-income/interest          "Bank interest"     — UK banks and building societies
+    /my-income/foreign_interest  "Foreign interest"  — overseas savings (new type)
+
+  FOLLOW-ON FROM dividend-panels.lua
+    That migration retired the old "Dividends and interest" category of 7
+    flat boxes. Boxes 1-3 of it were INTEREST (taxed UK / untaxed UK /
+    untaxed foreign), deactivated there with the note that interest wants
+    its own itemised panel under context='interest'. This is that panel.
+    Nothing is double-entered: those boxes are already inactive, so the
+    tables below are the only place interest is captured.
+
+  WHY TWO TYPES RATHER THAN TWO CATEGORIES ON ONE PAGE
+    Same reasoning as the dividend tabs: an income_type row is what
+    earns a tab on /my-income, a card + total on the overview, and its
+    own document routing. Auto-discovery does the rest — the frontend
+    convention is `income_type_key IS the profile-builder context`
+    (app/my-income/[type]/page.tsx), so seeding a category with
+    context='foreign_interest' is all it takes to render
+    /my-income/foreign_interest. Zero frontend routing code.
+
+    UK interest stays ONE page with two tables because untaxed and
+    taxed interest are the same transcription job off the same
+    statements — the supplied screen shows both stacked, and splitting
+    them would make a user with one of each visit two tabs.
+
+  SIDE EFFECT OF ADDING A CONTEXT
+    /my-income/interest currently renders the flat-entry list (one
+    amount per my_incomes row). Seeding a category with
+    context='interest' switches that page into profile-builder mode.
+    Existing my_incomes rows for the type are NOT deleted — they stay
+    in the DB, readable and exportable — but the flat Add-income
+    surface stops rendering, which is the point: the figures are
+    itemised per account now. Same trade dividend-panels.lua made.
+
+  BOX MAPPING
+    Every question keeps its HMRC mapping in config_json.hmrc_mapping
+    alongside `total_field` — the sub-field whose column total IS the
+    box figure:
+
+      int_untaxed_uk   SA100 box 2   total of `amount`
+      int_taxed_uk     SA100 box 1   total of `net`
+      fint_savings     SA106 box 3   total of `gross_income`
+
+    The filing worker reads that; nothing user-facing mentions a form
+    or a box number, by design.
+
+    SA100 box 1 wants the NET figure. The Tax column alongside it is
+    what the bank deducted — it doesn't have its own SA100 box (HMRC
+    grosses box 1 up), but it belongs on the row: users transcribe it
+    off the certificate, and the calculation needs it as tax already
+    paid. Kept as a totalled column rather than dropped.
+
+  WIDGET CONTRACT
+    Each panel is ONE question of type `repeating_group` whose
+    config_json declares the columns. `layout = "table"` renders the
+    grid: column headers, inline row inputs, a totals footer for
+    `total = true` columns, checkbox cells for `display = "checkbox"`
+    booleans, and read-only computed cells (see RepeatingGroupField.tsx).
+    Answers land as one user_profile_answers row per (user, question,
+    tax_year) holding a JSON array of row objects.
+
+  SA106 (context='foreign_income') is deliberately NOT touched. It
+  keeps its own "Foreign savings interest" section (boxes 3-5 as three
+  flat totals) for people filing the full supplementary form — exactly
+  the split dividend-panels.lua made with foreign dividends.
+
+  Idempotent: keyed on income_type_key / category slug / question_key.
+  Re-running refreshes labels + column config but never duplicates.
+
+  Only executed when PROJECT_CODE includes 'tax_copilot'.
+]]
+
+local db = require("lapis.db")
+local cjson = require("cjson")
+local MigrationUtils = require "helper.migration-utils"
+
+-- Column sets. Each mirrors one of the supplied screens 1:1 — column
+-- order, labels and which columns carry a total are all deliberate.
+--
+-- `total = true`  → the column gets a summed footer cell, and the
+--                   frontend counts it toward the page's headline
+--                   figure (ContextSections.numericTotal).
+-- `display`       → "checkbox" keeps a boolean to one cell's width;
+--                   the default Yes/No chip pair is too wide here.
+-- `computed`      → read-only cell derived from its siblings:
+--                     base − Σ subtract − Σ (subtract_unless whose
+--                     `unless_flag` column is unticked)
+--                   Declarative on purpose: no formula parser, and an
+--                   admin can retarget it from the admin panel.
+
+local UNTAXED_UK_FIELDS = {
+    { key = "description",    label = "Description",    type = "short_text", required = true,
+      placeholder = "e.g. Loyalty Saver" },
+    { key = "account_number", label = "Account number", type = "short_text",
+      placeholder = "e.g. 270037140" },
+    { key = "amount",         label = "Amount",         type = "currency", total = true },
+}
+
+local TAXED_UK_FIELDS = {
+    { key = "description",    label = "Description",    type = "short_text", required = true,
+      placeholder = "e.g. Reward Saver" },
+    { key = "account_number", label = "Account number", type = "short_text",
+      placeholder = "e.g. 57682563" },
+    { key = "net",            label = "Net",            type = "currency", total = true,
+      help_text = "What reached your account, after the bank took tax off." },
+    { key = "tax",            label = "Tax",            type = "currency", total = true,
+      help_text = "The tax the bank deducted, shown on your interest certificate." },
+}
+
+local FOREIGN_INTEREST_FIELDS = {
+    { key = "country",      label = "Country",              type = "short_text",
+      placeholder = "e.g. United States", required = true },
+    { key = "description",  label = "Description of income", type = "short_text",
+      placeholder = "e.g. Chase savings 8842" },
+    { key = "gross_income", label = "Gross income arising", type = "currency", total = true },
+    { key = "fig_relief",   label = "Relief claimed under the FIG regime", type = "currency", total = true },
+    { key = "foreign_tax",  label = "Foreign tax taken off", type = "currency", total = true },
+    { key = "uk_tax",       label = "UK tax taken off",      type = "currency", total = true },
+    { key = "taxable_amount", label = "Taxable amount", type = "currency", total = true,
+      computed = {
+          base = "gross_income",
+          subtract = { "fig_relief" },
+          -- Foreign tax is only deductible from the taxable amount
+          -- when you are NOT claiming Foreign Tax Credit Relief on
+          -- it — claiming FTCR credits it against the UK bill
+          -- instead, so deducting it here as well would relieve the
+          -- same tax twice. Same rule the foreign dividends panel uses.
+          subtract_unless = { { field = "foreign_tax", unless_flag = "ftcr_claim" } },
+      },
+      help_text = "Worked out for you from the amounts on this row." },
+    { key = "ftcr_claim", label = "Claim Foreign Tax Credit Relief?", type = "boolean",
+      display = "checkbox",
+      help_text = "Claims credit for the foreign tax against your UK tax on the same interest." },
+    { key = "pre_2025_remitted", label = "Pre 6 April 2025 income remitted this year?",
+      type = "boolean", display = "checkbox" },
+}
+
+-- income_types row for the NEW tab. `interest` already exists (seeded
+-- by income-types-system.lua) and is updated in place below.
+local NEW_INCOME_TYPES = {
+    {
+        key = "foreign_interest",
+        label = "Foreign interest",
+        description = "Interest from banks and savings accounts outside the UK.",
+        order = 51,
+        docs = {
+            { key = "interest_certificate", label = "Interest certificate",           required = false },
+            { key = "broker_statements",    label = "Bank / broker statements",       required = false },
+        },
+    },
+}
+
+local function seed_interest_panels()
+    local function nn(v) return v ~= nil and v or db.NULL end
+
+    -- ── income_types ────────────────────────────────────────────────
+    -- allows_manual_entry = false: these tabs capture itemised rows
+    -- through the profile builder, not one-amount-per-row my_incomes
+    -- entries. linked_form_* left NULL so no reference-form card
+    -- renders — the panels stand on their own copy.
+    local function ensure_income_type(t)
+        local exists = db.select("id FROM income_types WHERE income_type_key = ?", t.key)
+        if exists and #exists > 0 then
+            db.query([[
+                UPDATE income_types
+                   SET display_name = ?, description = ?,
+                       required_documents = ?::jsonb,
+                       allows_manual_entry = false,
+                       display_order = ?, is_active = true, updated_at = NOW()
+                 WHERE income_type_key = ?
+            ]], t.label, t.description, cjson.encode(t.docs), t.order, t.key)
+            return
+        end
+        db.query([[
+            INSERT INTO income_types
+                (uuid, income_type_key, display_name, description,
+                 required_documents, allows_manual_entry,
+                 keyword_rules, category_affinity, rules_markdown,
+                 hmrc_mapping, display_order, is_active, namespace_id,
+                 created_at, updated_at)
+            VALUES (?, ?, ?, ?,
+                    ?::jsonb, false,
+                    '[]'::jsonb, '{}'::jsonb, NULL,
+                    '{}'::jsonb, ?, true, NULL,
+                    NOW(), NOW())
+        ]], MigrationUtils.generateUUID(), t.key, t.label, t.description,
+            cjson.encode(t.docs), t.order)
+    end
+
+    local function ensure_year_category(context, slug, name, description, icon, display_order)
+        local exists = db.select("id FROM profile_categories WHERE slug = ?", slug)
+        if exists and #exists > 0 then
+            db.query([[
+                UPDATE profile_categories
+                   SET name = ?, description = ?, icon = ?, display_order = ?,
+                       context = ?, answer_scope = 'year', entity_type = NULL,
+                       is_active = true, is_archived = false, updated_at = NOW()
+                 WHERE slug = ?
+            ]], name, nn(description), nn(icon), display_order, context, slug)
+            return exists[1].id
+        end
+        db.query([[
+            INSERT INTO profile_categories
+                (uuid, namespace_id, name, slug, description, icon,
+                 display_order, context, answer_scope, entity_type,
+                 is_active, is_archived, created_at, updated_at)
+            VALUES (?, 0, ?, ?, ?, ?, ?, ?, 'year', NULL,
+                    true, false, NOW(), NOW())
+        ]], MigrationUtils.generateUUID(), name, slug, nn(description),
+            nn(icon), display_order, context)
+        local row = db.select("id FROM profile_categories WHERE slug = ?", slug)
+        return row and row[1] and row[1].id or nil
+    end
+
+    -- Upsert one question. `config` is optional (the notes questions
+    -- carry none). Re-running refreshes label / help / config so a
+    -- column tweak in this file reaches every environment.
+    local function ensure_question(cat_id, q)
+        local config_str = q.config and cjson.encode(q.config) or db.NULL
+        local exists = db.select("id FROM profile_questions WHERE question_key = ?", q.question_key)
+        if exists and #exists > 0 then
+            db.query([[
+                UPDATE profile_questions
+                   SET category_id = ?, label = ?, question_type = ?, is_required = ?,
+                       display_order = ?, help_text = ?, placeholder = '',
+                       config_json = ?, is_active = true, is_archived = false,
+                       updated_at = NOW()
+                 WHERE question_key = ?
+            ]], cat_id, q.label, q.question_type, q.is_required, q.display_order,
+                q.help_text or "", config_str, q.question_key)
+            return exists[1].id
+        end
+        db.query([[
+            INSERT INTO profile_questions
+                (uuid, category_id, question_key, label, question_type, is_required,
+                 display_order, help_text, placeholder, config_json,
+                 is_active, is_archived, version, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, '', ?, true, false, 1, NOW(), NOW())
+        ]], MigrationUtils.generateUUID(), cat_id, q.question_key, q.label,
+            q.question_type, q.is_required, q.display_order, q.help_text or "",
+            config_str)
+        local row = db.select("id FROM profile_questions WHERE question_key = ?", q.question_key)
+        return row and row[1] and row[1].id or nil
+    end
+
+    -- Table config for a panel: the column set plus the labels the
+    -- add-row affordances use.
+    local function table_config(fields, item_label, add_label, hmrc_form, hmrc_box, total_field)
+        return {
+            layout = "table",
+            item_label = item_label,
+            add_button_label = add_label,
+            fields = fields,
+            -- Filing metadata. Not rendered anywhere: the column
+            -- total named by `total_field` is what the worker puts in
+            -- the box.
+            hmrc_mapping = { form = hmrc_form, box = hmrc_box, total_field = total_field },
+        }
+    end
+
+    for _, t in ipairs(NEW_INCOME_TYPES) do ensure_income_type(t) end
+
+    -- The existing interest tab keeps its key (URLs and any stored
+    -- income_type references stay valid) but switches to itemised
+    -- capture: manual one-amount entry off, description reworded to
+    -- say the figures are per account now.
+    db.query([[
+        UPDATE income_types
+           SET display_name = 'Bank interest',
+               description = 'Interest from UK banks and building societies, listed per account.',
+               allows_manual_entry = false,
+               linked_form_title = NULL,
+               linked_form_description = NULL,
+               linked_form_weblink = NULL,
+               is_active = true, updated_at = NOW()
+         WHERE income_type_key = 'interest'
+    ]])
+
+    -- ── Tab 1, section 1: Untaxed UK interest ───────────────────────
+    -- Interest paid gross. Since April 2016 that is nearly every UK
+    -- bank and building society account, so this table leads.
+    local untaxed_id = ensure_year_category(
+        "interest-untaxed-uk",
+        "Untaxed UK interest",
+        "Interest paid without tax taken off — most UK bank and building society accounts since April 2016. One row per account.",
+        "pound-sign", 1)
+    if untaxed_id then
+        ensure_question(untaxed_id, {
+            question_key = "int_untaxed_uk",
+            label = "Untaxed UK interest",
+            question_type = "repeating_group",
+            is_required = false,
+            display_order = 1,
+            help_text = "Copy each account from your interest certificate or your bank's end-of-year summary. The amount is the interest credited during the tax year.",
+            config = table_config(UNTAXED_UK_FIELDS, "Account", "Add another account",
+                "SA100", "2", "amount"),
+        })
+    end
+
+    -- ── Tab 1, section 2: Taxed UK interest ─────────────────────────
+    -- Rarer post-2016 but still real: some annuities, PPI interest,
+    -- compensation payments and trust income arrive net of tax.
+    local taxed_id = ensure_year_category(
+        "interest-taxed-uk",
+        "Taxed UK interest",
+        "Interest that already had UK tax taken off before it reached you. Enter what you received and the tax deducted — both are on the certificate.",
+        "pound-sign", 2)
+    if taxed_id then
+        ensure_question(taxed_id, {
+            question_key = "int_taxed_uk",
+            label = "Taxed UK interest",
+            question_type = "repeating_group",
+            is_required = false,
+            display_order = 1,
+            help_text = "Leave this table empty if every account paid you gross. Net is what reached you; tax is what was deducted — don't add them together yourself.",
+            config = table_config(TAXED_UK_FIELDS, "Account", "Add another account",
+                "SA100", "1", "net"),
+        })
+    end
+
+    -- ── Tab 1, section 3: Additional information ────────────────────
+    -- The supplied screen carries one free-text note under both
+    -- tables, not one per table — its own section keeps that scope
+    -- obvious rather than making it look like a footnote to the
+    -- taxed table.
+    local notes_id = ensure_year_category(
+        "interest-notes",
+        "Additional information",
+        "Anything you want to explain to HMRC about your interest.",
+        "file-text", 3)
+    if notes_id then
+        ensure_question(notes_id, {
+            question_key = "int_notes",
+            label = "Additional text note for Tax Return",
+            question_type = "long_text",
+            is_required = false,
+            display_order = 1,
+            help_text = "Optional. Sent with your return — use it for anything the figures above don't explain on their own.",
+        })
+    end
+
+    -- ── Tab 2: Foreign interest ─────────────────────────────────────
+    local fi_id = ensure_year_category(
+        "foreign-savings-interest",
+        "Foreign savings interest",
+        "One row per overseas account. Amounts in sterling — convert at the rate on the date you were paid.",
+        "globe", 1)
+    if fi_id then
+        -- Page-level election. Ticking it is what makes the "Relief
+        -- claimed under the FIG regime" column meaningful; the column
+        -- stays editable either way rather than trapping anyone
+        -- behind a toggle they forgot to set. Mirrors the foreign
+        -- dividends panel.
+        ensure_question(fi_id, {
+            question_key = "fint_fig_regime_relief",
+            label = "Relief claimed under FIG regime?",
+            question_type = "boolean",
+            is_required = false,
+            display_order = 1,
+            help_text = "The Foreign Income and Gains regime for new UK residents. Tick only if you qualify and are claiming it.",
+        })
+        ensure_question(fi_id, {
+            question_key = "fint_savings_interest",
+            label = "Foreign savings interest",
+            question_type = "repeating_group",
+            is_required = false,
+            display_order = 2,
+            help_text = "The taxable amount is worked out for you: gross income, less any FIG-regime relief, less foreign tax where you are not claiming Foreign Tax Credit Relief on it.",
+            config = table_config(FOREIGN_INTEREST_FIELDS, "Account", "Add another account",
+                "SA106", "3", "gross_income"),
+        })
+        ensure_question(fi_id, {
+            question_key = "fint_notes",
+            label = "Additional text note for Tax Return",
+            question_type = "long_text",
+            is_required = false,
+            display_order = 3,
+            help_text = "Optional. Sent with your return — a good place to record the exchange rates you used.",
+        })
+    end
+
+    print("[Interest panels] Seeded 2 interest tabs (interest / foreign_interest)")
+end
+
+return {
+    -- =========================================================================
+    -- 1. Seed pass. Registered as 793 in migrations.lua.
+    -- =========================================================================
+    [1] = seed_interest_panels,
+
+    -- =========================================================================
+    -- 2. Re-run pass. Registered as 794. Safety net for a later edit to
+    --    this file leaving the seed half-applied in an environment that
+    --    already recorded 793 as run — the convention every catalog seed
+    --    here follows (see 760 / 764 / 767 / 792).
+    -- =========================================================================
+    [2] = seed_interest_panels,
+}

--- a/lapis/queries/FormSectionQueries.lua
+++ b/lapis/queries/FormSectionQueries.lua
@@ -29,6 +29,37 @@ local FormSectionQueries = {}
 local MAX_AMOUNT = 9999999999999.99
 FormSectionQueries.MAX_AMOUNT = MAX_AMOUNT
 
+-- SQL fragment reading one money column out of a repeating-group row
+-- (`elem`, from jsonb_array_elements) as a numeric, defaulting to 0.
+--
+-- Why not a bare `(elem->>'key')::numeric`: in Postgres that is a hard
+-- ERROR on anything non-numeric, not a NULL. card_summary runs on every
+-- /my-income load, so one bad cell anywhere in one user's answers takes
+-- their whole hub down with a 500. Two ways a cell gets here
+-- non-numeric — the widget stores an untouched money cell as "" (empty
+-- string distinguishes "not entered" from a deliberate 0), and an admin
+-- retyping a column from currency to short_text in the profile-builder
+-- panel leaves free text behind in rows already saved.
+--
+-- Numbers stored as JSON numbers take the first branch; the regex
+-- catches values written as numeric STRINGS by other paths (AI
+-- extraction, backfills, the iOS client) so those still count rather
+-- than being silently dropped.
+--
+-- `{0,1}` not `?`: lapis counts every '?' in a query string as a bind
+-- placeholder, so a '?' inside a regex literal would shift every
+-- parameter after it.
+local function money_cell(key)
+    return string.format([[
+                 CASE
+                   WHEN jsonb_typeof(elem->'%s') = 'number'
+                     THEN (elem->>'%s')::numeric
+                   WHEN elem->>'%s' ~ '^-{0,1}[0-9]+(\.[0-9]+){0,1}$'
+                     THEN (elem->>'%s')::numeric
+                   ELSE 0
+                 END]], key, key, key, key)
+end
+
 local function resolveUserId(user)
     if not user then return nil, "User not authenticated" end
     local user_uuid = user.uuid or user.id
@@ -908,6 +939,12 @@ function FormSectionQueries.card_summary(user)
     --   answer_number, so the generic sum reads zero for them. Their
     --   branch below sums the array elements (same shape as pension).
     --
+    --   interest / foreign_interest — same shape, same reason (see
+    --   migration interest-panels.lua). Excluded here rather than
+    --   left to the generic sum because their panels ALSO hold
+    --   non-array numeric answers in future admin-added questions;
+    --   the branch below is the single source of their totals.
+    --
     --   Per-entity contexts (property, business, overseas_property,
     --   rental_business, employment) — these DON'T correspond 1:1 to
     --   an income_type_key (rental hub is 'rental', not
@@ -929,7 +966,8 @@ function FormSectionQueries.card_summary(user)
         JOIN income_types it      ON it.income_type_key = c.context
         WHERE a.user_id = ?
           AND it.income_type_key NOT IN ('salary', 'pension_payments', 'capital_gains', 'other',
-                                         'dividends', 'foreign_dividends', 'other_dividends')
+                                         'dividends', 'foreign_dividends', 'other_dividends',
+                                         'interest', 'foreign_interest')
           AND c.is_active = true
           AND c.is_archived = false
           AND it.is_active = true
@@ -966,21 +1004,19 @@ function FormSectionQueries.card_summary(user)
     -- admin panel, but its key is the stable contract the seed and
     -- this query share. jsonb_typeof guard keeps a non-array answer
     -- (possible if an admin retypes the question) from throwing.
-    local dividend_rows = db.query([[
+    local dividend_rows = db.query(string.format([[
         SELECT CASE q.question_key
                  WHEN 'div_uk_dividends'  THEN 'dividends'
                  WHEN 'fdiv_dividends'    THEN 'foreign_dividends'
                  WHEN 'odiv_dividends'    THEN 'other_dividends'
                END                                    AS income_type_key,
-               -- NULLIF: the widget stores an untouched money cell as
-               -- "" (empty string distinguishes "not entered" from a
-               -- deliberate 0), and ''::numeric is a hard error — a
-               -- row where only the description is filled in would
-               -- 500 every /my-income load without this.
+               -- money_cell casts only what is certainly a number —
+               -- see the helper for why a bare ::numeric here is a
+               -- whole-hub outage waiting to happen.
                COALESCE(SUM(CASE q.question_key
-                 WHEN 'div_uk_dividends' THEN NULLIF(elem->>'dividend', '')::numeric
-                 WHEN 'fdiv_dividends'   THEN NULLIF(elem->>'gross_income', '')::numeric
-                 WHEN 'odiv_dividends'   THEN NULLIF(elem->>'dividend_received', '')::numeric
+                 WHEN 'div_uk_dividends' THEN %s
+                 WHEN 'fdiv_dividends'   THEN %s
+                 WHEN 'odiv_dividends'   THEN %s
                END), 0)                               AS total,
                COUNT(*)                               AS row_count
         FROM user_profile_answers a
@@ -992,8 +1028,59 @@ function FormSectionQueries.card_summary(user)
           AND a.answer_json <> ''
           AND jsonb_typeof(a.answer_json::jsonb) = 'array'
         GROUP BY 1
-    ]], internal_user_id) or {}
+    ]], money_cell("dividend"), money_cell("gross_income"),
+        money_cell("dividend_received")), internal_user_id) or {}
     for _, r in ipairs(dividend_rows) do
+        local entry = by_type[r.income_type_key]
+        if not entry then
+            entry = { income_type_key = r.income_type_key, total = 0, row_count = 0 }
+            out[#out + 1] = entry
+            by_type[r.income_type_key] = entry
+        end
+        entry.total = tonumber(r.total) or 0
+        entry.row_count = tonumber(r.row_count) or 0
+    end
+
+    -- ── Interest tabs ───────────────────────────────────────────────
+    -- Two income types, itemised tables (see migration
+    -- interest-panels.lua). Identical shape to the dividend branch
+    -- above — amounts live inside an answer_json array of row
+    -- objects, one row per account, so the generic answer_number sum
+    -- sees nothing and both /my-income cards would read "Nothing
+    -- recorded yet".
+    --
+    -- Total = SUM of the money column that IS that tab's headline
+    -- figure. Note 'interest' draws from TWO questions: untaxed
+    -- interest is the `amount` column, taxed interest is the `net`
+    -- column (its `tax` column is what the bank deducted, so adding
+    -- it would inflate the income figure). GROUP BY the mapped
+    -- income type folds both into one card total.
+    -- Count = number of account rows across every tax year, matching
+    -- the pension / dividend convention.
+    local interest_rows = db.query(string.format([[
+        SELECT CASE q.question_key
+                 WHEN 'int_untaxed_uk'        THEN 'interest'
+                 WHEN 'int_taxed_uk'          THEN 'interest'
+                 WHEN 'fint_savings_interest' THEN 'foreign_interest'
+               END                                    AS income_type_key,
+               COALESCE(SUM(CASE q.question_key
+                 WHEN 'int_untaxed_uk'        THEN %s
+                 WHEN 'int_taxed_uk'          THEN %s
+                 WHEN 'fint_savings_interest' THEN %s
+               END), 0)                               AS total,
+               COUNT(*)                               AS row_count
+        FROM user_profile_answers a
+        JOIN profile_questions q ON q.id = a.question_id
+        CROSS JOIN LATERAL jsonb_array_elements(a.answer_json::jsonb) elem
+        WHERE a.user_id = ?
+          AND q.question_key IN ('int_untaxed_uk', 'int_taxed_uk', 'fint_savings_interest')
+          AND a.answer_json IS NOT NULL
+          AND a.answer_json <> ''
+          AND jsonb_typeof(a.answer_json::jsonb) = 'array'
+        GROUP BY 1
+    ]], money_cell("amount"), money_cell("net"),
+        money_cell("gross_income")), internal_user_id) or {}
+    for _, r in ipairs(interest_rows) do
         local entry = by_type[r.income_type_key]
         if not entry then
             entry = { income_type_key = r.income_type_key, total = 0, row_count = 0 }


### PR DESCRIPTION
Follow-on from #510 (dividend panels), which deactivated the flat interest boxes 1-3 sitting on the dividends tab and noted that interest wants its own itemised panel under `context='interest'`. This is it — same widget, same table layout, modelled on the screens the product owner supplied.

## What ships

**`/my-income/interest` — Bank interest** (existing type, was flat-entry)

| Section | Columns |
|---|---|
| Untaxed UK interest | description\* · account number · **amount** |
| Taxed UK interest | description\* · account number · **net** · **tax** |
| Additional information | free-text note sent with the return |

**`/my-income/foreign_interest` — Foreign interest** (new income type)

Page-level "Relief claimed under FIG regime?", then one row per account: country\* · description · **gross income arising** · **FIG relief** · **foreign tax taken off** · **UK tax taken off** · **taxable amount** (computed, read-only) · claim FTCR? · pre 6 Apr 2025 remitted?

Bold columns carry a totals footer.

## Decisions worth reviewing

- **UK interest stays one page with two tables**, rather than splitting into tabs the way dividends did. Untaxed and taxed are the same transcription job off the same statements, and the reference screen stacks them — splitting would send a user with one of each to two tabs.
- **Taxed interest carries both net and tax.** Only `net` is the box figure (HMRC grosses box 1 up); `tax` has no box of its own but belongs on the row — users read it off the certificate and the calculation needs it as tax already paid. It foots in the table without reaching the headline total, so "interest received" stays honest.
- **The foreign taxable amount reuses the dividends rule**: gross, less FIG relief, less foreign tax *except* where that row claims FTCR — claiming it credits the tax against the UK bill, so deducting it here too would relieve the same tax twice.
- **SA106 (`context='foreign_income'`) is untouched** — it keeps its own foreign savings interest section (three flat totals) for people filing the full supplementary form. Same split #510 made with foreign dividends.

## Behaviour change to be aware of

Adding a context to `interest` switches `/my-income/interest` out of flat-entry mode. Existing `my_incomes` rows are untouched and still readable/exportable, but the one-amount Add-income surface stops rendering — the same trade #510 made for dividends.

## card_summary

`interest` and `foreign_interest` need their own branch for the same reason dividends did: amounts live in `answer_json` arrays, so the generic `answer_number` sum reads zero and both hub cards would claim "Nothing recorded yet". `interest` draws from two questions, folded into one card total by the `GROUP BY`.

## Bug fix carried into the shared code

A bare `(elem->>'key')::numeric` is a hard **ERROR** in Postgres on anything non-numeric, not a NULL — and this query runs on every `/my-income` load, so one bad cell in one user's answers takes their whole hub down with a 500. The `NULLIF` in #510 covered the widget's empty-string cells but not an admin retyping a column from currency to short_text, which leaves free text behind in rows already saved.

`money_cell()` now casts JSON numbers directly and numeric strings via regex (so values written by extraction or backfill still count), everything else as 0. It spells the quantifiers `{0,1}` rather than `?` because lapis counts every `?` in a query string as a bind placeholder — a `?` inside a regex literal would shift every parameter after it.

## Notes

- Migrations registered as 793 (seed) / 794 (re-run safety net), following the 760 / 764 / 767 / 792 convention. Idempotent on `income_type_key` / category slug / `question_key`.
- `foreign_interest` becomes selectable in the income questionnaire automatically — that question sources its options from the `income_types` catalogue.
- Companion frontend PR: bwalia/diy-tax-return-uk#822.

🤖 Generated with [Claude Code](https://claude.com/claude-code)