### PR TITLE
fix(menu): show feature-only-code modules (Domains) in the sidebar

### DIFF
--- a/lapis/queries/MenuQueries.lua
+++ b/lapis/queries/MenuQueries.lua
@@ -223,6 +223,31 @@ function MenuQueries.getForNamespace(namespace_id, namespace_permissions, is_nam
                 allowed_modules[m.machine_name] = true
             end
         end
+
+        -- Feature-only codes (e.g. "services") are deployment-wide add-ons
+        -- layered onto EVERY namespace of this deployment (see project-config
+        -- FEATURE_ONLY_CODES) — the namespace's own project_code never lists
+        -- them. Merge their feature modules in from the environment PROJECT_CODE
+        -- so their menu items (e.g. Domains) appear wherever their routes are
+        -- actually loaded; without this a `tax_copilot,services` deployment
+        -- migrates + serves /api/v2/domains but the sidebar item stays hidden.
+        local env_code = ProjectConfig.getProjectCode() or ""
+        for code in env_code:gmatch("[^,]+") do
+            code = code:gsub("^%s+", ""):gsub("%s+$", "")
+            if ProjectConfig.isFeatureOnlyCode and ProjectConfig.isFeatureOnlyCode(code) then
+                local feats = ProjectConfig.PROJECT_FEATURES[code]
+                if feats then
+                    for _, feature in ipairs(feats) do
+                        local fmods = ProjectConfig.PROJECT_MODULES[feature]
+                        if fmods then
+                            for _, m in ipairs(fmods) do
+                                allowed_modules[m.machine_name] = true
+                            end
+                        end
+                    end
+                end
+            end
+        end
     end
 
     local filtered_items = {}


### PR DESCRIPTION
## Symptom
With `PROJECT_CODE=tax_copilot,services`, the Domains **API works** (`/api/v2/domains/*` → 200) but **Domains never appears in the sidebar** (`/api/v2/user/menu`).

## Root cause
`MenuQueries.getForNamespace` builds its `allowed_modules` set from the **namespace's own `project_code`** (`tax_copilot`). `services` is a **feature-only code** (`project-config.FEATURE_ONLY_CODES`) — a deployment-wide add-on enabled via the *environment* `PROJECT_CODE`, never stored on the namespace. So `domains` (a module of the SERVICES feature) isn't in `allowed_modules`, and the menu item is filtered out before the owner-bypass — even though its routes are loaded and tables migrated.

## Fix
Merge the environment `PROJECT_CODE`'s **feature-only-code** feature-modules into `allowed_modules`. `PROJECT_MODULES["services"]` already includes `domains`, so it now passes the filter wherever the feature is enabled. Non-feature-only codes and other namespaces are unaffected (the merge only adds modules for codes flagged `FEATURE_ONLY_CODES`).

## Verification
Local `tax_copilot,services`: `/api/v2/user/menu` now returns the `domains` item (`"key":"domains","name":"Domains","path":"/dashboard/domains"`); `luajit` syntax check passes; non-services namespaces unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)