### PR TITLE
fix(bank-accounts): count dms bank statements in statement_count (follow-up to #533)

### DIFF
--- a/lapis/queries/TaxBankAccountQueries.lua
+++ b/lapis/queries/TaxBankAccountQueries.lua
@@ -210,9 +210,23 @@ function TaxBankAccountQueries.all(params, user)
 
     local accounts = paginated:get_page(page)
 
-    -- Add statement count for each account
+    -- Add statement count for each account. Counts BOTH pipelines so
+    -- the /bank-accounts summary matches the list under each account:
+    --   - tax_statements: /upload + /bank-accounts workflow uploads
+    --   - dms_documents:  /my-income drill-down slot uploads
+    --     (doc_type_key='bank_statement', bank_account_uuid set)
+    -- Same UNION rationale as TaxStatementQueries.all — see the comment
+    -- there for the full picture.
     for _, account in ipairs(accounts) do
-        local count_result = db.query("SELECT COUNT(*) as count FROM tax_statements WHERE bank_account_id = (SELECT id FROM tax_bank_accounts WHERE uuid = ?)", account.id)
+        local count_result = db.query([[
+            SELECT
+              (SELECT COUNT(*) FROM tax_statements
+                 WHERE bank_account_id = (SELECT id FROM tax_bank_accounts WHERE uuid = ?))
+              +
+              (SELECT COUNT(*) FROM dms_documents
+                 WHERE bank_account_uuid = ? AND doc_type_key = 'bank_statement')
+              AS count
+        ]], account.id, account.id)
         account.statement_count = count_result[1] and count_result[1].count or 0
     end
 
@@ -251,8 +265,17 @@ function TaxBankAccountQueries.show(uuid, user)
 
     if result and #result > 0 then
         local account = result[1]
-        -- Add statement count
-        local count_result = db.query("SELECT COUNT(*) as count FROM tax_statements WHERE bank_account_id = (SELECT id FROM tax_bank_accounts WHERE uuid = ?)", uuid)
+        -- Add statement count. Counts both pipelines — see the loop
+        -- in .all for the full rationale.
+        local count_result = db.query([[
+            SELECT
+              (SELECT COUNT(*) FROM tax_statements
+                 WHERE bank_account_id = (SELECT id FROM tax_bank_accounts WHERE uuid = ?))
+              +
+              (SELECT COUNT(*) FROM dms_documents
+                 WHERE bank_account_uuid = ? AND doc_type_key = 'bank_statement')
+              AS count
+        ]], uuid, uuid)
         account.statement_count = count_result[1] and count_result[1].count or 0
         return account
     end


### PR DESCRIPTION
## Summary

Follow-up to **#533** (merged). PR #533 fixed the /bank-accounts *list* so DMS-uploaded bank statements appear, but the per-account `statement_count` (used in the header "N bank accounts · X statements" AND the tile "N Statements" on the right of each row) was still reading 0 for accounts whose statements came in via the /my-income drill-down.

Same union rationale — sum both stores in the count query.

## Change

`TaxBankAccountQueries.all` + `.show` — count now:

```sql
(SELECT COUNT(*) FROM tax_statements WHERE bank_account_id = ba.id)
+
(SELECT COUNT(*) FROM dms_documents WHERE bank_account_uuid = ba.uuid AND doc_type_key = 'bank_statement')
```

## Reproduction (before this PR)

- HSBC 84a757c7-... has 0 tax_statements + 1 dms_document
- After #533: list shows the 1 statement ✅
- But header + tile still read "0 statements" ❌

## After

- Header: "1 bank account · **1** statement"
- Tile: "**1** Statements"

## Verified locally

Query returns `total_statements=1` for HSBC 84a757c7-... after applying the change to the container. Same fix in both `.all` (list) and `.show` (single) code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)