### PR TITLE
fix(backup): follow redirects when downloading mc client

### DIFF
--- a/devops/helm-charts/diytaxreturn-lapis/templates/configmaps.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/templates/configmaps.yaml
@@ -88,7 +88,7 @@ data:
       pg_dump -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB" -F c | gzip > "/tmp/$BACKUP_FILE"
 
       # Install MinIO Client
-      curl -O https://dl.min.io/client/mc/release/linux-amd64/mc
+      curl -fSL --retry 3 -o mc https://dl.min.io/client/mc/release/linux-amd64/mc
       chmod +x mc && mv mc /usr/local/bin/
 
       # Configure MinIO and upload backup

--- a/devops/helm-charts/diytaxreturn-lapis/templates/cronjob.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/templates/cronjob.yaml
@@ -42,7 +42,7 @@ spec:
                     exit 1
                   fi
                   # Install MinIO Client
-                  curl -O https://dl.min.io/client/mc/release/linux-amd64/mc
+                  curl -fSL --retry 3 -o mc https://dl.min.io/client/mc/release/linux-amd64/mc
                   chmod +x mc && mv mc /usr/local/bin/
 
                   # Debugging: Ensure MinIO variables are set
@@ -170,7 +170,7 @@ spec:
                     exit 1
                   fi
                   # Install MinIO Client
-                  curl -O https://dl.min.io/client/mc/release/linux-amd64/mc
+                  curl -fSL --retry 3 -o mc https://dl.min.io/client/mc/release/linux-amd64/mc
                   chmod +x mc && mv mc /usr/local/bin/
 
                   # Debugging: Ensure MinIO variables are set


### PR DESCRIPTION
## Problem

The DB backup CronJobs (`workstation-opsapi-int-db-backup-daily` and `-hourly`) are failing at the MinIO upload step:

```
/usr/local/bin/mc: line 1: can't open a: no such file
MinIO upload failed!
```

**Root cause:** `dl.min.io` now returns an HTTP 302 redirect to GitHub releases. The backup scripts download `mc` with `curl -O` (no `-L`), so the 141-byte HTML redirect body (`<a href="...">Found</a>.`) was saved as `/usr/local/bin/mc` and executed as a shell script. The `pg_dump` itself succeeds — only the upload fails.

Reproduced directly: `curl -w` against the download URL returns `HTTP 302, 141 bytes` with body `<a href="https://github.com/minio/mc/releases/...">Found</a>.` — matching the byte count in the failing pod's logs exactly.

## Fix

Replace `curl -O` with `curl -fSL --retry 3 -o mc` in all three places (hourly + daily CronJobs in `cronjob.yaml`, and the backup-script ConfigMap):
- `-L` follows the redirect
- `-f` fails loudly on HTTP errors instead of saving error pages
- `--retry 3` covers transient failures

`sre/k3s/manifests/backup-cronjob.yaml` (wget, follows redirects) and `.github/workflows/db_backup.yml` (`curl -fsSL`) already handle redirects and are untouched.

## Verification plan

After merge + redeploy to int, trigger a one-off run and confirm the upload succeeds:

```bash
kubectl -n int create job --from=cronjob/workstation-opsapi-int-db-backup-daily backup-fix-test
kubectl -n int wait --for=condition=complete --timeout=10m job/backup-fix-test
kubectl -n int logs job/backup-fix-test | tail -5   # expect: Backup successfully uploaded to MinIO.
kubectl -n int delete job backup-fix-test
```

## Not included (follow-ups)

- Both CronJobs upload to a hardcoded `myminio/opsapi-test-pg/` bucket while validating-but-ignoring `$MINIO_BUCKET` (= `opsapi`). Switching to `$MINIO_BUCKET` changes where backups land, so it needs a deliberate decision.
- Longer term: bake a pinned `mc` binary into the image (or use a pinned `minio/mc` container) instead of downloading from the internet on every backup run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)