### PR TITLE
feat(domains): Domain Management module → main

### DIFF
--- a/DOMAINS_USER_GUIDE.md
+++ b/DOMAINS_USER_GUIDE.md
@@ -1,0 +1,146 @@
+# Domains — Simple User Guide
+
+A plain-English guide to adding your website addresses (domains), keeping an eye
+on when they expire, and putting them live. No technical knowledge needed.
+
+---
+
+## What this does, in one sentence
+
+It's an address book for your websites. You add a domain (like
+`api.diytaxreturn.co.uk`), the system watches when it and its security
+certificate expire, and — with one click — it sets everything up so the domain
+works.
+
+---
+
+## The three things you'll do
+
+1. **Set it up once** (connect it to GitHub) — takes 2 minutes, once.
+2. **Add domains** — whenever you have a new one.
+3. **Publish** — one button to make them live.
+
+That's it.
+
+---
+
+## Step 1 — Set it up once (⚙️ Sync Settings)
+
+You only do this the **first time**.
+
+1. Open the **Domains** page in the dashboard.
+2. Click **Sync Settings** (the gear icon, top right).
+3. Fill in where your domains should be saved:
+   - **owner** and **repo** — your project's GitHub location (e.g. `bwalia` /
+     `diy-tax-return-uk`). *If you're not sure, ask whoever set up your project —
+     they'll give you these two words.*
+   - **branch** — leave it as `main`.
+   - **environment** — choose `prod` for your live site.
+4. Under **GitHub authentication**, either:
+   - **pick an existing** connection from the list, **or**
+   - choose **Add token**, paste the access key your tech team gives you, and
+     give it a name like "Domain Sync".
+5. Click **Save settings**.
+
+Done. The system now remembers all of this — you won't be asked again.
+
+> 💡 The access key is stored **encrypted** (scrambled) and is never shown again.
+> Think of it like saving a password in your browser.
+
+---
+
+## Step 2 — Add a domain
+
+1. On the **Domains** page, click **Add Domain**.
+2. Type the **domain name** (for example `api.diytaxreturn.co.uk`).
+3. Pick the **environment** (usually `prod`).
+4. The other boxes (rule, SSL email, target) are usually pre-set or provided by
+   your tech team — you can leave them if you're not sure.
+5. Click **Add domain**.
+
+The domain now appears in your list. **Adding it does not put it live yet** — it
+just saves it. You go live in Step 3.
+
+---
+
+## Step 3 — Put your domains live (▶️ Run Pipeline)
+
+When you're ready to make your domains work:
+
+1. Click **Run Pipeline** (top right).
+2. Click **Start**.
+3. Watch the steps turn green:
+   - **sync** — saves your domains to GitHub
+   - **cloudflare-dns-reconcile** — points the domain at the right place on the internet
+   - **wslproxy-register-domains** — sets up the web server so the site loads
+
+Each step shows a **"view run ↗"** link if you want to see the details. When all
+three are green, you're live. If one turns red, it stops there and shows you what
+went wrong (nothing half-finished).
+
+> 💡 **Tip:** the first time, ask your tech team to do a "dry run" (a safe
+> test that changes nothing) before the real one.
+
+---
+
+## Reading the domain list
+
+Each domain shows two expiry dates with a coloured label:
+
+| Colour | Meaning |
+|---|---|
+| 🟢 **Green** | Fine — plenty of time left |
+| 🟠 **Amber** | Expiring soon — renew it |
+| 🔴 **Red** | Expired — needs attention now |
+
+- **Registration** = when you'd need to renew the domain name itself.
+- **SSL** = when the little padlock/security certificate expires.
+
+Click **Check All** any time to refresh these dates. You'll also get a
+notification when something is close to expiring.
+
+---
+
+## Common questions
+
+**Do I need to understand DNS, SSL, or servers?**
+No. You add the domain name and click Run Pipeline. The system handles the
+technical parts.
+
+**I added a domain but the website isn't working — why?**
+Adding a domain only saves it. You still need to click **Run Pipeline** to make
+it live.
+
+**Something went red. What do I do?**
+Nothing breaks — the pipeline stops safely. Click the **"view run ↗"** link to
+see the message, or send a screenshot to your tech team.
+
+**Will this change other people's domains?**
+No. It only touches the domains you add here. Everyone else's stay exactly as
+they are.
+
+**Who can use this?**
+Only people with permission on your workspace (owners and admins). Regular
+members won't see it unless they're given access.
+
+---
+
+## Words explained (in plain English)
+
+- **Domain** — a website address, like `api.diytaxreturn.co.uk`.
+- **DNS** — the internet's phone book; it points a domain to the right place.
+- **SSL / certificate** — the padlock that makes a site secure (`https`).
+- **Environment** — which version of your site: `prod` (live), plus test ones
+  like `acc`, `test`, `int`, `dev`.
+- **Pipeline** — the "make it live" button that runs the steps in order.
+- **Sync / GitHub** — where your domain list is safely saved and versioned.
+
+---
+
+### Quick recap
+
+1. **Sync Settings** once → connect GitHub.
+2. **Add Domain** → type the name, pick the environment, save.
+3. **Run Pipeline** → watch it go green → you're live.
+
+That's the whole system. 🎉

--- a/DOMAIN_MANAGEMENT.md
+++ b/DOMAIN_MANAGEMENT.md
@@ -1,0 +1,126 @@
+# Domain Management
+
+Namespace-scoped domain registry with **registration + SSL expiry monitoring**, **two-way
+Cloudflare DNS management**, and a **k3s job** that periodically syncs the domain list as JSON
+to a GitHub repo.
+
+Feature-gated under **`services`** (shares the infrastructure remit — no dedicated `PROJECT_CODE`).
+Enabled for any project whose `PROJECT_CODE` includes `services` (e.g. `all`, `collaboration`).
+
+## What it does
+
+- **Central registry** — add/list/edit/soft-delete domains, scoped by `namespace_id`. Platform
+  admins get a cross-namespace super-view (`GET /api/v2/domains?all=true`).
+- **Expiry monitoring** — per domain:
+  - **Registration expiry** via an RDAP lookup (`https://rdap.org` bootstrap, follows redirects),
+    also capturing the registrar name + registry status.
+  - **SSL/TLS expiry** via a live TLS handshake that reads the leaf certificate's `notAfter`
+    and issuer. Colour-coded in the UI; a lifecycle `status` (`active | expiring_soon | expired
+    | error`) is stored, and a notification is raised for the domain owner when within the
+    per-domain `alert_threshold_days` (default 30).
+- **Cloudflare DNS** — list zones and read/create/update/delete DNS records from the dashboard.
+- **k3s sync job** — generate a Kubernetes `CronJob` (or run-once `Job`) that pushes
+  `domains.json` to a configured GitHub repo/branch/path on a schedule.
+
+## Architecture (follows the standard OpsAPI layering)
+
+| Layer | Files |
+|-------|-------|
+| Migrations | `lapis/migrations/domain-management.lua` (tables), `lapis/migrations/domain-menu-items.lua` (menu/RBAC), registered in `lapis/migrations.lua` (`600`–`606`, gated on `SERVICES`) |
+| Models | `lapis/models/Domain{,Credential,SyncConfig}Model.lua` |
+| Queries | `lapis/queries/Domain{,Credential,SyncConfig}Queries.lua` |
+| External clients | `lapis/lib/cloudflare.lua` (CF v4 API), `lapis/helper/tls-cert.lua` (raw-TLS cert reader) |
+| Expiry engine | `lapis/helper/domain-expiry.lua` (RDAP + TLS + notifications) |
+| Sync generator | `lapis/helper/domain-sync-manifest.lua` (CronJob / Job YAML) |
+| Routes | `lapis/routes/domains.lua` (gated via `load_if("services", …)` in `app.lua`) |
+| Frontend | `opsapi-dashboard/services/domain.service.ts`, `opsapi-dashboard/app/dashboard/domains/page.tsx` |
+
+Tables: `domains`, `domain_credentials`, `domain_sync_configs`.
+
+## Secrets policy (important)
+
+Two distinct credential paths, **neither stored in plaintext**:
+
+1. **Cloudflare API token** — saved per namespace in `domain_credentials.encrypted_secret`,
+   **AES-encrypted** at rest via `Global.encryptSecret` (keyed by `OPENSSL_SECRET_KEY`). Decrypted
+   server-side only to call the Cloudflare API; never returned over the API (`has_secret` flag only).
+   In production, source `OPENSSL_SECRET_KEY` itself from the vault/ESO.
+
+2. **GitHub token + opsapi token for the k3s job** — **never** stored by opsapi and **never** baked
+   into the generated manifest. The sync config only references a **Kubernetes Secret name**
+   (`github_token_secret_ref`) populated by the **External Secrets Operator** from the vault. The
+   generated manifest wires two keys from that Secret into the job's env:
+   - `github-token` (default key) → `GITHUB_TOKEN` — the GitHub PAT for `git push`.
+   - `opsapi-token` (default key) → `OPSAPI_TOKEN` — an opsapi bearer token the job uses to fetch
+     the live export (`GET /api/v2/domains/export`).
+
+### Example ExternalSecret for the sync job
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: domain-sync-secrets
+  namespace: default
+spec:
+  secretStoreRef: { name: wslvault-backend, kind: ClusterSecretStore }
+  target: { name: domain-sync-secrets }   # <- github_token_secret_ref
+  data:
+    - secretKey: github-token
+      remoteRef: { key: kv/data/domains/sync, property: github_token }
+    - secretKey: opsapi-token
+      remoteRef: { key: kv/data/domains/sync, property: opsapi_token }
+```
+
+## The k3s sync flow
+
+1. Create a sync config (dashboard → **Sync Jobs**, or `POST /api/v2/domains/sync-configs`) with:
+   `github_repo` (owner/repo), `github_branch`, `file_path`, `schedule` (cron),
+   `github_token_secret_ref` (the ESO Secret above), and `opsapi_base_url` (in-cluster export URL,
+   e.g. `http://opsapi.<ns>.svc.cluster.local`).
+2. Download the manifest (`GET …/sync-configs/:uuid/manifest`) and apply it, or commit it to GitOps.
+3. On schedule the CronJob: `curl`s the export using `OPSAPI_TOKEN` + `X-Namespace-Id`, writes
+   `domains.json`, and `git push`es it to the repo using `GITHUB_TOKEN`.
+4. **Sync now**: `POST …/sync-configs/:uuid/run-now` returns an immediately-appliable run-once `Job`.
+
+opsapi has no in-cluster kube credentials, so it **generates** manifests; the cluster (kubectl /
+GitOps / Argo) executes them.
+
+## API summary
+
+```
+GET    /api/v2/domains                         list (?all=true = admin super-view)
+GET    /api/v2/domains/stats                    aggregate counts
+GET    /api/v2/domains/export                   JSON export consumed by the k3s job
+POST   /api/v2/domains                          create
+GET|PUT|DELETE /api/v2/domains/:uuid            get / update / soft-delete
+POST   /api/v2/domains/:uuid/refresh-expiry     refresh one (RDAP + TLS)
+POST   /api/v2/domains/refresh-expiry           bulk refresh (namespace)
+
+GET|POST  /api/v2/domains/credentials           list / save (encrypts) provider token
+POST      /api/v2/domains/credentials/verify     verify Cloudflare token
+DELETE    /api/v2/domains/credentials/:provider  delete
+
+GET    /api/v2/domains/cloudflare/zones                        list zones
+GET|POST /api/v2/domains/:uuid/cloudflare/records             list / create DNS record
+PUT|DELETE /api/v2/domains/:uuid/cloudflare/records/:record_id update / delete
+
+GET|POST  /api/v2/domains/sync-configs           list / create
+GET|PUT|DELETE /api/v2/domains/sync-configs/:uuid get / update / delete
+GET    /api/v2/domains/sync-configs/:uuid/manifest   render CronJob YAML
+POST   /api/v2/domains/sync-configs/:uuid/run-now    render run-once Job YAML
+```
+
+All routes require the `domains` RBAC action (`read`/`create`/`update`/`delete`) via
+`NamespaceMiddleware.requirePermission`. Platform admins and namespace owners bypass.
+
+## Environment notes
+
+- **SSL expiry detection** uses a minimal TLS 1.2 `ClientHello` (in `helper/tls-cert.lua`) to read
+  the cleartext `Certificate` message, because this OpenResty build lacks the
+  `lua-resty-openssl-aux-module` needed for the cosocket→peer-cert bridge. A TLS 1.3-only host
+  (rare) that refuses TLS 1.2 will report an SSL check error; registration expiry still works, and
+  the field can be maintained manually.
+- Cloudflare TLS verification is environment-aware (`CLOUDFLARE_ENVIRONMENT` / `OPSAPI_SSL_VERIFY`);
+  verified by default. Production already ships `lua_ssl_trusted_certificate` in `nginx.conf`.
+- The generated CronJob image is `alpine:3.20` and installs `git curl jq` at runtime.

--- a/lapis/app.lua
+++ b/lapis/app.lua
@@ -460,6 +460,10 @@ load_if("hospital", "routes.patient-audit-logs")
 -- ============================================
 load_if("services", "routes.services")
 
+-- Domain Management (registry, SSL/expiry monitoring, Cloudflare DNS, k3s sync).
+-- Shares the SERVICES feature (infrastructure remit) — no dedicated project code.
+load_if("services", "routes.domains")
+
 -- ============================================
 -- SECRET VAULT
 -- ============================================

