### PR TITLE
fix(wslproxy): drop jwt_token_validation from opsapi/minio prod rules (fixes redirect loop)

### DIFF
--- a/.github/wslproxy/data/rules/prod/minio-prod-default.json
+++ b/.github/wslproxy/data/rules/prod/minio-prod-default.json
@@ -7,8 +7,7 @@
   "match": {
     "rules": {
       "path": "/",
-      "path_key": "starts_with",
-      "jwt_token_validation": "equals"
+      "path_key": "starts_with"
     },
     "response": {
       "code": 305,

--- a/.github/wslproxy/data/rules/prod/opsapi-prod-default.json
+++ b/.github/wslproxy/data/rules/prod/opsapi-prod-default.json
@@ -7,8 +7,7 @@
   "match": {
     "rules": {
       "path": "/",
-      "path_key": "starts_with",
-      "jwt_token_validation": "equals"
+      "path_key": "starts_with"
     },
     "response": {
       "code": 305,


### PR DESCRIPTION
## Symptom
`int-opsapi.workstation.co.uk` (and `acc-`/`test-`/`opsapi.workstation.co.uk`, plus the `*-minio.workstation.co.uk` hosts) are unreachable — an **infinite `https → https` 301 redirect loop** at the wslproxy edge (`pop0.wslproxy.com`). `curl -L` hits 50 redirects and never resolves.

## What's actually fine
- The deploy pipeline **succeeds** and the `workstation-opsapi` pod is **healthy**: `curl <podIP>/health` → `{"status":"healthy"}`, `/` → `build_number: 266`.
- TLS is fine — a **valid Let's Encrypt cert** is served (`issuer Let's Encrypt YR1`).
- The k8s ingress is plain HTTP with no redirect annotations.

So the loop is purely at the **edge rule**, not the app or k8s.

## Root cause
`opsapi-prod-default` and `minio-prod-default` carried a spurious `match.rules.jwt_token_validation: "equals"`. Every **working, live** prod rule (`diytax-prod-cloud003`, `diytax-prod-spectoncr-manchester`, `diytax-acc-default` — all serving 200/401) has **no** such field. That incomplete match condition stops the rule binding its backend (`13.42.188.136:80`, k3s1 traefik) on the edge, so requests fall through to the `ssl_force_https` redirect and loop — on 443 as well as 80.

Removing it makes `match.rules` = `{path, path_key}`, identical to the working rules, so the 443 server proxies to the backend instead of redirecting.

## Change
- `rules/prod/opsapi-prod-default.json` — remove `jwt_token_validation`
- `rules/prod/minio-prod-default.json` — remove `jwt_token_validation`

(2 lines removed; both JSON files validated.)

## Rollout / verification
The deploy pipeline's **Register WSL Proxy** step runs with `ACTIVATE_CONFIG=true`, so merging re-pushes these rules and the edge re-renders the vhosts. After merge, `https://int-opsapi.workstation.co.uk/health` should return the app's `200` instead of looping.

## Not covered here (separate)
`opsapi.workstation.co.uk` (prod host) additionally has **no k8s Ingress/deployment** — this workflow deploys only `int`. Even with the rule fixed it will 404 until a prod ring is deployed. Flagging separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)