### PR TITLE
fix(wslproxy): vhost `rules` must be a string id, not an array (unblocks register)

### DIFF
--- a/.github/wslproxy/data/servers/prod/host:acc-opsapi.workstation.co.uk.json
+++ b/.github/wslproxy/data/servers/prod/host:acc-opsapi.workstation.co.uk.json
@@ -1,9 +1,7 @@
 {
   "cache_enabled": false,
   "custom_location_block": {},
-  "rules": [
-    "opsapi-prod-default"
-  ],
+  "rules": "opsapi-prod-default",
   "custom_http_block": {},
   "config_status": true,
   "profile_id": "prod",

--- a/.github/wslproxy/data/servers/prod/host:int-opsapi.workstation.co.uk.json
+++ b/.github/wslproxy/data/servers/prod/host:int-opsapi.workstation.co.uk.json
@@ -1,9 +1,7 @@
 {
   "cache_enabled": false,
   "custom_location_block": {},
-  "rules": [
-    "opsapi-prod-default"
-  ],
+  "rules": "opsapi-prod-default",
   "custom_http_block": {},
   "config_status": true,
   "profile_id": "prod",

--- a/.github/wslproxy/data/servers/prod/host:opsapi.workstation.co.uk.json
+++ b/.github/wslproxy/data/servers/prod/host:opsapi.workstation.co.uk.json
@@ -1,9 +1,7 @@
 {
   "cache_enabled": false,
   "custom_location_block": {},
-  "rules": [
-    "opsapi-prod-default"
-  ],
+  "rules": "opsapi-prod-default",
   "custom_http_block": {},
   "config_status": true,
   "profile_id": "prod",

--- a/.github/wslproxy/data/servers/prod/host:test-opsapi.workstation.co.uk.json
+++ b/.github/wslproxy/data/servers/prod/host:test-opsapi.workstation.co.uk.json
@@ -1,9 +1,7 @@
 {
   "cache_enabled": false,
   "custom_location_block": {},
-  "rules": [
-    "opsapi-prod-default"
-  ],
+  "rules": "opsapi-prod-default",
   "custom_http_block": {},
   "config_status": true,
   "profile_id": "prod",


### PR DESCRIPTION
## Symptom
The **Register WSL Proxy** job fails at *Validate inputs and data dir* (run 31362997257):
```
host:int-opsapi.workstation.co.uk.json references rule '[
]' but .github/wslproxy/data/rules/prod/[ ... ].json is missing
```

## Cause
The validator resolves the server→rule link with `RID=$(jq -r '.rules') ; [ -f "$RULES_DIR/$RID.json" ]`. PR #541 set the 4 workstation vhosts' `rules` to an **array** (`["opsapi-prod-default"]`, copied from a diytax template). `jq -r` on an array prints the whole `[ … ]`, so `$RID` becomes `[...]` and the file check fails. The original stubs (and the validator) use a plain **string**.

## Fix
Set `"rules": "opsapi-prod-default"` (string) on all four `*-opsapi.workstation.co.uk` vhosts. Verified locally that `jq -r '.rules'` now yields the id and `rules/prod/opsapi-prod-default.json` resolves for all four.

Follow-up to #541 — this is the only thing blocking the automated register/deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)