--- a/lapis/helper/domain-expiry.lua
+++ b/lapis/helper/domain-expiry.lua
@@ -1,0 +1,277 @@
+--[[
+    Domain Expiry Engine
+    ====================
+
+    Auto-detects, per domain:
+      - Registration expiry  → RDAP lookup (https://rdap.org bootstrap, follows
+        redirects to the authoritative registry RDAP server). Also pulls the
+        registrar name and registry status.
+      - SSL/TLS expiry       → live TLS handshake to the host:443 using an
+        ngx cosocket, reading the peer certificate's notAfter via
+        resty.openssl (ssl_verify off so even an expired/invalid cert is read).
+
+    Computes a lifecycle status (active | expiring_soon | expired | error),
+    persists it via DomainQueries.applyExpiryResult, and best-effort raises a
+    notification for the domain owner when within the alert threshold. Every
+    step is guarded — a lookup failure records last_check_error and never throws.
+]]
+
+local DomainQueries = require("queries.DomainQueries")
+local db = require("lapis.db")
+
+local DomainExpiry = {}
+
+--------------------------------------------------------------------------------
+-- Helpers
+--------------------------------------------------------------------------------
+
+-- Normalise an ISO-8601 timestamp ("2025-08-06T12:00:00Z" / "...+00:00") into a
+-- Postgres-friendly "YYYY-MM-DD HH:MM:SS". Returns nil if unparseable.
+local function iso_to_pg(iso)
+    if type(iso) ~= "string" then return nil end
+    local y, mo, d, h, mi, s = iso:match("(%d%d%d%d)%-(%d%d)%-(%d%d)[Tt ](%d%d):(%d%d):(%d%d)")
+    if not y then
+        -- date only
+        y, mo, d = iso:match("(%d%d%d%d)%-(%d%d)%-(%d%d)")
+        if not y then return nil end
+        return string.format("%s-%s-%s 00:00:00", y, mo, d)
+    end
+    return string.format("%s-%s-%s %s:%s:%s", y, mo, d, h, mi, s)
+end
+
+-- Days from now until a Postgres timestamp string (UTC). Negative = past.
+local function days_until(pg_ts)
+    if not pg_ts then return nil end
+    local y, mo, d, h, mi, s = pg_ts:match("(%d+)%-(%d+)%-(%d+)%s+(%d+):(%d+):(%d+)")
+    if not y then return nil end
+    local target = os.time({
+        year = tonumber(y), month = tonumber(mo), day = tonumber(d),
+        hour = tonumber(h), min = tonumber(mi), sec = tonumber(s),
+    })
+    -- os.time treats the table as local time; good enough for day-granularity alerts.
+    return math.floor((target - os.time()) / 86400)
+end
+
+local function http_client(timeout)
+    local ok, http = pcall(require, "resty.http")
+    if not ok then return nil, "resty.http not available" end
+    local httpc = http.new()
+    httpc:set_timeout(timeout or 15000)
+    return httpc, nil
+end
+
+--------------------------------------------------------------------------------
+-- RDAP: registration expiry
+--------------------------------------------------------------------------------
+function DomainExpiry.check_rdap(domain_name)
+    local httpc, err = http_client(15000)
+    if not httpc then return nil, err end
+
+    local url = "https://rdap.org/domain/" .. domain_name
+    local res
+    for _ = 1, 5 do
+        local r, rerr = httpc:request_uri(url, {
+            method = "GET",
+            headers = { ["Accept"] = "application/rdap+json" },
+            ssl_verify = true,
+        })
+        if not r then return nil, "RDAP request failed: " .. tostring(rerr) end
+        if r.status >= 300 and r.status < 400 then
+            local loc = r.headers and (r.headers["Location"] or r.headers["location"])
+            if not loc then return nil, "RDAP redirect without Location" end
+            url = loc
+        else
+            res = r
+            break
+        end
+    end
+    if not res then return nil, "RDAP too many redirects" end
+    if res.status == 404 then return nil, "Domain not found in RDAP" end
+    if res.status >= 400 then return nil, "RDAP HTTP " .. tostring(res.status) end
+
+    local cjson = require("cjson")
+    local ok, data = pcall(cjson.decode, res.body or "")
+    if not ok or type(data) ~= "table" then return nil, "RDAP non-JSON response" end
+
+    local out = {}
+
+    if type(data.events) == "table" then
+        for _, ev in ipairs(data.events) do
+            if ev.eventAction == "expiration" and ev.eventDate then
+                out.registration_expires_at = iso_to_pg(ev.eventDate)
+            end
+        end
+    end
+
+    if type(data.status) == "table" then
+        out.registrar_status = table.concat(data.status, ", ")
+    end
+
+    -- Registrar name from the entity with role "registrar".
+    if type(data.entities) == "table" then
+        for _, ent in ipairs(data.entities) do
+            local roles = ent.roles or {}
+            local is_registrar = false
+            for _, role in ipairs(roles) do
+                if role == "registrar" then is_registrar = true break end
+            end
+            if is_registrar and type(ent.vcardArray) == "table" and ent.vcardArray[2] then
+                for _, field in ipairs(ent.vcardArray[2]) do
+                    if field[1] == "fn" and field[4] then
+                        out.registrar = field[4]
+                        break
+                    end
+                end
+            end
+        end
+    end
+
+    if not out.registration_expires_at then
+        return out, "RDAP had no expiration event"
+    end
+    return out, nil
+end
+
+--------------------------------------------------------------------------------
+-- Live TLS handshake: SSL certificate expiry
+--------------------------------------------------------------------------------
+function DomainExpiry.check_ssl(host, port)
+    -- Uses a raw TLS 1.2 ClientHello to read the cleartext Certificate message —
+    -- see helper/tls-cert.lua for why (no cosocket→SSL bridge in this build).
+    local TLSCert = require("helper.tls-cert")
+    local info, err = TLSCert.fetch(host, port or 443, 8000)
+    if not info then return nil, err end
+    return {
+        ssl_expires_at = os.date("!%Y-%m-%d %H:%M:%S", info.not_after),
+        ssl_issuer = info.issuer,
+    }, nil
+end
+
+--------------------------------------------------------------------------------
+-- Best-effort notification for the domain owner
+--------------------------------------------------------------------------------
+local function notify_owner(domain, level, min_days)
+    if not domain.owner_user_uuid or domain.owner_user_uuid == "" then return end
+    local ok = pcall(function()
+        -- notifications table is user-scoped (user_id FK). Resolve owner id.
+        local users = db.query("SELECT id FROM users WHERE uuid = ? LIMIT 1", domain.owner_user_uuid)
+        local user = users and users[1]
+        if not user then return end
+
+        -- Dedup: skip if an unread domain-expiry notice for this domain exists < 24h old.
+        local recent = db.query([[
+            SELECT id FROM notifications
+            WHERE user_id = ? AND type = 'domain_expiry'
+              AND related_entity_id = ?
+              AND is_read = FALSE
+              AND created_at > NOW() - INTERVAL '24 hours'
+            LIMIT 1
+        ]], user.id, domain.uuid)
+        if recent and #recent > 0 then return end
+
+        local Global = require("helper.global")
+        local cjson = require("cjson")
+        local title = (level == "expired") and ("Domain expired: " .. domain.domain_name)
+            or ("Domain expiring soon: " .. domain.domain_name)
+        local message
+        if level == "expired" then
+            message = domain.domain_name .. " has an expired registration or SSL certificate."
+        else
+            message = domain.domain_name .. " expires in " .. tostring(min_days) .. " day(s). Renew soon."
+        end
+
+        db.insert("notifications", {
+            uuid = Global.generateUUID(),
+            user_id = user.id,
+            type = "domain_expiry",
+            title = title,
+            message = message,
+            data = cjson.encode({ domain_uuid = domain.uuid, level = level, days = min_days }),
+            related_entity_type = "domain",
+            related_entity_id = domain.uuid,
+            is_read = false,
+            created_at = db.raw("NOW()"),
+        })
+    end)
+    if not ok then
+        ngx.log(ngx.WARN, "[domain-expiry] notification insert failed for ", domain.domain_name)
+    end
+end
+
+--------------------------------------------------------------------------------
+-- Refresh a single domain row (table from DB). Returns the updated row.
+--------------------------------------------------------------------------------
+function DomainExpiry.refresh(domain)
+    local result = {}
+    local errors = {}
+
+    local rdap, rerr = DomainExpiry.check_rdap(domain.domain_name)
+    if rdap then
+        result.registration_expires_at = rdap.registration_expires_at
+        result.registrar = rdap.registrar
+        result.registrar_status = rdap.registrar_status
+    end
+    if rerr then table.insert(errors, "RDAP: " .. rerr) end
+
+    local sslr, serr = DomainExpiry.check_ssl(domain.domain_name, 443)
+    if sslr then
+        result.ssl_expires_at = sslr.ssl_expires_at
+        result.ssl_issuer = sslr.ssl_issuer
+    end
+    if serr then table.insert(errors, "SSL: " .. serr) end
+
+    -- Compute status from the soonest of the two expiries.
+    local threshold = tonumber(domain.alert_threshold_days) or 30
+    local reg_days = days_until(result.registration_expires_at or domain.registration_expires_at)
+    local ssl_days = days_until(result.ssl_expires_at or domain.ssl_expires_at)
+
+    local min_days = nil
+    for _, dgs in ipairs({ reg_days, ssl_days }) do
+        if dgs ~= nil and (min_days == nil or dgs < min_days) then min_days = dgs end
+    end
+
+    local status
+    if min_days ~= nil and min_days < 0 then
+        status = "expired"
+    elseif min_days ~= nil and min_days <= threshold then
+        status = "expiring_soon"
+    elseif #errors > 0 and not result.registration_expires_at and not result.ssl_expires_at then
+        status = "error"
+    else
+        status = "active"
+    end
+    result.status = status
+    result.error = (#errors > 0) and table.concat(errors, "; ") or nil
+
+    local updated = DomainQueries.applyExpiryResult(domain.uuid, result)
+
+    if status == "expired" then
+        notify_owner(domain, "expired", min_days)
+    elseif status == "expiring_soon" then
+        notify_owner(domain, "expiring_soon", min_days)
+    end
+
+    return updated, result
+end
+
+--------------------------------------------------------------------------------
+-- Bulk refresh every domain in a namespace. Returns a summary.
+--------------------------------------------------------------------------------
+function DomainExpiry.refresh_namespace(namespace_id)
+    local domains = DomainQueries.getAllForNamespace(namespace_id)
+    local summary = { checked = 0, expiring_soon = 0, expired = 0, errors = 0 }
+    for _, domain in ipairs(domains or {}) do
+        local ok, _, result = pcall(DomainExpiry.refresh, domain)
+        summary.checked = summary.checked + 1
+        if ok and result then
+            if result.status == "expiring_soon" then summary.expiring_soon = summary.expiring_soon + 1 end
+            if result.status == "expired" then summary.expired = summary.expired + 1 end
+            if result.status == "error" then summary.errors = summary.errors + 1 end
+        else
+            summary.errors = summary.errors + 1
+        end
+    end
+    return summary
+end
+
+return DomainExpiry

--- a/lapis/helper/domain-pipeline.lua
+++ b/lapis/helper/domain-pipeline.lua
@@ -1,0 +1,177 @@
+--[[
+    Domain Pipeline Orchestrator
+    ============================
+
+    opsapi-driven chain (decision: "opsapi drives each step"):
+      1. sync    — render domains → WSL Proxy vhost files, commit to the repo
+      2. cloudflare-dns-reconcile   (dispatch → wait for completion)
+      3. wslproxy-register-domains  (dispatch → wait)
+      4. auto-tag-main              (dispatch → wait)
+
+    Each step gates the next; a failure stops the pipeline. Runs in an ngx.timer
+    so the HTTP request returns immediately; progress is written to
+    domain_pipeline_runs for the dashboard to poll. See routes/domains.lua.
+
+    The GitHub token comes from the namespace's services GitHub integration
+    (encrypted at rest). All GitHub calls go through lib/github-repo.lua.
+]]
+
+local DomainPipelineRunQueries = require("queries.DomainPipelineRunQueries")
+
+local DomainPipeline = {}
+
+-- Default workflow chain: sync → Cloudflare DNS reconcile → WSL Proxy register.
+-- (auto-tag is intentionally NOT part of this pipeline — domain syncs must not
+-- tag/build images. auto-tag still runs for human merges to main.)
+-- Callers may override via opts.steps, but this is the canonical order.
+function DomainPipeline.default_steps(env)
+    return {
+        { name = "sync",                     type = "sync",     status = "pending" },
+        { name = "cloudflare-dns-reconcile", type = "workflow", workflow = "cloudflare-dns-reconcile.yml",
+          inputs = { ENV = env, DRY_RUN = "false", SOURCE = "opsapi" }, status = "pending" },
+        { name = "wslproxy-register-domains", type = "workflow", workflow = "wslproxy-register-domains.yml",
+          inputs = { TARGET_ENV = env, ACTIVATE_CONFIG = "false" }, status = "pending" },
+    }
+end
+
+-- Resolve + decrypt the GitHub token for a run's integration.
+local function resolve_token(run)
+    local ok, ServiceQueries = pcall(require, "queries.ServiceQueries")
+    if not ok then return nil, "services module unavailable" end
+    local integration = ServiceQueries.getGithubIntegration(run.github_integration_id, true)
+    if not integration then return nil, "GitHub integration not found" end
+    if tonumber(integration.namespace_id) ~= tonumber(run.namespace_id) then
+        return nil, "Integration belongs to another namespace"
+    end
+    local token = integration.github_token_decrypted
+    if not token or token == "" then return nil, "Could not decrypt integration token" end
+    return token, nil
+end
+
+-- Render + commit the WSL Proxy vhost files for the run's env. Returns commit sha.
+local function do_sync(run, token)
+    local DomainQueries = require("queries.DomainQueries")
+    local WslproxyServer = require("helper.wslproxy-server")
+    local GithubRepo = require("lib.github-repo")
+
+    local rows = DomainQueries.getAllForNamespace(run.namespace_id)
+    local built = WslproxyServer.build_sync_files(rows, run.environment)
+    if built.count == 0 then return nil, "no domains for environment " .. tostring(run.environment) end
+
+    return GithubRepo.commit_files({
+        token = token, owner = run.owner, repo = run.repo, branch = run.branch,
+        message = "chore(domains): sync " .. built.count .. " " .. run.environment .. " domains from opsapi",
+        files = built.files, author_name = "opsapi-domain-sync", author_email = "domain-sync@opsapi",
+    })
+end
+
+-- Persist the steps array + top-level fields for a run.
+local function save(run_uuid, steps, patch)
+    patch = patch or {}
+    patch.steps = steps
+    DomainPipelineRunQueries.update(run_uuid, patch)
+end
+
+--- The background worker. `premature` is the ngx.timer flag.
+function DomainPipeline.execute(premature, run_uuid)
+    if premature then return end
+
+    local run = DomainPipelineRunQueries.get(run_uuid)
+    if not run then return end
+    local steps = run.steps or {}
+
+    DomainPipelineRunQueries.update(run_uuid, { status = "running", started_at = require("lapis.db").raw("NOW()") })
+
+    local token, terr = resolve_token(run)
+    if not token then
+        save(run_uuid, steps, { status = "failed", error = terr, finished_at = require("lapis.db").raw("NOW()") })
+        return
+    end
+
+    local GithubRepo = require("lib.github-repo")
+
+    for i, step in ipairs(steps) do
+        step.status = "running"
+        step.started_at = os.date("!%Y-%m-%dT%H:%M:%SZ")
+        save(run_uuid, steps, { current_step = i })
+
+        local ok, err = pcall(function()
+            if step.type == "sync" then
+                local sha, serr = do_sync(run, token)
+                if not sha then error(serr or "sync failed") end
+                step.commit = sha
+                DomainPipelineRunQueries.update(run_uuid, { commit_sha = sha })
+            else
+                -- Capture the dispatch moment (with buffer) to locate the run.
+                local since = os.date("!%Y-%m-%dT%H:%M:%SZ", os.time() - 10)
+                local wf_opts = { token = token, owner = run.owner, repo = run.repo,
+                                  workflow = step.workflow, ref = run.branch }
+                local dok, derr = GithubRepo.dispatch_workflow({
+                    token = token, owner = run.owner, repo = run.repo,
+                    workflow = step.workflow, ref = run.branch, inputs = step.inputs,
+                })
+                if not dok then error("dispatch failed: " .. tostring(derr)) end
+
+                local found, ferr = GithubRepo.find_run_after(wf_opts, since)
+                if not found then error(ferr or "run not found") end
+                step.run_id = found.id
+                step.run_url = found.html_url
+                save(run_uuid, steps, {})
+
+                local done, werr = GithubRepo.wait_for_run(wf_opts, found.id, 1200, 15)
+                if not done then error(werr or "wait failed") end
+                step.conclusion = done.conclusion
+                if done.conclusion ~= "success" then
+                    error("workflow concluded '" .. tostring(done.conclusion) .. "'")
+                end
+            end
+        end)
+
+        step.finished_at = os.date("!%Y-%m-%dT%H:%M:%SZ")
+        if not ok then
+            step.status = "failed"
+            step.error = tostring(err)
+            save(run_uuid, steps, { status = "failed", error = step.name .. ": " .. tostring(err),
+                                    finished_at = require("lapis.db").raw("NOW()") })
+            return
+        end
+        step.status = "success"
+        save(run_uuid, steps, {})
+    end
+
+    save(run_uuid, steps, { status = "success", finished_at = require("lapis.db").raw("NOW()") })
+end
+
+--- Create a run record and kick off the background orchestration.
+-- @param cfg { namespace_id, environment, owner, repo, branch, github_integration_id, triggered_by_uuid, steps? }
+-- @return run_row, nil OR nil, err
+function DomainPipeline.start(cfg)
+    if not cfg.owner or not cfg.repo then return nil, "owner and repo are required" end
+    if not cfg.github_integration_id then return nil, "github_integration_id is required" end
+
+    local env = cfg.environment or "prod"
+    local steps = cfg.steps or DomainPipeline.default_steps(env)
+
+    local run = DomainPipelineRunQueries.create({
+        namespace_id = cfg.namespace_id,
+        status = "pending",
+        environment = env,
+        owner = cfg.owner,
+        repo = cfg.repo,
+        branch = cfg.branch or "main",
+        github_integration_id = tostring(cfg.github_integration_id),
+        triggered_by_uuid = cfg.triggered_by_uuid,
+        steps = steps,
+    })
+    if not run then return nil, "failed to create pipeline run" end
+
+    local ok, err = ngx.timer.at(0, DomainPipeline.execute, run.uuid)
+    if not ok then
+        DomainPipelineRunQueries.update(run.uuid, { status = "failed", error = "could not schedule: " .. tostring(err) })
+        return nil, "could not schedule pipeline: " .. tostring(err)
+    end
+
+    return run, nil
+end
+
+return DomainPipeline

--- a/lapis/helper/domain-sync-manifest.lua
+++ b/lapis/helper/domain-sync-manifest.lua
@@ -1,0 +1,188 @@
+--[[
+    Domain Sync — k3s Manifest Generator
+    ====================================
+
+    Renders a self-contained Kubernetes CronJob (scheduled) or Job (run-once)
+    that, each run:
+      1. fetches the live domain export from opsapi (GET /api/v2/domains/export),
+      2. writes it as JSON to the configured path inside the target GitHub repo,
+      3. commits and pushes to the configured branch.
+
+    Secrets: NONE are baked into the manifest. Both the GitHub PAT and the opsapi
+    machine token are read at runtime from a single Kubernetes Secret whose name
+    is `github_token_secret_ref` — populated by the External Secrets Operator from
+    the vault (see docs). The manifest references only the Secret + key names.
+
+    Non-secret parameters (repo, branch, path, schedule, base URL, namespace) are
+    rendered as literals; they are not sensitive.
+]]
+
+local DomainSyncManifest = {}
+
+-- Minimal YAML scalar escaping: wrap in double quotes, escape backslash + quote.
+local function q(s)
+    s = tostring(s or "")
+    s = s:gsub("\\", "\\\\"):gsub('"', '\\"')
+    return '"' .. s .. '"'
+end
+
+-- Kubernetes name-safe slug.
+local function slug(s)
+    s = tostring(s or "sync"):lower():gsub("[^a-z0-9%-]", "-"):gsub("%-+", "-"):gsub("^%-", ""):gsub("%-$", "")
+    if s == "" then s = "sync" end
+    return s:sub(1, 40)
+end
+
+-- The container script (POSIX sh). Fails loudly (set -e). x-access-token:<PAT>
+-- is GitHub's documented way to authenticate a git push with a PAT.
+local function container_script()
+    return table.concat({
+        "set -eu",
+        "apk add --no-cache git curl jq >/dev/null",
+        'echo "Fetching domain export from opsapi..."',
+        'curl -fsSL -H "Authorization: Bearer ${OPSAPI_TOKEN}" -H "X-Namespace-Id: ${NAMESPACE_ID}" ' ..
+            '"${OPSAPI_BASE}/api/v2/domains/export" | jq . > /tmp/domains.json',
+        'echo "Cloning ${GIT_REPO} (${GIT_BRANCH})..."',
+        'git clone --depth 1 -b "${GIT_BRANCH}" ' ..
+            '"https://x-access-token:${GITHUB_TOKEN}@github.com/${GIT_REPO}.git" /tmp/repo',
+        'mkdir -p "/tmp/repo/$(dirname "${FILE_PATH}")"',
+        'cp /tmp/domains.json "/tmp/repo/${FILE_PATH}"',
+        'cd /tmp/repo',
+        'git config user.name "${AUTHOR_NAME}"',
+        'git config user.email "${AUTHOR_EMAIL}"',
+        'git add "${FILE_PATH}"',
+        'if git diff --cached --quiet; then echo "No changes"; exit 0; fi',
+        'git commit -m "chore(domains): sync $(date -u +%Y-%m-%dT%H:%M:%SZ)"',
+        'git push origin "${GIT_BRANCH}"',
+        'echo "Domain sync complete."',
+    }, "\n")
+end
+
+-- Build the pod spec (containers + env), each line prefixed with `indent`.
+local function pod_spec_lines(cfg, opts, indent)
+    local gh_key = cfg.github_token_secret_key or "github-token"
+    local op_key = cfg.opsapi_token_secret_key or "opsapi-token"
+    local env = {
+        { "GIT_REPO", cfg.github_repo },
+        { "GIT_BRANCH", cfg.github_branch or "main" },
+        { "FILE_PATH", cfg.file_path or "domains.json" },
+        { "OPSAPI_BASE", opts.base_url },
+        { "NAMESPACE_ID", opts.namespace_uuid or "" },
+        { "AUTHOR_NAME", cfg.commit_author_name or "opsapi-domain-sync" },
+        { "AUTHOR_EMAIL", cfg.commit_author_email or "domain-sync@opsapi" },
+    }
+
+    local lines = {}
+    local function add(s) table.insert(lines, indent .. s) end
+
+    add("restartPolicy: Never")
+    add("containers:")
+    add("  - name: domain-sync")
+    add('    image: "alpine:3.20"')
+    add('    command: ["/bin/sh", "-c"]')
+    add("    args:")
+    add("      - |")
+    -- script body, indented under the block scalar
+    for sline in (container_script() .. "\n"):gmatch("([^\n]*)\n") do
+        table.insert(lines, indent .. "        " .. sline)
+    end
+    add("    env:")
+    for _, kv in ipairs(env) do
+        add("      - name: " .. kv[1])
+        add("        value: " .. q(kv[2]))
+    end
+    -- Secrets from the ESO-populated k8s Secret
+    add("      - name: GITHUB_TOKEN")
+    add("        valueFrom:")
+    add("          secretKeyRef:")
+    add("            name: " .. q(cfg.github_token_secret_ref))
+    add("            key: " .. q(gh_key))
+    add("      - name: OPSAPI_TOKEN")
+    add("        valueFrom:")
+    add("          secretKeyRef:")
+    add("            name: " .. q(cfg.github_token_secret_ref))
+    add("            key: " .. q(op_key))
+
+    return lines
+end
+
+-- Validate the config + resolve the base URL. Returns base_url, err.
+local function resolve(cfg, opts)
+    if not cfg then return nil, "sync config required" end
+    if not cfg.github_repo or cfg.github_repo == "" then
+        return nil, "github_repo is required (owner/repo)"
+    end
+    if not cfg.github_token_secret_ref or cfg.github_token_secret_ref == "" then
+        return nil, "github_token_secret_ref is required (name of the ESO-populated k8s Secret)"
+    end
+    local base_url = (opts and opts.opsapi_base_url_override) or cfg.opsapi_base_url
+    if not base_url or base_url == "" then
+        return nil, "opsapi_base_url is required (where the CronJob fetches the export)"
+    end
+    return base_url, nil
+end
+
+--- Render a scheduled CronJob manifest.
+function DomainSyncManifest.render_cronjob(cfg, opts)
+    opts = opts or {}
+    local base_url, err = resolve(cfg, opts)
+    if not base_url then return nil, err end
+    opts.base_url = base_url
+
+    local name = "domain-sync-" .. slug(cfg.name or cfg.uuid)
+    local k8s_ns = opts.k8s_namespace or "default"
+
+    local out = {
+        "apiVersion: batch/v1",
+        "kind: CronJob",
+        "metadata:",
+        "  name: " .. q(name),
+        "  namespace: " .. q(k8s_ns),
+        "  labels:",
+        '    app.kubernetes.io/managed-by: "opsapi"',
+        '    opsapi.io/feature: "domain-sync"',
+        "spec:",
+        "  schedule: " .. q(cfg.schedule or "0 3 * * *"),
+        "  concurrencyPolicy: Forbid",
+        "  successfulJobsHistoryLimit: 3",
+        "  failedJobsHistoryLimit: 3",
+        "  jobTemplate:",
+        "    spec:",
+        "      backoffLimit: 2",
+        "      template:",
+        "        spec:",
+    }
+    for _, l in ipairs(pod_spec_lines(cfg, opts, "          ")) do table.insert(out, l) end
+    return table.concat(out, "\n") .. "\n", nil
+end
+
+--- Render a run-once Job manifest (for "sync now").
+function DomainSyncManifest.render_job(cfg, opts)
+    opts = opts or {}
+    local base_url, err = resolve(cfg, opts)
+    if not base_url then return nil, err end
+    opts.base_url = base_url
+
+    local name = "domain-sync-run-" .. slug(cfg.name or cfg.uuid)
+    local k8s_ns = opts.k8s_namespace or "default"
+
+    local out = {
+        "apiVersion: batch/v1",
+        "kind: Job",
+        "metadata:",
+        "  name: " .. q(name),
+        "  namespace: " .. q(k8s_ns),
+        "  labels:",
+        '    app.kubernetes.io/managed-by: "opsapi"',
+        '    opsapi.io/feature: "domain-sync"',
+        "spec:",
+        "  backoffLimit: 2",
+        "  ttlSecondsAfterFinished: 600",
+        "  template:",
+        "    spec:",
+    }
+    for _, l in ipairs(pod_spec_lines(cfg, opts, "      ")) do table.insert(out, l) end
+    return table.concat(out, "\n") .. "\n", nil
+end
+
+return DomainSyncManifest

--- a/lapis/helper/project-config.lua
+++ b/lapis/helper/project-config.lua
@@ -153,7 +153,30 @@ ProjectConfig.PROJECT_FEATURES = {
         ProjectConfig.FEATURES.MENU,
         ProjectConfig.FEATURES.THEMES,
     },
+
+    -- Services (Domain management + GitHub workflow integration). This is a
+    -- FEATURE-ONLY code (see FEATURE_ONLY_CODES): it exists so a deployment can
+    -- inherit the SERVICES feature + its migrations into its PRIMARY namespace by
+    -- combining codes — e.g. PROJECT_CODE=tax_copilot,services keeps a single
+    -- `tax_copilot` tenant but also enables and migrates SERVICES/domains.
+    services = {
+        ProjectConfig.FEATURES.CORE,
+        ProjectConfig.FEATURES.SERVICES,
+    },
 }
+
+-- Project codes that ONLY contribute features (and their migrations) and must
+-- NOT seed their own tenant when combined with a real project code. See
+-- scripts/setup-namespace.lua runMulti(), which filters these out of tenant
+-- creation so PROJECT_CODE=tax_copilot,services yields exactly one namespace.
+ProjectConfig.FEATURE_ONLY_CODES = {
+    services = true,
+}
+
+--- Is this project code feature-only (no dedicated tenant)?
+function ProjectConfig.isFeatureOnlyCode(code)
+    return ProjectConfig.FEATURE_ONLY_CODES[tostring(code or ""):lower()] == true
+end
 
 -- Cache for enabled features
 local _enabled_features = nil
@@ -384,9 +407,11 @@ ProjectConfig.PROJECT_MODULES = {
         { machine_name = "projects", name = "Projects", description = "Kanban projects and tasks", category = "Productivity" },
     },
 
-    -- Services modules
+    -- Services modules (includes Domain Management — same infrastructure remit,
+    -- gated under FEATURES.SERVICES rather than a dedicated project code)
     services = {
         { machine_name = "services", name = "Services", description = "Service deployment and management", category = "Infrastructure" },
+        { machine_name = "domains", name = "Domains", description = "Domain registry, SSL/expiry monitoring, Cloudflare DNS, and k3s sync", category = "Infrastructure" },
     },
 
     -- Hospital modules

