### PR TITLE
fix(helm): keep opsapi pods off lubuntu001 — AppArmor breaks postStart bootstrap

### DIFF
--- a/devops/helm-charts/diytaxreturn-lapis/templates/deployment.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/templates/deployment.yaml
@@ -21,6 +21,22 @@ spec:
       labels:
         app: {{ .Release.Name }}
     spec:
+      # The postStart bootstrap attaches to nginx via `lapis exec`, which must
+      # signal the nginx master from the hook's exec session. On Ubuntu nodes
+      # the kernel mediates AppArmor signals and exec sessions run under a
+      # stacked label (cri-containerd.apparmor.d//&unconfined), so the kill is
+      # denied and the hook fails -> CrashLoopBackOff (int, lubuntu001,
+      # 2026-08-05). Debian nodes do not mediate signals. Keep this workload
+      # off Ubuntu nodes until the node profile allows cross-label signals.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values:
+                      - lubuntu001
       containers:
         - name: {{ .Release.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
## Problem

`workstation-opsapi` in `int` went into CrashLoopBackOff (38 restarts over ~3.5h) after a `kubectl rollout restart` on 2026-08-05 10:15 rescheduled the pod onto **lubuntu001** — the cluster's only Ubuntu node.

## Root cause

The chart's postStart hook (`bootstrap-nginx.sh`) uses `lapis exec`, which attaches to the running server by sending `kill -HUP` to the nginx master from the hook's exec session. On Ubuntu kernels, AppArmor mediates signals between labels — and exec sessions (hooks, probes, `kubectl exec`) run under a **stacked label** `cri-containerd.apparmor.d//&unconfined`, while the container's main process tree runs under the plain `cri-containerd.apparmor.d` profile. The cross-label signal is denied:

```
sh: can't kill pid 22: Permission denied
Error: Timed out waiting for server to open (9.36)
```

Both `lapis exec` calls time out, the (fatal) namespace-setup step exits 1 → `FailedPostStartHook` → container killed (137) → CrashLoopBackOff. Debian's stock kernels do not mediate AppArmor signals, so all `debian*` nodes are unaffected.

## Verification

Ran the identical image digest (`sha256:3dacee8d…`) with the identical bootstrap in debug pods on both node types:

| Node | `lapis exec` result |
|---|---|
| debian004 | `attach-ok` ✅ |
| lubuntu001 | `kill: Permission denied` → 9s attach timeout ❌ |

AppArmor labels confirmed via `/proc/*/attr/current`: stacked label on lubuntu001 exec sessions, uniform label on debian004.

## Fix

Required nodeAffinity keeping this chart's pods off `lubuntu001`, with a comment citing the incident. Smallest-hammer option: no AppArmor downgrade (`Unconfined` would also work but removes confinement), and no cluster-level cordon (lubuntu001 stays usable for workloads that don't signal across exec sessions).

## Follow-ups (out of scope)

- Real fix is node-level: extend the containerd AppArmor profile on lubuntu001 to allow signals to/from the stacked exec label, or rebuild the node to match the Debian fleet — then this affinity block can be dropped.
- Any other chart whose hooks/probes signal the container's main processes will hit the same wall on lubuntu001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)