### PR TITLE
feat(crm-leads-public): send confirmation email + treat leads as core

### DIFF
--- a/lapis/app.lua
+++ b/lapis/app.lua
@@ -543,8 +543,16 @@ load_if("crm", "routes.crm-accounts")
 load_if("crm", "routes.crm-contacts")
 load_if("crm", "routes.crm-deals")
 load_if("crm", "routes.crm-activities")
-load_if("crm", "routes.crm-leads")
-load_if("crm", "routes.crm-leads-public")
+-- Leads are core: capture (public submit + manual CRUD) works for every
+-- project regardless of whether the full CRM feature (accounts, contacts,
+-- deals, pipelines) is enabled. A lead is inbound raw contact info — most
+-- projects need a way to receive it even if they don't run the pipeline
+-- side of CRM. The convert-to-contact/deal endpoint inside crm-leads
+-- self-gates on the CRM feature (it needs crm_contacts + crm_deals), so
+-- the "core"-ness only exposes capture + list + edit + archive, never the
+-- convert path.
+safe_load_routes("routes.crm-leads")
+safe_load_routes("routes.crm-leads-public")
 
 -- ============================================
 -- TIMESHEETS (Time tracking and approval)

--- a/lapis/routes/crm-leads-public.lua
+++ b/lapis/routes/crm-leads-public.lua
@@ -7,12 +7,55 @@
 
     Endpoints:
     - POST /api/v2/public/leads/:namespace_slug - Submit a lead (no auth required)
+
+    Confirmation email:
+    On successful capture with a valid email, a "we got your enquiry"
+    confirmation is sent to the submitter via helper.mail. The send is
+    fire-and-forget (Mail.send default is async via ngx.timer.at) so the
+    HTTP response never waits on SMTP. If SMTP isn't configured, Mail.send
+    logs a warning and returns false — the lead is still stored, only the
+    email side-effect is skipped. Duplicates (same email in same namespace
+    within 5 minutes) do not re-send the email — the earlier submission
+    already produced one.
 ]]
 
 local cjson = require("cjson")
 local db = require("lapis.db")
 local RateLimit = require("middleware.rate-limit")
 local CrmLeadQueries = require("queries.CrmLeadQueries")
+local Mail = require("helper.mail")
+
+--- Fire the "thanks for reaching out" confirmation to the submitter.
+-- Non-blocking (Mail.send is async by default) and non-throwing: any
+-- SMTP problem is logged and swallowed so a mail-side-effect never
+-- fails a lead capture that already succeeded database-side.
+-- @param lead_data table  Parsed request body (first_name, company_name, notes, ...)
+-- @param recipient string Verified email from the request
+local function send_lead_confirmation(lead_data, recipient)
+    if not recipient or recipient == "" then return end
+    if not Mail.isConfigured() then
+        ngx.log(ngx.NOTICE, "[crm-leads-public] SMTP not configured — skipping confirmation email to ", recipient)
+        return
+    end
+
+    local ok, err = pcall(Mail.send, {
+        to = recipient,
+        subject = "We got your enquiry — thanks for getting in touch",
+        template = "lead_confirmation",
+        data = {
+            first_name = lead_data.first_name,
+            company_name = lead_data.company_name,
+            notes = lead_data.comments or lead_data.notes,
+            -- app_name / current_year are auto-populated by render_template.
+        },
+    })
+    if not ok then
+        ngx.log(ngx.WARN, "[crm-leads-public] confirmation email send raised: ", tostring(err))
+    elseif err then
+        -- Mail.send returns (false, "reason") on non-fatal failures.
+        ngx.log(ngx.WARN, "[crm-leads-public] confirmation email not sent: ", tostring(err))
+    end
+end
 
 return function(app)
     -- POST /api/v2/public/leads/:namespace_slug - Public lead submission
@@ -71,11 +114,17 @@ return function(app)
 
             if not lead then
                 if err == "duplicate" then
-                    -- Return success to avoid leaking info about existing submissions
+                    -- Return success to avoid leaking info about existing submissions.
+                    -- Do NOT re-send the confirmation email — the original submission
+                    -- (within the last 5 minutes) already produced one; sending again
+                    -- would risk looking like phishing to the recipient.
                     return { status = 200, json = { success = true, message = "Thank you for your submission" } }
                 end
                 return { status = 500, json = { success = false, error = "Submission failed" } }
             end
+
+            -- Fresh capture succeeded — fire the confirmation. Non-blocking, non-throwing.
+            send_lead_confirmation(data, data.email)
 
             return { status = 201, json = { success = true, message = "Thank you for your submission" } }
         end)

--- a/lapis/views/emails/lead_confirmation.etlua
+++ b/lapis/views/emails/lead_confirmation.etlua
@@ -1,0 +1,18 @@
+<h2>Thank you<% if first_name and first_name ~= "" then %>, <%= first_name %><% end %>!</h2>
+
+<p>We've received your enquiry and one of our team will get back to you shortly. This email confirms your submission — no action is required from you right now.</p>
+
+<% if company_name and company_name ~= "" then %>
+  <p><strong>Company:</strong> <%= company_name %></p>
+<% end %>
+
+<% if notes and notes ~= "" then %>
+  <p><strong>Your message:</strong></p>
+  <div class="info-box">
+    <%= notes %>
+  </div>
+<% end %>
+
+<p>If any of the details above look wrong, or you'd like to add anything, just reply to this email and we'll pick it up.</p>
+
+<p>Thanks,<br>The <%= app_name %> Team</p>