--- a/lapis/helper/tls-cert.lua
+++ b/lapis/helper/tls-cert.lua
@@ -1,0 +1,185 @@
+--[[
+    TLS Peer Certificate Fetcher
+    ============================
+
+    Reads a remote host's leaf TLS certificate (notAfter + issuer) WITHOUT the
+    OpenResty cosocket→SSL bridge (this build lacks lua-resty-openssl-aux-module,
+    so resty.openssl.ssl.from_socket is unavailable).
+
+    Approach: open a raw TCP socket and send a minimal TLS 1.2 ClientHello that
+    deliberately does NOT advertise TLS 1.3 (no supported_versions extension), so
+    the server replies with a TLS 1.2 handshake whose Certificate message is sent
+    in cleartext. We parse the handshake records, pull the leaf certificate DER,
+    and hand it to resty.openssl.x509 (which loads fine — only the socket bridge
+    was missing) to read notAfter + issuer.
+
+    Limitation: a TLS 1.3-only server (rare) that refuses TLS 1.2 will not return
+    a cleartext Certificate; check_ssl degrades gracefully in that case.
+]]
+
+local byte, char, sub = string.byte, string.char, string.sub
+
+local TLSCert = {}
+
+-- 16-bit / 24-bit big-endian encoders
+local function u16(n) return char(math.floor(n / 256) % 256, n % 256) end
+local function u24(n) return char(math.floor(n / 65536) % 256, math.floor(n / 256) % 256, n % 256) end
+local function u16be(s, off) return byte(s, off) * 256 + byte(s, off + 1) end
+local function u24be(s, off) return byte(s, off) * 65536 + byte(s, off + 1) * 256 + byte(s, off + 2) end
+
+-- Build a ClientHello TLS record for the given SNI hostname.
+local function client_hello(host)
+    -- 32-byte "random" — cryptographic strength is irrelevant here (we never
+    -- derive keys); Math.random is unavailable in this runtime anyway.
+    local rnd = "opsapi-domain-tls-probe-0000000\0"
+    rnd = sub((rnd .. rnd), 1, 32)
+
+    local cipher_suites = {
+        0xc02f, 0xc030, 0xc02b, 0xc02c, -- ECDHE-(RSA|ECDSA)-AES-GCM
+        0x009c, 0x009d,                 -- RSA-AES-GCM
+        0x002f, 0x0035,                 -- RSA-AES-CBC-SHA
+        0x000a,                         -- RSA-3DES (legacy fallback)
+        0x00ff,                         -- TLS_EMPTY_RENEGOTIATION_INFO_SCSV
+    }
+    local cs = {}
+    for _, c in ipairs(cipher_suites) do cs[#cs + 1] = u16(c) end
+    cs = table.concat(cs)
+
+    -- Extensions ----------------------------------------------------------
+    -- SNI (server_name). Entry = name_type(1 byte, 0=host_name) + name(u16 len + bytes)
+    local sni_host = host
+    local sni_entry = char(0) .. u16(#sni_host) .. sni_host
+    local sni_list = u16(#sni_entry) .. sni_entry   -- ServerNameList
+    local ext_sni = u16(0x0000) .. u16(#sni_list) .. sni_list
+
+    -- supported_groups: x25519, secp256r1, secp384r1
+    local groups = u16(0x001d) .. u16(0x0017) .. u16(0x0018)
+    local sg = u16(#groups) .. groups
+    local ext_groups = u16(0x000a) .. u16(#sg) .. sg
+
+    -- ec_point_formats: uncompressed
+    local epf = char(1) .. char(0)
+    local ext_epf = u16(0x000b) .. u16(#epf) .. epf
+
+    -- signature_algorithms
+    local sigs = {
+        0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501,
+        0x0806, 0x0601, 0x0201, 0x0203,
+    }
+    local sa = {}
+    for _, s in ipairs(sigs) do sa[#sa + 1] = u16(s) end
+    sa = table.concat(sa)
+    sa = u16(#sa) .. sa
+    local ext_sa = u16(0x000d) .. u16(#sa) .. sa
+
+    local extensions = ext_sni .. ext_groups .. ext_epf .. ext_sa
+    local ext_block = u16(#extensions) .. extensions
+
+    -- ClientHello body ----------------------------------------------------
+    local body = u16(0x0303)            -- client_version = TLS 1.2
+        .. rnd                          -- random
+        .. char(0)                      -- session_id length = 0
+        .. u16(#cs) .. cs               -- cipher_suites
+        .. char(1) .. char(0)           -- compression_methods: null
+        .. ext_block
+
+    local handshake = char(1) .. u24(#body) .. body      -- type 1 = ClientHello
+    local record = char(22) .. u16(0x0301) .. u16(#handshake) .. handshake
+    return record
+end
+
+-- Read one TLS record. Returns content_type, payload or nil, err.
+local function read_record(sock)
+    local hdr, err = sock:receive(5)
+    if not hdr then return nil, "record header: " .. tostring(err) end
+    local ctype = byte(hdr, 1)
+    local len = u16be(hdr, 4)
+    if len == 0 then return ctype, "" end
+    local payload, perr = sock:receive(len)
+    if not payload then return nil, "record body: " .. tostring(perr) end
+    return ctype, payload
+end
+
+-- From an accumulated handshake byte-stream, find the Certificate (type 11)
+-- message and return the leaf certificate DER, or nil if not yet present.
+local function extract_leaf_cert(hs)
+    local i = 1
+    local n = #hs
+    while i + 4 <= n + 1 do
+        local mtype = byte(hs, i)
+        local mlen = u24be(hs, i + 1)
+        local body_start = i + 4
+        if body_start + mlen - 1 > n then
+            return nil -- incomplete message; need more records
+        end
+        if mtype == 11 then -- Certificate
+            -- body: certs_len(3) then [ cert_len(3) cert(der) ]...
+            local p = body_start
+            -- local certs_len = u24be(hs, p)  -- total, unused
+            p = p + 3
+            local cert_len = u24be(hs, p)
+            p = p + 3
+            return sub(hs, p, p + cert_len - 1)
+        end
+        i = body_start + mlen
+    end
+    return nil
+end
+
+--- Fetch the leaf certificate's expiry + issuer for host:port.
+-- @return { not_after = <epoch>, issuer = <string> } or nil, err
+function TLSCert.fetch(host, port, timeout)
+    port = port or 443
+    local sock = ngx.socket.tcp()
+    sock:settimeout(timeout or 8000)
+
+    local ok, cerr = sock:connect(host, port)
+    if not ok then return nil, "TCP connect failed: " .. tostring(cerr) end
+
+    local bytes_sent, serr = sock:send(client_hello(host))
+    if not bytes_sent then sock:close(); return nil, "send ClientHello: " .. tostring(serr) end
+
+    local hs = {}
+    local hs_len = 0
+    local leaf = nil
+    -- Read up to a bounded number of records for the handshake certificate.
+    for _ = 1, 24 do
+        local ctype, payload = read_record(sock)
+        if not ctype then break end
+        if ctype == 21 then -- Alert
+            sock:close()
+            return nil, "server sent TLS alert (likely TLS 1.3-only or handshake refused)"
+        elseif ctype == 22 then -- Handshake
+            hs[#hs + 1] = payload
+            hs_len = hs_len + #payload
+            local joined = table.concat(hs)
+            leaf = extract_leaf_cert(joined)
+            if leaf then break end
+        end
+        -- ignore other content types (e.g. ChangeCipherSpec)
+        if hs_len > 65536 then break end
+    end
+    sock:close()
+
+    if not leaf then
+        return nil, "no Certificate message received"
+    end
+
+    local x509_ok, x509 = pcall(require, "resty.openssl.x509")
+    if not x509_ok then return nil, "resty.openssl.x509 not available: " .. tostring(x509) end
+
+    local cert, e1 = x509.new(leaf, "DER")
+    if not cert then return nil, "parse cert: " .. tostring(e1) end
+
+    local not_after, e2 = cert:get_not_after()
+    if not not_after then return nil, "no notAfter: " .. tostring(e2) end
+
+    local out = { not_after = not_after }
+    local ok_iss, issuer = pcall(function() return cert:get_issuer_name() end)
+    if ok_iss and issuer then
+        out.issuer = tostring(issuer):sub(1, 255)
+    end
+    return out, nil
+end
+
+return TLSCert

--- a/lapis/helper/wslproxy-server.lua
+++ b/lapis/helper/wslproxy-server.lua
@@ -1,0 +1,175 @@
+--[[
+    WSL Proxy Server (vhost) Renderer
+    =================================
+
+    Turns an opsapi `domains` row into a WSL Proxy server-config file matching
+    the shape consumed by diy-tax-return-uk's
+    .github/wslproxy/data/servers/<env>/host:<domain>.json and the
+    wslproxy-register-domains.yml workflow.
+
+    The committed convention (verified against existing files):
+      - `config` is a base64-encoded nginx server block
+      - `config_status` is false (staged; the register workflow flips it live)
+      - `rules` references a rule id in data/rules/<env>/
+      - `id` and filename are `host:<server_name>`
+]]
+
+local cjson = require("cjson")
+
+local WslproxyServer = {}
+
+-- Base64-encode a plaintext nginx config (matches the committed import format).
+local function b64(s)
+    if ngx and ngx.encode_base64 then return ngx.encode_base64(s) end
+    -- Fallback (non-nginx contexts) — should not be hit in the worker.
+    local mime_ok, mime = pcall(require, "mime")
+    if mime_ok then return (mime.b64(s)) end
+    return s
+end
+
+-- Render the nginx server block for a domain (mirrors the existing template).
+local function nginx_config(domain)
+    local name = domain.domain_name
+    local root = domain.wslproxy_root or "/var/www/html"
+    local lines = {
+        "server {",
+        "      listen 80;  # Listen on port (HTTP)",
+        "      server_name " .. name .. ";  # Your domain name",
+        "      root " .. root .. ";  # Document root directory",
+        "      index index.html;  # Default index files",
+        "      access_log logs/" .. name .. ".access.log;  # Access log file location",
+        "      error_log logs/" .. name .. ".error.log;  # Error log file location",
+        "",
+        "",
+        "",
+        "  }",
+        "",
+        "  ",
+    }
+    return table.concat(lines, "\n")
+end
+
+local function bool(v, default)
+    if v == nil then return default end
+    if type(v) == "boolean" then return v end
+    if v == "true" or v == "t" or v == 1 or v == "1" then return true end
+    if v == "false" or v == "f" or v == 0 or v == "0" then return false end
+    return default
+end
+
+--- Build the listens array from a comma-separated port list ("80,443").
+local function build_listens(listen_ports)
+    local out = {}
+    for p in tostring(listen_ports or "80"):gmatch("[^,%s]+") do
+        table.insert(out, { listen = p })
+    end
+    if #out == 0 then out = { { listen = "80" } } end
+    return out
+end
+
+--- Render a domain row to a WSL Proxy server config table.
+-- @param domain table domains row (with wslproxy fields)
+-- @return table { filename, env, id, content } where content is the Lua table
+function WslproxyServer.render(domain)
+    local name = domain.domain_name
+    local env = domain.environment or "prod"
+    local id = "host:" .. name
+
+    local config = {
+        id = id,
+        server_name = name,
+        proxy_server_name = name,
+        profile_id = env,
+        rules = domain.wslproxy_rule_id or "",
+        config_status = false, -- staged; register workflow activates
+        ssl_enabled = bool(domain.ssl_enabled, true),
+        ssl_email = domain.ssl_email or "",
+        ssl_auto_renew = bool(domain.ssl_auto_renew, true),
+        ssl_force_https = bool(domain.ssl_force_https, true),
+        ssl_staging = bool(domain.ssl_staging, false),
+        cache_enabled = false,
+        index = "index.html",
+        root = domain.wslproxy_root or "/var/www/html",
+        access_log = "logs/" .. name .. ".access.log",
+        error_log = "logs/" .. name .. ".error.log",
+        -- Empty Lua tables encode as {} objects (matching the committed files).
+        custom_headers = {},
+        match_cases = {},
+        listens = build_listens(domain.listen_ports),
+        config = b64(nginx_config(domain)),
+    }
+
+    return {
+        filename = "host:" .. name .. ".json",
+        env = env,
+        id = id,
+        content = config,
+    }
+end
+
+-- opsapi's cjson encodes empty Lua tables as `[]`. The committed wslproxy files
+-- use `{}` for custom_headers / match_cases — force those two back to objects.
+-- Deterministic: only these two keys are ever empty tables in the payload.
+function WslproxyServer.encode(content)
+    local s = cjson.encode(content)
+    s = s:gsub('"custom_headers":%[%]', '"custom_headers":{}')
+    s = s:gsub('"match_cases":%[%]', '"match_cases":{}')
+    return s
+end
+
+--- Convenience: render to a compact JSON string (wslproxy-faithful).
+function WslproxyServer.render_json(domain)
+    local rendered = WslproxyServer.render(domain)
+    return WslproxyServer.encode(rendered.content), rendered.filename, rendered.env
+end
+
+--- Repo path (relative) for a rendered server file under a data root.
+-- @param env string environment/profile
+-- @param filename string host:<domain>.json
+-- @param base string|nil data root (default .github/wslproxy/data)
+function WslproxyServer.repo_path(env, filename, base)
+    base = base or ".github/wslproxy/data"
+    return base .. "/servers/" .. env .. "/" .. filename
+end
+
+--- Path of the opsapi-managed-domains manifest. Deliberately OUTSIDE
+--- servers/<env>/ (which the register workflow globs as *.json) so it is never
+--- treated as a vhost. The DNS reconcile reads this to scope reconciliation to
+--- opsapi-managed domains only (never the hand-authored ones).
+function WslproxyServer.manifest_path(env)
+    return ".github/wslproxy/opsapi/domains-" .. env .. ".json"
+end
+
+--- Build the full set of files to commit for a namespace's domains in one env:
+--- one server file per domain PLUS the opsapi-managed manifest.
+-- @param domains table list of domain rows
+-- @param env string environment
+-- @param data_base string|nil server data root
+-- @return { files = {{path,content}...}, rendered = {{path,server_name,content}...}, count }
+function WslproxyServer.build_sync_files(domains, env, data_base)
+    local files, rendered, manifest = {}, {}, {}
+    for _, d in ipairs(domains or {}) do
+        if (d.environment or "prod") == env then
+            local r = WslproxyServer.render(d)
+            local path = WslproxyServer.repo_path(env, r.filename, data_base)
+            local content = WslproxyServer.encode(r.content)
+            table.insert(files, { path = path, content = content })
+            table.insert(rendered, { path = path, server_name = d.domain_name, content = content })
+            table.insert(manifest, { server_name = d.domain_name, target = d.proxy_target or "" })
+        end
+    end
+    if #files > 0 then
+        local mpath = WslproxyServer.manifest_path(env)
+        local mcontent = cjson.encode({
+            environment = env,
+            generated_at = os.date("!%Y-%m-%dT%H:%M:%SZ"),
+            count = #manifest,
+            domains = manifest,
+        })
+        table.insert(files, { path = mpath, content = mcontent })
+        table.insert(rendered, { path = mpath, server_name = "(opsapi manifest)", content = mcontent })
+    end
+    return { files = files, rendered = rendered, count = #manifest }
+end
+
+return WslproxyServer

--- a/lapis/lib/cloudflare.lua
+++ b/lapis/lib/cloudflare.lua
@@ -1,0 +1,173 @@
+--[[
+    Cloudflare API Client
+    =====================
+
+    Thin wrapper over the Cloudflare v4 API for the Domain Management module.
+    Two-way: list zones, and read/create/update/delete DNS records.
+
+    Auth: a per-namespace API token, stored AES-encrypted in domain_credentials
+    and decrypted server-side via DomainCredentialQueries.getDecryptedSecret.
+    The token is passed to Client.new(token) — this module never reads the DB.
+
+    TLS: ssl_verify is environment-aware, mirroring lib/hmrc-mtd-client.lua.
+    Production verifies certs (requires lua_ssl_trusted_certificate in nginx.conf,
+    already present); local/sandbox may relax it via CLOUDFLARE_ENVIRONMENT or the
+    generic OPSAPI_SSL_VERIFY flag.
+
+    Every method returns (result, nil) on success or (nil, err_string) on failure —
+    HTTP errors and Cloudflare error envelopes are normalised into err_string.
+]]
+
+local cjson = require("cjson")
+
+local Cloudflare = {}
+Cloudflare.__index = Cloudflare
+
+local API_BASE = "https://api.cloudflare.com/client/v4"
+
+-- Verify TLS unless explicitly told not to. Cloudflare is always real TLS, so the
+-- only reason to relax is a local box without a CA bundle.
+local function tls_verify()
+    local env = (os.getenv("CLOUDFLARE_ENVIRONMENT") or ""):lower()
+    if env == "sandbox" or env == "local" or env == "development" then
+        return false
+    end
+    local flag = os.getenv("OPSAPI_SSL_VERIFY")
+    if flag ~= nil and flag ~= "" then
+        return flag == "true" or flag == "1"
+    end
+    return true -- default: verify
+end
+
+local function http_client()
+    local ok, http = pcall(require, "resty.http")
+    if not ok then return nil, "resty.http not available" end
+    local httpc = http.new()
+    httpc:set_timeout(20000)
+    return httpc, nil
+end
+
+--- Create a client bound to a token.
+-- @param token string Cloudflare API token (already decrypted)
+function Cloudflare.new(token)
+    return setmetatable({ token = token }, Cloudflare)
+end
+
+-- Core request. Returns (result_table, nil) or (nil, err).
+function Cloudflare:request(method, path, body)
+    if not self.token or self.token == "" then
+        return nil, "Cloudflare token not configured"
+    end
+    local httpc, err = http_client()
+    if not httpc then return nil, err end
+
+    local headers = {
+        ["Authorization"] = "Bearer " .. self.token,
+        ["Content-Type"] = "application/json",
+        ["Accept"] = "application/json",
+    }
+    local payload = nil
+    if body ~= nil then
+        local enc_ok, enc = pcall(cjson.encode, body)
+        if not enc_ok then return nil, "Failed to encode request body" end
+        payload = enc
+    end
+
+    local res, rerr = httpc:request_uri(API_BASE .. path, {
+        method = method,
+        headers = headers,
+        body = payload,
+        ssl_verify = tls_verify(),
+    })
+    if not res then
+        return nil, "Cloudflare request failed: " .. tostring(rerr)
+    end
+
+    local ok, decoded = pcall(cjson.decode, res.body or "")
+    if not ok or type(decoded) ~= "table" then
+        return nil, "Cloudflare returned a non-JSON response (HTTP " .. tostring(res.status) .. ")"
+    end
+
+    if decoded.success == false or (res.status and res.status >= 400) then
+        local msg = "Cloudflare API error (HTTP " .. tostring(res.status) .. ")"
+        if type(decoded.errors) == "table" and decoded.errors[1] then
+            local e = decoded.errors[1]
+            msg = msg .. ": " .. tostring(e.message or e.code or "unknown")
+        end
+        return nil, msg
+    end
+
+    return decoded, nil
+end
+
+--------------------------------------------------------------------------------
+-- Zones
+--------------------------------------------------------------------------------
+function Cloudflare:list_zones(opts)
+    opts = opts or {}
+    local qs = "?per_page=" .. tostring(opts.per_page or 50)
+    if opts.name and opts.name ~= "" then
+        qs = qs .. "&name=" .. opts.name
+    end
+    local res, err = self:request("GET", "/zones" .. qs)
+    if not res then return nil, err end
+    return res.result or {}, nil
+end
+
+--- Find a zone id by (apex) domain name.
+function Cloudflare:find_zone_id(name)
+    local zones, err = self:list_zones({ name = name })
+    if not zones then return nil, err end
+    if zones[1] then return zones[1].id, nil end
+    return nil, "Zone not found for " .. tostring(name)
+end
+
+--------------------------------------------------------------------------------
+-- DNS records (read + create/update/delete)
+--------------------------------------------------------------------------------
+function Cloudflare:list_dns_records(zone_id, opts)
+    opts = opts or {}
+    if not zone_id or zone_id == "" then return nil, "zone_id required" end
+    local qs = "?per_page=" .. tostring(opts.per_page or 100)
+    if opts.type and opts.type ~= "" then qs = qs .. "&type=" .. opts.type end
+    if opts.name and opts.name ~= "" then qs = qs .. "&name=" .. opts.name end
+    local res, err = self:request("GET", "/zones/" .. zone_id .. "/dns_records" .. qs)
+    if not res then return nil, err end
+    return res.result or {}, nil
+end
+
+-- record = { type, name, content, ttl?, proxied?, priority? }
+function Cloudflare:create_dns_record(zone_id, record)
+    if not zone_id or zone_id == "" then return nil, "zone_id required" end
+    if not record or not record.type or not record.name or record.content == nil then
+        return nil, "record requires type, name and content"
+    end
+    local res, err = self:request("POST", "/zones/" .. zone_id .. "/dns_records", record)
+    if not res then return nil, err end
+    return res.result, nil
+end
+
+function Cloudflare:update_dns_record(zone_id, record_id, record)
+    if not zone_id or zone_id == "" then return nil, "zone_id required" end
+    if not record_id or record_id == "" then return nil, "record_id required" end
+    local res, err = self:request("PUT", "/zones/" .. zone_id .. "/dns_records/" .. record_id, record)
+    if not res then return nil, err end
+    return res.result, nil
+end
+
+function Cloudflare:delete_dns_record(zone_id, record_id)
+    if not zone_id or zone_id == "" then return nil, "zone_id required" end
+    if not record_id or record_id == "" then return nil, "record_id required" end
+    local res, err = self:request("DELETE", "/zones/" .. zone_id .. "/dns_records/" .. record_id)
+    if not res then return nil, err end
+    return res.result, nil
+end
+
+--- Cheap credential validation: GET /user/tokens/verify.
+function Cloudflare:verify_token()
+    local res, err = self:request("GET", "/user/tokens/verify")
+    if not res then return nil, err end
+    return res.result or {}, nil
+end
+
+return Cloudflare

--- a/lapis/lib/github-repo.lua
+++ b/lapis/lib/github-repo.lua
@@ -1,0 +1,213 @@
+--[[
+    GitHub Repo Commit Helper (Git Data API)
+    ========================================
+
+    Commits a set of files to a repo/branch in ONE atomic commit using the Git
+    Trees API. Because the new tree is created with `base_tree` = the current
+    commit's tree, only the paths we pass are added/updated — every other file
+    in the repo is preserved. We never send deletions, so this is strictly
+    add/update-only (safe alongside hand-authored files).
+
+    Auth: a GitHub token (PAT / fine-grained) passed in — this module never
+    reads the DB. Reuse the services module's stored, encrypted integration
+    token to obtain it.
+
+    Usage:
+      local GH = require("lib.github-repo")
+      local sha, err = GH.commit_files({
+        token = "...", owner = "bwalia", repo = "diy-tax-return-uk",
+        branch = "main", message = "chore(domains): sync",
+        files = { { path = ".github/.../host:x.json", content = "{...}" } },
+      })
+]]
+
+local cjson = require("cjson")
+
+local GithubRepo = {}
+
+local API = "https://api.github.com"
+
+local function http_client(timeout)
+    local ok, http = pcall(require, "resty.http")
+    if not ok then return nil, "resty.http not available" end
+    local httpc = http.new()
+    httpc:set_timeout(timeout or 20000)
+    return httpc, nil
+end
+
+-- One GitHub API call. Returns decoded_body, status, err.
+local function api(token, method, path, body)
+    local httpc, herr = http_client()
+    if not httpc then return nil, nil, herr end
+    local headers = {
+        ["Authorization"] = "Bearer " .. token,
+        ["Accept"] = "application/vnd.github+json",
+        ["User-Agent"] = "opsapi-domain-sync",
+        ["X-GitHub-Api-Version"] = "2022-11-28",
+    }
+    local payload
+    if body ~= nil then
+        headers["Content-Type"] = "application/json"
+        payload = cjson.encode(body)
+    end
+    local res, rerr = httpc:request_uri(API .. path, {
+        method = method, headers = headers, body = payload, ssl_verify = true,
+    })
+    if not res then return nil, nil, "request failed: " .. tostring(rerr) end
+    local decoded
+    if res.body and res.body ~= "" then
+        local ok, d = pcall(cjson.decode, res.body)
+        if ok then decoded = d end
+    end
+    if res.status >= 400 then
+        local msg = "GitHub API " .. tostring(res.status)
+        if decoded and decoded.message then msg = msg .. ": " .. decoded.message end
+        return decoded, res.status, msg
+    end
+    return decoded, res.status, nil
+end
+
+--- Commit files atomically. add/update-only (base_tree preserves everything else).
+-- @param opts { token, owner, repo, branch, message, files={{path,content}...}, author_name?, author_email? }
+-- @return commit_sha, nil OR nil, err
+function GithubRepo.commit_files(opts)
+    assert(opts and opts.token and opts.owner and opts.repo, "token/owner/repo required")
+    local branch = opts.branch or "main"
+    local files = opts.files or {}
+    if #files == 0 then return nil, "no files to commit" end
+
+    local base = "/repos/" .. opts.owner .. "/" .. opts.repo
+
+    -- 1. Current branch ref → base commit sha
+    local ref, _, err = api(opts.token, "GET", base .. "/git/ref/heads/" .. branch)
+    if err then return nil, "get ref: " .. err end
+    local base_commit_sha = ref and ref.object and ref.object.sha
+    if not base_commit_sha then return nil, "could not resolve branch head sha" end
+
+    -- 2. Base commit → base tree sha
+    local commit, _, cerr = api(opts.token, "GET", base .. "/git/commits/" .. base_commit_sha)
+    if cerr then return nil, "get base commit: " .. cerr end
+    local base_tree_sha = commit and commit.tree and commit.tree.sha
+    if not base_tree_sha then return nil, "could not resolve base tree sha" end
+
+    -- 3. One blob per file
+    local tree_entries = {}
+    for _, f in ipairs(files) do
+        local blob, _, berr = api(opts.token, "POST", base .. "/git/blobs", {
+            content = ngx.encode_base64(f.content),
+            encoding = "base64",
+        })
+        if berr then return nil, "create blob (" .. tostring(f.path) .. "): " .. berr end
+        if not (blob and blob.sha) then return nil, "create blob (" .. tostring(f.path) .. "): no sha returned" end
+        table.insert(tree_entries, {
+            path = f.path, mode = "100644", type = "blob", sha = blob.sha,
+        })
+    end
+
+    -- 4. New tree on top of the base tree (only our paths change)
+    local tree, _, terr = api(opts.token, "POST", base .. "/git/trees", {
+        base_tree = base_tree_sha,
+        tree = tree_entries,
+    })
+    if terr then return nil, "create tree: " .. terr end
+    if not (tree and tree.sha) then return nil, "create tree: no sha returned" end
+
+    -- 5. New commit
+    local body = {
+        message = opts.message or "chore(domains): sync from opsapi",
+        tree = tree.sha,
+        parents = { base_commit_sha },
+    }
+    if opts.author_name and opts.author_email then
+        body.author = { name = opts.author_name, email = opts.author_email, date = os.date("!%Y-%m-%dT%H:%M:%SZ") }
+    end
+    local newcommit, _, ncerr = api(opts.token, "POST", base .. "/git/commits", body)
+    if ncerr then return nil, "create commit: " .. ncerr end
+    if not (newcommit and newcommit.sha) then return nil, "create commit: no sha returned" end
+
+    -- 6. Fast-forward the branch ref
+    local _, _, uerr = api(opts.token, "PATCH", base .. "/git/refs/heads/" .. branch, {
+        sha = newcommit.sha, force = false,
+    })
+    if uerr then return nil, "update ref: " .. uerr end
+
+    return newcommit.sha, nil
+end
+
+--- Dispatch a workflow_dispatch event (thin wrapper; the services module has a
+--- fuller one, but the pipeline reuses this for a uniform token path).
+-- @param opts { token, owner, repo, workflow (file name or id), ref?, inputs? }
+function GithubRepo.dispatch_workflow(opts)
+    assert(opts and opts.token and opts.owner and opts.repo and opts.workflow, "token/owner/repo/workflow required")
+    local path = string.format("/repos/%s/%s/actions/workflows/%s/dispatches",
+        opts.owner, opts.repo, opts.workflow)
+    local _, status, err = api(opts.token, "POST", path, {
+        ref = opts.ref or "main",
+        inputs = opts.inputs or nil,
+    })
+    if err then return nil, err end
+    return status == 204 or status == 200, nil
+end
+
+--- Find the workflow run created by a dispatch. workflow_dispatch returns no run
+--- id, so we poll the workflow's runs and pick the newest created at/after
+--- `since_iso` (an ISO-8601 UTC string captured just before dispatch). Retries a
+--- few times because the run can take a few seconds to appear.
+-- @param opts { token, owner, repo, workflow, ref? }
+-- @param since_iso string e.g. "2026-08-06T09:00:00Z"
+-- @return run_table, nil OR nil, err   (run_table has id, status, conclusion, html_url, created_at)
+function GithubRepo.find_run_after(opts, since_iso)
+    local path = string.format("/repos/%s/%s/actions/workflows/%s/runs?event=workflow_dispatch&per_page=15",
+        opts.owner, opts.repo, opts.workflow)
+    if opts.ref then path = path .. "&branch=" .. opts.ref end
+
+    for attempt = 1, 8 do
+        local body, _, err = api(opts.token, "GET", path)
+        if not err and body and type(body.workflow_runs) == "table" then
+            local newest
+            for _, run in ipairs(body.workflow_runs) do
+                if run.created_at and run.created_at >= since_iso then
+                    if not newest or run.created_at > newest.created_at then newest = run end
+                end
+            end
+            if newest then return newest, nil end
+        end
+        if ngx and ngx.sleep then ngx.sleep(3) end
+        if attempt == 8 then
+            return nil, "run did not appear after dispatch (timed out finding run)"
+        end
+    end
+    return nil, "run not found"
+end
+
+--- Get a single workflow run's current state.
+function GithubRepo.get_run(opts, run_id)
+    local body, _, err = api(opts.token, "GET",
+        string.format("/repos/%s/%s/actions/runs/%s", opts.owner, opts.repo, run_id))
+    if err then return nil, err end
+    return body, nil
+end
+
+--- Poll a run until it completes (status == "completed") or times out.
+-- @param opts { token, owner, repo }
+-- @param run_id number
+-- @param timeout_s number total seconds to wait (default 900)
+-- @param interval_s number poll interval (default 15)
+-- @return run_table (completed), nil  OR  nil, err (timeout/error). Caller checks .conclusion.
+function GithubRepo.wait_for_run(opts, run_id, timeout_s, interval_s)
+    timeout_s = timeout_s or 900
+    interval_s = interval_s or 15
+    local waited = 0
+    while waited <= timeout_s do
+        local run, err = GithubRepo.get_run(opts, run_id)
+        if err then return nil, err end
+        if run and run.status == "completed" then
+            return run, nil
+        end
+        if ngx and ngx.sleep then ngx.sleep(interval_s) end
+        waited = waited + interval_s
+    end
+    return nil, "timed out waiting for run " .. tostring(run_id) .. " to complete"
+end
+
+return GithubRepo

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -316,6 +316,15 @@ local crm_menu_items_migrations = load_if_enabled(ProjectConfig.FEATURES.CRM, "m
 -- registry entries 510/511 (core) and 512 (CRM) below.
 local crm_leads_migrations = require("migrations.crm-leads")
 
+-- Domain Management (domains registry + credentials + k3s sync configs + menu).
+-- Gated on the existing SERVICES feature (shares the infrastructure remit) —
+-- no dedicated project code.
+local domain_management_migrations = load_if_enabled(ProjectConfig.FEATURES.SERVICES, "migrations.domain-management") or {}
+local domain_menu_items_migrations = load_if_enabled(ProjectConfig.FEATURES.SERVICES, "migrations.domain-menu-items") or {}
+local domain_wslproxy_fields_migrations = load_if_enabled(ProjectConfig.FEATURES.SERVICES, "migrations.domain-wslproxy-fields") or {}
+local domain_pipeline_runs_migrations = load_if_enabled(ProjectConfig.FEATURES.SERVICES, "migrations.domain-pipeline-runs") or {}
+local domain_sync_settings_migrations = load_if_enabled(ProjectConfig.FEATURES.SERVICES, "migrations.domain-sync-settings") or {}
+
 -- Timesheets
 local timesheet_system_migrations = load_if_enabled(ProjectConfig.FEATURES.TIMESHEETS, "migrations.timesheet-system") or {}
 local timesheet_menu_items_migrations = load_if_enabled(ProjectConfig.FEATURES.TIMESHEETS, "migrations.timesheet-menu-items") or {}
@@ -1710,6 +1719,19 @@ local _migrations = {
     -- CRM-only: attach converted_contact_id/converted_deal_id foreign keys.
     -- Sorts after 501-504 (crm_contacts/crm_deals) so the FK targets exist.
     ['512_crm_leads_crm_fks'] = conditional_array(ProjectConfig.FEATURES.CRM, crm_leads_migrations, 3),
+
+    -- Domain Management (600-606): registry + encrypted credentials + sync configs + menu.
+    -- Gated on FEATURES.SERVICES; namespace-scoped tables sort after namespaces (152).
+    ['600_domains_create'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_management_migrations, 1),
+    ['601_domain_credentials_create'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_management_migrations, 2),
+    ['602_domain_sync_configs_create'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_management_migrations, 3),
+    ['603_seed_domain_menu_item'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_menu_items_migrations, 1),
+    ['604_seed_domain_modules'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_menu_items_migrations, 2),
+    ['605_grant_domain_permissions'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_menu_items_migrations, 3),
+    ['606_enable_domain_menu_for_namespaces'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_menu_items_migrations, 4),
+    ['607_domain_wslproxy_fields'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_wslproxy_fields_migrations, 1),
+    ['608_domain_pipeline_runs'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_pipeline_runs_migrations, 1),
+    ['609_domain_sync_settings'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_sync_settings_migrations, 1),
 
     -- CRM menu items (720-723): surface CRM in the backend-driven sidebar
     ['720_seed_crm_menu_items'] = conditional_array(ProjectConfig.FEATURES.CRM, crm_menu_items_migrations, 1),

--- a/lapis/migrations/domain-management.lua
+++ b/lapis/migrations/domain-management.lua
@@ -1,0 +1,176 @@
+--[[
+    Domain Management Migrations
+    ============================
+
+    Central, namespace-scoped domain registry with:
+      - domains               : the domain records (registration + SSL expiry tracking)
+      - domain_credentials    : provider API tokens (e.g. Cloudflare), AES-encrypted at rest
+      - domain_sync_configs   : k3s-job sync destinations (push domains.json to a GitHub repo)
+
+    Gated on FEATURES.SERVICES in migrations.lua (shares the infrastructure remit;
+    no dedicated project code). Every table carries namespace_id and is filtered by
+    it in queries (platform admins get a cross-namespace view).
+
+    Secrets policy:
+      - Cloudflare API tokens live in domain_credentials.encrypted_secret, encrypted
+        with Global.encryptSecret (AES via OPENSSL_SECRET_KEY) so the backend can
+        decrypt them server-side to call the Cloudflare API. Never stored plaintext.
+      - The GitHub token used by the generated k3s CronJob is NOT stored here — the
+        sync config only references a Kubernetes Secret name (populated by ESO / the
+        external vault). See helper/domain-sync-manifest.lua.
+]]
+
+local db = require("lapis.db")
+
+-- NOTE: scope to public BASE TABLEs. A bare information_schema.tables check on
+-- table_name='domains' also matches the built-in information_schema.domains view,
+-- which would make this guard skip creating our real table. to_regclass is the
+-- unambiguous test for "does public.<name> exist as a relation".
+local function table_exists(name)
+    local result = db.query("SELECT to_regclass('public.' || ?) IS NOT NULL AS exists", name)
+    return result and result[1] and result[1].exists
+end
+
+return {
+    -- ========================================
+    -- [1] domains — the core registry
+    -- ========================================
+    [1] = function()
+        if table_exists("domains") then return end
+
+        db.query([[
+            CREATE TABLE IF NOT EXISTS domains (
+                id BIGSERIAL PRIMARY KEY,
+                uuid TEXT UNIQUE NOT NULL,
+                namespace_id BIGINT NOT NULL REFERENCES namespaces(id) ON DELETE CASCADE,
+
+                -- Identity
+                domain_name TEXT NOT NULL,
+                registrar TEXT,
+                dns_provider TEXT DEFAULT 'cloudflare',
+                cloudflare_zone_id TEXT,
+
+                -- Lifecycle status: active | expiring_soon | expired | error | pending
+                status TEXT DEFAULT 'active',
+
+                -- Registration (WHOIS/RDAP) expiry
+                registration_expires_at TIMESTAMP,
+                registrar_status TEXT,
+
+                -- SSL / TLS certificate expiry (live handshake)
+                ssl_expires_at TIMESTAMP,
+                ssl_issuer TEXT,
+
+                -- Monitoring bookkeeping
+                last_checked_at TIMESTAMP,
+                last_check_error TEXT,
+                alert_threshold_days INTEGER DEFAULT 30,
+                auto_renew BOOLEAN DEFAULT FALSE,
+
+                -- Ownership / free-form
+                owner_user_uuid TEXT,
+                notes TEXT,
+                metadata JSONB DEFAULT '{}',
+
+                created_at TIMESTAMP DEFAULT NOW(),
+                updated_at TIMESTAMP DEFAULT NOW(),
+                deleted_at TIMESTAMP,
+
+                CONSTRAINT domains_namespace_domain_unique UNIQUE (namespace_id, domain_name)
+            )
+        ]])
+
+        pcall(function() db.query([[CREATE INDEX domains_namespace_status_idx ON domains (namespace_id, status)]]) end)
+        pcall(function() db.query([[CREATE INDEX domains_uuid_idx ON domains (uuid)]]) end)
+        pcall(function() db.query([[CREATE INDEX domains_domain_name_idx ON domains (domain_name)]]) end)
+        pcall(function() db.query([[CREATE INDEX domains_reg_expires_idx ON domains (registration_expires_at)]]) end)
+        pcall(function() db.query([[CREATE INDEX domains_ssl_expires_idx ON domains (ssl_expires_at)]]) end)
+        pcall(function() db.query([[CREATE INDEX domains_owner_user_uuid_idx ON domains (owner_user_uuid)]]) end)
+    end,
+
+    -- ========================================
+    -- [2] domain_credentials — encrypted provider tokens (Cloudflare, ...)
+    -- ========================================
+    [2] = function()
+        if table_exists("domain_credentials") then return end
+
+        db.query([[
+            CREATE TABLE IF NOT EXISTS domain_credentials (
+                id BIGSERIAL PRIMARY KEY,
+                uuid TEXT UNIQUE NOT NULL,
+                namespace_id BIGINT NOT NULL REFERENCES namespaces(id) ON DELETE CASCADE,
+
+                provider TEXT NOT NULL DEFAULT 'cloudflare',
+                label TEXT,
+
+                -- AES-encrypted (Global.encryptSecret) — NEVER plaintext.
+                encrypted_secret TEXT NOT NULL,
+
+                -- Non-secret provider metadata
+                account_id TEXT,
+                email TEXT,
+                metadata JSONB DEFAULT '{}',
+
+                created_at TIMESTAMP DEFAULT NOW(),
+                updated_at TIMESTAMP DEFAULT NOW(),
+
+                CONSTRAINT domain_credentials_namespace_provider_unique UNIQUE (namespace_id, provider)
+            )
+        ]])
+
+        pcall(function() db.query([[CREATE INDEX domain_credentials_namespace_idx ON domain_credentials (namespace_id)]]) end)
+        pcall(function() db.query([[CREATE INDEX domain_credentials_uuid_idx ON domain_credentials (uuid)]]) end)
+    end,
+
+    -- ========================================
+    -- [3] domain_sync_configs — k3s sync destinations
+    -- ========================================
+    [3] = function()
+        if table_exists("domain_sync_configs") then return end
+
+        db.query([[
+            CREATE TABLE IF NOT EXISTS domain_sync_configs (
+                id BIGSERIAL PRIMARY KEY,
+                uuid TEXT UNIQUE NOT NULL,
+                namespace_id BIGINT NOT NULL REFERENCES namespaces(id) ON DELETE CASCADE,
+
+                name TEXT NOT NULL,
+                destination_type TEXT NOT NULL DEFAULT 'github',
+
+                -- GitHub destination
+                github_repo TEXT,          -- owner/repo
+                github_branch TEXT DEFAULT 'main',
+                file_path TEXT DEFAULT 'domains.json',
+                commit_author_name TEXT DEFAULT 'opsapi-domain-sync',
+                commit_author_email TEXT DEFAULT 'domain-sync@opsapi',
+
+                -- Reference (NOT the token) to a Kubernetes Secret populated by ESO / the vault.
+                -- The same Secret carries the GitHub PAT and the opsapi machine token
+                -- (two keys) so the generated CronJob holds NO secret literals.
+                github_token_secret_ref TEXT,
+                github_token_secret_key TEXT DEFAULT 'github-token',
+
+                -- Where the CronJob fetches the live domain export from, and which
+                -- key in the same Secret holds the opsapi bearer token for that call.
+                opsapi_base_url TEXT,
+                opsapi_token_secret_key TEXT DEFAULT 'opsapi-token',
+
+                -- Cron schedule for the generated k3s CronJob
+                schedule TEXT DEFAULT '0 3 * * *',
+
+                is_enabled BOOLEAN DEFAULT TRUE,
+                last_synced_at TIMESTAMP,
+                last_status TEXT,          -- success | error | never
+                last_error TEXT,
+                metadata JSONB DEFAULT '{}',
+
+                created_at TIMESTAMP DEFAULT NOW(),
+                updated_at TIMESTAMP DEFAULT NOW(),
+                deleted_at TIMESTAMP
+            )
+        ]])
+
+        pcall(function() db.query([[CREATE INDEX domain_sync_configs_namespace_idx ON domain_sync_configs (namespace_id)]]) end)
+        pcall(function() db.query([[CREATE INDEX domain_sync_configs_uuid_idx ON domain_sync_configs (uuid)]]) end)
+    end,
+}

--- a/lapis/migrations/domain-menu-items.lua
+++ b/lapis/migrations/domain-menu-items.lua
@@ -1,0 +1,149 @@
+--[[
+    Domain Management Menu Items Seeding Migration
+
+    Surfaces the Domain Management module in the backend-driven sidebar, registers
+    its RBAC module ("domains"), grants default permissions to owner/admin roles,
+    and enables the menu item for existing namespaces. Mirrors crm-menu-items.lua.
+    Feature-gated under FEATURES.SERVICES.
+]]
+
+local db = require("lapis.db")
+
+return {
+    -- [1] Insert the Domains menu item
+    [1] = function()
+        local MigrationUtils = require("helper.migration-utils")
+        local timestamp = MigrationUtils.getCurrentTimestamp()
+
+        local items = {
+            {
+                key = "domains",
+                name = "Domains",
+                icon = "Globe",
+                path = "/dashboard/domains",
+                module = "domains",
+                required_action = "read",
+                priority = 60,
+            },
+        }
+
+        for _, item in ipairs(items) do
+            local existing = db.select("* FROM menu_items WHERE key = ?", item.key)
+            if #existing == 0 then
+                db.insert("menu_items", {
+                    uuid = MigrationUtils.generateUUID(),
+                    key = item.key,
+                    name = item.name,
+                    icon = item.icon,
+                    path = item.path,
+                    module = item.module,
+                    required_action = item.required_action,
+                    priority = item.priority,
+                    is_active = true,
+                    is_admin_only = false,
+                    always_show = false,
+                    settings = "{}",
+                    created_at = timestamp,
+                    updated_at = timestamp,
+                })
+                print("[Domains] Added menu item: " .. item.key)
+            end
+        end
+    end,
+
+    -- [2] Register the Domains RBAC module
+    [2] = function()
+        local MigrationUtils = require("helper.migration-utils")
+        local timestamp = MigrationUtils.getCurrentTimestamp()
+
+        local modules = {
+            { machine_name = "domains", name = "Domains", description = "Domain registry, SSL/expiry monitoring, Cloudflare & sync", priority = 60 },
+        }
+
+        for _, mod in ipairs(modules) do
+            local existing = db.select("* FROM modules WHERE machine_name = ?", mod.machine_name)
+            if #existing == 0 then
+                db.insert("modules", {
+                    uuid = MigrationUtils.generateUUID(),
+                    machine_name = mod.machine_name,
+                    name = mod.name,
+                    description = mod.description,
+                    priority = mod.priority,
+                    created_at = timestamp,
+                    updated_at = timestamp,
+                })
+                print("[Domains] Registered module: " .. mod.machine_name)
+            end
+        end
+    end,
+
+    -- [3] Grant permissions to owner + admin roles
+    [3] = function()
+        local cjson_ok, cjson = pcall(require, "cjson")
+        if not cjson_ok then return end
+
+        local domain_modules = { "domains" }
+
+        local owner_roles = db.select(
+            "* FROM namespace_roles WHERE role_name IN ('Owner', 'owner', 'Namespace Owner')"
+        )
+        local owner_actions = { "create", "read", "update", "delete", "manage" }
+        for _, role in ipairs(owner_roles) do
+            local perms = {}
+            if role.permissions and role.permissions ~= "" then
+                local ok, decoded = pcall(cjson.decode, role.permissions)
+                if ok and type(decoded) == "table" then perms = decoded end
+            end
+            for _, mod_name in ipairs(domain_modules) do
+                if not perms[mod_name] then perms[mod_name] = owner_actions end
+            end
+            db.update("namespace_roles", { permissions = cjson.encode(perms) }, { id = role.id })
+        end
+
+        local admin_roles = db.select(
+            "* FROM namespace_roles WHERE role_name IN ('Admin', 'admin', 'Namespace Admin')"
+        )
+        local admin_actions = { "create", "read", "update", "delete" }
+        for _, role in ipairs(admin_roles) do
+            local perms = {}
+            if role.permissions and role.permissions ~= "" then
+                local ok, decoded = pcall(cjson.decode, role.permissions)
+                if ok and type(decoded) == "table" then perms = decoded end
+            end
+            for _, mod_name in ipairs(domain_modules) do
+                if not perms[mod_name] then perms[mod_name] = admin_actions end
+            end
+            db.update("namespace_roles", { permissions = cjson.encode(perms) }, { id = role.id })
+        end
+    end,
+
+    -- [4] Enable the menu item for all existing namespaces
+    [4] = function()
+        local MigrationUtils = require("helper.migration-utils")
+        local timestamp = MigrationUtils.getCurrentTimestamp()
+
+        for _, key in ipairs({ "domains" }) do
+            local menu_rows = db.select("* FROM menu_items WHERE key = ?", key)
+            if #menu_rows > 0 then
+                local menu_item = menu_rows[1]
+                local namespaces = db.select("* FROM namespaces")
+                for _, ns in ipairs(namespaces) do
+                    local exists = db.select([[
+                        * FROM namespace_menu_config
+                        WHERE namespace_id = ? AND menu_item_id = ?
+                    ]], ns.id, menu_item.id)
+                    if #exists == 0 then
+                        db.insert("namespace_menu_config", {
+                            uuid = MigrationUtils.generateUUID(),
+                            namespace_id = ns.id,
+                            menu_item_id = menu_item.id,
+                            is_enabled = true,
+                            created_at = timestamp,
+                            updated_at = timestamp,
+                        })
+                    end
+                end
+            end
+        end
+    end,
+}

--- a/lapis/migrations/domain-pipeline-runs.lua
+++ b/lapis/migrations/domain-pipeline-runs.lua
@@ -1,0 +1,53 @@
+--[[
+    Domain Pipeline Runs
+    ====================
+
+    Tracks an opsapi-driven "domain pipeline": sync domains → repo, then dispatch
+    a chain of GitHub workflows in order (cloudflare-dns-reconcile →
+    wslproxy-register-domains → auto-tag-main), waiting for each before the next.
+
+    The orchestration runs in an ngx.timer (background), updating this row so the
+    dashboard can poll progress. See helper/domain-pipeline.lua. Gated SERVICES.
+]]
+
+local db = require("lapis.db")
+
+local function table_exists(name)
+    local r = db.query("SELECT to_regclass('public.' || ?) IS NOT NULL AS ok", name)
+    return r and r[1] and r[1].ok
+end
+
+return {
+    [1] = function()
+        if table_exists("domain_pipeline_runs") then return end
+
+        db.query([[
+            CREATE TABLE IF NOT EXISTS domain_pipeline_runs (
+                id BIGSERIAL PRIMARY KEY,
+                uuid TEXT UNIQUE NOT NULL,
+                namespace_id BIGINT NOT NULL REFERENCES namespaces(id) ON DELETE CASCADE,
+
+                status TEXT NOT NULL DEFAULT 'pending',   -- pending|running|success|failed
+                environment TEXT DEFAULT 'prod',
+                owner TEXT,
+                repo TEXT,
+                branch TEXT DEFAULT 'main',
+                github_integration_id TEXT,
+
+                commit_sha TEXT,                          -- from the sync step
+                current_step INTEGER DEFAULT 0,
+                steps JSONB DEFAULT '[]',                 -- [{name,workflow,status,run_id,run_url,conclusion,error,...}]
+                error TEXT,
+
+                triggered_by_uuid TEXT,
+                started_at TIMESTAMP,
+                finished_at TIMESTAMP,
+                created_at TIMESTAMP DEFAULT NOW(),
+                updated_at TIMESTAMP DEFAULT NOW()
+            )
+        ]])
+
+        pcall(function() db.query([[CREATE INDEX domain_pipeline_runs_ns_idx ON domain_pipeline_runs (namespace_id, created_at DESC)]]) end)
+        pcall(function() db.query([[CREATE INDEX domain_pipeline_runs_uuid_idx ON domain_pipeline_runs (uuid)]]) end)
+    end,
+}

--- a/lapis/migrations/domain-sync-settings.lua
+++ b/lapis/migrations/domain-sync-settings.lua
@@ -1,0 +1,55 @@
+--[[
+    Domain Sync Settings
+    ====================
+
+    ONE persisted target per namespace so the Domains module remembers where to
+    sync (repo + branch) and which GitHub authentication to use — configure once,
+    then "Sync to Repo" / "Run Pipeline" just work with no re-entry.
+
+    The GitHub token is NOT stored here — this row references a Services-module
+    GitHub integration (namespace_github_integrations) by id; that integration
+    holds the encrypted PAT. Keeps a single source of truth for credentials.
+
+    Gated on FEATURES.SERVICES.
+]]
+
+local db = require("lapis.db")
+
+local function table_exists(name)
+    local r = db.query("SELECT to_regclass('public.' || ?) IS NOT NULL AS ok", name)
+    return r and r[1] and r[1].ok
+end
+
+return {
+    [1] = function()
+        if table_exists("domain_sync_settings") then return end
+
+        db.query([[
+            CREATE TABLE IF NOT EXISTS domain_sync_settings (
+                id BIGSERIAL PRIMARY KEY,
+                uuid TEXT UNIQUE NOT NULL,
+                namespace_id BIGINT NOT NULL REFERENCES namespaces(id) ON DELETE CASCADE,
+
+                -- Target repo (owner/repo) + branch to commit the vhosts/manifest to
+                owner TEXT,
+                repo TEXT,
+                branch TEXT DEFAULT 'main',
+
+                -- Which Services GitHub integration (encrypted PAT) authenticates
+                github_integration_id TEXT,
+
+                -- Optional overrides
+                data_base TEXT,          -- server-files root (default .github/wslproxy/data)
+                default_environment TEXT DEFAULT 'prod',
+
+                created_at TIMESTAMP DEFAULT NOW(),
+                updated_at TIMESTAMP DEFAULT NOW(),
+
+                -- Exactly one settings row per namespace
+                CONSTRAINT domain_sync_settings_namespace_unique UNIQUE (namespace_id)
+            )
+        ]])
+
+        pcall(function() db.query([[CREATE INDEX domain_sync_settings_namespace_idx ON domain_sync_settings (namespace_id)]]) end)
+    end,
+}

--- a/lapis/migrations/domain-wslproxy-fields.lua
+++ b/lapis/migrations/domain-wslproxy-fields.lua
@@ -1,0 +1,41 @@
+--[[
+    Domain → WSL Proxy fields
+    =========================
+
+    Adds the metadata a domain needs to be rendered as a WSL Proxy vhost
+    (server) file for a consumer repo (e.g. diy-tax-return-uk's
+    .github/wslproxy/data/servers/<env>/host:<domain>.json).
+
+    See helper/wslproxy-server.lua for the renderer and routes/domains.lua
+    (sync-to-repo) for the commit path. Gated on FEATURES.SERVICES.
+
+    Idempotent: ADD COLUMN IF NOT EXISTS.
+]]
+
+local db = require("lapis.db")
+
+local function add_column(sql)
+    pcall(function() db.query(sql) end)
+end
+
+return {
+    [1] = function()
+        -- to_regclass guards against running before the domains table exists.
+        local exists = db.query("SELECT to_regclass('public.domains') IS NOT NULL AS ok")
+        if not (exists and exists[1] and exists[1].ok) then return end
+
+        add_column([[ALTER TABLE domains ADD COLUMN IF NOT EXISTS environment TEXT DEFAULT 'prod']])
+        add_column([[ALTER TABLE domains ADD COLUMN IF NOT EXISTS wslproxy_rule_id TEXT]])
+        add_column([[ALTER TABLE domains ADD COLUMN IF NOT EXISTS ssl_email TEXT]])
+        add_column([[ALTER TABLE domains ADD COLUMN IF NOT EXISTS ssl_enabled BOOLEAN DEFAULT TRUE]])
+        add_column([[ALTER TABLE domains ADD COLUMN IF NOT EXISTS ssl_auto_renew BOOLEAN DEFAULT TRUE]])
+        add_column([[ALTER TABLE domains ADD COLUMN IF NOT EXISTS ssl_force_https BOOLEAN DEFAULT TRUE]])
+        add_column([[ALTER TABLE domains ADD COLUMN IF NOT EXISTS ssl_staging BOOLEAN DEFAULT FALSE]])
+        add_column([[ALTER TABLE domains ADD COLUMN IF NOT EXISTS wslproxy_root TEXT DEFAULT '/var/www/html']])
+        add_column([[ALTER TABLE domains ADD COLUMN IF NOT EXISTS listen_ports TEXT DEFAULT '80']])
+        -- CNAME target used by the DNS reconcile (e.g. pop1.diytaxreturn.co.uk).
+        add_column([[ALTER TABLE domains ADD COLUMN IF NOT EXISTS proxy_target TEXT]])
+        -- Index by environment for per-env export.
+        add_column([[CREATE INDEX IF NOT EXISTS domains_namespace_env_idx ON domains (namespace_id, environment)]])
+    end,
+}

--- a/lapis/models/DomainCredentialModel.lua
+++ b/lapis/models/DomainCredentialModel.lua
@@ -1,0 +1,3 @@
+local Model = require("lapis.db.model").Model
+local DomainCredentials = Model:extend("domain_credentials", { timestamp = true })
+return DomainCredentials

--- a/lapis/models/DomainModel.lua
+++ b/lapis/models/DomainModel.lua
@@ -1,0 +1,3 @@
+local Model = require("lapis.db.model").Model
+local Domains = Model:extend("domains", { timestamp = true })
+return Domains

--- a/lapis/models/DomainPipelineRunModel.lua
+++ b/lapis/models/DomainPipelineRunModel.lua
@@ -1,0 +1,3 @@
+local Model = require("lapis.db.model").Model
+local DomainPipelineRuns = Model:extend("domain_pipeline_runs", { timestamp = true })
+return DomainPipelineRuns

--- a/lapis/models/DomainSyncConfigModel.lua
+++ b/lapis/models/DomainSyncConfigModel.lua
@@ -1,0 +1,3 @@
+local Model = require("lapis.db.model").Model
+local DomainSyncConfigs = Model:extend("domain_sync_configs", { timestamp = true })
+return DomainSyncConfigs

--- a/lapis/models/DomainSyncSettingsModel.lua
+++ b/lapis/models/DomainSyncSettingsModel.lua
@@ -1,0 +1,3 @@
+local Model = require("lapis.db.model").Model
+local DomainSyncSettings = Model:extend("domain_sync_settings", { timestamp = true })
+return DomainSyncSettings

--- a/lapis/queries/DomainCredentialQueries.lua
+++ b/lapis/queries/DomainCredentialQueries.lua
@@ -1,0 +1,117 @@
+--[[
+    Domain Credential Queries
+    =========================
+
+    Namespace-scoped provider credentials (Cloudflare API tokens today). The
+    secret itself is stored AES-encrypted (Global.encryptSecret, keyed by
+    OPENSSL_SECRET_KEY) so the backend can decrypt it server-side to call the
+    provider API — never persisted in plaintext, and never returned to clients.
+
+    One credential per (namespace, provider) — upsert semantics on save.
+]]
+
+local DomainCredentialModel = require("models.DomainCredentialModel")
+local Global = require("helper.global")
+local db = require("lapis.db")
+
+local DomainCredentialQueries = {}
+
+-- Public-safe projection: everything EXCEPT encrypted_secret, plus a boolean flag.
+local function sanitize(row)
+    if not row then return nil end
+    return {
+        uuid = row.uuid,
+        namespace_id = row.namespace_id,
+        provider = row.provider,
+        label = row.label,
+        account_id = row.account_id,
+        email = row.email,
+        has_secret = row.encrypted_secret ~= nil and row.encrypted_secret ~= "",
+        created_at = row.created_at,
+        updated_at = row.updated_at,
+    }
+end
+DomainCredentialQueries.sanitize = sanitize
+
+--- Create or update the credential for (namespace, provider). Encrypts the token.
+-- @param params { namespace_id, provider, label?, secret (plaintext token), account_id?, email? }
+function DomainCredentialQueries.save(params)
+    assert(params.namespace_id, "namespace_id required")
+    local provider = params.provider or "cloudflare"
+
+    local existing = db.query([[
+        SELECT * FROM domain_credentials WHERE namespace_id = ? AND provider = ? LIMIT 1
+    ]], params.namespace_id, provider)
+    existing = existing and existing[1] or nil
+
+    local encrypted = existing and existing.encrypted_secret or nil
+    if params.secret and params.secret ~= "" then
+        encrypted = Global.encryptSecret(params.secret)
+    end
+    if not encrypted then
+        return nil, "secret is required"
+    end
+
+    if existing then
+        local model = DomainCredentialModel:find({ id = existing.id })
+        return sanitize(model:update({
+            label = params.label or existing.label,
+            encrypted_secret = encrypted,
+            account_id = params.account_id ~= nil and params.account_id or existing.account_id,
+            email = params.email ~= nil and params.email or existing.email,
+            updated_at = db.raw("NOW()"),
+        }, { returning = "*" }))
+    end
+
+    local created = DomainCredentialModel:create({
+        uuid = Global.generateUUID(),
+        namespace_id = params.namespace_id,
+        provider = provider,
+        label = params.label,
+        encrypted_secret = encrypted,
+        account_id = params.account_id,
+        email = params.email,
+        metadata = "{}",
+        created_at = db.raw("NOW()"),
+        updated_at = db.raw("NOW()"),
+    }, { returning = "*" })
+    return sanitize(created)
+end
+
+--- Public listing (no secrets) for a namespace.
+function DomainCredentialQueries.list(namespace_id)
+    local rows = db.query([[
+        SELECT * FROM domain_credentials WHERE namespace_id = ? ORDER BY provider ASC
+    ]], namespace_id)
+    local out = {}
+    for _, r in ipairs(rows or {}) do
+        table.insert(out, sanitize(r))
+    end
+    return out
+end
+
+--- Internal: fetch and DECRYPT the token for server-side provider calls.
+-- Returns plaintext token or nil, err. Never expose this over the API.
+function DomainCredentialQueries.getDecryptedSecret(namespace_id, provider)
+    provider = provider or "cloudflare"
+    local rows = db.query([[
+        SELECT * FROM domain_credentials WHERE namespace_id = ? AND provider = ? LIMIT 1
+    ]], namespace_id, provider)
+    local row = rows and rows[1] or nil
+    if not row or not row.encrypted_secret or row.encrypted_secret == "" then
+        return nil, "No " .. provider .. " credential configured for this namespace"
+    end
+    local ok, secret = pcall(Global.decryptSecret, row.encrypted_secret)
+    if not ok or not secret then
+        return nil, "Failed to decrypt stored credential"
+    end
+    return secret, nil, row
+end
+
+function DomainCredentialQueries.delete(namespace_id, provider)
+    provider = provider or "cloudflare"
+    db.query([[DELETE FROM domain_credentials WHERE namespace_id = ? AND provider = ?]], namespace_id, provider)
+    return true
+end
+
+return DomainCredentialQueries

--- a/lapis/queries/DomainPipelineRunQueries.lua
+++ b/lapis/queries/DomainPipelineRunQueries.lua
@@ -1,0 +1,64 @@
+--[[
+    Domain Pipeline Run Queries
+    ===========================
+
+    CRUD + step-state helpers for domain_pipeline_runs. The orchestrator
+    (helper/domain-pipeline.lua) mutates a run's steps as it advances.
+]]
+
+local DomainPipelineRunModel = require("models.DomainPipelineRunModel")
+local Global = require("helper.global")
+local cjson = require("cjson")
+local db = require("lapis.db")
+
+local DomainPipelineRunQueries = {}
+
+-- Decode the steps jsonb into a Lua array (defensive).
+local function decode_steps(row)
+    if not row then return row end
+    if type(row.steps) == "string" then
+        local ok, decoded = pcall(cjson.decode, row.steps)
+        row.steps = ok and decoded or {}
+    end
+    return row
+end
+DomainPipelineRunQueries.decode_steps = decode_steps
+
+function DomainPipelineRunQueries.create(params)
+    params.uuid = params.uuid or Global.generateUUID()
+    params.created_at = db.raw("NOW()")
+    params.updated_at = db.raw("NOW()")
+    if type(params.steps) == "table" then
+        params.steps = cjson.encode(params.steps)
+    end
+    return DomainPipelineRunModel:create(params, { returning = "*" })
+end
+
+function DomainPipelineRunQueries.get(uuid)
+    local rows = db.query("SELECT * FROM domain_pipeline_runs WHERE uuid = ? LIMIT 1", uuid)
+    return decode_steps(rows and rows[1] or nil)
+end
+
+function DomainPipelineRunQueries.list(namespace_id, limit)
+    local rows = db.query([[
+        SELECT * FROM domain_pipeline_runs
+        WHERE namespace_id = ?
+        ORDER BY created_at DESC
+        LIMIT ?
+    ]], namespace_id, tonumber(limit) or 20)
+    for _, r in ipairs(rows or {}) do decode_steps(r) end
+    return rows or {}
+end
+
+-- Full update by uuid. `patch` may include steps (Lua table → encoded).
+function DomainPipelineRunQueries.update(uuid, patch)
+    local run = DomainPipelineRunModel:find({ uuid = uuid })
+    if not run then return nil end
+    if type(patch.steps) == "table" then
+        patch.steps = cjson.encode(patch.steps)
+    end
+    patch.updated_at = db.raw("NOW()")
+    return run:update(patch, { returning = "*" })
+end
+
+return DomainPipelineRunQueries

--- a/lapis/queries/DomainQueries.lua
+++ b/lapis/queries/DomainQueries.lua
@@ -1,0 +1,223 @@
+--[[
+    Domain Queries
+    ==============
+
+    Business logic for the namespace-scoped domain registry: CRUD, pagination,
+    filters, and expiry-field updates. Every query filters by namespace_id.
+
+    Platform admins get a cross-namespace "super-view": pass opts.platform_admin
+    = true to getDomains to list domains across all namespaces (the route layer
+    decides who is a platform admin via helper/admin-check.lua).
+]]
+
+local DomainModel = require("models.DomainModel")
+local Global = require("helper.global")
+local db = require("lapis.db")
+
+local DomainQueries = {}
+
+-- Whitelisted, user-writable columns (never trust arbitrary keys into SQL).
+local WRITABLE_FIELDS = {
+    "domain_name", "registrar", "dns_provider", "cloudflare_zone_id",
+    "status", "alert_threshold_days", "auto_renew", "owner_user_uuid", "notes",
+    -- WSL Proxy vhost rendering fields (see helper/wslproxy-server.lua)
+    "environment", "wslproxy_rule_id", "ssl_email", "ssl_enabled",
+    "ssl_auto_renew", "ssl_force_https", "ssl_staging", "wslproxy_root",
+    "listen_ports", "proxy_target",
+}
+
+--------------------------------------------------------------------------------
+-- Create
+--------------------------------------------------------------------------------
+function DomainQueries.createDomain(params)
+    if not params.uuid then
+        params.uuid = Global.generateUUID()
+    end
+    params.created_at = db.raw("NOW()")
+    params.updated_at = db.raw("NOW()")
+    return DomainModel:create(params, { returning = "*" })
+end
+
+--------------------------------------------------------------------------------
+-- List (namespace-scoped, or cross-namespace for platform admins)
+--------------------------------------------------------------------------------
+function DomainQueries.getDomains(namespace_id, params)
+    params = params or {}
+    local page = tonumber(params.page) or 1
+    local per_page = tonumber(params.per_page) or 20
+    if per_page > 200 then per_page = 200 end
+    local offset = (page - 1) * per_page
+
+    local where_parts = { "d.deleted_at IS NULL" }
+    local where_values = {}
+
+    -- Platform-admin super-view skips the namespace filter; everyone else is scoped.
+    if not params.platform_admin then
+        table.insert(where_parts, "d.namespace_id = ?")
+        table.insert(where_values, namespace_id)
+    end
+
+    if params.status and params.status ~= "" then
+        table.insert(where_parts, "d.status = ?")
+        table.insert(where_values, params.status)
+    end
+
+    if params.dns_provider and params.dns_provider ~= "" then
+        table.insert(where_parts, "d.dns_provider = ?")
+        table.insert(where_values, params.dns_provider)
+    end
+
+    if params.search and params.search ~= "" then
+        table.insert(where_parts, "(d.domain_name ILIKE ? OR d.registrar ILIKE ? OR d.notes ILIKE ?)")
+        local term = "%" .. params.search .. "%"
+        table.insert(where_values, term)
+        table.insert(where_values, term)
+        table.insert(where_values, term)
+    end
+
+    -- "expiring" convenience filter: registration OR SSL within N days.
+    if params.expiring_within_days and tonumber(params.expiring_within_days) then
+        local days = tonumber(params.expiring_within_days)
+        table.insert(where_parts, [[(
+            (d.registration_expires_at IS NOT NULL AND d.registration_expires_at <= NOW() + (? || ' days')::interval)
+            OR (d.ssl_expires_at IS NOT NULL AND d.ssl_expires_at <= NOW() + (? || ' days')::interval)
+        )]])
+        table.insert(where_values, days)
+        table.insert(where_values, days)
+    end
+
+    local where_clause = table.concat(where_parts, " AND ")
+
+    local count_sql = string.format("SELECT COUNT(*) as total FROM domains d WHERE %s", where_clause)
+    local count_result = db.query(count_sql, unpack(where_values))
+    local total = tonumber(count_result[1].total) or 0
+
+    local data_values = { unpack(where_values) }
+    table.insert(data_values, per_page)
+    table.insert(data_values, offset)
+    local data_sql = string.format([[
+        SELECT d.*
+        FROM domains d
+        WHERE %s
+        ORDER BY
+            CASE WHEN d.registration_expires_at IS NULL THEN 1 ELSE 0 END,
+            d.registration_expires_at ASC,
+            d.created_at DESC
+        LIMIT ? OFFSET ?
+    ]], where_clause)
+    local domains = db.query(data_sql, unpack(data_values))
+
+    return {
+        items = domains,
+        meta = {
+            total = total,
+            page = page,
+            per_page = per_page,
+            total_pages = math.ceil(total / per_page),
+        },
+    }
+end
+
+--------------------------------------------------------------------------------
+-- Get single (by uuid). Ownership is re-checked in the route handler.
+--------------------------------------------------------------------------------
+function DomainQueries.getDomain(uuid)
+    local result = db.query([[
+        SELECT d.* FROM domains d WHERE d.uuid = ? AND d.deleted_at IS NULL
+    ]], uuid)
+    return result and result[1] or nil
+end
+
+--------------------------------------------------------------------------------
+-- Update (whitelisted fields only)
+--------------------------------------------------------------------------------
+function DomainQueries.updateDomain(uuid, params)
+    local domain = DomainModel:find({ uuid = uuid })
+    if not domain then return nil end
+
+    local update_params = {}
+    for _, field in ipairs(WRITABLE_FIELDS) do
+        if params[field] ~= nil then
+            update_params[field] = params[field]
+        end
+    end
+    if params.metadata ~= nil then
+        update_params.metadata = params.metadata
+    end
+    if next(update_params) == nil then
+        return domain
+    end
+    update_params.updated_at = db.raw("NOW()")
+    return domain:update(update_params, { returning = "*" })
+end
+
+--------------------------------------------------------------------------------
+-- Persist expiry-check results (called by the expiry engine)
+--------------------------------------------------------------------------------
+function DomainQueries.applyExpiryResult(uuid, result)
+    local domain = DomainModel:find({ uuid = uuid })
+    if not domain then return nil end
+
+    local update = {
+        last_checked_at = db.raw("NOW()"),
+        updated_at = db.raw("NOW()"),
+        last_check_error = result.error,
+    }
+    if result.registration_expires_at ~= nil then update.registration_expires_at = result.registration_expires_at end
+    if result.registrar ~= nil then update.registrar = result.registrar end
+    if result.registrar_status ~= nil then update.registrar_status = result.registrar_status end
+    if result.ssl_expires_at ~= nil then update.ssl_expires_at = result.ssl_expires_at end
+    if result.ssl_issuer ~= nil then update.ssl_issuer = result.ssl_issuer end
+    if result.status ~= nil then update.status = result.status end
+
+    return domain:update(update, { returning = "*" })
+end
+
+--------------------------------------------------------------------------------
+-- Soft delete
+--------------------------------------------------------------------------------
+function DomainQueries.deleteDomain(uuid)
+    local domain = DomainModel:find({ uuid = uuid })
+    if not domain then return nil end
+    return domain:update({
+        deleted_at = db.raw("NOW()"),
+        updated_at = db.raw("NOW()"),
+    }, { returning = "*" })
+end
+
+--------------------------------------------------------------------------------
+-- All active domains for a namespace (used by the sync export + bulk refresh)
+--------------------------------------------------------------------------------
+function DomainQueries.getAllForNamespace(namespace_id)
+    return db.query([[
+        SELECT * FROM domains
+        WHERE namespace_id = ? AND deleted_at IS NULL
+        ORDER BY domain_name ASC
+    ]], namespace_id)
+end
+
+--------------------------------------------------------------------------------
+-- Aggregate stats for the dashboard header
+--------------------------------------------------------------------------------
+function DomainQueries.getStats(namespace_id)
+    local result = db.query([[
+        SELECT
+            COUNT(*) AS total_domains,
+            COUNT(*) FILTER (WHERE status = 'expired') AS expired,
+            COUNT(*) FILTER (WHERE status = 'expiring_soon') AS expiring_soon,
+            COUNT(*) FILTER (WHERE status = 'error') AS errored,
+            COUNT(*) FILTER (
+                WHERE registration_expires_at IS NOT NULL
+                  AND registration_expires_at <= NOW() + INTERVAL '30 days'
+            ) AS reg_expiring_30d,
+            COUNT(*) FILTER (
+                WHERE ssl_expires_at IS NOT NULL
+                  AND ssl_expires_at <= NOW() + INTERVAL '30 days'
+            ) AS ssl_expiring_30d
+        FROM domains
+        WHERE namespace_id = ? AND deleted_at IS NULL
+    ]], namespace_id)
+    return result and result[1] or {}
+end
+
+return DomainQueries

--- a/lapis/queries/DomainSyncConfigQueries.lua
+++ b/lapis/queries/DomainSyncConfigQueries.lua
@@ -1,0 +1,82 @@
+--[[
+    Domain Sync Config Queries
+    ==========================
+
+    Namespace-scoped configuration for the k3s domain-sync job: where to push the
+    exported domains.json (GitHub repo/branch/path), on what cron schedule, and
+    which Kubernetes Secret (populated by ESO / the external vault) carries the
+    GitHub token. The token itself is NEVER stored here — only the secret name.
+]]
+
+local DomainSyncConfigModel = require("models.DomainSyncConfigModel")
+local Global = require("helper.global")
+local db = require("lapis.db")
+
+local DomainSyncConfigQueries = {}
+
+local WRITABLE_FIELDS = {
+    "name", "destination_type", "github_repo", "github_branch", "file_path",
+    "commit_author_name", "commit_author_email",
+    "github_token_secret_ref", "github_token_secret_key",
+    "opsapi_base_url", "opsapi_token_secret_key",
+    "schedule", "is_enabled",
+}
+
+function DomainSyncConfigQueries.create(params)
+    if not params.uuid then params.uuid = Global.generateUUID() end
+    params.created_at = db.raw("NOW()")
+    params.updated_at = db.raw("NOW()")
+    return DomainSyncConfigModel:create(params, { returning = "*" })
+end
+
+function DomainSyncConfigQueries.list(namespace_id)
+    return db.query([[
+        SELECT * FROM domain_sync_configs
+        WHERE namespace_id = ? AND deleted_at IS NULL
+        ORDER BY created_at DESC
+    ]], namespace_id)
+end
+
+function DomainSyncConfigQueries.get(uuid)
+    local rows = db.query([[
+        SELECT * FROM domain_sync_configs WHERE uuid = ? AND deleted_at IS NULL
+    ]], uuid)
+    return rows and rows[1] or nil
+end
+
+function DomainSyncConfigQueries.update(uuid, params)
+    local cfg = DomainSyncConfigModel:find({ uuid = uuid })
+    if not cfg then return nil end
+
+    local update_params = {}
+    for _, field in ipairs(WRITABLE_FIELDS) do
+        if params[field] ~= nil then
+            update_params[field] = params[field]
+        end
+    end
+    if next(update_params) == nil then return cfg end
+    update_params.updated_at = db.raw("NOW()")
+    return cfg:update(update_params, { returning = "*" })
+end
+
+function DomainSyncConfigQueries.recordRun(uuid, status, err)
+    local cfg = DomainSyncConfigModel:find({ uuid = uuid })
+    if not cfg then return nil end
+    return cfg:update({
+        last_synced_at = db.raw("NOW()"),
+        last_status = status,
+        last_error = err,
+        updated_at = db.raw("NOW()"),
+    }, { returning = "*" })
+end
+
+function DomainSyncConfigQueries.delete(uuid)
+    local cfg = DomainSyncConfigModel:find({ uuid = uuid })
+    if not cfg then return nil end
+    return cfg:update({
+        deleted_at = db.raw("NOW()"),
+        updated_at = db.raw("NOW()"),
+    }, { returning = "*" })
+end
+
+return DomainSyncConfigQueries

--- a/lapis/queries/DomainSyncSettingsQueries.lua
+++ b/lapis/queries/DomainSyncSettingsQueries.lua
@@ -1,0 +1,68 @@
+--[[
+    Domain Sync Settings Queries
+    ============================
+
+    One row per namespace (upsert). Stores the sync target (owner/repo/branch),
+    the linked Services GitHub integration id, and optional overrides. The token
+    itself lives in the integration (encrypted) — never here.
+]]
+
+local DomainSyncSettingsModel = require("models.DomainSyncSettingsModel")
+local Global = require("helper.global")
+local db = require("lapis.db")
+
+local DomainSyncSettingsQueries = {}
+
+local WRITABLE = { "owner", "repo", "branch", "github_integration_id", "data_base", "default_environment" }
+
+--- Get the namespace's settings (or nil).
+function DomainSyncSettingsQueries.get(namespace_id)
+    local rows = db.query("SELECT * FROM domain_sync_settings WHERE namespace_id = ? LIMIT 1", namespace_id)
+    return rows and rows[1] or nil
+end
+
+--- Create or update the single settings row for a namespace.
+function DomainSyncSettingsQueries.upsert(namespace_id, params)
+    local existing = DomainSyncSettingsQueries.get(namespace_id)
+
+    local set = {}
+    for _, f in ipairs(WRITABLE) do
+        if params[f] ~= nil then set[f] = params[f] end
+    end
+
+    if existing then
+        if next(set) == nil then return existing end
+        local model = DomainSyncSettingsModel:find({ id = existing.id })
+        set.updated_at = db.raw("NOW()")
+        return model:update(set, { returning = "*" })
+    end
+
+    set.uuid = Global.generateUUID()
+    set.namespace_id = namespace_id
+    set.branch = set.branch or "main"
+    set.created_at = db.raw("NOW()")
+    set.updated_at = db.raw("NOW()")
+    return DomainSyncSettingsModel:create(set, { returning = "*" })
+end
+
+--- Resolve effective sync params: request overrides win over saved settings.
+-- Returns { owner, repo, branch, github_integration_id, data_base, environment }
+-- and a list of missing required fields.
+function DomainSyncSettingsQueries.resolve(namespace_id, req)
+    req = req or {}
+    local s = DomainSyncSettingsQueries.get(namespace_id) or {}
+    local eff = {
+        owner = req.owner or s.owner,
+        repo = req.repo or s.repo,
+        branch = req.branch or s.branch or "main",
+        github_integration_id = req.github_integration_id or s.github_integration_id,
+        data_base = req.data_base or s.data_base,
+        environment = req.environment or s.default_environment or "prod",
+    }
+    local missing = {}
+    if not eff.owner or eff.owner == "" then table.insert(missing, "owner") end
+    if not eff.repo or eff.repo == "" then table.insert(missing, "repo") end
+    return eff, missing
+end
+
+return DomainSyncSettingsQueries

--- a/lapis/routes/domains.lua
+++ b/lapis/routes/domains.lua
@@ -1,0 +1,703 @@
+--[[
+    Domain Management API Routes
+    ============================
+
+    Namespace-scoped domain registry with SSL/registration expiry monitoring,
+    two-way Cloudflare DNS management, encrypted provider credentials, and a
+    k3s-job sync generator. Gated on the SERVICES feature (see app.lua).
+
+    Permission model: every route requires the "domains" RBAC action via
+    NamespaceMiddleware.requirePermission (which itself enforces auth + namespace,
+    and lets platform admins / namespace owners through). Reads that a platform
+    admin can widen to all namespaces honour self.is_platform_admin.
+
+    Endpoints:
+      GET    /api/v2/domains                         List (?all=true = admin super-view)
+      GET    /api/v2/domains/stats                    Aggregate counts
+      GET    /api/v2/domains/export                   JSON array for the k3s sync job
+      POST   /api/v2/domains                          Create
+      GET    /api/v2/domains/:uuid                    Get one
+      PUT    /api/v2/domains/:uuid                    Update
+      DELETE /api/v2/domains/:uuid                    Soft delete
+      POST   /api/v2/domains/refresh-expiry           Bulk refresh (namespace)
+      POST   /api/v2/domains/:uuid/refresh-expiry     Refresh one
+
+      GET    /api/v2/domains/credentials              List provider creds (no secrets)
+      POST   /api/v2/domains/credentials              Save/replace a cred (encrypts)
+      POST   /api/v2/domains/credentials/verify       Verify the Cloudflare token
+      DELETE /api/v2/domains/credentials/:provider    Delete a cred
+
+      GET    /api/v2/domains/cloudflare/zones          List Cloudflare zones
+      GET    /api/v2/domains/:uuid/cloudflare/records   List DNS records
+      POST   /api/v2/domains/:uuid/cloudflare/records   Create DNS record
+      PUT    /api/v2/domains/:uuid/cloudflare/records/:record_id   Update
+      DELETE /api/v2/domains/:uuid/cloudflare/records/:record_id   Delete
+
+      GET    /api/v2/domains/sync-configs              List sync configs
+      POST   /api/v2/domains/sync-configs              Create
+      GET    /api/v2/domains/sync-configs/:uuid        Get one
+      PUT    /api/v2/domains/sync-configs/:uuid        Update
+      DELETE /api/v2/domains/sync-configs/:uuid        Delete
+      GET    /api/v2/domains/sync-configs/:uuid/manifest   Render CronJob YAML
+      POST   /api/v2/domains/sync-configs/:uuid/run-now    Render run-once Job YAML
+]]
+
+local cjson = require("cjson")
+local AuthMiddleware = require("middleware.auth")
+local NamespaceMiddleware = require("middleware.namespace")
+local DomainQueries = require("queries.DomainQueries")
+local DomainCredentialQueries = require("queries.DomainCredentialQueries")
+local DomainSyncConfigQueries = require("queries.DomainSyncConfigQueries")
+
+return function(app)
+    -- Parse a request body supporting BOTH JSON and form-encoded (the dashboard
+    -- posts form-encoded via toFormData; Lapis exposes those in self.params).
+    local function parse_body(self)
+        ngx.req.read_body()
+        local raw = ngx.req.get_body_data()
+        if raw and raw ~= "" then
+            local ok, data = pcall(cjson.decode, raw)
+            if ok and type(data) == "table" then return data end
+        end
+        local params = {}
+        if self and self.params then
+            for k, v in pairs(self.params) do params[k] = v end
+        end
+        return params
+    end
+
+    local function ok_resp(data, meta)
+        if meta then
+            return { status = 200, json = { success = true, data = data, meta = meta } }
+        end
+        return { status = 200, json = { success = true, data = data } }
+    end
+
+    local function err_resp(status, msg)
+        return { status = status, json = { success = false, error = msg } }
+    end
+
+    -- Load a domain and enforce namespace ownership (platform admins bypass).
+    local function load_owned_domain(self, uuid)
+        local domain = DomainQueries.getDomain(uuid)
+        if not domain then return nil, err_resp(404, "Domain not found") end
+        if not self.is_platform_admin and tonumber(domain.namespace_id) ~= tonumber(self.namespace.id) then
+            return nil, err_resp(403, "Access denied")
+        end
+        return domain, nil
+    end
+
+    -- Resolve + decrypt the namespace's Cloudflare token, return a client or error.
+    local function cloudflare_client(namespace_id)
+        local token, terr = DomainCredentialQueries.getDecryptedSecret(namespace_id, "cloudflare")
+        if not token then return nil, terr end
+        local Cloudflare = require("lib.cloudflare")
+        return Cloudflare.new(token), nil
+    end
+
+    local function domain_zone_id(client, domain)
+        if domain.cloudflare_zone_id and domain.cloudflare_zone_id ~= "" then
+            return domain.cloudflare_zone_id, nil
+        end
+        return client:find_zone_id(domain.domain_name)
+    end
+
+    -- ========================================================================
+    -- LIST / STATS / EXPORT  (specific paths registered before /:uuid)
+    -- ========================================================================
+
+    app:get("/api/v2/domains", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "read", function(self)
+            local want_all = (self.params.all == "true" or self.params.all == "1") and self.is_platform_admin
+            local result = DomainQueries.getDomains(self.namespace.id, {
+                page = self.params.page,
+                per_page = self.params.per_page,
+                status = self.params.status,
+                dns_provider = self.params.dns_provider,
+                search = self.params.search,
+                expiring_within_days = self.params.expiring_within_days,
+                platform_admin = want_all,
+            })
+            return ok_resp(result.items, result.meta)
+        end)
+    ))
+
+    app:get("/api/v2/domains/stats", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "read", function(self)
+            return ok_resp(DomainQueries.getStats(self.namespace.id))
+        end)
+    ))
+
+    -- Export: a bare JSON array consumed by the k3s sync job.
+    app:get("/api/v2/domains/export", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "read", function(self)
+            local rows = DomainQueries.getAllForNamespace(self.namespace.id)
+            local out = {}
+            for _, d in ipairs(rows or {}) do
+                table.insert(out, {
+                    domain_name = d.domain_name,
+                    registrar = d.registrar,
+                    dns_provider = d.dns_provider,
+                    status = d.status,
+                    registration_expires_at = d.registration_expires_at,
+                    ssl_expires_at = d.ssl_expires_at,
+                    ssl_issuer = d.ssl_issuer,
+                    cloudflare_zone_id = d.cloudflare_zone_id,
+                })
+            end
+            return { status = 200, json = { generated_at = os.date("!%Y-%m-%dT%H:%M:%SZ"), count = #out, domains = out } }
+        end)
+    ))
+
+    -- Render all domains for an environment as WSL Proxy server files and commit
+    -- them to a GitHub repo (add/update only — never deletes hand-authored files).
+    -- Body: { environment?, owner, repo, branch?, github_integration_id, data_base?,
+    --         message?, dry_run? }. The GitHub token comes from the namespace's
+    --         services GitHub integration (encrypted at rest).
+    app:post("/api/v2/domains/sync-to-repo", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "update", function(self)
+            local data = parse_body(self)
+            -- Resolve target from saved Sync Settings; request params override.
+            local SyncSettings = require("queries.DomainSyncSettingsQueries")
+            local eff, missing = SyncSettings.resolve(self.namespace.id, data)
+            if #missing > 0 then
+                return err_resp(400, "Missing " .. table.concat(missing, ", ")
+                    .. " — set them here or configure Sync Settings once")
+            end
+            local env = eff.environment
+            local owner = eff.owner
+            local repo = eff.repo
+
+            -- Render every domain in this namespace+env to a WSL Proxy server file
+            -- (+ the opsapi-managed manifest used by the DNS reconcile).
+            local WslproxyServer = require("helper.wslproxy-server")
+            local rows = DomainQueries.getAllForNamespace(self.namespace.id)
+            local built = WslproxyServer.build_sync_files(rows, env, eff.data_base)
+            local files = built.files
+            local rendered = built.rendered
+
+            if built.count == 0 then
+                return err_resp(400, "No domains for environment '" .. env .. "' to sync")
+            end
+
+            -- Dry-run: return the rendered files without committing.
+            if data.dry_run == true or data.dry_run == "true" then
+                return ok_resp({ dry_run = true, environment = env, count = #files, files = rendered })
+            end
+
+            -- Resolve the GitHub token from the linked services integration.
+            if not eff.github_integration_id then
+                return err_resp(400, "No GitHub integration linked — configure Sync Settings (repo + GitHub auth)")
+            end
+            local ok_sq, ServiceQueries = pcall(require, "queries.ServiceQueries")
+            if not ok_sq then return err_resp(500, "services module unavailable") end
+            local integration = ServiceQueries.getGithubIntegration(eff.github_integration_id, true)
+            if not integration then return err_resp(404, "GitHub integration not found") end
+            if tonumber(integration.namespace_id) ~= tonumber(self.namespace.id) then
+                return err_resp(403, "Integration belongs to another namespace")
+            end
+            local token = integration.github_token_decrypted
+            if not token or token == "" then
+                return err_resp(400, "Could not decrypt the GitHub integration token")
+            end
+
+            local GithubRepo = require("lib.github-repo")
+            local sha, gerr = GithubRepo.commit_files({
+                token = token,
+                owner = owner,
+                repo = repo,
+                branch = eff.branch,
+                message = data.message or ("chore(domains): sync " .. #files .. " " .. env .. " domains from opsapi"),
+                files = files,
+                author_name = "opsapi-domain-sync",
+                author_email = "domain-sync@opsapi",
+            })
+            if not sha then return err_resp(502, "GitHub commit failed: " .. tostring(gerr)) end
+
+            return ok_resp({
+                environment = env,
+                repo = owner .. "/" .. repo,
+                branch = eff.branch,
+                commit = sha,
+                count = #files,
+                files = rendered,
+            })
+        end)
+    ))
+
+    -- ========================================================================
+    -- PIPELINE (opsapi-driven: sync → dns-reconcile → wslproxy-register → auto-tag)
+    -- ========================================================================
+
+    app:post("/api/v2/domains/pipeline/run", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "update", function(self)
+            local data = parse_body(self)
+            -- Resolve target from saved Sync Settings; request params override.
+            local SyncSettings = require("queries.DomainSyncSettingsQueries")
+            local eff, missing = SyncSettings.resolve(self.namespace.id, data)
+            if #missing > 0 then
+                return err_resp(400, "Missing " .. table.concat(missing, ", ")
+                    .. " — configure Sync Settings once (repo + GitHub auth)")
+            end
+            if not eff.github_integration_id then
+                return err_resp(400, "No GitHub integration linked — configure Sync Settings")
+            end
+
+            local DomainPipeline = require("helper.domain-pipeline")
+            local run, err = DomainPipeline.start({
+                namespace_id = self.namespace.id,
+                environment = eff.environment,
+                owner = eff.owner,
+                repo = eff.repo,
+                branch = eff.branch,
+                github_integration_id = eff.github_integration_id,
+                triggered_by_uuid = self.current_user.uuid,
+            })
+            if not run then return err_resp(400, err) end
+            return { status = 202, json = { success = true, data = run } }
+        end)
+    ))
+
+    app:get("/api/v2/domains/pipeline/runs", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "read", function(self)
+            local Q = require("queries.DomainPipelineRunQueries")
+            return ok_resp(Q.list(self.namespace.id, self.params.limit))
+        end)
+    ))
+
+    app:get("/api/v2/domains/pipeline/runs/:uuid", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "read", function(self)
+            local Q = require("queries.DomainPipelineRunQueries")
+            local run = Q.get(self.params.uuid)
+            if not run then return err_resp(404, "Pipeline run not found") end
+            if not self.is_platform_admin and tonumber(run.namespace_id) ~= tonumber(self.namespace.id) then
+                return err_resp(403, "Access denied")
+            end
+            return ok_resp(run)
+        end)
+    ))
+
+    -- ========================================================================
+    -- SYNC SETTINGS (persisted per-namespace target: repo + branch + GitHub auth)
+    -- ========================================================================
+
+    app:get("/api/v2/domains/sync-settings", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "read", function(self)
+            local SyncSettings = require("queries.DomainSyncSettingsQueries")
+            local s = SyncSettings.get(self.namespace.id)
+            -- Enrich with the linked integration's display name (no token).
+            local integration_name = nil
+            if s and s.github_integration_id then
+                local ok_sq, ServiceQueries = pcall(require, "queries.ServiceQueries")
+                if ok_sq then
+                    local integ = ServiceQueries.getGithubIntegration(s.github_integration_id, false)
+                    if integ then integration_name = integ.name or integ.github_username end
+                end
+            end
+            return ok_resp({ settings = s, integration_name = integration_name })
+        end)
+    ))
+
+    app:put("/api/v2/domains/sync-settings", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "update", function(self)
+            local data = parse_body(self)
+
+            -- Inline GitHub auth: if a raw token is supplied, create (validate +
+            -- encrypt) a Services integration and link it. Otherwise use the
+            -- github_integration_id the caller picked.
+            local integration_id = data.github_integration_id
+            if data.github_token and data.github_token ~= "" and data.github_token ~= "********" then
+                local ok_sq, ServiceQueries = pcall(require, "queries.ServiceQueries")
+                if not ok_sq then return err_resp(500, "services module unavailable") end
+                local created, cerr = ServiceQueries.createGithubIntegration(self.namespace.id, {
+                    name = data.integration_name or "Domain Sync",
+                    github_token = data.github_token,
+                    github_username = data.github_username,
+                    created_by = self.current_user and self.current_user.uuid,
+                })
+                if not created then return err_resp(400, cerr or "GitHub token validation failed") end
+                integration_id = created.uuid
+            end
+
+            local SyncSettings = require("queries.DomainSyncSettingsQueries")
+            local saved = SyncSettings.upsert(self.namespace.id, {
+                owner = data.owner,
+                repo = data.repo,
+                branch = data.branch,
+                github_integration_id = integration_id,
+                data_base = data.data_base,
+                default_environment = data.default_environment,
+            })
+            if not saved then return err_resp(500, "Failed to save sync settings") end
+            return ok_resp(saved)
+        end)
+    ))
+
+    -- Convenience: list the namespace's GitHub integrations (masked) for the
+    -- Sync-Settings picker — gated on domains, so a domains admin needn't hold
+    -- the separate services permission.
+    app:get("/api/v2/domains/github-integrations", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "read", function(self)
+            local ok_sq, ServiceQueries = pcall(require, "queries.ServiceQueries")
+            if not ok_sq then return ok_resp({}) end
+            local list = ServiceQueries.getGithubIntegrations(self.namespace.id) or {}
+            return ok_resp(list)
+        end)
+    ))
+
+    -- ========================================================================
+    -- CREDENTIALS (before /:uuid)
+    -- ========================================================================
+
+    app:get("/api/v2/domains/credentials", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "read", function(self)
+            return ok_resp(DomainCredentialQueries.list(self.namespace.id))
+        end)
+    ))
+
+    app:post("/api/v2/domains/credentials", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "update", function(self)
+            local data = parse_body(self)
+            if not data.secret or data.secret == "" then
+                return err_resp(400, "secret (API token) is required")
+            end
+            local cred, cerr = DomainCredentialQueries.save({
+                namespace_id = self.namespace.id,
+                provider = data.provider or "cloudflare",
+                label = data.label,
+                secret = data.secret,
+                account_id = data.account_id,
+                email = data.email,
+            })
+            if not cred then return err_resp(500, cerr or "Failed to save credential") end
+            return ok_resp(cred)
+        end)
+    ))
+
+    app:post("/api/v2/domains/credentials/verify", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "read", function(self)
+            local client, cerr = cloudflare_client(self.namespace.id)
+            if not client then return err_resp(400, cerr) end
+            local res, verr = client:verify_token()
+            if not res then return err_resp(400, verr) end
+            return ok_resp({ valid = true, status = res.status })
+        end)
+    ))
+
+    app:delete("/api/v2/domains/credentials/:provider", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "delete", function(self)
+            DomainCredentialQueries.delete(self.namespace.id, self.params.provider)
+            return ok_resp({ message = "Credential deleted" })
+        end)
+    ))
+
+    -- ========================================================================
+    -- CLOUDFLARE ZONES (before /:uuid)
+    -- ========================================================================
+
+    app:get("/api/v2/domains/cloudflare/zones", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "read", function(self)
+            local client, cerr = cloudflare_client(self.namespace.id)
+            if not client then return err_resp(400, cerr) end
+            local zones, zerr = client:list_zones({ name = self.params.name })
+            if not zones then return err_resp(400, zerr) end
+            return ok_resp(zones)
+        end)
+    ))
+
+    -- ========================================================================
+    -- SYNC CONFIGS (before /:uuid)
+    -- ========================================================================
+
+    app:get("/api/v2/domains/sync-configs", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "read", function(self)
+            return ok_resp(DomainSyncConfigQueries.list(self.namespace.id))
+        end)
+    ))
+
+    app:post("/api/v2/domains/sync-configs", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "create", function(self)
+            local data = parse_body(self)
+            if not data.name or data.name == "" then return err_resp(400, "name is required") end
+            if not data.github_repo or data.github_repo == "" then
+                return err_resp(400, "github_repo (owner/repo) is required")
+            end
+            local cfg = DomainSyncConfigQueries.create({
+                namespace_id = self.namespace.id,
+                name = data.name,
+                destination_type = data.destination_type or "github",
+                github_repo = data.github_repo,
+                github_branch = data.github_branch or "main",
+                file_path = data.file_path or "domains.json",
+                commit_author_name = data.commit_author_name,
+                commit_author_email = data.commit_author_email,
+                github_token_secret_ref = data.github_token_secret_ref,
+                github_token_secret_key = data.github_token_secret_key or "github-token",
+                opsapi_base_url = data.opsapi_base_url,
+                opsapi_token_secret_key = data.opsapi_token_secret_key or "opsapi-token",
+                schedule = data.schedule or "0 3 * * *",
+                is_enabled = data.is_enabled ~= nil and data.is_enabled or true,
+                metadata = "{}",
+            })
+            if not cfg then return err_resp(500, "Failed to create sync config") end
+            return { status = 201, json = { success = true, data = cfg } }
+        end)
+    ))
+
+    local function load_owned_sync(self, uuid)
+        local cfg = DomainSyncConfigQueries.get(uuid)
+        if not cfg then return nil, err_resp(404, "Sync config not found") end
+        if not self.is_platform_admin and tonumber(cfg.namespace_id) ~= tonumber(self.namespace.id) then
+            return nil, err_resp(403, "Access denied")
+        end
+        return cfg, nil
+    end
+
+    app:get("/api/v2/domains/sync-configs/:uuid", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "read", function(self)
+            local cfg, e = load_owned_sync(self, self.params.uuid)
+            if not cfg then return e end
+            return ok_resp(cfg)
+        end)
+    ))
+
+    app:put("/api/v2/domains/sync-configs/:uuid", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "update", function(self)
+            local cfg, e = load_owned_sync(self, self.params.uuid)
+            if not cfg then return e end
+            local data = parse_body(self)
+            local updated = DomainSyncConfigQueries.update(self.params.uuid, data)
+            if not updated then return err_resp(500, "Failed to update sync config") end
+            return ok_resp(updated)
+        end)
+    ))
+
+    app:delete("/api/v2/domains/sync-configs/:uuid", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "delete", function(self)
+            local cfg, e = load_owned_sync(self, self.params.uuid)
+            if not cfg then return e end
+            DomainSyncConfigQueries.delete(self.params.uuid)
+            return ok_resp({ message = "Sync config deleted" })
+        end)
+    ))
+
+    -- Render the scheduled CronJob manifest.
+    app:get("/api/v2/domains/sync-configs/:uuid/manifest", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "read", function(self)
+            local cfg, e = load_owned_sync(self, self.params.uuid)
+            if not cfg then return e end
+            local Manifest = require("helper.domain-sync-manifest")
+            local yaml, merr = Manifest.render_cronjob(cfg, {
+                namespace_uuid = self.namespace.uuid,
+                namespace_slug = self.namespace.slug,
+                k8s_namespace = self.params.k8s_namespace,
+                opsapi_base_url_override = self.params.opsapi_base_url,
+            })
+            if not yaml then return err_resp(400, merr) end
+            return ok_resp({ kind = "CronJob", filename = "domain-sync-cronjob.yaml", manifest = yaml })
+        end)
+    ))
+
+    -- Render a run-once Job manifest ("sync now") and mark the config as triggered.
+    app:post("/api/v2/domains/sync-configs/:uuid/run-now", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "update", function(self)
+            local cfg, e = load_owned_sync(self, self.params.uuid)
+            if not cfg then return e end
+            local Manifest = require("helper.domain-sync-manifest")
+            local yaml, merr = Manifest.render_job(cfg, {
+                namespace_uuid = self.namespace.uuid,
+                namespace_slug = self.namespace.slug,
+                k8s_namespace = self.params.k8s_namespace,
+                opsapi_base_url_override = self.params.opsapi_base_url,
+            })
+            if not yaml then return err_resp(400, merr) end
+            DomainSyncConfigQueries.recordRun(self.params.uuid, "manifest_generated", nil)
+            return ok_resp({
+                kind = "Job",
+                filename = "domain-sync-run-once.yaml",
+                manifest = yaml,
+                apply_hint = "kubectl apply -f domain-sync-run-once.yaml",
+            })
+        end)
+    ))
+
+    -- ========================================================================
+    -- BULK REFRESH (before /:uuid)
+    -- ========================================================================
+
+    app:post("/api/v2/domains/refresh-expiry", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "update", function(self)
+            local DomainExpiry = require("helper.domain-expiry")
+            local summary = DomainExpiry.refresh_namespace(self.namespace.id)
+            return ok_resp(summary)
+        end)
+    ))
+
+    -- ========================================================================
+    -- CREATE
+    -- ========================================================================
+
+    app:post("/api/v2/domains", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "create", function(self)
+            local data = parse_body(self)
+            if not data.domain_name or data.domain_name == "" then
+                return err_resp(400, "domain_name is required")
+            end
+
+            local metadata = data.metadata
+            if metadata and type(metadata) == "table" then metadata = cjson.encode(metadata) end
+
+            local created = DomainQueries.createDomain({
+                namespace_id = self.namespace.id,
+                domain_name = (data.domain_name):lower(),
+                registrar = data.registrar,
+                dns_provider = data.dns_provider or "cloudflare",
+                cloudflare_zone_id = data.cloudflare_zone_id,
+                status = data.status or "active",
+                alert_threshold_days = tonumber(data.alert_threshold_days) or 30,
+                auto_renew = data.auto_renew == true or data.auto_renew == "true",
+                owner_user_uuid = data.owner_user_uuid or self.current_user.uuid,
+                notes = data.notes,
+                -- WSL Proxy vhost fields
+                environment = data.environment or "prod",
+                wslproxy_rule_id = data.wslproxy_rule_id,
+                ssl_email = data.ssl_email,
+                ssl_enabled = data.ssl_enabled == nil and true or (data.ssl_enabled == true or data.ssl_enabled == "true"),
+                ssl_auto_renew = data.ssl_auto_renew == nil and true or (data.ssl_auto_renew == true or data.ssl_auto_renew == "true"),
+                ssl_force_https = data.ssl_force_https == nil and true or (data.ssl_force_https == true or data.ssl_force_https == "true"),
+                ssl_staging = data.ssl_staging == true or data.ssl_staging == "true",
+                wslproxy_root = data.wslproxy_root or "/var/www/html",
+                listen_ports = data.listen_ports or "80",
+                proxy_target = data.proxy_target,
+                metadata = metadata or "{}",
+            })
+            if not created then return err_resp(500, "Failed to create domain") end
+            return { status = 201, json = { success = true, data = created } }
+        end)
+    ))
+
+    -- ========================================================================
+    -- SINGLE-DOMAIN ROUTES (/:uuid ...)
+    -- ========================================================================
+
+    app:get("/api/v2/domains/:uuid", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "read", function(self)
+            local domain, e = load_owned_domain(self, self.params.uuid)
+            if not domain then return e end
+            return ok_resp(domain)
+        end)
+    ))
+
+    app:put("/api/v2/domains/:uuid", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "update", function(self)
+            local domain, e = load_owned_domain(self, self.params.uuid)
+            if not domain then return e end
+            local data = parse_body(self)
+            if data.metadata ~= nil and type(data.metadata) == "table" then
+                data.metadata = cjson.encode(data.metadata)
+            end
+            if data.domain_name then data.domain_name = (data.domain_name):lower() end
+            local updated = DomainQueries.updateDomain(self.params.uuid, data)
+            if not updated then return err_resp(500, "Failed to update domain") end
+            return ok_resp(updated)
+        end)
+    ))
+
+    app:delete("/api/v2/domains/:uuid", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "delete", function(self)
+            local domain, e = load_owned_domain(self, self.params.uuid)
+            if not domain then return e end
+            DomainQueries.deleteDomain(self.params.uuid)
+            return ok_resp({ message = "Domain deleted successfully" })
+        end)
+    ))
+
+    app:post("/api/v2/domains/:uuid/refresh-expiry", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "update", function(self)
+            local domain, e = load_owned_domain(self, self.params.uuid)
+            if not domain then return e end
+            local DomainExpiry = require("helper.domain-expiry")
+            local updated, result = DomainExpiry.refresh(domain)
+            if not updated then return err_resp(500, "Failed to refresh expiry") end
+            return ok_resp({ domain = updated, check = result })
+        end)
+    ))
+
+    -- ------------------------------------------------------------------
+    -- Cloudflare DNS records for a specific domain (two-way)
+    -- ------------------------------------------------------------------
+
+    app:get("/api/v2/domains/:uuid/cloudflare/records", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "read", function(self)
+            local domain, e = load_owned_domain(self, self.params.uuid)
+            if not domain then return e end
+            local client, cerr = cloudflare_client(domain.namespace_id)
+            if not client then return err_resp(400, cerr) end
+            local zone_id, zerr = domain_zone_id(client, domain)
+            if not zone_id then return err_resp(400, zerr) end
+            local records, rerr = client:list_dns_records(zone_id, {
+                type = self.params.type, name = self.params.name,
+            })
+            if not records then return err_resp(400, rerr) end
+            return ok_resp({ zone_id = zone_id, records = records })
+        end)
+    ))
+
+    app:post("/api/v2/domains/:uuid/cloudflare/records", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "update", function(self)
+            local domain, e = load_owned_domain(self, self.params.uuid)
+            if not domain then return e end
+            local data = parse_body(self)
+            local client, cerr = cloudflare_client(domain.namespace_id)
+            if not client then return err_resp(400, cerr) end
+            local zone_id, zerr = domain_zone_id(client, domain)
+            if not zone_id then return err_resp(400, zerr) end
+            local record, rerr = client:create_dns_record(zone_id, {
+                type = data.type,
+                name = data.name,
+                content = data.content,
+                ttl = tonumber(data.ttl) or 1,
+                proxied = data.proxied == true or data.proxied == "true",
+                priority = tonumber(data.priority),
+            })
+            if not record then return err_resp(400, rerr) end
+            return { status = 201, json = { success = true, data = record } }
+        end)
+    ))
+
+    app:put("/api/v2/domains/:uuid/cloudflare/records/:record_id", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "update", function(self)
+            local domain, e = load_owned_domain(self, self.params.uuid)
+            if not domain then return e end
+            local data = parse_body(self)
+            local client, cerr = cloudflare_client(domain.namespace_id)
+            if not client then return err_resp(400, cerr) end
+            local zone_id, zerr = domain_zone_id(client, domain)
+            if not zone_id then return err_resp(400, zerr) end
+            local record, rerr = client:update_dns_record(zone_id, self.params.record_id, {
+                type = data.type,
+                name = data.name,
+                content = data.content,
+                ttl = tonumber(data.ttl) or 1,
+                proxied = data.proxied == true or data.proxied == "true",
+                priority = tonumber(data.priority),
+            })
+            if not record then return err_resp(400, rerr) end
+            return ok_resp(record)
+        end)
+    ))
+
+    app:delete("/api/v2/domains/:uuid/cloudflare/records/:record_id", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "update", function(self)
+            local domain, e = load_owned_domain(self, self.params.uuid)
+            if not domain then return e end
+            local client, cerr = cloudflare_client(domain.namespace_id)
+            if not client then return err_resp(400, cerr) end
+            local zone_id, zerr = domain_zone_id(client, domain)
+            if not zone_id then return err_resp(400, zerr) end
+            local res, rerr = client:delete_dns_record(zone_id, self.params.record_id)
+            if not res then return err_resp(400, rerr) end
+            return ok_resp({ message = "DNS record deleted", id = res.id })
+        end)
+    ))
+end

