### PR TITLE
fix(nino): pass user_uuid at the write-branch call site + log silent returns

### DIFF
--- a/lapis/routes/profile-builder.lua
+++ b/lapis/routes/profile-builder.lua
@@ -52,9 +52,34 @@ local LOCK_FIELD_BY_QUESTION_KEY = {
 -- doesn't roll back the caller's answer save, and a subsequent
 -- profile visit will re-attempt.
 local function mirror_nino_to_tax_user_profile(user_id, user_uuid, namespace_id, raw_value)
-    if raw_value == nil or raw_value == cjson.null then return end
+    -- Guard rails logged loudly rather than silently returning — the
+    -- silent-return path masked a call-site arity bug for the first
+    -- 24 hours of this helper's life (2026-08-05: PR #523 updated the
+    -- signature to add user_uuid but only reached one of the two call
+    -- sites via `replace_all`, so the other passed 3 args → raw_value
+    -- resolved to nil → this function noop'd invisibly). If any call
+    -- site ever passes something unusable we want it visible in
+    -- ngx.log(ngx.ERR), not silent.
+    if raw_value == nil or raw_value == cjson.null then
+        ngx.log(ngx.ERR,
+            "[ProfileBuilder] NINO mirror skipped: raw_value is nil ",
+            "(user_id=", tostring(user_id), " user_uuid=", tostring(user_uuid),
+            " namespace_id=", tostring(namespace_id), ")")
+        return
+    end
     local canonical = tostring(raw_value):upper():gsub("%s+", "")
-    if canonical == "" then return end
+    if canonical == "" then
+        ngx.log(ngx.ERR,
+            "[ProfileBuilder] NINO mirror skipped: canonical value is empty ",
+            "(user_id=", tostring(user_id), " raw=", tostring(raw_value), ")")
+        return
+    end
+    if not user_uuid or user_uuid == "" then
+        ngx.log(ngx.ERR,
+            "[ProfileBuilder] NINO mirror skipped: user_uuid is missing ",
+            "(user_id=", tostring(user_id), ") — INSERT branch would violate NOT NULL")
+        return
+    end
 
     local ok_enc, enc = pcall(Global.encryptSecret, canonical)
     if not ok_enc or not enc then
@@ -3692,7 +3717,7 @@ return function(app)
                             -- has_utr / utr_last4 columns yet.
                             if lock_field == "nino" then
                                 mirror_nino_to_tax_user_profile(
-                                    user_id, namespace_id, ans.answer_text
+                                    user_id, user_uuid, namespace_id, ans.answer_text
                                 )
                             end
 

--- a/lapis/routes/tax-hmrc-data.lua
+++ b/lapis/routes/tax-hmrc-data.lua
@@ -348,9 +348,19 @@ return function(app)
                           nino_consent_at = db.raw("NOW()"), updated_at = db.raw("NOW()") },
                         { user_id = user_id })
                 else
+                    -- user_uuid is NOT NULL on tax_user_profiles — omitting
+                    -- it fails this fresh-user INSERT path. Historically
+                    -- masked because established users usually have a row
+                    -- from another flow (default_profile_key set at
+                    -- register, HMRC obligations fetch, business-profile
+                    -- wizard) and take the UPDATE branch above. A truly
+                    -- fresh user routing NINO through this endpoint hits
+                    -- this INSERT and needs the uuid populated. Same
+                    -- rationale as the profile-builder mirror INSERT.
                     db.insert("tax_user_profiles", {
                         uuid = Global.generateStaticUUID(),
                         user_id = user_id,
+                        user_uuid = user_uuid,
                         namespace_id = namespace_id,
                         nino_encrypted = enc,
                         nino_last4 = last4,


### PR DESCRIPTION
## Root cause of "NINO still empty on /settings HMRC after profile save"

PR #523 extended the `mirror_nino_to_tax_user_profile` helper to take `user_uuid` and updated the noop-branch call site. It intended to update the write-branch call site too via `replace_all` — but the two call sites have different indentation (28 vs 32 spaces on the args), so only ONE matched.

Result: for a fresh user answering NINO on `/profile` for the first time, the **write branch** fires (their answer isn't a same-value re-save). The 3-arg call shifted every positional arg:

| Helper param | 3-arg call passes | Should be |
|---|---|---|
| `user_id` | `user_id` | ✓ |
| `user_uuid` | `namespace_id` | ✗ shifted |
| `namespace_id` | `ans.answer_text` | ✗ shifted |
| `raw_value` | (nothing) → `nil` | ✗ missing |

Inside the helper, `raw_value == nil` hit the empty-value guard and silently returned. `tax_user_profiles` was never mirrored. `stampLock` + audit row still fired (they're outside the mirror call), so the audit log showed `NINO_SAVED_AND_LOCKED` — but `has_nino` / `nino_encrypted` / `nino_last4` all stayed empty.

## Fixes in this PR

1. **write-branch call site** (`routes/profile-builder.lua` ~L3694): pass `user_uuid` as the second arg, matching the helper's signature and the noop-branch call.

2. **Log silent returns loudly.** All three early-return paths in the mirror helper (raw_value nil / canonical empty / user_uuid missing) now emit `ngx.log(ngx.ERR, ...)` with the user_id + user_uuid + namespace_id. Silent skips masked this arity bug for a full day; future call-site mistakes will surface immediately in the error log.

3. **Defence in depth — `tax-hmrc-data.lua` saveNino INSERT**: the `POST /api/v2/hmrc/nino` handler had the same missing `user_uuid` in its INSERT branch (flagged in #523's out-of-scope note). Historically masked because `/settings` HMRC users usually already have a `tax_user_profiles` row from another flow (default_profile_key set at register, HMRC obligations fetch, business-profile wizard) and take the UPDATE path. Added `user_uuid = user_uuid` to the INSERT column list.

## Why this isn't a patch — it's the permanent fix

- Every code path that writes `tax_user_profiles.user_id` now also sets `user_uuid`, which is what the NOT NULL schema constraint requires. No more silent NOT NULL violations under any flow.
- The mirror helper is now observably safe: any future call-site mistake (wrong arg order, forgotten arg, wrong type) logs to nginx error before returning. Failures are visible instead of hidden.

## Verified locally end-to-end

User `hidar@mailinator.com` (id 12), fresh user testing on latest opsapi image with #521+#522+#523 already applied — her frontend save left `has_nino=false`. After hot-patching this fix and re-saving on `/profile`: `has_nino=t, nino_last4=131A, enc=t, is_locked=t` on a single save.

## Test plan

- [ ] Brand-new user (no prior `tax_user_profiles` row) answers NINO on `/profile` → single save populates row with `has_nino=true` + `user_uuid` set correctly
- [ ] Same user opens `/settings?tab=hmrc` → NINO displays locked with masked last-4, no re-entry prompt
- [ ] Fresh user saves NINO via `POST /api/v2/hmrc/nino` directly → INSERT succeeds (user_uuid populated), no NOT NULL violation
- [ ] Established user (existing `tax_user_profiles` row) re-saves NINO → UPDATE branch fires on both endpoints, no regression
- [ ] Bad-args call to the mirror (e.g. `nil` raw_value) surfaces `[ProfileBuilder] NINO mirror skipped: …` in the error log instead of silent noop

🤖 Generated with [Claude Code](https://claude.com/claude-code)