### PR TITLE
fix(cors): allow diytaxreturn.co.uk origins on prod public lead capture

### DIFF
--- a/devops/helm-charts/diytaxreturn-lapis/templates/deployment.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/templates/deployment.yaml
@@ -132,6 +132,32 @@ spec:
             - name: PASSWORD_RESET_ALLOWED_ORIGINS
               value: {{ .Values.passwordResetAllowedOrigins | quote }}
             {{- end }}
+            # ── Browser CORS allow-list ────────────────────────────────────
+            # Consumed by lapis/middleware/cors.lua. Without a match the
+            # middleware sets NO Access-Control-Allow-Origin and the browser
+            # blocks the call — this is what broke public marketing-site form
+            # posts to /api/v2/public/leads/:namespace_slug from
+            # https://diytaxreturn.co.uk (prod returned 204 + Vary: Origin
+            # but no ACAO header).
+            #
+            # ``corsAllowedDomains``  = comma-separated bare domains. Each one
+            # matches the apex AND every subdomain, http or https, any port
+            # (so "diytaxreturn.co.uk" also covers www./app./acc.).
+            # ``corsAllowedOrigins``  = comma-separated exact origins, for
+            # hosts that aren't under an allowed domain (e.g. a preview URL).
+            #
+            # Both are OPTIONAL here: when unset, whatever Vault ships in the
+            # ExternalSecret (envFrom above) still applies. When set, this
+            # env entry WINS over envFrom for that key — so only set them in
+            # values-*.yaml for envs where git should own the allow-list.
+            {{- if .Values.corsAllowedDomains }}
+            - name: CORS_ALLOWED_DOMAINS
+              value: {{ .Values.corsAllowedDomains | quote }}
+            {{- end }}
+            {{- if .Values.corsAllowedOrigins }}
+            - name: CORS_ALLOWED_ORIGINS
+              value: {{ .Values.corsAllowedOrigins | quote }}
+            {{- end }}
       volumes:
         - name: {{ .Release.Name }}-cm-{{ .Release.Namespace }}-vol
           configMap:

--- a/devops/helm-charts/diytaxreturn-lapis/values-prod.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/values-prod.yaml
@@ -20,6 +20,25 @@ projectCode: tax_copilot
 frontendUrl: "https://app.diytaxreturn.co.uk"
 # passwordResetAllowedOrigins: ""
 
+# ─── Browser CORS allow-list ──────────────────────────────────────────
+# Read by lapis/middleware/cors.lua. The bare domain matches the apex and
+# every subdomain (www./app./…), http or https, with or without a port —
+# so this single entry covers https://diytaxreturn.co.uk,
+# https://www.diytaxreturn.co.uk and https://app.diytaxreturn.co.uk.
+#
+# Needed for the public marketing-site form posting to
+# POST /api/v2/public/leads/tax-copilot: before this, prod answered the
+# preflight with 204 + `Vary: Origin` but no Access-Control-Allow-Origin,
+# so the browser blocked every submission.
+#
+# NOTE: setting this here means git — not Vault — owns the prod
+# allow-list (the env entry overrides the ExternalSecret's envFrom value).
+corsAllowedDomains: "diytaxreturn.co.uk"
+# Exact origins that are NOT under an allowed domain above. The two
+# public site origins are listed explicitly as well so the allow-list is
+# greppable and survives any future narrowing of corsAllowedDomains.
+corsAllowedOrigins: "https://diytaxreturn.co.uk,https://www.diytaxreturn.co.uk"
+
 image:
   repository: bwalia/opsapi
   tag: latest


### PR DESCRIPTION
## Problem

Form posts from `https://diytaxreturn.co.uk` and `https://www.diytaxreturn.co.uk` to `POST /api/v2/public/leads/:namespace_slug` are blocked by the browser on production.

Verified against the live prod API **before** this change:

| Origin | Preflight `Access-Control-Allow-Origin` |
|---|---|
| `https://diytaxreturn.co.uk` | *(none)* → browser blocks |
| `https://www.diytaxreturn.co.uk` | *(none)* → browser blocks |
| `https://app.diytaxreturn.co.uk` | *(none)* → browser blocks |
| `http://localhost:3000` | `http://localhost:3000` |

Only the hardcoded Tier 1 localhost rule in `lapis/middleware/cors.lua` matches, so `CORS_ALLOWED_DOMAINS` is effectively **empty** in prod — not merely missing this domain. `app.diytaxreturn.co.uk` was blocked too.

The failure is easy to misdiagnose: the middleware answers the preflight `204` with `Vary: Origin` but simply omits `Access-Control-Allow-Origin` when nothing matches, so it surfaces as a silent client-side block rather than an API error.

## Why the fix is in the chart

`CORS_ALLOWED_DOMAINS` / `CORS_ALLOWED_ORIGINS` reached the pod only through the Vault-backed ExternalSecret (`secret/diytaxreturnuk/opsapi/<env>/config`), so nothing in git could set them. This adds optional chart values following the existing `passwordResetAllowedOrigins` pattern.

- `templates/deployment.yaml` — new `corsAllowedDomains` / `corsAllowedOrigins` values, each gated on being set
- `values-prod.yaml` — `corsAllowedDomains: "diytaxreturn.co.uk"` plus both public origins listed explicitly

A bare domain matches the apex **and** every subdomain, http or https, with or without a port — so the single entry covers all three hostnames above.

## Verification

Pattern matching exercised against the real `buildDomainPatterns()` code in-container:

```
https://diytaxreturn.co.uk       -> ALLOWED
https://www.diytaxreturn.co.uk   -> ALLOWED
https://app.diytaxreturn.co.uk   -> ALLOWED
https://evil.com                 -> blocked
https://notdiytaxreturn.co.uk    -> blocked   (no prefix leak)
```

## Reviewer notes

1. **Ownership shift.** A `env` entry beats `envFrom`, so where these values are set the allow-list moves from Vault into git. Deliberate, and scoped to prod only — every other env leaves both unset and keeps Vault as the source of truth. If you'd rather keep Vault authoritative for prod too, drop the `values-prod.yaml` hunk and set `CORS_ALLOWED_DOMAINS=diytaxreturn.co.uk` in Vault instead; the `deployment.yaml` hunk still stands as the escape hatch.
2. **Deploy path.** ArgoCD `opsapi-prod` tracks the `release` branch, so this needs to reach `release` — merging to `main` alone will not fix prod.
3. **Out of scope, worth a look.** `acc-api.diytaxreturn.co.uk` returns `access-control-allow-origin: https://acc.diytaxreturn.co.uk` regardless of the request Origin. The Lua middleware cannot produce that (it only ever echoes the caller's own origin), so something in front of it — likely the `wslproxy` ingress — is injecting a fixed header. Not touched here.
4. Separately noted while testing: the prod API has **no `/opsapi` path prefix** (that is an acc convention). `/opsapi/health` returns `401 Missing Authorization header` because the prefix is not stripped and the app never sees the URI as public. The correct form endpoint is `https://api.diytaxreturn.co.uk/api/v2/public/leads/tax-copilot`.

No test POST was sent to prod — that would create a real lead in the CRM. Happy to fire one after deploy to confirm end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)