--- a/lapis/scripts/setup-namespace.lua
+++ b/lapis/scripts/setup-namespace.lua
@@ -459,10 +459,30 @@ function SetupNamespace.runMulti(config)
     local admin_email = resolve(config, "admin_email", "ADMIN_EMAIL", "admin@opsapi.com")
     local admin_password = resolve(config, "admin_password", "ADMIN_PASSWORD", "Admin@123")
 
+    -- Feature-only codes (e.g. `services`) enable features + run their migrations
+    -- but must NOT seed a separate tenant — they are inherited into the primary
+    -- namespace. Drop them from the per-code seeding list so, for example,
+    -- PROJECT_CODE=tax_copilot,services yields exactly one `tax_copilot` tenant.
+    local ProjectConfig = require("helper.project-config")
+    local seed_codes = {}
+    for _, code in ipairs(valid_codes) do
+        if ProjectConfig.isFeatureOnlyCode and ProjectConfig.isFeatureOnlyCode(code) then
+            print("Skipping tenant creation for feature-only code: " .. code
+                .. " (its features/migrations still apply to the deployment)")
+        else
+            table.insert(seed_codes, code)
+        end
+    end
+    if #seed_codes == 0 then
+        -- All codes were feature-only — nothing to seed, but not an error.
+        print("No tenant-seeding project codes after filtering feature-only codes; skipping namespace setup.")
+        return { total = 0, succeeded = 0, failed = 0, failures = {} }
+    end
+
     local failures = {}
     local succeeded = 0
 