### PR DESCRIPTION
## Two related fixes shipped together

The public lead capture endpoint (`POST /api/v2/public/leads/:namespace_slug`) has two problems that made it non-functional for projects that don't declare `crm` in their PROJECT_FEATURES (e.g. `tax_copilot`):

1. **Route not loaded.** `app.lua` gated both `routes.crm-leads` and `routes.crm-leads-public` behind `load_if(\"crm\", ...)`. On `tax_copilot` (no `crm` feature), the routes silently skip at boot and every POST returns `SYSTEM_500 - Failed to find route`.
2. **No submitter confirmation email.** Even where the route DID load, capturing a lead was silent — the submitter got a JSON `{success: true}` back but no email. Public forms typically expect a "we got your enquiry" auto-response.

## The fix

### `lapis/app.lua` — leads are core

```diff
 load_if("crm", "routes.crm-activities")
-load_if("crm", "routes.crm-leads")
-load_if("crm", "routes.crm-leads-public")
+-- Leads are core: capture (public submit + manual CRUD) works for
+-- every project regardless of whether the full CRM feature (accounts,
+-- contacts, deals, pipelines) is enabled. The convert-to-contact/deal
+-- endpoint inside crm-leads self-gates on the CRM feature (it needs
+-- crm_contacts + crm_deals), so the "core"-ness only exposes capture +
+-- list + edit + archive, never the convert path.
+safe_load_routes("routes.crm-leads")
+safe_load_routes("routes.crm-leads-public")
```

### `lapis/routes/crm-leads-public.lua` — fire confirmation email async

After `createLeadFromPublic` returns a fresh (non-duplicate) lead with an email address:

- Calls `Mail.send({template = "lead_confirmation", data = {first_name, company_name, notes}})` — async default, so the HTTP response never waits on SMTP.
- `pcall`-wrapped so any Lua-level error is logged and swallowed — a mail side-effect can never fail a capture that already succeeded database-side.
- `Mail.isConfigured()` short-circuit — if SMTP isn't set up in the env, log a NOTICE and skip. Lead still stored.
- **Duplicates skip the email intentionally.** The existing 5-minute duplicate window in `createLeadFromPublic` returns `err == "duplicate"` and a 200-with-thanks response — re-sending on every retry would look like phishing to the recipient.

### `lapis/views/emails/lead_confirmation.etlua` — new template

Short, non-committal (no "someone will call in X hours" — we can't promise SLA from a public capture form). Uses the existing `_base` layout and `app_name` / `current_year` vars that `render_template` injects automatically.

## Verified end-to-end on int

Hotfix ConfigMap overlay mounted onto the running `diytaxreturn-lapis` deployment (`kubectl patch deploy … --patch-file` adding the ConfigMap volume + 3 `subPath` file mounts). After rollout:

```
POST https://int-api.diytaxreturn.co.uk/opsapi/api/v2/public/leads/tax-copilot
→ HTTP 201 {"message": "Thank you for your submission", "success": true}
```

Nginx error log shows the async Mail worker firing with the correct template + recipient. SMTP itself is currently failing on int with `535-5.7.8 Username and Password not accepted` from Gmail — that's an infra credential issue (Gmail App Password rotated / mismatch in the `diytaxreturn-lapis-secrets` Vault entry), not a code problem, and it affects every existing opsapi email flow (OTP / welcome / password reset) equally. Flagged for the operator to rotate the App Password separately.

## Not changed

- `helper/mail.lua` — untouched. Existing SMTP config, suppression regex, non-prod subject enrichment all still apply.
- `queries/CrmLeadQueries.createLeadFromPublic` — untouched. Duplicate detection stays where it is; email suppression on duplicates lives in the route (where "was this a duplicate?" is directly observable).
- No env-var / Secret / ExternalSecret changes required. SMTP env vars are already present on int/test/acc.

## Test plan

- [x] Endpoint returns 201 on fresh submission with valid email
- [x] Endpoint returns 200 on duplicate email within 5 minutes (no email re-sent)
- [x] Endpoint returns 400 when neither email nor first_name is provided
- [x] `lead_confirmation.etlua` renders through the `_base` layout without template errors
- [x] Mail.send fires async (Lua log shows `ngx.timer.at` context on retries)
- [ ] After Gmail App Password is rotated, verify the confirmation email actually lands in the recipient's inbox

## Follow-up (not this PR)

- Rotate Gmail App Password for the SMTP_USER on int/test/acc so all opsapi email flows work again (not caused by this PR — pre-existing).
- Once this PR merges and a new opsapi image ships, remove the temporary ConfigMap + Deployment patch on int (`kubectl -n int delete cm opsapi-hotfix-lead-email` + revert the volumeMounts / volumes stanza).

🤖 Generated with [Claude Code](https://claude.com/claude-code)