### PR TITLE
feat(income-types): accept include_in_tax_preview in update()

### DIFF
--- a/lapis/queries/IncomeTypeQueries.lua
+++ b/lapis/queries/IncomeTypeQueries.lua
@@ -213,6 +213,16 @@ function IncomeTypeQueries.update(uuid, body)
         table.insert(sets, "is_active = " ..
             db.interpolate_query("?", body.is_active and true or false))
     end
+    -- Admin-controlled opt-in for the /file-my-tax local tax preview
+    -- (see backend/app/api/my_income_tax.py in the consumer repo).
+    -- Column is added by consumer migration
+    -- 20260804_002_income_types_include_in_tax_preview.lua with a
+    -- default of FALSE — the preview only sums income types an admin
+    -- has explicitly ticked here.
+    if body.include_in_tax_preview ~= nil then
+        table.insert(sets, "include_in_tax_preview = " ..
+            db.interpolate_query("?", body.include_in_tax_preview and true or false))
+    end
     table.insert(sets, "updated_at = NOW()")
 
     db.query("UPDATE income_types SET " .. table.concat(sets, ", ") .. " WHERE uuid = ?", uuid)


### PR DESCRIPTION
## Summary
Teaches ``IncomeTypeQueries.update`` to accept the ``include_in_tax_preview`` boolean added by consumer migration ``20260804_002_income_types_include_in_tax_preview.lua`` (in [bwalia/diy-tax-return-uk#881](https://github.com/bwalia/diy-tax-return-uk/pull/881)).

## Why this is needed for the consumer PR to work on int/acc/prod
The consumer PR adds a "Include in local tax preview" checkbox on ``/admin/income-types`` and reads the column at ``/api/my-income/tax-preview``. Without this Lua change:
- Admin ticks the box → save → Lua ignores the field.
- The response comes back with the previous value.
- The checkbox visibly reverts on the next load.
- ``/file-my-tax`` keeps returning £0 tax regardless of admin intent — with no error message.

## What changed
Follows the exact pattern of the neighbouring booleans (``allows_manual_entry``, ``is_active``):
- Explicit ``~= nil`` check (so a JSON ``false`` doesn't get coerced away by Lua truthiness).
- Interpolated as a boolean via ``db.interpolate_query``.

## Ownership boundary
No schema change here. The column lives in the consumer's migration space per [#513](https://github.com/bwalia/opsapi/pull/513) — opsapi is only teaching its update pipeline to pass the field through.

## Test plan
- [x] Local: hot-patched into the running container, verified via the /admin/income-types UI — the toggle now persists across reloads and drives the /file-my-tax preview.
- [ ] int: needs to land + a fresh ``bwalia/opsapi:latest`` image built + int redeployed with it before the consumer PR is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)