### PR TITLE
fix(migrations): crm_leads inline CRM FKs broke lapis migrate on non-CRM projects

### DIFF
--- a/lapis/migrations/crm-leads.lua
+++ b/lapis/migrations/crm-leads.lua
@@ -67,10 +67,13 @@ return {
                 -- Notes
                 notes TEXT,
 
-                -- Conversion tracking
+                -- Conversion tracking. Plain BIGINT columns here: crm_contacts/
+                -- crm_deals only exist when the CRM feature is enabled, and this
+                -- step runs for EVERY project. Step [3] (registry key 512,
+                -- CRM-gated) attaches the foreign keys where the targets exist.
                 converted_at TIMESTAMP,
-                converted_contact_id BIGINT REFERENCES crm_contacts(id) ON DELETE SET NULL,
-                converted_deal_id BIGINT REFERENCES crm_deals(id) ON DELETE SET NULL,
+                converted_contact_id BIGINT,
+                converted_deal_id BIGINT,
 
                 -- Standard CRM columns
                 metadata JSONB DEFAULT '{}',
@@ -122,6 +125,46 @@ return {
                     FOREIGN KEY (enquiry_id) REFERENCES enquiries(id) ON DELETE SET NULL
                 ]])
             end)
+        end
+    end,
+
+    -- ========================================
+    -- [3] Attach conversion FKs to crm_contacts/crm_deals (CRM-only)
+    -- Registered as key 512, gated on the CRM feature, sorting after
+    -- 501-504 so the FK targets exist. Guarded per-column so databases
+    -- created before this split (inline REFERENCES in step [1]) no-op.
+    -- ========================================
+    [3] = function()
+        if not table_exists("crm_leads") then return end
+
+        local function fk_exists(col)
+            local result = db.query([[
+                SELECT EXISTS (
+                    SELECT FROM information_schema.key_column_usage kcu
+                    JOIN information_schema.table_constraints tc
+                      ON tc.constraint_name = kcu.constraint_name
+                     AND tc.table_name = kcu.table_name
+                    WHERE tc.table_name = 'crm_leads'
+                      AND tc.constraint_type = 'FOREIGN KEY'
+                      AND kcu.column_name = ?
+                ) as exists
+            ]], col)
+            return result and result[1] and result[1].exists
+        end
+
+        if table_exists("crm_contacts") and not fk_exists("converted_contact_id") then
+            db.query([[
+                ALTER TABLE crm_leads
+                ADD CONSTRAINT crm_leads_converted_contact_fk
+                FOREIGN KEY (converted_contact_id) REFERENCES crm_contacts(id) ON DELETE SET NULL
+            ]])
+        end
+        if table_exists("crm_deals") and not fk_exists("converted_deal_id") then
+            db.query([[
+                ALTER TABLE crm_leads
+                ADD CONSTRAINT crm_leads_converted_deal_fk
+                FOREIGN KEY (converted_deal_id) REFERENCES crm_deals(id) ON DELETE SET NULL
+            ]])
         end
     end
 }


### PR DESCRIPTION
## Problem

Every deploy of `bwalia/opsapi:latest` to int has been crash-looping since Jul 29, and the Build and Deploy workflow has been red (latest: run 30533571953). Root cause chain:

1. `510_crm_create_leads` is registered **unconditionally** (lead capture is core), but its `CREATE TABLE crm_leads` still declared `converted_contact_id BIGINT REFERENCES crm_contacts(id)` / `converted_deal_id BIGINT REFERENCES crm_deals(id)` inline.
2. On any `PROJECT_CODE` without the CRM feature (int runs `tax_copilot`), `crm_contacts`/`crm_deals` are never created, so `lapis migrate` dies with `ERROR: relation "crm_contacts" does not exist`.
3. The postStart bootstrap hook retries migrate 5×, exits 1 → kubelet kills the container → `CrashLoopBackOff` → `kubectl rollout status` times out → red deploy job.
4. The Jul 29 smoke test (run 30459342468) caught exactly this ("lapis migrate failed against a fresh database — deploying this image would break the migrate hook"), but the broken image had already been pushed as `:latest`, so every subsequent int rollout restart picked it up.

The registry already anticipated the fix: key `512_crm_leads_crm_fks` (CRM-gated) points at `crm_leads_migrations[3]` — a step that was never written.

## Fix

- Step [1]: `converted_contact_id` / `converted_deal_id` are now plain `BIGINT` columns.
- Step [3] (new, wired to the existing 512 registry entry): attaches both FKs, guarded on target-table existence **and** per-column FK existence — so databases created before this split (with inline FKs) and repeat runs both no-op.

## Verification

Against fresh scratch databases using the current image:

- `PROJECT_CODE=tax_copilot`: `lapis migrate` runs to completion (previously died at 510); `crm_leads` exists with no crm_* references.
- `PROJECT_CODE=all`: migrate completes and `\d crm_leads` shows both `crm_leads_converted_contact_fk` and `crm_leads_converted_deal_fk` attached via step [3].
- LuaJIT bytecode compile passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)