### PR TITLE
perf(dashboard): cache-optimised Docker build (fast rebuilds)

### DIFF
--- a/opsapi-dashboard/.dockerignore
+++ b/opsapi-dashboard/.dockerignore
@@ -1,21 +1,19 @@
-# Dependencies
+# Dependencies + build output (rebuilt inside the image)
 node_modules
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-
-# Next.js
 .next
 out
+.turbo
 
-# Testing
+# Tests / coverage / e2e (not needed to build the app)
 coverage
+cypress
+cypress/videos
+cypress/screenshots
+playwright-report
+test-results
 
-# Misc
-.DS_Store
-*.pem
-
-# Debug
+# Logs / debug
+*.log
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
@@ -24,16 +22,19 @@ yarn-error.log*
 .env*.local
 .env
 
-# IDE
+# VCS + CI + IDE + docs
+.git
+.gitignore
+.github
 .idea
 .vscode
 *.swp
 *.swo
-
-# Git
-.git
-.gitignore
-
-# Documentation
-README.md
 *.md
+README.md
+
+# Misc
+.DS_Store
+*.pem
+Dockerfile
+.dockerignore

--- a/opsapi-dashboard/Dockerfile
+++ b/opsapi-dashboard/Dockerfile
@@ -1,52 +1,53 @@
-# Build stage
+# syntax=docker/dockerfile:1.7
+# ---------------------------------------------------------------------------
+# OpsAPI Dashboard (Next.js, standalone output) — cache-optimised multi-stage.
+#
+# Speed comes from three things (all rely on BuildKit / buildx):
+#   1. A dedicated `deps` stage that only re-runs `npm ci` when the lockfile
+#      changes — with the CI registry cache, unchanged deps skip entirely.
+#   2. A persistent npm cache mount (fast even on a cache miss).
+#   3. A persistent Next.js build cache mount (incremental rebuilds).
+# The runner is the Next standalone server run directly with `node` — no pm2
+# (k8s already does restarts + scaling via the Deployment).
+# ---------------------------------------------------------------------------
+
+# 1) deps — install node_modules once, keyed on the lockfile only
+FROM node:24.14-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci --no-audit --no-fund
+
+# 2) builder — compile the app
 FROM node:24.14-alpine AS builder
-
 WORKDIR /app
-
-# Build argument for API URL (passed from docker-compose)
 ARG NEXT_PUBLIC_API_URL=http://127.0.0.1:4010
-ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
-
-# Copy package files
-COPY package*.json ./
-
-# Install dependencies
-RUN npm ci
-
-# Copy source code
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL \
+    NEXT_TELEMETRY_DISABLED=1 \
+    NODE_ENV=production
+COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+# Cache the Next.js compiler cache across builds for incremental speedups.
+RUN --mount=type=cache,target=/app/.next/cache \
+    npm run build
 
-# Build the application
-RUN npm run build
-
-# Production stage
+# 3) runner — minimal standalone image
 FROM node:24.14-alpine AS runner
-
 WORKDIR /app
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    PORT=8039 \
+    HOSTNAME=0.0.0.0
 
-ENV NODE_ENV=production
+RUN addgroup -S -g 1001 nodejs && adduser -S -u 1001 nextjs
 
-# Install PM2 globally for process management, clustering, and auto-restart
-RUN npm install -g pm2
-
-# Create non-root user
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
-
-# Copy built assets from builder
+# Standalone output ships its own minimal node_modules + server.js.
 COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
-# Copy PM2 ecosystem config
-COPY --chown=nextjs:nodejs ecosystem.config.js ./
-
 USER nextjs
-
 EXPOSE 8039
 
-ENV PORT=8039
-ENV HOSTNAME="0.0.0.0"
-
-# Use PM2 to run with clustering for better concurrency and auto-restart on crash
-CMD ["pm2-runtime", "ecosystem.config.js"]
+# k8s handles restarts/replicas; run the standalone server directly.
+CMD ["node", "server.js"]


### PR DESCRIPTION
Speeds up the opsapi-dashboard image build dramatically:
- **deps stage** — `npm ci` re-runs only when `package-lock.json` changes; with the CI registry cache, unchanged deps skip entirely (the 682 MB install is the bulk of build time).
- **BuildKit cache mounts** — npm cache + Next.js compiler cache persist across builds.
- **Drop pm2** — run the Next standalone server directly (`node server.js`); k8s already does restarts/replicas. Smaller image, faster runner stage.
- Tighter `.dockerignore` (cypress/tests/CI cruft out of the context).

Pairs with the diytaxreturn deploy workflow adding `cache-from`/`cache-to` registry cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)