### PR TITLE
fix(tax): income overview cards see per-entity money + NINO/UTR editable by default

### DIFF
--- a/lapis/lib/identity_lock.lua
+++ b/lapis/lib/identity_lock.lua
@@ -81,16 +81,20 @@ function IdentityLock.getPolicy(namespace_id)
     if rows and #rows > 0 then
         return rows[1]
     end
-    -- Sane defaults matching the migration's DEFAULT clauses. If the
-    -- settings row is missing (tenant hasn't opened the admin UI yet),
-    -- we STILL enforce the lock — the client's whole ask is anti-fraud,
-    -- so the default posture is "protected".
+    -- Defaults matching the migration's DEFAULT clauses (updated by
+    -- migration 832: the client reversed the original anti-fraud ask on
+    -- 2026-08-06 — users must be able to correct their own NINO/UTR, so
+    -- the out-of-the-box posture is now "editable"). A tenant that wants
+    -- the lock back flips nino_lock_enabled / utr_lock_enabled in the
+    -- identity-lock admin settings; all enforcement machinery is intact.
+    -- Uniqueness stays on — it guards a different fraud vector (same
+    -- NINO across two accounts) and doesn't block self-correction.
     return {
-        nino_lock_enabled           = true,
+        nino_lock_enabled           = false,
         nino_confirmation_required  = true,
         nino_backfill_scheduled_at  = nil,
         nino_uniqueness_enforced    = true,
-        utr_lock_enabled            = true,
+        utr_lock_enabled            = false,
         utr_backfill_enabled        = false,
         utr_backfill_scheduled_at   = nil,
     }

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -157,6 +157,11 @@ local profile_builder_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_CO
 -- top of the earlier last_name / nino questions.
 local personal_details_cleanup_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.personal-details-cleanup") or {}
 
+-- Identity lock default flip — client reversed the anti-fraud freeze
+-- (2026-08-06): NINO/UTR stay user-editable unless a tenant re-enables
+-- the lock in admin settings. See migrations/identity-lock-defaults.lua.
+local identity_lock_defaults_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.identity-lock-defaults") or {}
+
 -- My Income (tax_copilot feature) — manually-entered income source-of-truth
 local my_income_migrations = load_if_enabled(ProjectConfig.FEATURES.TAX_COPILOT, "migrations.my-income-system") or {}
 
