### PR TITLE
fix(domains): decouple saving sync-settings from GitHub token validation

### DIFF
--- a/lapis/routes/domains.lua
+++ b/lapis/routes/domains.lua
@@ -302,16 +302,25 @@ return function(app)
         NamespaceMiddleware.requirePermission("domains", "update", function(self)
             local data = parse_body(self)
 
-            -- Inline GitHub auth: if a raw token is supplied, create (validate +
-            -- encrypt) a Services integration and link it. Otherwise use the
-            -- github_integration_id the caller picked.
+            -- Inline GitHub auth is OPTIONAL. Saving the sync target (owner/repo/
+            -- branch) must never be blocked by GitHub-token validation, so we
+            -- only validate + encrypt + link a Services integration when a
+            -- GENUINE new token is supplied. A nil / empty / whitespace-only /
+            -- masked ("********") value means "leave auth unchanged" — the caller
+            -- may instead pick an existing integration via github_integration_id,
+            -- or save no auth at all and add it later. (A real-but-invalid token
+            -- still returns a clear 400 so the user knows it was rejected.)
             local integration_id = data.github_integration_id
-            if data.github_token and data.github_token ~= "" and data.github_token ~= "********" then
+            local token = data.github_token
+            if type(token) == "string" then
+                token = token:gsub("^%s+", ""):gsub("%s+$", "")
+            end
+            if type(token) == "string" and token ~= "" and token ~= "********" then
                 local ok_sq, ServiceQueries = pcall(require, "queries.ServiceQueries")
                 if not ok_sq then return err_resp(500, "services module unavailable") end
                 local created, cerr = ServiceQueries.createGithubIntegration(self.namespace.id, {
                     name = data.integration_name or "Domain Sync",
-                    github_token = data.github_token,
+                    github_token = token,
                     github_username = data.github_username,
                     created_by = self.current_user and self.current_user.uuid,
                 })

--- a/opsapi-dashboard/app/dashboard/domains/page.tsx
+++ b/opsapi-dashboard/app/dashboard/domains/page.tsx
@@ -474,24 +474,30 @@ function SyncSettingsModal({ onClose }: { onClose: () => void }) {
 
   const save = async () => {
     if (!form.owner || !form.repo) { toast.error('owner and repo required'); return; }
-    if (authMode === 'new' && !newToken.trim()) { toast.error('Paste a GitHub token or pick an existing integration'); return; }
-    if (authMode === 'existing' && !form.github_integration_id) { toast.error('Pick a GitHub integration (or add a token)'); return; }
     setSaving(true);
     try {
+      // GitHub auth is OPTIONAL here — the sync target saves on its own. Only
+      // send a token when the user actually typed a new one (never a blank or
+      // the masked placeholder, which would otherwise trip token validation and
+      // block the save); only send an integration id when one is picked.
       const payload: Record<string, unknown> = {
         owner: form.owner, repo: form.repo, branch: form.branch, default_environment: form.default_environment,
       };
-      if (authMode === 'new') {
-        payload.github_token = newToken;
-        payload.integration_name = newTokenName || 'Domain Sync';
-      } else {
+      const token = newToken.trim();
+      if (authMode === 'new' && token && token !== '********') {
+        payload.github_token = token;
+        payload.integration_name = (newTokenName || '').trim() || 'Domain Sync';
+      } else if (authMode === 'existing' && form.github_integration_id) {
         payload.github_integration_id = form.github_integration_id;
       }
       await domainService.saveSyncSettings(payload);
       toast.success('Sync settings saved');
       onClose();
-    } catch {
-      toast.error('Save failed — check the token has repo Contents + Actions write');
+    } catch (e: unknown) {
+      // Surface the real API reason (e.g. "Token validation failed: Bad
+      // credentials") instead of a generic message.
+      const apiMsg = (e as { response?: { data?: { error?: string } } })?.response?.data?.error;
+      toast.error(apiMsg || 'Save failed — check the token has repo Contents + Actions write');
     } finally { setSaving(false); }
   };
 


### PR DESCRIPTION
## Problem
Saving Domain **sync-settings** validated the GitHub token synchronously against GitHub, and the form *forced* one — so a blank field, a masked value, or an invalid token returned `400 "Token validation failed"` and blocked saving the sync **target** (owner/repo/branch) at all. Users hit a confusing 400 when they just wanted to set the repo.

## Root-cause fix (both sides)
**Backend — `routes/domains.lua`** (authoritative): GitHub auth is now **optional**. The token is trimmed and `nil` / empty / whitespace-only / masked `"********"` means *"leave auth unchanged"* — only a **genuine** new token is validated + encrypted + linked. A real-but-invalid token still returns a clear `400` with GitHub's actual reason. So a blank/placeholder token can never block the save again.

**Frontend — dashboard domains page**: don't force a token — only send `github_token` when the user typed a real one (never blank/placeholder), only send `github_integration_id` when one is picked, and surface the **real** API error (e.g. "Token validation failed: Bad credentials") instead of a generic message.

## Verification (local)
| Input | Result |
|---|---|
| empty / whitespace / `********` / no token | **200** (saves target) |
| existing integration picked | 200 (links it) |
| genuine valid PAT | 200 (validates, encrypts, links) |
| real-but-invalid token (`sdfs`) | **400** `Token validation failed: Invalid token: Bad credentials` |

`luajit` syntax check + dashboard `tsc --noEmit` both pass.

## Depends on
Pairs with #536 (encryption + `created_by`) so the *valid-token* path also succeeds end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)