### PR TITLE
feat(tax-transactions): filter by bank_account_uuid + statement_uuid

### DIFF
--- a/lapis/routes/tax-transactions.lua
+++ b/lapis/routes/tax-transactions.lua
@@ -125,6 +125,28 @@ local function build_user_filters(params, user_id)
         end
     end
 
+    -- UUID filters — the frontend only ever has UUIDs (BankAccount.id
+    -- and Statement.id in the TypeScript surface are both the opaque
+    -- ``uuid`` column, never the numeric PK). Filtering by UUID means
+    -- the client side of /transactions can drop bank/statement values
+    -- straight from its dropdowns into the query string with no
+    -- extra "resolve uuid -> integer" round-trip.
+    --
+    -- The main list query LEFT JOINs both tax_bank_accounts (as ``ba``)
+    -- and tax_statements (as ``s``) already, so we just add conditions
+    -- on their ``uuid`` columns. Kept as separate params from the
+    -- integer forms above so no existing caller relying on the numeric
+    -- ``bank_account_id`` breaks — both work in parallel.
+    if params.bank_account_uuid and params.bank_account_uuid ~= "" then
+        table.insert(conds, "ba.uuid = ?")
+        table.insert(vals, params.bank_account_uuid)
+    end
+
+    if params.statement_uuid and params.statement_uuid ~= "" then
+        table.insert(conds, "s.uuid = ?")
+        table.insert(vals, params.statement_uuid)
+    end
+
     return conds, vals
 end
 


### PR DESCRIPTION
## Summary
- Adds `bank_account_uuid` and `statement_uuid` query params to `GET /api/v2/tax/transactions`
- The main list query already `LEFT JOIN`s both tables (aliased `ba`, `s`), so the new conditions piggyback on the join
- The legacy integer `bank_account_id` param stays in parallel — no breakage for existing callers

## Why
The client `/transactions` page exposes filter dropdowns for bank account + statement. Both dropdowns feed from `BankAccount.id` / `Statement.id`, which on the TypeScript surface are the opaque `uuid` column, never the numeric PK. The existing `bank_account_id` filter called `tonumber()` and expected the integer PK, so it silently returned zero rows from the browser.

Companion PR on the client side: [bwalia/diy-tax-return-uk#878](https://github.com/bwalia/diy-tax-return-uk/pull/878) — adds the two dropdowns and passes these params.

## Test plan
- [x] baseline: `GET /api/v2/tax/transactions?limit=3` returns 40 tx for the test user
- [x] `bank_account_uuid=<demo-finance>&limit=3` → 40 (single-bank user)
- [x] `statement_uuid=<april_2026>&limit=3` → 20 (that statement's tx)
- [x] combined bank + statement → 20 (intersection)
- [x] unknown UUID → 0
- [x] legacy `bank_account_id=<integer>` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)