@@ -2192,6 +2197,11 @@ local _migrations = {
     ['829_profile_utr_validation'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, personal_details_cleanup_migrations, 5),
     ['830_profile_migrate_lua_patterns_to_pcre'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, personal_details_cleanup_migrations, 6),
     ['831_profile_heal_empty_identity_locks'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, personal_details_cleanup_migrations, 7),
+    -- 832: disable the NINO/UTR identity lock by default (client
+    -- reversal 2026-08-06 — users must be able to correct their own
+    -- identifiers). Policy flags off + column defaults off; stamps and
+    -- enforcement machinery kept for tenants that re-enable.
+    ['832_identity_lock_disable_by_default'] = conditional_array(ProjectConfig.FEATURES.TAX_COPILOT, identity_lock_defaults_migrations, 1),
 
     -- =========================================================================
     -- Config-as-Code (CMI) prep — unique indexes on composite business keys

--- a/lapis/migrations/identity-lock-defaults.lua
+++ b/lapis/migrations/identity-lock-defaults.lua
@@ -1,0 +1,49 @@
+--[[
+    Identity lock — default posture flip (client ask, 2026-08-06).
+
+    The original anti-fraud requirement ("NINO/UTR freeze after first
+    save", PR #464) has been reversed by the client: users must be able
+    to correct their own NINO and UTR from profile setup and settings.
+
+    This migration flips the per-namespace policy to "editable":
+      - existing identity_lock_settings rows get both lock flags off;
+      - the column DEFAULTs flip so rows created later by the admin
+        settings page start unlocked too;
+      - lib/identity_lock.lua's no-row fallback was flipped in the same
+        PR, covering namespaces with no settings row at all.
+
+    NOTHING else is removed. Lock stamps (nino_locked_at /
+    utr_locked_at) stay on tax_user_profiles for audit; the enforcement
+    library, admin unlock route and RBAC module are intact. A tenant
+    that wants the freeze back re-enables nino_lock_enabled /
+    utr_lock_enabled in the identity-lock admin settings and every
+    existing stamp bites again immediately (the read/write paths gate
+    on policy, not on this migration).
+
+    nino_uniqueness_enforced is deliberately untouched — the
+    same-NINO-in-two-accounts check guards a different fraud vector
+    and doesn't stop a user correcting their own record.
+--]]
+
+local db = require "lapis.db"
+
+return {
+    [1] = function()
+        db.query([[
+            UPDATE identity_lock_settings
+            SET nino_lock_enabled = false,
+                utr_lock_enabled  = false,
+                updated_at        = NOW()
+            WHERE nino_lock_enabled = true OR utr_lock_enabled = true
+        ]])
+        db.query([[
+            ALTER TABLE identity_lock_settings
+            ALTER COLUMN nino_lock_enabled SET DEFAULT false
+        ]])
+        db.query([[
+            ALTER TABLE identity_lock_settings
+            ALTER COLUMN utr_lock_enabled SET DEFAULT false
+        ]])
+        print("[Tax Copilot] Identity lock disabled by default (NINO/UTR user-editable)")
+    end,
+}

--- a/lapis/queries/FormSectionQueries.lua
+++ b/lapis/queries/FormSectionQueries.lua
@@ -1204,6 +1204,97 @@ function FormSectionQueries.card_summary(user)
         other_entry.row_count = tonumber(other_row[1].row_count) or 0
     end
 
+    -- ── Per-entity types: self-employment + property ────────────────
+    -- The three hub types whose money does NOT live in profile answers
+    -- at all: business_line_values (one row per SA103F line per
+    -- business per year) and property_line_items (one row per rental
+    -- income/expense line per property per year). The generic
+    -- profile-builder branch above can't see either table, and their
+    -- entity contexts ('business', 'property', 'overseas_property')
+    -- never equal an income_type_key — so a user could fill in a whole
+    -- business's turnover and /my-income still said "Nothing recorded
+    -- yet". That was the bug this branch fixes.
+    --
+    -- Total   income-kind lines only (turnover, other business income,
+    --         rent) — expenses/allowances/balance-sheet lines would
+    --         make the headline meaningless.
+    -- Count   number of non-archived entities (businesses /
+    --         properties), matching the salary branch's "one entry =
+    --         one employment" convention.
+    --
+    -- Merged ADDITIVELY into any existing entry (the generic branch
+    -- may already hold year-scoped SA103F/SA105 completion boxes for
+    -- 'self_employment'/'rental'); entries are only CREATED when the
+    -- user actually has entities or lines, so an untouched type keeps
+    -- its "Add income" call-to-action.
+    local function fold_in(income_type_key, add_total, add_count)
+        if (add_total or 0) == 0 and (add_count or 0) == 0 then return end
+        local entry = by_type[income_type_key]
+        if not entry then
+            entry = { income_type_key = income_type_key, total = 0, row_count = 0 }
+            out[#out + 1] = entry
+            by_type[income_type_key] = entry
+        end
+        entry.total = entry.total + (add_total or 0)
+        entry.row_count = entry.row_count + (add_count or 0)
+    end
+
+    local se_rows = db.query([[
+        SELECT COALESCE(SUM(v.amount), 0) AS total
+        FROM business_line_values v
+        JOIN user_profile_entities e ON e.uuid = v.business_uuid
+        WHERE v.user_id = ?
+          AND v.kind = 'income'
+          AND e.entity_type = 'business'
+          AND e.is_archived = false
+    ]], internal_user_id)
+    local se_count = db.query([[
+        SELECT COUNT(*) AS n FROM user_profile_entities
+        WHERE user_id = ? AND entity_type = 'business' AND is_archived = false
+    ]], internal_user_id)
+    fold_in("self_employment",
+        tonumber(((se_rows or {})[1] or {}).total) or 0,
+        tonumber(((se_count or {})[1] or {}).n) or 0)
+
+    -- UK rental and overseas property share property_line_items; the
+    -- owning entity's entity_type says which hub card the money
+    -- belongs to ('property' → rental, 'overseas_property' → itself).
+    local prop_totals = db.query([[
+        SELECT e.entity_type,
+               COALESCE(SUM(li.amount), 0) AS total
+        FROM property_line_items li
+        JOIN user_profile_entities e ON e.uuid = li.property_uuid
+        WHERE li.user_id = ?
+          AND li.kind = 'income'
+          AND li.is_archived = false
+          AND e.entity_type IN ('property', 'overseas_property')
+          AND e.is_archived = false
+        GROUP BY e.entity_type
+    ]], internal_user_id) or {}
+    local prop_counts = db.query([[
+        SELECT entity_type, COUNT(*) AS n
+        FROM user_profile_entities
+        WHERE user_id = ?
+          AND entity_type IN ('property', 'overseas_property')
+          AND is_archived = false
+        GROUP BY entity_type
+    ]], internal_user_id) or {}
+    local prop_by_entity = {
+        property = { total = 0, count = 0, key = "rental" },
+        overseas_property = { total = 0, count = 0, key = "overseas_property" },
+    }
+    for _, r in ipairs(prop_totals) do
+        local slot = prop_by_entity[r.entity_type]
+        if slot then slot.total = tonumber(r.total) or 0 end
+    end
+    for _, r in ipairs(prop_counts) do
+        local slot = prop_by_entity[r.entity_type]
+        if slot then slot.count = tonumber(r.n) or 0 end
+    end
+    for _, slot in pairs(prop_by_entity) do
+        fold_in(slot.key, slot.total, slot.count)
+    end
+
     return out
 end
 

--- a/lapis/routes/profile-builder.lua
+++ b/lapis/routes/profile-builder.lua
@@ -1090,6 +1090,18 @@ return function(app)
                 user_utr_locked_at  = up_rows[1].utr_locked_at
             end
         end
+        -- Policy gate: a historical lock stamp only disables the field
+        -- while the tenant's lock policy is ON. With the policy off
+        -- (the default since migration 832) the write path skips
+        -- assertNotLocked, so reporting is_locked_for_user=true here
+        -- would grey out a field the server would happily accept — the
+        -- FE and the write path must agree. Stamps are kept (audit
+        -- semantics); re-enabling the policy re-locks instantly.
+        if user_nino_locked_at or user_utr_locked_at then
+            local lock_policy = IdentityLock.getPolicy(namespace_id or 0)
+            if not lock_policy.nino_lock_enabled then user_nino_locked_at = nil end
+            if not lock_policy.utr_lock_enabled then user_utr_locked_at = nil end
+        end
 
         local result = {}
         for _, cat in ipairs(categories or {}) do

--- a/lapis/routes/tax-profile.lua
+++ b/lapis/routes/tax-profile.lua
@@ -16,6 +16,7 @@ local TaxUserProfileQueries = require("queries.TaxUserProfileQueries")
 local HMRCBusinessQueries = require("queries.HMRCBusinessQueries")
 local HMRCObligationQueries = require("queries.HMRCObligationQueries")
 local HMRCTokenQueries = require("queries.HMRCTokenQueries")
+local IdentityLock = require("lib.identity_lock")
 
 -- Helper: parse JSON body into params
 local function parseJsonBody(self)
@@ -97,6 +98,23 @@ return function(app)
             nino_display = "****" .. profile.nino_last4
         end
 
+        -- Policy gate on the lock stamps (see migration 832): with the
+        -- tenant's lock policy off — the default since the client asked
+        -- for NINO/UTR to stay user-editable — the write path accepts
+        -- edits, so surfacing the historical stamp here would render a
+        -- "your NINO is locked" banner over a field the server no
+        -- longer locks. Stamps stay in the DB for audit; re-enabling
+        -- the policy makes them bite again.
+        local nino_locked_at = profile.nino_locked_at
+        local utr_locked_at  = profile.utr_locked_at
+        if nino_locked_at or utr_locked_at then
+            local pol_ok, policy = pcall(IdentityLock.getPolicy, profile.namespace_id or 0)
+            if pol_ok and policy then
+                if not policy.nino_lock_enabled then nino_locked_at = nil end
+                if not policy.utr_lock_enabled then utr_locked_at = nil end
+            end
+        end
+
         return {
             status = 200,
             json = {
@@ -108,8 +126,8 @@ return function(app)
                 -- reads these to render the locked card + support links
                 -- without probing a write and catching the 403. See PR
                 -- #464 / lib/identity_lock.lua for the enforcement logic.
-                nino_locked_at = profile.nino_locked_at,
-                utr_locked_at  = profile.utr_locked_at,
+                nino_locked_at = nino_locked_at,
+                utr_locked_at  = utr_locked_at,
                 hmrc_connected = hmrc_connected,
                 hmrc_token_expires_at = hmrc_token and hmrc_token.expires_at or nil,
                 default_business_id = profile.default_business_id,


### PR DESCRIPTION
Companion to bwalia/diy-tax-return-uk#905 (profile-setup fixes).

## 1. `/my-income` cards: "Add income" shown despite recorded income

`FormSectionQueries.card_summary` had no branch for the three types whose money never touches profile answers:

- **self_employment** — SA103F lines live in `business_line_values`
- **rental / overseas_property** — rent lines live in `property_line_items`

Their entity contexts (`business`, `property`, `overseas_property`) never equal an `income_type_key`, so the generic profile-builder join skipped them and the hub card stayed on "Add income" after a user had entered a full business's turnover.

New branches sum **income-kind lines only** (expenses/allowances would make the headline meaningless), count non-archived entities as `row_count` (same convention as the salary branch), and **fold additively** into any existing entry so year-scoped SA103F/SA105 completion boxes aren't overwritten. Entries are only created when something exists, so untouched types keep their "Add income" CTA.

## 2. NINO / UTR must stay user-editable

The client reversed the PR #464 anti-fraud ask — users need to correct their own identifiers. Default posture flips to **unlocked**, nothing is deleted:

- `lib/identity_lock.lua` no-row fallback: both lock flags now default `false` (uniqueness check untouched — different fraud vector).
- **Migration `832_identity_lock_disable_by_default`**: flags off in existing `identity_lock_settings` rows + column `DEFAULT false`.
- Read surfaces now gate stamps on policy: `profile-builder` schema only reports `is_locked_for_user` when the tenant's lock is enabled, and `GET /api/v2/tax/profile` only exposes `nino_locked_at`/`utr_locked_at` under an enabled policy — so the FE stops greying out / bannering fields the write path (already policy-gated via `assertNotLocked`) accepts.

Lock stamps, enforcement library, admin unlock route and RBAC module all stay; a tenant re-enabling the policy in admin settings re-locks every stamped user instantly.

## Testing
All edited files pass `luajit -bl` syntax check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)