### PR TITLE
feat(preferences): auto_process_statements toggle for the auto-process pipeline

### DIFF
--- a/lapis/routes/tax-settings.lua
+++ b/lapis/routes/tax-settings.lua
@@ -237,6 +237,15 @@ return function(app)
             notification_email = true,
             notification_deadlines = true,
             auto_categorise = true,
+            -- auto_process_statements: when true, uploading a bank
+            -- statement from /my-income drill-down slots (self-
+            -- employment/rental/salary) automatically fires the
+            -- extract → classify chain via
+            -- POST /api/statements/auto-process/<dms_uuid>. Defaults
+            -- OFF: existing users are unaffected until they opt in
+            -- from Settings. Phase 1 of a multi-phase feature (see
+            -- backend/app/api/statement_auto_process.py docstring).
+            auto_process_statements = false,
             currency = "GBP",
             date_format = "DD/MM/YYYY",
         }


### PR DESCRIPTION
Chunk 2 of the auto-process pipeline (Phase 1). Small opsapi-side change: adds an ``auto_process_statements`` per-user preference on ``GET/PUT /api/v2/tax/settings/preferences``.

## Behaviour

- Default: **FALSE**. Existing users are unaffected until they opt in from Settings.
- Storage: the existing ``tax_user_preferences`` JSON blob already accepts arbitrary keys, so no migration needed. Only the GET endpoint's defaults dict grows a key so first-load users see it as ``false`` rather than ``undefined``.

## Companion PRs

- Chunk 1 (already merged as part of the diy PR chain): ``backend/app/api/statement_auto_process.py`` — the actual endpoint that reads this flag.
- Chunk 2 frontend (diy): ``UserPreferences`` type + ``ToggleField`` row on Settings page.
- Chunk 3 (next): SlotUploader reads the flag and calls the auto-process endpoint on upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)