### PR TITLE
fix(profile-builder): mirror NINO answers into tax_user_profiles

### DIFF
--- a/lapis/routes/profile-builder.lua
+++ b/lapis/routes/profile-builder.lua
@@ -12,6 +12,7 @@
 local db = require("lapis.db")
 local cjson = require("cjson")
 local IdentityLock = require("lib.identity_lock")
+local Global = require("helper.global")
 
 -- ─── Locked-field guard for the generic answers endpoint ──────────────────
 -- The profile-builder /answers endpoint is the historical back-door for
@@ -3589,6 +3590,78 @@ return function(app)
                         -- value even if an admin mis-files an identity
                         -- question into a per-entity or per-year category.
                         if lock_field and not entity_uuid and not tax_year then
+                            -- ─── Mirror NINO into tax_user_profiles so HMRC
+                            -- filing sees the value ─────────────────────────
+                            --
+                            -- Historically the /profile builder wrote NINO
+                            -- to user_profile_answers only and left
+                            -- tax_user_profiles.nino_encrypted null. The
+                            -- /settings HMRC tab (which reads has_nino /
+                            -- nino_masked from tax_user_profiles) then
+                            -- re-asked for the number even though the user
+                            -- had already typed it, and HMRC filing
+                            -- couldn't proceed because tax-hmrc-filing.lua
+                            -- decrypts from nino_encrypted.
+                            --
+                            -- Fix: on every successful lock_field write,
+                            -- also upsert tax_user_profiles with the
+                            -- encrypted canonical value. Idempotent — a
+                            -- re-write with the same value produces the
+                            -- same encrypted output and updates the row
+                            -- in place. Same encryption path (AES-128-CBC
+                            -- via Global.encryptSecret) that /settings'
+                            -- POST /api/v2/hmrc/nino uses, so the two
+                            -- write paths are interchangeable at rest.
+                            --
+                            -- UTR mirror is intentionally not done here —
+                            -- tax_user_profiles has no utr_encrypted /
+                            -- has_utr / utr_last4 columns today. Add
+                            -- those alongside a UTR mirror when the
+                            -- filing flow needs the UTR in tax_user_profiles.
+                            if lock_field == "nino" then
+                                local raw = ans.answer_text
+                                if raw ~= nil and raw ~= cjson.null then
+                                    local canonical = tostring(raw)
+                                        :upper()
+                                        :gsub("%s+", "")
+                                    if canonical ~= "" then
+                                        local ok_enc, enc = pcall(
+                                            Global.encryptSecret, canonical
+                                        )
+                                        if ok_enc and enc then
+                                            local last4 = canonical:sub(-4)
+                                            local existing = db.select(
+                                                "id FROM tax_user_profiles WHERE user_id = ? LIMIT 1",
+                                                user_id
+                                            )
+                                            if existing and #existing > 0 then
+                                                pcall(db.update, "tax_user_profiles", {
+                                                    nino_encrypted = enc,
+                                                    nino_last4     = last4,
+                                                    has_nino       = true,
+                                                    updated_at     = db.raw("NOW()"),
+                                                }, { user_id = user_id })
+                                            else
+                                                pcall(db.insert, "tax_user_profiles", {
+                                                    uuid           = Global.generateStaticUUID and Global.generateStaticUUID() or nil,
+                                                    user_id        = user_id,
+                                                    namespace_id   = namespace_id or 0,
+                                                    nino_encrypted = enc,
+                                                    nino_last4     = last4,
+                                                    has_nino       = true,
+                                                    created_at     = db.raw("NOW()"),
+                                                    updated_at     = db.raw("NOW()"),
+                                                })
+                                            end
+                                        else
+                                            ngx.log(ngx.ERR,
+                                                "[ProfileBuilder] NINO mirror encrypt failed: ",
+                                                tostring(enc))
+                                        end
+                                    end
+                                end
+                            end
+
                             IdentityLock.stampLock(user_uuid, namespace_id or 0, lock_field)
                             IdentityLock.emitAuditRow({
                                 user_id      = user_id,


### PR DESCRIPTION
## Summary

- Mirrors NINO answers written via `POST /api/v2/profile-builder/answers` into `tax_user_profiles.nino_encrypted / nino_last4 / has_nino` alongside the existing `nino_locked_at` stamp.
- Unifies the two write paths (this endpoint + `POST /api/v2/hmrc/nino`) so they produce interchangeable state at rest — same AES-128-CBC encryption via `Global.encryptSecret`.
- UTR intentionally not mirrored — `tax_user_profiles` has no `utr_encrypted / has_utr / utr_last4` columns today. Add those alongside a UTR mirror when the filing flow needs UTR from `tax_user_profiles`.

## Motivation

Client feedback (2026-08-05): "In the profile section we already asking for nino number and here again we are asking the nino number [in /settings?tab=hmrc]. Can you please just fetch the nino number from profile and display here and make sure it is locked."

Root cause: the profile-builder answers endpoint wrote NINO to `user_profile_answers` only and stamped `tax_user_profiles.nino_locked_at`, but never populated the encrypted mirror. Three cascading consequences:

1. `GET /api/v2/hmrc/tax-profile` reported `has_nino=false` even after the user answered in `/profile` — the `/settings` HMRC tab then re-asked for it.
2. `routes/tax-hmrc-filing.lua` decrypts from `nino_encrypted`, so users could not file HMRC returns after only answering in `/profile`.
3. Attempting to re-save via `POST /api/v2/hmrc/nino` hit `assertNotLocked` and 403'd because `nino_locked_at` was already set — leaving the user unable to complete HMRC setup at all.

## Companion changes in the consumer repo

Consumer `diy-tax-return-uk` ships a backfill migration for existing users whose NINO was captured before this mirror landed:

`migrations/opsapi/migrations/20260805_003_backfill_nino_from_profile_answers.lua` — reads `user_profile_answers` with `question_key IN ('nino', 'ni_number')`, normalises + validates against the canonical UK NINO pattern, encrypts via the identical `Global.encryptSecret` path, and upserts `tax_user_profiles`. Idempotent, safe to re-run.

Both need to land for the fix to be complete end-to-end; the route change fixes going-forward writes, the backfill fixes users already in the system.

## Test plan

- [ ] `docker compose restart opsapi` and confirm no boot errors
- [ ] Fresh user completes `/profile` NINO question → `SELECT has_nino, nino_last4, nino_encrypted IS NOT NULL AS has_encrypted, nino_locked_at IS NOT NULL AS is_locked FROM tax_user_profiles WHERE user_id = <id>` all show `true`
- [ ] Same user visits `/settings?tab=hmrc` → NINO displays as locked with masked last-4, no re-entry prompt
- [ ] Same user's HMRC filing flow decrypts the NINO successfully
- [ ] Re-answering the same NINO in `/profile` is a no-op (existing idempotency logic)
- [ ] Empty submission on the NINO question does not stamp anything (existing empty-submission short-circuit)
- [ ] Consumer backfill migration mirrors an existing pre-mirror user's NINO on next opsapi restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)