-    for i, code in ipairs(valid_codes) do
+    for i, code in ipairs(seed_codes) do
         local code_slug = code:gsub("_", "-")
         local code_name = code:gsub("_", " "):gsub("(%a)([%w_']*)", function(a, b)
             return a:upper() .. b

--- a/opsapi-dashboard/app/dashboard/domains/page.tsx
+++ b/opsapi-dashboard/app/dashboard/domains/page.tsx
@@ -1,0 +1,1014 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  Search, Plus, Trash2, Edit, RefreshCw, Globe, ShieldCheck, AlertTriangle,
+  Clock, X, Cloud, GitBranch, Download, Play, KeyRound, Settings,
+} from 'lucide-react';
+import { Input, Table, Badge, Pagination, Card, Modal, Button, ConfirmDialog } from '@/components/ui';
+import { ProtectedPage } from '@/components/permissions';
+import {
+  domainService,
+  type Domain,
+  type DomainStats,
+  type DomainStatus,
+  type CloudflareRecord,
+  type DomainSyncConfig,
+  type SyncToRepoResult,
+  type PipelineRun,
+  type GithubIntegrationLite,
+} from '@/services/domain.service';
+import { formatDate } from '@/lib/utils';
+import type { TableColumn } from '@/types';
+import toast from 'react-hot-toast';
+
+// Days until a date (UTC-ish, day granularity). null if no date.
+function daysUntil(dateStr?: string): number | null {
+  if (!dateStr) return null;
+  const t = new Date(dateStr.replace(' ', 'T') + 'Z').getTime();
+  if (Number.isNaN(t)) return null;
+  return Math.floor((t - Date.now()) / 86_400_000);
+}
+
+function ExpiryCell({ dateStr, threshold = 30 }: { dateStr?: string; threshold?: number }) {
+  if (!dateStr) return <span className="text-secondary-400">—</span>;
+  const d = daysUntil(dateStr);
+  let variant: 'success' | 'warning' | 'error' | 'secondary' = 'success';
+  if (d === null) variant = 'secondary';
+  else if (d < 0) variant = 'error';
+  else if (d <= threshold) variant = 'warning';
+  return (
+    <div className="flex flex-col">
+      <span className="text-sm">{formatDate(dateStr)}</span>
+      <Badge variant={variant}>
+        {d === null ? 'unknown' : d < 0 ? `expired ${-d}d ago` : `in ${d}d`}
+      </Badge>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: DomainStatus }) {
+  const map: Record<DomainStatus, 'success' | 'warning' | 'error' | 'secondary' | 'info'> = {
+    active: 'success',
+    expiring_soon: 'warning',
+    expired: 'error',
+    error: 'error',
+    pending: 'secondary',
+  };
+  return <Badge variant={map[status] ?? 'secondary'}>{status.replace('_', ' ')}</Badge>;
+}
+
+function StatCard({ icon, label, value, tone }: { icon: React.ReactNode; label: string; value: number; tone: string }) {
+  return (
+    <Card>
+      <div className="flex items-center gap-3 p-4">
+        <div className={`rounded-lg p-2 ${tone}`}>{icon}</div>
+        <div>
+          <div className="text-2xl font-semibold">{value}</div>
+          <div className="text-xs text-secondary-500">{label}</div>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+const EMPTY_FORM = {
+  domain_name: '',
+  registrar: '',
+  dns_provider: 'cloudflare',
+  cloudflare_zone_id: '',
+  alert_threshold_days: 30,
+  notes: '',
+  // WSL Proxy vhost fields
+  environment: 'prod',
+  wslproxy_rule_id: '',
+  ssl_email: '',
+  proxy_target: '',
+};
+
+function DomainsPageContent() {
+  const [domains, setDomains] = useState<Domain[]>([]);
+  const [stats, setStats] = useState<DomainStats | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [total, setTotal] = useState(0);
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState('all');
+  const [refreshingAll, setRefreshingAll] = useState(false);
+
+  // Modals
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<Domain | null>(null);
+  const [form, setForm] = useState({ ...EMPTY_FORM });
+  const [deleteTarget, setDeleteTarget] = useState<Domain | null>(null);
+  const [credOpen, setCredOpen] = useState(false);
+  const [dnsTarget, setDnsTarget] = useState<Domain | null>(null);
+  const [syncOpen, setSyncOpen] = useState(false);
+  const [repoSyncOpen, setRepoSyncOpen] = useState(false);
+  const [pipelineOpen, setPipelineOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await domainService.getDomains({
+        page,
+        perPage: 20,
+        search: search || undefined,
+        status: statusFilter,
+      });
+      setDomains(res.data);
+      setTotalPages(res.total_pages || 1);
+      setTotal(res.total || 0);
+    } catch {
+      toast.error('Failed to load domains');
+    } finally {
+      setLoading(false);
+    }
+  }, [page, search, statusFilter]);
+
+  const loadStats = useCallback(async () => {
+    try {
+      setStats(await domainService.getStats());
+    } catch {
+      /* non-fatal */
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+  useEffect(() => { loadStats(); }, [loadStats]);
+
+  const openCreate = () => { setEditing(null); setForm({ ...EMPTY_FORM }); setFormOpen(true); };
+  const openEdit = (d: Domain) => {
+    setEditing(d);
+    setForm({
+      domain_name: d.domain_name,
+      registrar: d.registrar || '',
+      dns_provider: d.dns_provider || 'cloudflare',
+      cloudflare_zone_id: d.cloudflare_zone_id || '',
+      alert_threshold_days: d.alert_threshold_days || 30,
+      notes: d.notes || '',
+      environment: d.environment || 'prod',
+      wslproxy_rule_id: d.wslproxy_rule_id || '',
+      ssl_email: d.ssl_email || '',
+      proxy_target: d.proxy_target || '',
+    });
+    setFormOpen(true);
+  };
+
+  const submitForm = async () => {
+    if (!form.domain_name.trim()) { toast.error('Domain name is required'); return; }
+    try {
+      if (editing) {
+        await domainService.updateDomain(editing.uuid, { ...form });
+        toast.success('Domain updated');
+      } else {
+        await domainService.createDomain({ ...form });
+        toast.success('Domain added');
+      }
+      setFormOpen(false);
+      load(); loadStats();
+    } catch {
+      toast.error('Save failed');
+    }
+  };
+
+  const refreshOne = async (d: Domain) => {
+    const tid = toast.loading(`Checking ${d.domain_name}…`);
+    try {
+      await domainService.refreshExpiry(d.uuid);
+      toast.success(`Checked ${d.domain_name}`, { id: tid });
+      load(); loadStats();
+    } catch {
+      toast.error('Check failed', { id: tid });
+    }
+  };
+
+  const refreshAll = async () => {
+    setRefreshingAll(true);
+    const tid = toast.loading('Checking all domains…');
+    try {
+      const s = await domainService.refreshAll();
+      toast.success(`Checked ${s.checked ?? 0} — ${s.expiring_soon ?? 0} expiring, ${s.expired ?? 0} expired`, { id: tid });
+      load(); loadStats();
+    } catch {
+      toast.error('Bulk check failed', { id: tid });
+    } finally {
+      setRefreshingAll(false);
+    }
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteTarget) return;
+    try {
+      await domainService.deleteDomain(deleteTarget.uuid);
+      toast.success('Domain deleted');
+      setDeleteTarget(null);
+      load(); loadStats();
+    } catch {
+      toast.error('Delete failed');
+    }
+  };
+
+  const columns: TableColumn<Domain>[] = [
+    {
+      key: 'domain_name',
+      header: 'Domain',
+      render: (d) => (
+        <div className="flex items-center gap-2">
+          <Globe className="h-4 w-4 text-secondary-400" />
+          <div>
+            <div className="font-medium">{d.domain_name}</div>
+            <div className="text-xs text-secondary-500">{d.dns_provider || '—'}</div>
+          </div>
+        </div>
+      ),
+    },
+    { key: 'status', header: 'Status', render: (d) => <StatusBadge status={d.status} /> },
+    {
+      key: 'registration_expires_at',
+      header: 'Registration',
+      render: (d) => <ExpiryCell dateStr={d.registration_expires_at} threshold={d.alert_threshold_days} />,
+    },
+    {
+      key: 'ssl_expires_at',
+      header: 'SSL',
+      render: (d) => <ExpiryCell dateStr={d.ssl_expires_at} threshold={d.alert_threshold_days} />,
+    },
+    { key: 'registrar', header: 'Registrar', render: (d) => <span className="text-sm">{d.registrar || '—'}</span> },
+    {
+      key: 'actions',
+      header: '',
+      render: (d) => (
+        <div className="flex items-center justify-end gap-1">
+          <button title="Check now" className="rounded p-1.5 hover:bg-secondary-100" onClick={() => refreshOne(d)}>
+            <RefreshCw className="h-4 w-4" />
+          </button>
+          <button title="Cloudflare DNS" className="rounded p-1.5 hover:bg-secondary-100" onClick={() => setDnsTarget(d)}>
+            <Cloud className="h-4 w-4" />
+          </button>
+          <button title="Edit" className="rounded p-1.5 hover:bg-secondary-100" onClick={() => openEdit(d)}>
+            <Edit className="h-4 w-4" />
+          </button>
+          <button title="Delete" className="rounded p-1.5 text-error-600 hover:bg-error-50" onClick={() => setDeleteTarget(d)}>
+            <Trash2 className="h-4 w-4" />
+          </button>
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <div className="space-y-6 p-6">
+      {/* Header */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold flex items-center gap-2">
+            <Globe className="h-6 w-6" /> Domains
+          </h1>
+          <p className="text-sm text-secondary-500">
+            Registration &amp; SSL expiry monitoring, Cloudflare DNS, and k3s sync.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="secondary" onClick={() => setCredOpen(true)}>
+            <KeyRound className="h-4 w-4 mr-1" /> Cloudflare Token
+          </Button>
+          <Button variant="secondary" onClick={() => setSettingsOpen(true)}>
+            <Settings className="h-4 w-4 mr-1" /> Sync Settings
+          </Button>
+          <Button onClick={() => setPipelineOpen(true)}>
+            <Play className="h-4 w-4 mr-1" /> Run Pipeline
+          </Button>
+          <Button variant="secondary" onClick={() => setRepoSyncOpen(true)}>
+            <GitBranch className="h-4 w-4 mr-1" /> Sync to Repo
+          </Button>
+          <Button variant="secondary" onClick={() => setSyncOpen(true)}>
+            <Clock className="h-4 w-4 mr-1" /> Sync Jobs
+          </Button>
+          <Button variant="secondary" onClick={refreshAll} disabled={refreshingAll}>
+            <RefreshCw className={`h-4 w-4 mr-1 ${refreshingAll ? 'animate-spin' : ''}`} /> Check All
+          </Button>
+          <Button onClick={openCreate}>
+            <Plus className="h-4 w-4 mr-1" /> Add Domain
+          </Button>
+        </div>
+      </div>
+
+      {/* Stats */}
+      {stats && (
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+          <StatCard icon={<Globe className="h-5 w-5 text-primary-600" />} label="Total domains" value={stats.total_domains} tone="bg-primary-50" />
+          <StatCard icon={<Clock className="h-5 w-5 text-warning-600" />} label="Expiring soon" value={stats.expiring_soon} tone="bg-warning-50" />
+          <StatCard icon={<AlertTriangle className="h-5 w-5 text-error-600" />} label="Expired" value={stats.expired} tone="bg-error-50" />
+          <StatCard icon={<ShieldCheck className="h-5 w-5 text-info-600" />} label="SSL ≤ 30d" value={stats.ssl_expiring_30d} tone="bg-info-50" />
+        </div>
+      )}
+
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="relative flex-1 min-w-[220px]">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-secondary-400" />
+          <Input
+            className="pl-9"
+            placeholder="Search domain, registrar, notes…"
+            value={search}
+            onChange={(e) => { setPage(1); setSearch(e.target.value); }}
+          />
+        </div>
+        <select
+          className="rounded-md border border-secondary-200 px-3 py-2 text-sm"
+          value={statusFilter}
+          onChange={(e) => { setPage(1); setStatusFilter(e.target.value); }}
+        >
+          <option value="all">All statuses</option>
+          <option value="active">Active</option>
+          <option value="expiring_soon">Expiring soon</option>
+          <option value="expired">Expired</option>
+          <option value="error">Error</option>
+        </select>
+      </div>
+
+      {/* Table */}
+      <Card>
+        <Table<Domain>
+          columns={columns}
+          data={domains}
+          isLoading={loading}
+          emptyMessage="No domains yet. Add one to start monitoring."
+          keyExtractor={(d) => d.uuid}
+        />
+      </Card>
+      {totalPages > 1 && (
+        <Pagination currentPage={page} totalPages={totalPages} totalItems={total} perPage={20} onPageChange={setPage} />
+      )}
+
+      {/* Add / Edit modal */}
+      <Modal isOpen={formOpen} onClose={() => setFormOpen(false)} title={editing ? 'Edit domain' : 'Add domain'}>
+        <div className="space-y-3">
+          <div>
+            <label className="text-sm font-medium">Domain name *</label>
+            <Input
+              placeholder="example.com"
+              value={form.domain_name}
+              disabled={!!editing}
+              onChange={(e) => setForm({ ...form, domain_name: e.target.value })}
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="text-sm font-medium">DNS provider</label>
+              <Input value={form.dns_provider} onChange={(e) => setForm({ ...form, dns_provider: e.target.value })} />
+            </div>
+            <div>
+              <label className="text-sm font-medium">Registrar</label>
+              <Input value={form.registrar} onChange={(e) => setForm({ ...form, registrar: e.target.value })} />
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="text-sm font-medium">Cloudflare zone ID</label>
+              <Input placeholder="(auto-resolved if blank)" value={form.cloudflare_zone_id} onChange={(e) => setForm({ ...form, cloudflare_zone_id: e.target.value })} />
+            </div>
+            <div>
+              <label className="text-sm font-medium">Alert threshold (days)</label>
+              <Input
+                type="number"
+                value={String(form.alert_threshold_days)}
+                onChange={(e) => setForm({ ...form, alert_threshold_days: Number(e.target.value) || 30 })}
+              />
+            </div>
+          </div>
+          <div className="rounded border border-secondary-200 p-3 space-y-3">
+            <div className="text-xs font-semibold uppercase text-secondary-500">WSL Proxy vhost (for repo sync)</div>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="text-sm font-medium">Environment</label>
+                <select className="w-full rounded-md border border-secondary-200 px-3 py-2 text-sm" value={form.environment} onChange={(e) => setForm({ ...form, environment: e.target.value })}>
+                  {['prod', 'acc', 'test', 'int', 'dev'].map((x) => <option key={x} value={x}>{x}</option>)}
+                </select>
+              </div>
+              <div>
+                <label className="text-sm font-medium">WSL Proxy rule id</label>
+                <Input placeholder="e.g. academy-prod-default" value={form.wslproxy_rule_id} onChange={(e) => setForm({ ...form, wslproxy_rule_id: e.target.value })} />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="text-sm font-medium">SSL email</label>
+                <Input placeholder="admin@example.com" value={form.ssl_email} onChange={(e) => setForm({ ...form, ssl_email: e.target.value })} />
+              </div>
+              <div>
+                <label className="text-sm font-medium">Proxy / DNS target</label>
+                <Input placeholder="pop1.diytaxreturn.co.uk" value={form.proxy_target} onChange={(e) => setForm({ ...form, proxy_target: e.target.value })} />
+              </div>
+            </div>
+          </div>
+          <div>
+            <label className="text-sm font-medium">Notes</label>
+            <Input value={form.notes} onChange={(e) => setForm({ ...form, notes: e.target.value })} />
+          </div>
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="secondary" onClick={() => setFormOpen(false)}>Cancel</Button>
+            <Button onClick={submitForm}>{editing ? 'Save' : 'Add domain'}</Button>
+          </div>
+        </div>
+      </Modal>
+
+      {/* Delete confirm */}
+      <ConfirmDialog
+        isOpen={!!deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={confirmDelete}
+        title="Delete domain"
+        message={`Remove ${deleteTarget?.domain_name}? This is a soft delete.`}
+        confirmText="Delete"
+        variant="danger"
+      />
+
+      {credOpen && <CredentialModal onClose={() => setCredOpen(false)} />}
+      {dnsTarget && <DnsModal domain={dnsTarget} onClose={() => setDnsTarget(null)} />}
+      {syncOpen && <SyncModal onClose={() => setSyncOpen(false)} />}
+      {repoSyncOpen && <RepoSyncModal onClose={() => setRepoSyncOpen(false)} />}
+      {pipelineOpen && <PipelineModal onClose={() => setPipelineOpen(false)} />}
+      {settingsOpen && <SyncSettingsModal onClose={() => setSettingsOpen(false)} />}
+    </div>
+  );
+}
+
+// ============================================================
+// Sync Settings modal — configure the repo target + GitHub auth ONCE.
+// ============================================================
+function SyncSettingsModal({ onClose }: { onClose: () => void }) {
+  const [form, setForm] = useState({ owner: '', repo: '', branch: 'main', default_environment: 'prod', github_integration_id: '' });
+  const [integrations, setIntegrations] = useState<GithubIntegrationLite[]>([]);
+  const [integrationName, setIntegrationName] = useState<string | undefined>();
+  const [authMode, setAuthMode] = useState<'existing' | 'new'>('existing');
+  const [newToken, setNewToken] = useState('');
+  const [newTokenName, setNewTokenName] = useState('Domain Sync');
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const [s, list] = await Promise.all([
+          domainService.getSyncSettings(),
+          domainService.listGithubIntegrations().catch(() => []),
+        ]);
+        setIntegrations(list);
+        setIntegrationName(s.integration_name);
+        if (s.settings) {
+          setForm({
+            owner: s.settings.owner || '',
+            repo: s.settings.repo || '',
+            branch: s.settings.branch || 'main',
+            default_environment: s.settings.default_environment || 'prod',
+            github_integration_id: s.settings.github_integration_id || '',
+          });
+        }
+        if ((list?.length ?? 0) === 0) setAuthMode('new');
+      } catch { /* first-time; leave blanks */ }
+    })();
+  }, []);
+
+  const save = async () => {
+    if (!form.owner || !form.repo) { toast.error('owner and repo required'); return; }
+    if (authMode === 'new' && !newToken.trim()) { toast.error('Paste a GitHub token or pick an existing integration'); return; }
+    if (authMode === 'existing' && !form.github_integration_id) { toast.error('Pick a GitHub integration (or add a token)'); return; }
+    setSaving(true);
+    try {
+      const payload: Record<string, unknown> = {
+        owner: form.owner, repo: form.repo, branch: form.branch, default_environment: form.default_environment,
+      };
+      if (authMode === 'new') {
+        payload.github_token = newToken;
+        payload.integration_name = newTokenName || 'Domain Sync';
+      } else {
+        payload.github_integration_id = form.github_integration_id;
+      }
+      await domainService.saveSyncSettings(payload);
+      toast.success('Sync settings saved');
+      onClose();
+    } catch {
+      toast.error('Save failed — check the token has repo Contents + Actions write');
+    } finally { setSaving(false); }
+  };
+
+  return (
+    <Modal isOpen onClose={onClose} title="Domain sync settings">
+      <div className="space-y-4">
+        <p className="text-sm text-secondary-500">
+          Configure the target repo and GitHub authentication <span className="font-medium">once</span>.
+          After this, “Sync to Repo” and “Run Pipeline” just work — no re-entering.
+        </p>
+
+        {/* Repo target */}
+        <div className="grid grid-cols-2 gap-2">
+          <Input placeholder="owner (e.g. bwalia)" value={form.owner} onChange={(e) => setForm({ ...form, owner: e.target.value })} />
+          <Input placeholder="repo (e.g. diy-tax-return-uk)" value={form.repo} onChange={(e) => setForm({ ...form, repo: e.target.value })} />
+          <Input placeholder="branch" value={form.branch} onChange={(e) => setForm({ ...form, branch: e.target.value })} />
+          <select className="rounded-md border border-secondary-200 px-3 py-2 text-sm" value={form.default_environment} onChange={(e) => setForm({ ...form, default_environment: e.target.value })}>
+            {['prod', 'acc', 'test', 'int', 'dev'].map((x) => <option key={x} value={x}>{x}</option>)}
+          </select>
+        </div>
+
+        {/* GitHub auth */}
+        <div className="rounded border border-secondary-200 p-3 space-y-2">
+          <div className="flex items-center gap-3 text-sm">
+            <span className="font-medium">GitHub authentication</span>
+            <label className="flex items-center gap-1"><input type="radio" checked={authMode === 'existing'} onChange={() => setAuthMode('existing')} /> Use existing</label>
+            <label className="flex items-center gap-1"><input type="radio" checked={authMode === 'new'} onChange={() => setAuthMode('new')} /> Add token</label>
+          </div>
+          {authMode === 'existing' ? (
+            <select className="w-full rounded-md border border-secondary-200 px-3 py-2 text-sm" value={form.github_integration_id} onChange={(e) => setForm({ ...form, github_integration_id: e.target.value })}>
+              <option value="">
+                {integrations.length ? (integrationName ? `Current: ${integrationName}` : 'Select an integration…') : 'No integrations — add a token'}
+              </option>
+              {integrations.map((i) => <option key={i.uuid} value={i.uuid}>{i.name || i.github_username || i.uuid.slice(0, 8)}</option>)}
+            </select>
+          ) : (
+            <div className="grid grid-cols-2 gap-2">
+              <Input className="col-span-2" type="password" placeholder="GitHub PAT (Contents + Actions: write)" value={newToken} onChange={(e) => setNewToken(e.target.value)} />
+              <Input className="col-span-2" placeholder="label (e.g. Domain Sync)" value={newTokenName} onChange={(e) => setNewTokenName(e.target.value)} />
+              <p className="col-span-2 text-xs text-secondary-500">Stored encrypted; validated against GitHub before saving.</p>
+            </div>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button variant="secondary" onClick={onClose}>Cancel</Button>
+          <Button onClick={save} disabled={saving}>Save settings</Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+// ============================================================
+// Pipeline modal (opsapi drives: sync → dns-reconcile → wslproxy-register → auto-tag)
+// ============================================================
+const EMPTY_PIPELINE = { environment: 'prod', owner: '', repo: '', branch: 'main', github_integration_id: '' };
+
+function stepBadge(status: string) {
+  const map: Record<string, 'success' | 'warning' | 'error' | 'secondary'> = {
+    success: 'success', running: 'warning', failed: 'error', pending: 'secondary',
+  };
+  return <Badge variant={map[status] ?? 'secondary'}>{status}</Badge>;
+}
+
+function PipelineModal({ onClose }: { onClose: () => void }) {
+  const [form, setForm] = useState({ ...EMPTY_PIPELINE });
+  const [run, setRun] = useState<PipelineRun | null>(null);
+  const [starting, setStarting] = useState(false);
+
+  // Prefill from saved Sync Settings so the pipeline runs with one click.
+  useEffect(() => {
+    domainService.getSyncSettings().then((s) => {
+      if (!s.settings) return;
+      setForm((f) => ({
+        ...f,
+        environment: s.settings?.default_environment || f.environment,
+        owner: s.settings?.owner || '',
+        repo: s.settings?.repo || '',
+        branch: s.settings?.branch || 'main',
+        github_integration_id: s.settings?.github_integration_id || '',
+      }));
+    }).catch(() => {});
+  }, []);
+
+  // Poll while a run is active.
+  useEffect(() => {
+    if (!run || (run.status !== 'pending' && run.status !== 'running')) return;
+    const t = setInterval(async () => {
+      try {
+        const latest = await domainService.getPipelineRun(run.uuid);
+        setRun(latest);
+      } catch { /* keep last */ }
+    }, 4000);
+    return () => clearInterval(t);
+  }, [run]);
+
+  const start = async () => {
+    if (!form.owner || !form.repo) { toast.error('owner and repo required'); return; }
+    if (!form.github_integration_id) { toast.error('GitHub integration id required'); return; }
+    setStarting(true);
+    try {
+      const r = await domainService.runPipeline({ ...form });
+      setRun(r);
+      toast.success('Pipeline started');
+    } catch { toast.error('Could not start pipeline'); } finally { setStarting(false); }
+  };
+
+  return (
+    <Modal isOpen onClose={onClose} title="Run domain pipeline">
+      <div className="space-y-4">
+        <p className="text-sm text-secondary-500">
+          opsapi commits the WSL Proxy vhosts, then runs — in order, waiting for each —
+          <span className="font-medium"> Cloudflare DNS reconcile → WSL Proxy register → Auto-tag (build &amp; push)</span>.
+        </p>
+
+        {!run && (
+          <div className="grid grid-cols-2 gap-2">
+            <select className="rounded-md border border-secondary-200 px-3 py-2 text-sm" value={form.environment} onChange={(e) => setForm({ ...form, environment: e.target.value })}>
+              {['prod', 'acc', 'test', 'int', 'dev'].map((x) => <option key={x} value={x}>{x}</option>)}
+            </select>
+            <Input placeholder="branch" value={form.branch} onChange={(e) => setForm({ ...form, branch: e.target.value })} />
+            <Input placeholder="owner (e.g. bwalia)" value={form.owner} onChange={(e) => setForm({ ...form, owner: e.target.value })} />
+            <Input placeholder="repo (e.g. diy-tax-return-uk)" value={form.repo} onChange={(e) => setForm({ ...form, repo: e.target.value })} />
+            <Input className="col-span-2" placeholder="GitHub integration id (uuid)" value={form.github_integration_id} onChange={(e) => setForm({ ...form, github_integration_id: e.target.value })} />
+          </div>
+        )}
+
+        {run && (
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 text-sm">
+              <span className="font-medium">Run</span>
+              <span className="text-secondary-500">{run.uuid.slice(0, 8)}</span>
+              {stepBadge(run.status)}
+              {run.commit_sha && <span className="text-xs text-secondary-500">commit {run.commit_sha.slice(0, 7)}</span>}
+            </div>
+            {run.error && <div className="rounded bg-error-50 p-2 text-xs text-error-700">{run.error}</div>}
+            <ol className="space-y-1">
+              {run.steps.map((s) => (
+                <li key={s.name} className="flex items-center justify-between rounded border border-secondary-200 px-2 py-1 text-sm">
+                  <span className="flex items-center gap-2">
+                    {stepBadge(s.status)}
+                    <span>{s.name}</span>
+                    {s.conclusion && s.conclusion !== 'success' && <span className="text-xs text-error-600">({s.conclusion})</span>}
+                  </span>
+                  {s.run_url && (
+                    <a href={s.run_url} target="_blank" rel="noopener noreferrer" className="text-xs text-primary-600 hover:underline">view run ↗</a>
+                  )}
+                </li>
+              ))}
+            </ol>
+            {s_error(run) && <div className="text-xs text-error-600">{s_error(run)}</div>}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button variant="secondary" onClick={onClose}>Close</Button>
+          {!run && <Button onClick={start} disabled={starting}><Play className="h-4 w-4 mr-1" /> Start</Button>}
+          {run && (run.status === 'success' || run.status === 'failed') && (
+            <Button onClick={() => setRun(null)}>New run</Button>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+// Surface the failing step's error, if any.
+function s_error(run: PipelineRun): string | null {
+  const failed = run.steps.find((s) => s.status === 'failed' && s.error);
+  return failed?.error ? `${failed.name}: ${failed.error}` : null;
+}
+
+// ============================================================
+// Sync-to-repo modal (render wslproxy vhost files → commit to GitHub)
+// ============================================================
+const EMPTY_REPO = { environment: 'prod', owner: '', repo: '', branch: 'main', github_integration_id: '' };
+
+function RepoSyncModal({ onClose }: { onClose: () => void }) {
+  const [form, setForm] = useState({ ...EMPTY_REPO });
+  const [preview, setPreview] = useState<SyncToRepoResult | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // Prefill from saved Sync Settings so no re-entry is needed.
+  useEffect(() => {
+    domainService.getSyncSettings().then((s) => {
+      if (!s.settings) return;
+      setForm((f) => ({
+        ...f,
+        environment: s.settings?.default_environment || f.environment,
+        owner: s.settings?.owner || '',
+        repo: s.settings?.repo || '',
+        branch: s.settings?.branch || 'main',
+        github_integration_id: s.settings?.github_integration_id || '',
+      }));
+    }).catch(() => {});
+  }, []);
+
+  const dryRun = async () => {
+    if (!form.owner || !form.repo) { toast.error('owner and repo required'); return; }
+    setBusy(true);
+    try {
+      setPreview(await domainService.syncToRepo({ ...form, dry_run: true }));
+    } catch { toast.error('Preview failed'); } finally { setBusy(false); }
+  };
+
+  const commit = async () => {
+    if (!form.owner || !form.repo) { toast.error('owner and repo required'); return; }
+    if (!form.github_integration_id) { toast.error('Select a GitHub integration id'); return; }
+    setBusy(true);
+    const tid = toast.loading('Committing to repo…');
+    try {
+      const r = await domainService.syncToRepo({ ...form });
+      toast.success(`Committed ${r.count} file(s) — ${r.commit?.slice(0, 7)}`, { id: tid });
+      setPreview(r);
+    } catch { toast.error('Commit failed — check integration & permissions', { id: tid }); } finally { setBusy(false); }
+  };
+
+  return (
+    <Modal isOpen onClose={onClose} title="Sync domains → repo (WSL Proxy vhosts)">
+      <div className="space-y-3">
+        <p className="text-sm text-secondary-500">
+          Renders each domain in the selected environment as a WSL Proxy server file and commits them
+          in one atomic commit (add/update only — existing files are never touched). The GitHub token
+          comes from a services GitHub integration.
+        </p>
+        <div className="grid grid-cols-2 gap-2">
+          <select className="rounded-md border border-secondary-200 px-3 py-2 text-sm" value={form.environment} onChange={(e) => setForm({ ...form, environment: e.target.value })}>
+            {['prod', 'acc', 'test', 'int', 'dev'].map((x) => <option key={x} value={x}>{x}</option>)}
+          </select>
+          <Input placeholder="branch" value={form.branch} onChange={(e) => setForm({ ...form, branch: e.target.value })} />
+          <Input placeholder="owner (e.g. bwalia)" value={form.owner} onChange={(e) => setForm({ ...form, owner: e.target.value })} />
+          <Input placeholder="repo (e.g. diy-tax-return-uk)" value={form.repo} onChange={(e) => setForm({ ...form, repo: e.target.value })} />
+          <Input className="col-span-2" placeholder="GitHub integration id (uuid)" value={form.github_integration_id} onChange={(e) => setForm({ ...form, github_integration_id: e.target.value })} />
+        </div>
+
+        {preview && (
+          <div className="rounded border border-secondary-200 p-2 text-sm">
+            <div className="mb-1 font-medium">
+              {preview.dry_run ? 'Preview' : `Committed ${preview.commit?.slice(0, 7)}`} — {preview.count} file(s)
+            </div>
+            <ul className="max-h-40 overflow-auto text-xs text-secondary-600">
+              {preview.files.map((f) => <li key={f.path}>{f.path}</li>)}
+            </ul>
+          </div>
+        )}
+
+        <div className="flex justify-between pt-2">
+          <Button variant="secondary" onClick={dryRun} disabled={busy}><Download className="h-4 w-4 mr-1" /> Preview</Button>
+          <div className="flex gap-2">
+            <Button variant="secondary" onClick={onClose}>Close</Button>
+            <Button onClick={commit} disabled={busy}><GitBranch className="h-4 w-4 mr-1" /> Commit</Button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+// ============================================================
+// Cloudflare credential modal
+// ============================================================
+function CredentialModal({ onClose }: { onClose: () => void }) {
+  const [token, setToken] = useState('');
+  const [hasSecret, setHasSecret] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    domainService.listCredentials()
+      .then((c) => setHasSecret(c.some((x) => x.provider === 'cloudflare' && x.has_secret)))
+      .catch(() => {});
+  }, []);
+
+  const save = async () => {
+    if (!token.trim()) { toast.error('Enter a token'); return; }
+    setSaving(true);
+    try {
+      await domainService.saveCredential({ provider: 'cloudflare', secret: token });
+      toast.success('Cloudflare token saved (encrypted)');
+      setToken(''); setHasSecret(true);
+    } catch { toast.error('Save failed'); } finally { setSaving(false); }
+  };
+
+  const verify = async () => {
+    try {
+      const r = await domainService.verifyCloudflare();
+      toast.success(r.valid ? `Token valid (${r.status ?? 'active'})` : 'Token invalid');
+    } catch { toast.error('Verification failed'); }
+  };
+
+  return (
+    <Modal isOpen onClose={onClose} title="Cloudflare API token">
+      <div className="space-y-3">
+        <p className="text-sm text-secondary-500">
+          Stored encrypted at rest (AES). Used server-side for zone &amp; DNS management.
+          {hasSecret && <span className="ml-1 text-success-600">A token is already configured.</span>}
+        </p>
+        <Input
+          type="password"
+          placeholder={hasSecret ? '•••••••• (replace)' : 'CF API token'}
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+        />
+        <div className="flex justify-between pt-2">
+          <Button variant="secondary" onClick={verify} disabled={!hasSecret}>Verify</Button>
+          <div className="flex gap-2">
+            <Button variant="secondary" onClick={onClose}>Close</Button>
+            <Button onClick={save} disabled={saving}>Save token</Button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+// ============================================================
+// Cloudflare DNS records modal
+// ============================================================
+function DnsModal({ domain, onClose }: { domain: Domain; onClose: () => void }) {
+  const [records, setRecords] = useState<CloudflareRecord[]>([]);
+  const [zoneId, setZoneId] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+  const [newRec, setNewRec] = useState({ type: 'A', name: '', content: '', ttl: 1, proxied: false });
+
+  const load = useCallback(async () => {
+    setLoading(true); setErr(null);
+    try {
+      const r = await domainService.listRecords(domain.uuid);
+      setRecords(r.records || []); setZoneId(r.zone_id);
+    } catch {
+      setErr('Could not load records. Configure a Cloudflare token and ensure the zone exists.');
+    } finally { setLoading(false); }
+  }, [domain.uuid]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const addRecord = async () => {
+    if (!newRec.name || !newRec.content) { toast.error('Name and content required'); return; }
+    try {
+      await domainService.createRecord(domain.uuid, newRec);
+      toast.success('Record created');
+      setNewRec({ type: 'A', name: '', content: '', ttl: 1, proxied: false });
+      load();
+    } catch { toast.error('Create failed'); }
+  };
+
+  const del = async (id: string) => {
+    try { await domainService.deleteRecord(domain.uuid, id); toast.success('Record deleted'); load(); }
+    catch { toast.error('Delete failed'); }
+  };
+
+  return (
+    <Modal isOpen onClose={onClose} title={`Cloudflare DNS — ${domain.domain_name}`}>
+      <div className="space-y-4">
+        {err && <div className="rounded bg-error-50 p-3 text-sm text-error-700">{err}</div>}
+        {zoneId && <div className="text-xs text-secondary-500">Zone: {zoneId}</div>}
+
+        {/* Add record */}
+        <div className="grid grid-cols-12 gap-2 rounded border border-secondary-200 p-2">
+          <select className="col-span-2 rounded border px-2 py-1 text-sm" value={newRec.type} onChange={(e) => setNewRec({ ...newRec, type: e.target.value })}>
+            {['A', 'AAAA', 'CNAME', 'TXT', 'MX', 'NS'].map((t) => <option key={t}>{t}</option>)}
+          </select>
+          <input className="col-span-3 rounded border px-2 py-1 text-sm" placeholder="name" value={newRec.name} onChange={(e) => setNewRec({ ...newRec, name: e.target.value })} />
+          <input className="col-span-5 rounded border px-2 py-1 text-sm" placeholder="content" value={newRec.content} onChange={(e) => setNewRec({ ...newRec, content: e.target.value })} />
+          <Button className="col-span-2" onClick={addRecord}><Plus className="h-4 w-4" /></Button>
+        </div>
+
+        {/* Records list */}
+        <div className="max-h-72 overflow-auto">
+          {loading ? (
+            <div className="p-4 text-center text-sm text-secondary-500">Loading…</div>
+          ) : records.length === 0 ? (
+            <div className="p-4 text-center text-sm text-secondary-500">No records.</div>
+          ) : (
+            <table className="w-full text-sm">
+              <thead><tr className="text-left text-secondary-500"><th className="p-1">Type</th><th className="p-1">Name</th><th className="p-1">Content</th><th /></tr></thead>
+              <tbody>
+                {records.map((r) => (
+                  <tr key={r.id} className="border-t border-secondary-100">
+                    <td className="p-1"><Badge variant="secondary">{r.type}</Badge></td>
+                    <td className="p-1">{r.name}{r.proxied && <span className="ml-1 text-warning-600" title="Proxied">☁</span>}</td>
+                    <td className="p-1 truncate max-w-[200px]" title={r.content}>{r.content}</td>
+                    <td className="p-1 text-right">
+                      <button className="rounded p-1 text-error-600 hover:bg-error-50" onClick={() => del(r.id)}><Trash2 className="h-4 w-4" /></button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+        <div className="flex justify-end"><Button variant="secondary" onClick={onClose}>Close</Button></div>
+      </div>
+    </Modal>
+  );
+}
+
+// ============================================================
+// Sync configs modal (k3s job)
+// ============================================================
+const EMPTY_SYNC = {
+  name: '', github_repo: '', github_branch: 'main', file_path: 'domains.json',
+  schedule: '0 3 * * *', github_token_secret_ref: '', opsapi_base_url: '',
+};
+
+function SyncModal({ onClose }: { onClose: () => void }) {
+  const [configs, setConfigs] = useState<DomainSyncConfig[]>([]);
+  const [form, setForm] = useState({ ...EMPTY_SYNC });
+  const [manifest, setManifest] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try { setConfigs(await domainService.listSyncConfigs()); } catch { /* */ }
+  }, []);
+  useEffect(() => {
+    let active = true;
+    domainService.listSyncConfigs().then((c) => { if (active) setConfigs(c); }).catch(() => {});
+    return () => { active = false; };
+  }, []);
+
+  const create = async () => {
+    if (!form.name || !form.github_repo) { toast.error('Name and repo required'); return; }
+    try {
+      await domainService.createSyncConfig({ ...form });
+      toast.success('Sync job created');
+      setForm({ ...EMPTY_SYNC }); load();
+    } catch { toast.error('Create failed'); }
+  };
+
+  const showManifest = async (c: DomainSyncConfig) => {
+    try { setManifest((await domainService.getManifest(c.uuid)).manifest); }
+    catch { toast.error('Set opsapi_base_url + github_token_secret_ref first'); }
+  };
+
+  const runNow = async (c: DomainSyncConfig) => {
+    try { const r = await domainService.runNow(c.uuid); setManifest(r.manifest); toast.success('Run-once Job manifest ready — apply it to run now'); }
+    catch { toast.error('Could not generate run manifest'); }
+  };
+
+  const download = () => {
+    if (!manifest) return;
+    const blob = new Blob([manifest], { type: 'text/yaml' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = 'domain-sync.yaml'; a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const del = async (c: DomainSyncConfig) => {
+    try { await domainService.deleteSyncConfig(c.uuid); toast.success('Deleted'); load(); }
+    catch { toast.error('Delete failed'); }
+  };
+
+  return (
+    <Modal isOpen onClose={onClose} title="Domain sync jobs (k3s)">
+      <div className="space-y-4">
+        <p className="text-sm text-secondary-500">
+          Generate a Kubernetes CronJob that pushes your domain list as JSON to a GitHub repo on a
+          schedule. Secrets (GitHub PAT + opsapi token) come from a k8s Secret populated by the vault/ESO —
+          never stored here.
+        </p>
+
+        {/* Existing configs */}
+        {configs.length > 0 && (
+          <div className="space-y-2">
+            {configs.map((c) => (
+              <div key={c.uuid} className="flex items-center justify-between rounded border border-secondary-200 p-2 text-sm">
+                <div>
+                  <div className="font-medium">{c.name}</div>
+                  <div className="text-xs text-secondary-500">{c.github_repo} · {c.schedule} · last: {c.last_status || 'never'}</div>
+                </div>
+                <div className="flex gap-1">
+                  <button title="View CronJob manifest" className="rounded p-1.5 hover:bg-secondary-100" onClick={() => showManifest(c)}><Download className="h-4 w-4" /></button>
+                  <button title="Run once now" className="rounded p-1.5 hover:bg-secondary-100" onClick={() => runNow(c)}><Play className="h-4 w-4" /></button>
+                  <button title="Delete" className="rounded p-1.5 text-error-600 hover:bg-error-50" onClick={() => del(c)}><Trash2 className="h-4 w-4" /></button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* New config */}
+        <div className="grid grid-cols-2 gap-2 rounded border border-secondary-200 p-3">
+          <Input placeholder="Name *" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} />
+          <Input placeholder="owner/repo *" value={form.github_repo} onChange={(e) => setForm({ ...form, github_repo: e.target.value })} />
+          <Input placeholder="branch" value={form.github_branch} onChange={(e) => setForm({ ...form, github_branch: e.target.value })} />
+          <Input placeholder="file path (domains.json)" value={form.file_path} onChange={(e) => setForm({ ...form, file_path: e.target.value })} />
+          <Input placeholder="cron (0 3 * * *)" value={form.schedule} onChange={(e) => setForm({ ...form, schedule: e.target.value })} />
+          <Input placeholder="k8s Secret name (ESO)" value={form.github_token_secret_ref} onChange={(e) => setForm({ ...form, github_token_secret_ref: e.target.value })} />
+          <Input className="col-span-2" placeholder="opsapi base URL (in-cluster export endpoint)" value={form.opsapi_base_url} onChange={(e) => setForm({ ...form, opsapi_base_url: e.target.value })} />
+          <div className="col-span-2 flex justify-end"><Button onClick={create}><Plus className="h-4 w-4 mr-1" /> Create sync job</Button></div>
+        </div>
+
+        {/* Manifest preview */}
+        {manifest && (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium">Manifest</span>
+              <div className="flex gap-2">
+                <Button variant="secondary" onClick={download}><Download className="h-4 w-4 mr-1" /> Download</Button>
+                <button className="rounded p-1 hover:bg-secondary-100" onClick={() => setManifest(null)}><X className="h-4 w-4" /></button>
+              </div>
+            </div>
+            <pre className="max-h-64 overflow-auto rounded bg-secondary-900 p-3 text-xs text-secondary-100">{manifest}</pre>
+          </div>
+        )}
+
+        <div className="flex justify-end"><Button variant="secondary" onClick={onClose}>Close</Button></div>
+      </div>
+    </Modal>
+  );
+}
+
+export default function DomainsPage() {
+  return (
+    <ProtectedPage module="domains" title="Domains">
+      <DomainsPageContent />
+    </ProtectedPage>
+  );
+}

--- a/opsapi-dashboard/services/domain.service.ts
+++ b/opsapi-dashboard/services/domain.service.ts
@@ -1,0 +1,373 @@
+import apiClient, { toFormData, buildQueryString } from '@/lib/api-client';
+
+// ============================================================
+// Types
+// ============================================================
+
+export type DomainStatus = 'active' | 'expiring_soon' | 'expired' | 'error' | 'pending';
+
+export interface Domain {
+  uuid: string;
+  namespace_id?: number;
+  domain_name: string;
+  registrar?: string;
+  dns_provider?: string;
+  cloudflare_zone_id?: string;
+  status: DomainStatus;
+  registration_expires_at?: string;
+  registrar_status?: string;
+  ssl_expires_at?: string;
+  ssl_issuer?: string;
+  last_checked_at?: string;
+  last_check_error?: string;
+  alert_threshold_days?: number;
+  auto_renew?: boolean;
+  owner_user_uuid?: string;
+  notes?: string;
+  // WSL Proxy vhost fields
+  environment?: string;
+  wslproxy_rule_id?: string;
+  ssl_email?: string;
+  ssl_enabled?: boolean;
+  ssl_auto_renew?: boolean;
+  ssl_force_https?: boolean;
+  ssl_staging?: boolean;
+  wslproxy_root?: string;
+  listen_ports?: string;
+  proxy_target?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SyncToRepoResult {
+  environment: string;
+  repo?: string;
+  branch?: string;
+  commit?: string;
+  count: number;
+  dry_run?: boolean;
+  files: { path: string; server_name: string; content?: string }[];
+}
+
+export interface DomainStats {
+  total_domains: number;
+  expired: number;
+  expiring_soon: number;
+  errored: number;
+  reg_expiring_30d: number;
+  ssl_expiring_30d: number;
+}
+
+export interface DomainCredential {
+  uuid: string;
+  provider: string;
+  label?: string;
+  account_id?: string;
+  email?: string;
+  has_secret: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CloudflareZone {
+  id: string;
+  name: string;
+  status?: string;
+}
+
+export interface CloudflareRecord {
+  id: string;
+  type: string;
+  name: string;
+  content: string;
+  ttl?: number;
+  proxied?: boolean;
+  priority?: number;
+}
+
+export interface DomainSyncConfig {
+  uuid: string;
+  name: string;
+  destination_type: string;
+  github_repo?: string;
+  github_branch?: string;
+  file_path?: string;
+  commit_author_name?: string;
+  commit_author_email?: string;
+  github_token_secret_ref?: string;
+  github_token_secret_key?: string;
+  opsapi_base_url?: string;
+  opsapi_token_secret_key?: string;
+  schedule?: string;
+  is_enabled?: boolean;
+  last_synced_at?: string;
+  last_status?: string;
+  last_error?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DomainListParams {
+  page?: number;
+  perPage?: number;
+  search?: string;
+  status?: string;
+  dnsProvider?: string;
+  expiringWithinDays?: number;
+  all?: boolean;
+}
+
+export interface DomainPaginatedResponse {
+  data: Domain[];
+  total: number;
+  page: number;
+  per_page: number;
+  total_pages: number;
+}
+
+export interface ManifestResponse {
+  kind: string;
+  filename: string;
+  manifest: string;
+  apply_hint?: string;
+}
+
+export interface PipelineStep {
+  name: string;
+  type: string;
+  workflow?: string;
+  status: 'pending' | 'running' | 'success' | 'failed';
+  run_id?: number;
+  run_url?: string;
+  conclusion?: string;
+  commit?: string;
+  error?: string;
+  started_at?: string;
+  finished_at?: string;
+}
+
+export interface DomainSyncSettings {
+  uuid?: string;
+  owner?: string;
+  repo?: string;
+  branch?: string;
+  github_integration_id?: string;
+  data_base?: string;
+  default_environment?: string;
+}
+
+export interface GithubIntegrationLite {
+  uuid: string;
+  name?: string;
+  github_username?: string;
+}
+
+export interface PipelineRun {
+  uuid: string;
+  status: 'pending' | 'running' | 'success' | 'failed';
+  environment: string;
+  owner?: string;
+  repo?: string;
+  branch?: string;
+  commit_sha?: string;
+  current_step?: number;
+  steps: PipelineStep[];
+  error?: string;
+  started_at?: string;
+  finished_at?: string;
+  created_at: string;
+}
+
+// ============================================================
+// Helpers
+// ============================================================
+
+function buildDomainParams(params: DomainListParams): Record<string, unknown> {
+  const q: Record<string, unknown> = {};
+  if (params.page) q.page = params.page;
+  if (params.perPage) q.per_page = params.perPage;
+  if (params.search) q.search = params.search;
+  if (params.status && params.status !== 'all') q.status = params.status;
+  if (params.dnsProvider && params.dnsProvider !== 'all') q.dns_provider = params.dnsProvider;
+  if (params.expiringWithinDays) q.expiring_within_days = params.expiringWithinDays;
+  if (params.all) q.all = 'true';
+  return q;
+}
+
+function parsePaginated(response: { data: unknown }): DomainPaginatedResponse {
+  const d = response.data as Record<string, unknown>;
+  return {
+    data: Array.isArray(d?.data) ? (d.data as Domain[]) : [],
+    total: (d?.meta as Record<string, number>)?.total ?? 0,
+    page: (d?.meta as Record<string, number>)?.page ?? 1,
+    per_page: (d?.meta as Record<string, number>)?.per_page ?? 20,
+    total_pages: (d?.meta as Record<string, number>)?.total_pages ?? 0,
+  };
+}
+
+function unwrap<T>(response: { data: unknown }): T {
+  const d = response.data as Record<string, unknown>;
+  return (d?.data ?? d) as T;
+}
+
+// ============================================================
+// Service
+// ============================================================
+
+export const domainService = {
+  // ---- Domains ----
+  async getDomains(params: DomainListParams = {}): Promise<DomainPaginatedResponse> {
+    const qs = buildQueryString(buildDomainParams(params));
+    const response = await apiClient.get(`/api/v2/domains${qs}`);
+    return parsePaginated(response);
+  },
+
+  async getDomain(uuid: string): Promise<Domain> {
+    const response = await apiClient.get(`/api/v2/domains/${uuid}`);
+    return unwrap<Domain>(response);
+  },
+
+  async createDomain(data: Record<string, unknown>): Promise<Domain> {
+    const response = await apiClient.post('/api/v2/domains', toFormData(data));
+    return unwrap<Domain>(response);
+  },
+
+  async updateDomain(uuid: string, data: Record<string, unknown>): Promise<Domain> {
+    const response = await apiClient.put(`/api/v2/domains/${uuid}`, toFormData(data));
+    return unwrap<Domain>(response);
+  },
+
+  async deleteDomain(uuid: string): Promise<void> {
+    await apiClient.delete(`/api/v2/domains/${uuid}`);
+  },
+
+  async refreshExpiry(uuid: string): Promise<{ domain: Domain; check: Record<string, unknown> }> {
+    const response = await apiClient.post(`/api/v2/domains/${uuid}/refresh-expiry`, toFormData({}));
+    return unwrap(response);
+  },
+
+  async refreshAll(): Promise<Record<string, number>> {
+    const response = await apiClient.post('/api/v2/domains/refresh-expiry', toFormData({}));
+    return unwrap(response);
+  },
+
+  async getStats(): Promise<DomainStats> {
+    const response = await apiClient.get('/api/v2/domains/stats');
+    return unwrap<DomainStats>(response);
+  },
+
+  async syncToRepo(data: Record<string, unknown>): Promise<SyncToRepoResult> {
+    const response = await apiClient.post('/api/v2/domains/sync-to-repo', toFormData(data));
+    return unwrap<SyncToRepoResult>(response);
+  },
+
+  // ---- Pipeline (opsapi-driven: sync → dns-reconcile → wslproxy-register → auto-tag) ----
+  async runPipeline(data: Record<string, unknown>): Promise<PipelineRun> {
+    const response = await apiClient.post('/api/v2/domains/pipeline/run', toFormData(data));
+    return unwrap<PipelineRun>(response);
+  },
+
+  async getPipelineRun(uuid: string): Promise<PipelineRun> {
+    const response = await apiClient.get(`/api/v2/domains/pipeline/runs/${uuid}`);
+    return unwrap<PipelineRun>(response);
+  },
+
+  async listPipelineRuns(): Promise<PipelineRun[]> {
+    const response = await apiClient.get('/api/v2/domains/pipeline/runs');
+    return unwrap<PipelineRun[]>(response);
+  },
+
+  // ---- Credentials ----
+  async listCredentials(): Promise<DomainCredential[]> {
+    const response = await apiClient.get('/api/v2/domains/credentials');
+    return unwrap<DomainCredential[]>(response);
+  },
+
+  async saveCredential(data: Record<string, unknown>): Promise<DomainCredential> {
+    const response = await apiClient.post('/api/v2/domains/credentials', toFormData(data));
+    return unwrap<DomainCredential>(response);
+  },
+
+  async verifyCloudflare(): Promise<{ valid: boolean; status?: string }> {
+    const response = await apiClient.post('/api/v2/domains/credentials/verify', toFormData({}));
+    return unwrap(response);
+  },
+
+  async deleteCredential(provider: string): Promise<void> {
+    await apiClient.delete(`/api/v2/domains/credentials/${provider}`);
+  },
+
+  // ---- Cloudflare DNS ----
+  async listZones(name?: string): Promise<CloudflareZone[]> {
+    const qs = buildQueryString(name ? { name } : {});
+    const response = await apiClient.get(`/api/v2/domains/cloudflare/zones${qs}`);
+    return unwrap<CloudflareZone[]>(response);
+  },
+
+  async listRecords(uuid: string): Promise<{ zone_id: string; records: CloudflareRecord[] }> {
+    const response = await apiClient.get(`/api/v2/domains/${uuid}/cloudflare/records`);
+    return unwrap(response);
+  },
+
+  async createRecord(uuid: string, data: Record<string, unknown>): Promise<CloudflareRecord> {
+    const response = await apiClient.post(`/api/v2/domains/${uuid}/cloudflare/records`, toFormData(data));
+    return unwrap<CloudflareRecord>(response);
+  },
+
+  async updateRecord(uuid: string, recordId: string, data: Record<string, unknown>): Promise<CloudflareRecord> {
+    const response = await apiClient.put(`/api/v2/domains/${uuid}/cloudflare/records/${recordId}`, toFormData(data));
+    return unwrap<CloudflareRecord>(response);
+  },
+
+  async deleteRecord(uuid: string, recordId: string): Promise<void> {
+    await apiClient.delete(`/api/v2/domains/${uuid}/cloudflare/records/${recordId}`);
+  },
+
+  // ---- Sync configs (k3s job) ----
+  async listSyncConfigs(): Promise<DomainSyncConfig[]> {
+    const response = await apiClient.get('/api/v2/domains/sync-configs');
+    return unwrap<DomainSyncConfig[]>(response);
+  },
+
+  async createSyncConfig(data: Record<string, unknown>): Promise<DomainSyncConfig> {
+    const response = await apiClient.post('/api/v2/domains/sync-configs', toFormData(data));
+    return unwrap<DomainSyncConfig>(response);
+  },
+
+  async updateSyncConfig(uuid: string, data: Record<string, unknown>): Promise<DomainSyncConfig> {
+    const response = await apiClient.put(`/api/v2/domains/sync-configs/${uuid}`, toFormData(data));
+    return unwrap<DomainSyncConfig>(response);
+  },
+
+  async deleteSyncConfig(uuid: string): Promise<void> {
+    await apiClient.delete(`/api/v2/domains/sync-configs/${uuid}`);
+  },
+
+  async getManifest(uuid: string): Promise<ManifestResponse> {
+    const response = await apiClient.get(`/api/v2/domains/sync-configs/${uuid}/manifest`);
+    return unwrap<ManifestResponse>(response);
+  },
+
+  async runNow(uuid: string): Promise<ManifestResponse> {
+    const response = await apiClient.post(`/api/v2/domains/sync-configs/${uuid}/run-now`, toFormData({}));
+    return unwrap<ManifestResponse>(response);
+  },
+
+  // ---- Sync settings (persisted target: repo + branch + GitHub auth) ----
+  async getSyncSettings(): Promise<{ settings: DomainSyncSettings | null; integration_name?: string }> {
+    const response = await apiClient.get('/api/v2/domains/sync-settings');
+    return unwrap(response);
+  },
+
+  async saveSyncSettings(data: Record<string, unknown>): Promise<DomainSyncSettings> {
+    const response = await apiClient.put('/api/v2/domains/sync-settings', toFormData(data));
+    return unwrap<DomainSyncSettings>(response);
+  },
+
+  async listGithubIntegrations(): Promise<GithubIntegrationLite[]> {
+    const response = await apiClient.get('/api/v2/domains/github-integrations');
+    return unwrap<GithubIntegrationLite[]>(response);
+  },
+};
+
+export default domainService;


### PR DESCRIPTION
Brings the **Domain Management** module directly to `main` (cherry-picked cleanly off the earlier `feat/config-as-code`-based work — no conflicts, independent of the CMI branch).

Namespace-scoped domains registry gated on **SERVICES**: RDAP + live-TLS expiry, two-way Cloudflare DNS, WSL Proxy vhost rendering (byte-identical to committed format, passes `validate.py`), atomic add/update-only GitHub commits, and an opsapi-driven pipeline (sync → Cloudflare reconcile → WSL Proxy register). `services` is a **feature-only** code so `PROJECT_CODE=tax_copilot,services` migrates the module into the primary namespace with **no extra tenant**. Sync settings persist the repo + GitHub auth so it works with no re-entry.

Verified: migrations 600–609 apply, all Lua syntax-checked against `main`, dashboard `tsc`+`eslint` clean, rendered vhost passes the repo `validate.py`. Docs: `DOMAIN_MANAGEMENT.md` + `DOMAINS_USER_GUIDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)