### PR TITLE
fix: Domain sync-settings 500 — hex-decode OPENSSL keys + coerce created_by

### DIFF
--- a/lapis/helper/global.lua
+++ b/lapis/helper/global.lua
@@ -102,14 +102,32 @@ local function validateEncryptionConfig()
         error("OPENSSL_SECRET_IV environment variable is not set")
     end
 
-    -- AES-128 requires 16-byte key and IV
-    -- Keys can be provided as 16 raw bytes or 32 hex characters
-    if #secretKey < 16 then
-        ngx.log(ngx.WARN, "OPENSSL_SECRET_KEY is ", #secretKey, " bytes, AES-128 requires 16 bytes. Key will be padded.")
+    -- AES needs RAW bytes: a 16-byte (AES-128) or 32-byte (AES-256) key, and a
+    -- 16-byte IV. Keys/IVs are commonly generated hex-encoded — `openssl rand
+    -- -hex 16` is 32 chars, `-hex 32` is 64 chars — which resty.aes rejects if
+    -- passed through verbatim (a 64-byte "key" / 32-byte "IV" match no cipher,
+    -- so AES:new returns nil and encrypt/decrypt throw "Failed to initialize
+    -- AES encryption"). Decode hex to raw ONLY when the raw length isn't a
+    -- valid AES size but the hex-decoded length is; a value already at a valid
+    -- raw length is used as-is, so existing raw-byte configs are unaffected.
+    local function to_raw(s, valid)
+        if valid[#s] then return s end
+        if #s % 2 == 0 and s:match("^[0-9a-fA-F]+$") and valid[#s / 2] then
+            return (s:gsub("..", function(cc) return string.char(tonumber(cc, 16)) end))
+        end
+        return s
+    end
+    secretKey = to_raw(secretKey, { [16] = true, [32] = true })
+    secretIV = to_raw(secretIV, { [16] = true })
+
+    if #secretKey ~= 16 and #secretKey ~= 32 then
+        ngx.log(ngx.WARN, "OPENSSL_SECRET_KEY is ", #secretKey,
+            " bytes after hex-normalisation; AES needs 16 (AES-128) or 32 (AES-256).")
     end
 
-    if #secretIV < 16 then
-        ngx.log(ngx.WARN, "OPENSSL_SECRET_IV is ", #secretIV, " bytes, AES-128 requires 16 bytes. IV will be padded.")
+    if #secretIV ~= 16 then
+        ngx.log(ngx.WARN, "OPENSSL_SECRET_IV is ", #secretIV,
+            " bytes after hex-normalisation; AES-CBC needs 16.")
     end
 
     return secretKey, secretIV

--- a/lapis/queries/ServiceQueries.lua
+++ b/lapis/queries/ServiceQueries.lua
@@ -238,7 +238,11 @@ function ServiceQueries.createGithubIntegration(namespace_id, data)
         github_username = github_username,
         status = "active",
         last_validated_at = timestamp,  -- Set validation timestamp
-        created_by = data.created_by,
+        -- created_by is a nullable INTEGER column, but callers pass a user UUID
+        -- (self.current_user.uuid). Coerce so a UUID becomes NULL rather than
+        -- 500ing the INSERT with "invalid input syntax for type integer"; a real
+        -- integer id, if ever supplied, is preserved.
+        created_by = tonumber(data.created_by),
         created_at = timestamp,
         updated_at = timestamp
     }


### PR DESCRIPTION
Fixes the `SYSTEM_500` when saving Domain **sync-settings with a GitHub token** (`PUT /api/v2/domains/sync-settings`, occurrence `c7946d04-…` on `api.diytaxreturn.co.uk`). There were **two** bugs on that path — both fixed here, both verified end-to-end against prod (rolled back).

## Bug 1 — AES key/IV are hex, used as raw bytes (`helper/global.lua`)
`Global.encryptSecret` (encrypting the GitHub PAT) passes `OPENSSL_SECRET_KEY`/`OPENSSL_SECRET_IV` to `resty.aes` as raw bytes. In prod they're hex-encoded (KEY=64 chars, IV=32 chars), so `resty.aes` sees a 64-byte key / 32-byte IV → matches no cipher → `AES:new` returns nil → assert throws `"Failed to initialize AES encryption"` → 500.

**Fix:** `validateEncryptionConfig` hex-decodes **only** when the raw length isn't a valid AES size but the decoded length is (`64hex→32`, `32hex→16`). Valid raw keys are untouched — no re-encryption, no Vault change. Verified: decoded KEY=32/IV=16, `AES:new` ok, encrypt→decrypt round-trip passes.

## Bug 2 — `created_by` UUID into an INTEGER column (`queries/ServiceQueries.lua`)
Past encryption, `createGithubIntegration` inserts `created_by = self.current_user.uuid`, but `namespace_github_integrations.created_by` is a nullable **INTEGER** → `INSERT` fails with `invalid input syntax for type integer: <uuid>`.

**Fix:** `created_by = tonumber(data.created_by)` — a UUID coerces to `NULL` (a real integer id is preserved).

## Verification (prod, transaction rolled back)
- `encryptSecret` → token encrypts (`6cxxNf+8…`)
- `createGithubIntegration` → `INSERT` **succeeds**, returns the row
- `luajit` syntax check passes on both files

No secret/Vault change needed — merging + deploying makes the sync-settings save (and all secret encryption) work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)