### PR TITLE
fix(workstation-opsapi): mirror the working beacon setup (backend + stub vhosts + wslproxy)

### DIFF
--- a/.github/wslproxy/data/rules/prod/opsapi-prod-default.json
+++ b/.github/wslproxy/data/rules/prod/opsapi-prod-default.json
@@ -3,7 +3,11 @@
   "name": "opsapi-prod-default",
   "profile_id": "prod",
   "priority": 1,
-  "rules_tags": ["opsapi", "workstation", "prod"],
+  "rules_tags": [
+    "opsapi",
+    "workstation",
+    "prod"
+  ],
   "match": {
     "rules": {
       "path": "/",
@@ -11,13 +15,13 @@
     },
     "response": {
       "code": 305,
-      "redirect_uri": "72.62.211.28:80",
+      "redirect_uri": "193.237.176.232:8888",
       "strip_path": false,
       "backends": [
         {
-          "address": "72.62.211.28:80",
+          "address": "193.237.176.232:8888",
           "weight": 100,
-          "label": "cloud001 (72.62.211.28) traefik-edge public entry; workstation-opsapi routes by Host header. The public WSL Proxy edge can't reach the debian LAN, so it proxies here; traefik-edge routes to the ClusterIP Service (pod pinned to debworker00)."
+          "label": "193.237.176.232:8888 k3s ingress entry (same backend as the working beacon/*.workstation.co.uk hosts); routes by Host header"
         }
       ],
       "routing": {

--- a/.github/wslproxy/data/servers/prod/host:acc-opsapi.workstation.co.uk.json
+++ b/.github/wslproxy/data/servers/prod/host:acc-opsapi.workstation.co.uk.json
@@ -1,81 +1,25 @@
 {
-  "cache_enabled": false,
-  "custom_location_block": {},
-  "rules": "opsapi-prod-default",
-  "custom_http_block": {},
-  "config_status": true,
-  "profile_id": "prod",
-  "cache_ttl": 3600,
-  "ssl_email": "admin@workstation.co.uk",
-  "ssl_auto_renew": true,
-  "ssl_force_https": true,
-  "ssl_staging": false,
-  "cache_bypass_auth": true,
-  "cache_docker_blobs": false,
-  "cache_docker_blobs_ttl": "2592000",
-  "match_cases": [
-    {
-      "statement": "c01433b8-52b8-5f21-e38f-f0726e4f6597",
-      "condition": "and"
-    },
-    {
-      "statement": "9e6caceb-c963-a51a-ad4a-36005b13f665",
-      "condition": "and"
-    }
-  ],
-  "cache_docker_manifests_ttl": "3600",
-  "cache_docker_serve_stale": false,
-  "cache_docker_stale_ttl": "31536000",
-  "custom_headers": {},
-  "custom_response_headers": {},
-  "proxy_server_name": "acc-opsapi.workstation.co.uk",
-  "server_name": "acc-opsapi.workstation.co.uk",
-  "rate_limit": {
-    "requests_per_second": 100,
-    "burst": 50
-  },
-  "dns_record_type": "A",
-  "access_log": "logs/acc-opsapi.workstation.co.uk.access.log",
-  "ssl_enabled": true,
-  "root": "/var/www/html",
   "id": "host:acc-opsapi.workstation.co.uk",
-  "proxy_timeouts": {
-    "read_timeout": "",
-    "connect_timeout": "",
-    "send_timeout": ""
-  },
+  "server_name": "acc-opsapi.workstation.co.uk",
+  "proxy_server_name": "acc-opsapi.workstation.co.uk",
+  "root": "/var/www/html",
+  "index": "index.html",
+  "access_log": "logs/acc-opsapi.workstation.co.uk.access.log",
+  "error_log": "logs/acc-opsapi.workstation.co.uk.error.log",
+  "config_status": false,
+  "profile_id": "prod",
+  "rules": "opsapi-prod-default",
   "listens": [
     {
       "listen": "80"
     }
   ],
-  "varnish_enabled": false,
-  "waf_enabled": false,
-  "config": "CnNlcnZlciB7CiAgICBsaXN0ZW4gODA7CiAgICBzZXJ2ZXJfbmFtZSBhY2Mtb3BzYXBpLndvcmtzdGF0aW9uLmNvLnVrOwogICAgbG9jYXRpb24gLy53ZWxsLWtub3duL2FjbWUtY2hhbGxlbmdlLyB7IGNvbnRlbnRfYnlfbHVhX2Jsb2NrIHsgYXV0b19zc2w6Y2hhbGxlbmdlX3NlcnZlcigpIH0gfQogICAgbG9jYXRpb24gLyB7IHJldHVybiAzMDEgaHR0cHM6Ly8kaG9zdCRyZXF1ZXN0X3VyaTsgfQp9CnNlcnZlciB7CiAgICAgIGxpc3RlbiA4MDsKICAgICAgCiAgICAgIGxpc3RlbiA0NDMgc3NsIGh0dHAyOwogICAgICBzc2xfY2VydGlmaWNhdGVfYnlfbHVhX2Jsb2NrIHsgYXV0b19zc2w6c3NsX2NlcnRpZmljYXRlKCkgfQogICAgICBzc2xfY2VydGlmaWNhdGUgL2V0Yy9zc2wvcmVzdHktYXV0by1zc2wtZmFsbGJhY2suY3J0OwogICAgICBzc2xfY2VydGlmaWNhdGVfa2V5IC9ldGMvc3NsL3Jlc3R5LWF1dG8tc3NsLWZhbGxiYWNrLmtleTsKICAgICAgc3NsX3Nlc3Npb25fdGltZW91dCAxZDsKICAgICAgc3NsX3Nlc3Npb25fY2FjaGUgc2hhcmVkOlNTTDo1MG07CiAgICAgIHNzbF9zZXNzaW9uX3RpY2tldHMgb2ZmOwogICAgICBzc2xfcHJvdG9jb2xzIFRMU3YxLjIgVExTdjEuMzsKICAgICAgc3NsX2NpcGhlcnMgRUNESEUtRUNEU0EtQUVTMTI4LUdDTS1TSEEyNTY6RUNESEUtUlNBLUFFUzEyOC1HQ00tU0hBMjU2OkVDREhFLUVDRFNBLUFFUzI1Ni1HQ00tU0hBMzg0OkVDREhFLVJTQS1BRVMyNTYtR0NNLVNIQTM4NDpFQ0RIRS1FQ0RTQS1DSEFDSEEyMC1QT0xZMTMwNTpFQ0RIRS1SU0EtQ0hBQ0hBMjAtUE9MWTEzMDU6REhFLVJTQS1BRVMxMjgtR0NNLVNIQTI1NjpESEUtUlNBLUFFUzI1Ni1HQ00tU0hBMzg0OwogICAgICBzc2xfcHJlZmVyX3NlcnZlcl9jaXBoZXJzIG9mZjsKICAgICAgYWRkX2hlYWRlciBTdHJpY3QtVHJhbnNwb3J0LVNlY3VyaXR5ICJtYXgtYWdlPTMxNTM2MDAwOyBpbmNsdWRlU3ViRG9tYWlucyIgYWx3YXlzOwogICAgICBzZXJ2ZXJfbmFtZSBhY2Mtb3BzYXBpLndvcmtzdGF0aW9uLmNvLnVrOwogICAgICByb290IC92YXIvd3d3L2h0bWw7CiAgICAgIGluZGV4IGluZGV4Lmh0bWw7CiAgICAgIGFjY2Vzc19sb2cgbG9ncy9hY2Mtb3BzYXBpLndvcmtzdGF0aW9uLmNvLnVrLmFjY2Vzcy5sb2c7CiAgICAgIGVycm9yX2xvZyBsb2dzL2FjYy1vcHNhcGkud29ya3N0YXRpb24uY28udWsuZXJyb3IubG9nOwogICAgICAKICAgICAgbG9jYXRpb24gLy53ZWxsLWtub3duL2FjbWUtY2hhbGxlbmdlLyB7CiAgICAgICAgICBjb250ZW50X2J5X2x1YV9ibG9jayB7IGF1dG9fc3NsOmNoYWxsZW5nZV9zZXJ2ZXIoKSB9CiAgICAgIH0KICAgICAgCiAgICAgIAogIH0KICAKICA=",
-  "rate_limit_enabled": false,
-  "cache_docker_manifests": false,
-  "index": "index.html",
-  "varnish_config": {
-    "health_check_url": "/health",
-    "health_check_interval": 5,
-    "backend_connect_timeout": 5,
-    "backend_between_bytes_timeout": 10,
-    "cache_ttl_default": 120,
-    "cache_grace": 3600,
-    "cache_keep": 7200,
-    "cache_size": "256m",
-    "health_check_enabled": false,
-    "listen_address": "0.0.0.0",
-    "listen_port": "6081",
-    "backend_first_byte_timeout": 60,
-    "health_check_timeout": 2,
-    "admin_listen_port": "6082"
-  },
-  "cached_mime_types": {},
-  "varnish_snippets": {},
-  "servers_tags": {},
-  "custom_block": {},
-  "locations": {},
-  "pop_ids": {},
-  "error_log": "logs/acc-opsapi.workstation.co.uk.error.log"
+  "ssl_enabled": true,
+  "ssl_force_https": true,
+  "ssl_staging": false,
+  "ssl_auto_renew": true,
+  "ssl_email": "admin@workstation.co.uk",
+  "cache_enabled": false,
+  "match_cases": {},
+  "custom_headers": []
 }

--- a/.github/wslproxy/data/servers/prod/host:int-opsapi.workstation.co.uk.json
+++ b/.github/wslproxy/data/servers/prod/host:int-opsapi.workstation.co.uk.json
@@ -1,81 +1,25 @@
 {
-  "cache_enabled": false,
-  "custom_location_block": {},
-  "rules": "opsapi-prod-default",
-  "custom_http_block": {},
-  "config_status": true,
-  "profile_id": "prod",
-  "cache_ttl": 3600,
-  "ssl_email": "admin@workstation.co.uk",
-  "ssl_auto_renew": true,
-  "ssl_force_https": true,
-  "ssl_staging": false,
-  "cache_bypass_auth": true,
-  "cache_docker_blobs": false,
-  "cache_docker_blobs_ttl": "2592000",
-  "match_cases": [
-    {
-      "statement": "c01433b8-52b8-5f21-e38f-f0726e4f6597",
-      "condition": "and"
-    },
-    {
-      "statement": "9e6caceb-c963-a51a-ad4a-36005b13f665",
-      "condition": "and"
-    }
-  ],
-  "cache_docker_manifests_ttl": "3600",
-  "cache_docker_serve_stale": false,
-  "cache_docker_stale_ttl": "31536000",
-  "custom_headers": {},
-  "custom_response_headers": {},
-  "proxy_server_name": "int-opsapi.workstation.co.uk",
-  "server_name": "int-opsapi.workstation.co.uk",
-  "rate_limit": {
-    "requests_per_second": 100,
-    "burst": 50
-  },
-  "dns_record_type": "A",
-  "access_log": "logs/int-opsapi.workstation.co.uk.access.log",
-  "ssl_enabled": true,
-  "root": "/var/www/html",
   "id": "host:int-opsapi.workstation.co.uk",
-  "proxy_timeouts": {
-    "read_timeout": "",
-    "connect_timeout": "",
-    "send_timeout": ""
-  },
+  "server_name": "int-opsapi.workstation.co.uk",
+  "proxy_server_name": "int-opsapi.workstation.co.uk",
+  "root": "/var/www/html",
+  "index": "index.html",
+  "access_log": "logs/int-opsapi.workstation.co.uk.access.log",
+  "error_log": "logs/int-opsapi.workstation.co.uk.error.log",
+  "config_status": false,
+  "profile_id": "prod",
+  "rules": "opsapi-prod-default",
   "listens": [
     {
       "listen": "80"
     }
   ],
-  "varnish_enabled": false,
-  "waf_enabled": false,
-  "config": "CnNlcnZlciB7CiAgICBsaXN0ZW4gODA7CiAgICBzZXJ2ZXJfbmFtZSBpbnQtb3BzYXBpLndvcmtzdGF0aW9uLmNvLnVrOwogICAgbG9jYXRpb24gLy53ZWxsLWtub3duL2FjbWUtY2hhbGxlbmdlLyB7IGNvbnRlbnRfYnlfbHVhX2Jsb2NrIHsgYXV0b19zc2w6Y2hhbGxlbmdlX3NlcnZlcigpIH0gfQogICAgbG9jYXRpb24gLyB7IHJldHVybiAzMDEgaHR0cHM6Ly8kaG9zdCRyZXF1ZXN0X3VyaTsgfQp9CnNlcnZlciB7CiAgICAgIGxpc3RlbiA4MDsKICAgICAgCiAgICAgIGxpc3RlbiA0NDMgc3NsIGh0dHAyOwogICAgICBzc2xfY2VydGlmaWNhdGVfYnlfbHVhX2Jsb2NrIHsgYXV0b19zc2w6c3NsX2NlcnRpZmljYXRlKCkgfQogICAgICBzc2xfY2VydGlmaWNhdGUgL2V0Yy9zc2wvcmVzdHktYXV0by1zc2wtZmFsbGJhY2suY3J0OwogICAgICBzc2xfY2VydGlmaWNhdGVfa2V5IC9ldGMvc3NsL3Jlc3R5LWF1dG8tc3NsLWZhbGxiYWNrLmtleTsKICAgICAgc3NsX3Nlc3Npb25fdGltZW91dCAxZDsKICAgICAgc3NsX3Nlc3Npb25fY2FjaGUgc2hhcmVkOlNTTDo1MG07CiAgICAgIHNzbF9zZXNzaW9uX3RpY2tldHMgb2ZmOwogICAgICBzc2xfcHJvdG9jb2xzIFRMU3YxLjIgVExTdjEuMzsKICAgICAgc3NsX2NpcGhlcnMgRUNESEUtRUNEU0EtQUVTMTI4LUdDTS1TSEEyNTY6RUNESEUtUlNBLUFFUzEyOC1HQ00tU0hBMjU2OkVDREhFLUVDRFNBLUFFUzI1Ni1HQ00tU0hBMzg0OkVDREhFLVJTQS1BRVMyNTYtR0NNLVNIQTM4NDpFQ0RIRS1FQ0RTQS1DSEFDSEEyMC1QT0xZMTMwNTpFQ0RIRS1SU0EtQ0hBQ0hBMjAtUE9MWTEzMDU6REhFLVJTQS1BRVMxMjgtR0NNLVNIQTI1NjpESEUtUlNBLUFFUzI1Ni1HQ00tU0hBMzg0OwogICAgICBzc2xfcHJlZmVyX3NlcnZlcl9jaXBoZXJzIG9mZjsKICAgICAgYWRkX2hlYWRlciBTdHJpY3QtVHJhbnNwb3J0LVNlY3VyaXR5ICJtYXgtYWdlPTMxNTM2MDAwOyBpbmNsdWRlU3ViRG9tYWlucyIgYWx3YXlzOwogICAgICBzZXJ2ZXJfbmFtZSBpbnQtb3BzYXBpLndvcmtzdGF0aW9uLmNvLnVrOwogICAgICByb290IC92YXIvd3d3L2h0bWw7CiAgICAgIGluZGV4IGluZGV4Lmh0bWw7CiAgICAgIGFjY2Vzc19sb2cgbG9ncy9pbnQtb3BzYXBpLndvcmtzdGF0aW9uLmNvLnVrLmFjY2Vzcy5sb2c7CiAgICAgIGVycm9yX2xvZyBsb2dzL2ludC1vcHNhcGkud29ya3N0YXRpb24uY28udWsuZXJyb3IubG9nOwogICAgICAKICAgICAgbG9jYXRpb24gLy53ZWxsLWtub3duL2FjbWUtY2hhbGxlbmdlLyB7CiAgICAgICAgICBjb250ZW50X2J5X2x1YV9ibG9jayB7IGF1dG9fc3NsOmNoYWxsZW5nZV9zZXJ2ZXIoKSB9CiAgICAgIH0KICAgICAgCiAgICAgIAogIH0KICAKICA=",
-  "rate_limit_enabled": false,
-  "cache_docker_manifests": false,
-  "index": "index.html",
-  "varnish_config": {
-    "health_check_url": "/health",
-    "health_check_interval": 5,
-    "backend_connect_timeout": 5,
-    "backend_between_bytes_timeout": 10,
-    "cache_ttl_default": 120,
-    "cache_grace": 3600,
-    "cache_keep": 7200,
-    "cache_size": "256m",
-    "health_check_enabled": false,
-    "listen_address": "0.0.0.0",
-    "listen_port": "6081",
-    "backend_first_byte_timeout": 60,
-    "health_check_timeout": 2,
-    "admin_listen_port": "6082"
-  },
-  "cached_mime_types": {},
-  "varnish_snippets": {},
-  "servers_tags": {},
-  "custom_block": {},
-  "locations": {},
-  "pop_ids": {},
-  "error_log": "logs/int-opsapi.workstation.co.uk.error.log"
+  "ssl_enabled": true,
+  "ssl_force_https": true,
+  "ssl_staging": false,
+  "ssl_auto_renew": true,
+  "ssl_email": "admin@workstation.co.uk",
+  "cache_enabled": false,
+  "match_cases": {},
+  "custom_headers": []
 }

--- a/.github/wslproxy/data/servers/prod/host:opsapi.workstation.co.uk.json
+++ b/.github/wslproxy/data/servers/prod/host:opsapi.workstation.co.uk.json
@@ -1,81 +1,25 @@
 {
-  "cache_enabled": false,
-  "custom_location_block": {},
-  "rules": "opsapi-prod-default",
-  "custom_http_block": {},
-  "config_status": true,
-  "profile_id": "prod",
-  "cache_ttl": 3600,
-  "ssl_email": "admin@workstation.co.uk",
-  "ssl_auto_renew": true,
-  "ssl_force_https": true,
-  "ssl_staging": false,
-  "cache_bypass_auth": true,
-  "cache_docker_blobs": false,
-  "cache_docker_blobs_ttl": "2592000",
-  "match_cases": [
-    {
-      "statement": "c01433b8-52b8-5f21-e38f-f0726e4f6597",
-      "condition": "and"
-    },
-    {
-      "statement": "9e6caceb-c963-a51a-ad4a-36005b13f665",
-      "condition": "and"
-    }
-  ],
-  "cache_docker_manifests_ttl": "3600",
-  "cache_docker_serve_stale": false,
-  "cache_docker_stale_ttl": "31536000",
-  "custom_headers": {},
-  "custom_response_headers": {},
-  "proxy_server_name": "opsapi.workstation.co.uk",
-  "server_name": "opsapi.workstation.co.uk",
-  "rate_limit": {
-    "requests_per_second": 100,
-    "burst": 50
-  },
-  "dns_record_type": "A",
-  "access_log": "logs/opsapi.workstation.co.uk.access.log",
-  "ssl_enabled": true,
-  "root": "/var/www/html",
   "id": "host:opsapi.workstation.co.uk",
-  "proxy_timeouts": {
-    "read_timeout": "",
-    "connect_timeout": "",
-    "send_timeout": ""
-  },
+  "server_name": "opsapi.workstation.co.uk",
+  "proxy_server_name": "opsapi.workstation.co.uk",
+  "root": "/var/www/html",
+  "index": "index.html",
+  "access_log": "logs/opsapi.workstation.co.uk.access.log",
+  "error_log": "logs/opsapi.workstation.co.uk.error.log",
+  "config_status": false,
+  "profile_id": "prod",
+  "rules": "opsapi-prod-default",
   "listens": [
     {
       "listen": "80"
     }
   ],
-  "varnish_enabled": false,
-  "waf_enabled": false,
-  "config": "CnNlcnZlciB7CiAgICBsaXN0ZW4gODA7CiAgICBzZXJ2ZXJfbmFtZSBvcHNhcGkud29ya3N0YXRpb24uY28udWs7CiAgICBsb2NhdGlvbiAvLndlbGwta25vd24vYWNtZS1jaGFsbGVuZ2UvIHsgY29udGVudF9ieV9sdWFfYmxvY2sgeyBhdXRvX3NzbDpjaGFsbGVuZ2Vfc2VydmVyKCkgfSB9CiAgICBsb2NhdGlvbiAvIHsgcmV0dXJuIDMwMSBodHRwczovLyRob3N0JHJlcXVlc3RfdXJpOyB9Cn0Kc2VydmVyIHsKICAgICAgbGlzdGVuIDgwOwogICAgICAKICAgICAgbGlzdGVuIDQ0MyBzc2wgaHR0cDI7CiAgICAgIHNzbF9jZXJ0aWZpY2F0ZV9ieV9sdWFfYmxvY2sgeyBhdXRvX3NzbDpzc2xfY2VydGlmaWNhdGUoKSB9CiAgICAgIHNzbF9jZXJ0aWZpY2F0ZSAvZXRjL3NzbC9yZXN0eS1hdXRvLXNzbC1mYWxsYmFjay5jcnQ7CiAgICAgIHNzbF9jZXJ0aWZpY2F0ZV9rZXkgL2V0Yy9zc2wvcmVzdHktYXV0by1zc2wtZmFsbGJhY2sua2V5OwogICAgICBzc2xfc2Vzc2lvbl90aW1lb3V0IDFkOwogICAgICBzc2xfc2Vzc2lvbl9jYWNoZSBzaGFyZWQ6U1NMOjUwbTsKICAgICAgc3NsX3Nlc3Npb25fdGlja2V0cyBvZmY7CiAgICAgIHNzbF9wcm90b2NvbHMgVExTdjEuMiBUTFN2MS4zOwogICAgICBzc2xfY2lwaGVycyBFQ0RIRS1FQ0RTQS1BRVMxMjgtR0NNLVNIQTI1NjpFQ0RIRS1SU0EtQUVTMTI4LUdDTS1TSEEyNTY6RUNESEUtRUNEU0EtQUVTMjU2LUdDTS1TSEEzODQ6RUNESEUtUlNBLUFFUzI1Ni1HQ00tU0hBMzg0OkVDREhFLUVDRFNBLUNIQUNIQTIwLVBPTFkxMzA1OkVDREhFLVJTQS1DSEFDSEEyMC1QT0xZMTMwNTpESEUtUlNBLUFFUzEyOC1HQ00tU0hBMjU2OkRIRS1SU0EtQUVTMjU2LUdDTS1TSEEzODQ7CiAgICAgIHNzbF9wcmVmZXJfc2VydmVyX2NpcGhlcnMgb2ZmOwogICAgICBhZGRfaGVhZGVyIFN0cmljdC1UcmFuc3BvcnQtU2VjdXJpdHkgIm1heC1hZ2U9MzE1MzYwMDA7IGluY2x1ZGVTdWJEb21haW5zIiBhbHdheXM7CiAgICAgIHNlcnZlcl9uYW1lIG9wc2FwaS53b3Jrc3RhdGlvbi5jby51azsKICAgICAgcm9vdCAvdmFyL3d3dy9odG1sOwogICAgICBpbmRleCBpbmRleC5odG1sOwogICAgICBhY2Nlc3NfbG9nIGxvZ3Mvb3BzYXBpLndvcmtzdGF0aW9uLmNvLnVrLmFjY2Vzcy5sb2c7CiAgICAgIGVycm9yX2xvZyBsb2dzL29wc2FwaS53b3Jrc3RhdGlvbi5jby51ay5lcnJvci5sb2c7CiAgICAgIAogICAgICBsb2NhdGlvbiAvLndlbGwta25vd24vYWNtZS1jaGFsbGVuZ2UvIHsKICAgICAgICAgIGNvbnRlbnRfYnlfbHVhX2Jsb2NrIHsgYXV0b19zc2w6Y2hhbGxlbmdlX3NlcnZlcigpIH0KICAgICAgfQogICAgICAKICAgICAgCiAgfQogIAogIA==",
-  "rate_limit_enabled": false,
-  "cache_docker_manifests": false,
-  "index": "index.html",
-  "varnish_config": {
-    "health_check_url": "/health",
-    "health_check_interval": 5,
-    "backend_connect_timeout": 5,
-    "backend_between_bytes_timeout": 10,
-    "cache_ttl_default": 120,
-    "cache_grace": 3600,
-    "cache_keep": 7200,
-    "cache_size": "256m",
-    "health_check_enabled": false,
-    "listen_address": "0.0.0.0",
-    "listen_port": "6081",
-    "backend_first_byte_timeout": 60,
-    "health_check_timeout": 2,
-    "admin_listen_port": "6082"
-  },
-  "cached_mime_types": {},
-  "varnish_snippets": {},
-  "servers_tags": {},
-  "custom_block": {},
-  "locations": {},
-  "pop_ids": {},
-  "error_log": "logs/opsapi.workstation.co.uk.error.log"
+  "ssl_enabled": true,
+  "ssl_force_https": true,
+  "ssl_staging": false,
+  "ssl_auto_renew": true,
+  "ssl_email": "admin@workstation.co.uk",
+  "cache_enabled": false,
+  "match_cases": {},
+  "custom_headers": []
 }

--- a/.github/wslproxy/data/servers/prod/host:test-opsapi.workstation.co.uk.json
+++ b/.github/wslproxy/data/servers/prod/host:test-opsapi.workstation.co.uk.json
@@ -1,81 +1,25 @@
 {
-  "cache_enabled": false,
-  "custom_location_block": {},
-  "rules": "opsapi-prod-default",
-  "custom_http_block": {},
-  "config_status": true,
-  "profile_id": "prod",
-  "cache_ttl": 3600,
-  "ssl_email": "admin@workstation.co.uk",
-  "ssl_auto_renew": true,
-  "ssl_force_https": true,
-  "ssl_staging": false,
-  "cache_bypass_auth": true,
-  "cache_docker_blobs": false,
-  "cache_docker_blobs_ttl": "2592000",
-  "match_cases": [
-    {
-      "statement": "c01433b8-52b8-5f21-e38f-f0726e4f6597",
-      "condition": "and"
-    },
-    {
-      "statement": "9e6caceb-c963-a51a-ad4a-36005b13f665",
-      "condition": "and"
-    }
-  ],
-  "cache_docker_manifests_ttl": "3600",
-  "cache_docker_serve_stale": false,
-  "cache_docker_stale_ttl": "31536000",
-  "custom_headers": {},
-  "custom_response_headers": {},
-  "proxy_server_name": "test-opsapi.workstation.co.uk",
-  "server_name": "test-opsapi.workstation.co.uk",
-  "rate_limit": {
-    "requests_per_second": 100,
-    "burst": 50
-  },
-  "dns_record_type": "A",
-  "access_log": "logs/test-opsapi.workstation.co.uk.access.log",
-  "ssl_enabled": true,
-  "root": "/var/www/html",
   "id": "host:test-opsapi.workstation.co.uk",
-  "proxy_timeouts": {
-    "read_timeout": "",
-    "connect_timeout": "",
-    "send_timeout": ""
-  },
+  "server_name": "test-opsapi.workstation.co.uk",
+  "proxy_server_name": "test-opsapi.workstation.co.uk",
+  "root": "/var/www/html",
+  "index": "index.html",
+  "access_log": "logs/test-opsapi.workstation.co.uk.access.log",
+  "error_log": "logs/test-opsapi.workstation.co.uk.error.log",
+  "config_status": false,
+  "profile_id": "prod",
+  "rules": "opsapi-prod-default",
   "listens": [
     {
       "listen": "80"
     }
   ],
-  "varnish_enabled": false,
-  "waf_enabled": false,
-  "config": "CnNlcnZlciB7CiAgICBsaXN0ZW4gODA7CiAgICBzZXJ2ZXJfbmFtZSB0ZXN0LW9wc2FwaS53b3Jrc3RhdGlvbi5jby51azsKICAgIGxvY2F0aW9uIC8ud2VsbC1rbm93bi9hY21lLWNoYWxsZW5nZS8geyBjb250ZW50X2J5X2x1YV9ibG9jayB7IGF1dG9fc3NsOmNoYWxsZW5nZV9zZXJ2ZXIoKSB9IH0KICAgIGxvY2F0aW9uIC8geyByZXR1cm4gMzAxIGh0dHBzOi8vJGhvc3QkcmVxdWVzdF91cmk7IH0KfQpzZXJ2ZXIgewogICAgICBsaXN0ZW4gODA7CiAgICAgIAogICAgICBsaXN0ZW4gNDQzIHNzbCBodHRwMjsKICAgICAgc3NsX2NlcnRpZmljYXRlX2J5X2x1YV9ibG9jayB7IGF1dG9fc3NsOnNzbF9jZXJ0aWZpY2F0ZSgpIH0KICAgICAgc3NsX2NlcnRpZmljYXRlIC9ldGMvc3NsL3Jlc3R5LWF1dG8tc3NsLWZhbGxiYWNrLmNydDsKICAgICAgc3NsX2NlcnRpZmljYXRlX2tleSAvZXRjL3NzbC9yZXN0eS1hdXRvLXNzbC1mYWxsYmFjay5rZXk7CiAgICAgIHNzbF9zZXNzaW9uX3RpbWVvdXQgMWQ7CiAgICAgIHNzbF9zZXNzaW9uX2NhY2hlIHNoYXJlZDpTU0w6NTBtOwogICAgICBzc2xfc2Vzc2lvbl90aWNrZXRzIG9mZjsKICAgICAgc3NsX3Byb3RvY29scyBUTFN2MS4yIFRMU3YxLjM7CiAgICAgIHNzbF9jaXBoZXJzIEVDREhFLUVDRFNBLUFFUzEyOC1HQ00tU0hBMjU2OkVDREhFLVJTQS1BRVMxMjgtR0NNLVNIQTI1NjpFQ0RIRS1FQ0RTQS1BRVMyNTYtR0NNLVNIQTM4NDpFQ0RIRS1SU0EtQUVTMjU2LUdDTS1TSEEzODQ6RUNESEUtRUNEU0EtQ0hBQ0hBMjAtUE9MWTEzMDU6RUNESEUtUlNBLUNIQUNIQTIwLVBPTFkxMzA1OkRIRS1SU0EtQUVTMTI4LUdDTS1TSEEyNTY6REhFLVJTQS1BRVMyNTYtR0NNLVNIQTM4NDsKICAgICAgc3NsX3ByZWZlcl9zZXJ2ZXJfY2lwaGVycyBvZmY7CiAgICAgIGFkZF9oZWFkZXIgU3RyaWN0LVRyYW5zcG9ydC1TZWN1cml0eSAibWF4LWFnZT0zMTUzNjAwMDsgaW5jbHVkZVN1YkRvbWFpbnMiIGFsd2F5czsKICAgICAgc2VydmVyX25hbWUgdGVzdC1vcHNhcGkud29ya3N0YXRpb24uY28udWs7CiAgICAgIHJvb3QgL3Zhci93d3cvaHRtbDsKICAgICAgaW5kZXggaW5kZXguaHRtbDsKICAgICAgYWNjZXNzX2xvZyBsb2dzL3Rlc3Qtb3BzYXBpLndvcmtzdGF0aW9uLmNvLnVrLmFjY2Vzcy5sb2c7CiAgICAgIGVycm9yX2xvZyBsb2dzL3Rlc3Qtb3BzYXBpLndvcmtzdGF0aW9uLmNvLnVrLmVycm9yLmxvZzsKICAgICAgCiAgICAgIGxvY2F0aW9uIC8ud2VsbC1rbm93bi9hY21lLWNoYWxsZW5nZS8gewogICAgICAgICAgY29udGVudF9ieV9sdWFfYmxvY2sgeyBhdXRvX3NzbDpjaGFsbGVuZ2Vfc2VydmVyKCkgfQogICAgICB9CiAgICAgIAogICAgICAKICB9CiAgCiAg",
-  "rate_limit_enabled": false,
-  "cache_docker_manifests": false,
-  "index": "index.html",
-  "varnish_config": {
-    "health_check_url": "/health",
-    "health_check_interval": 5,
-    "backend_connect_timeout": 5,
-    "backend_between_bytes_timeout": 10,
-    "cache_ttl_default": 120,
-    "cache_grace": 3600,
-    "cache_keep": 7200,
-    "cache_size": "256m",
-    "health_check_enabled": false,
-    "listen_address": "0.0.0.0",
-    "listen_port": "6081",
-    "backend_first_byte_timeout": 60,
-    "health_check_timeout": 2,
-    "admin_listen_port": "6082"
-  },
-  "cached_mime_types": {},
-  "varnish_snippets": {},
-  "servers_tags": {},
-  "custom_block": {},
-  "locations": {},
-  "pop_ids": {},
-  "error_log": "logs/test-opsapi.workstation.co.uk.error.log"
+  "ssl_enabled": true,
+  "ssl_force_https": true,
+  "ssl_staging": false,
+  "ssl_auto_renew": true,
+  "ssl_email": "admin@workstation.co.uk",
+  "cache_enabled": false,
+  "match_cases": {},
+  "custom_headers": []
 }

--- a/devops/helm-charts/diytaxreturn-lapis/values-workstation-acc.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/values-workstation-acc.yaml
@@ -30,7 +30,7 @@ service:
 # no cert-manager on k3s1). See values-workstation-int.yaml.
 ingress:
   enabled: true
-  className: traefik-edge
+  className: wslproxy
   annotations: {}
   hosts:
     - host: acc-opsapi.workstation.co.uk

--- a/devops/helm-charts/diytaxreturn-lapis/values-workstation-int.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/values-workstation-int.yaml
@@ -36,20 +36,18 @@ service:
   type: ClusterIP
   port: 80
 
-# Dedicated Ingress for this release. className `traefik-edge` = the ingress
-# class served by the `traefik-edge` daemonset on the PUBLIC k3s1 edge nodes
-# (cloud00x). The public WSL Proxy edge (an external host) cannot reach the
-# debian LAN nodes (192.168.1.x) directly, so it proxies to a public edge node
-# (cloud001, 72.62.211.28 — see the opsapi-prod-default rule backend) which
-# runs traefik-edge and routes by Host header to THIS release's Service. The
-# pod itself still runs on a debian node (see nodeSelector below) — the edge
-# node is only the HTTP entry, not where the app runs. Same working pattern as
-# the *.diytaxreturn.co.uk hosts. NO cert-manager / NO tls block: TLS is
-# terminated at the WSL Proxy edge (ssl_enabled in the committed server JSON);
-# traefik serves plain HTTP :80 behind it.
+# Dedicated Ingress for this release. className `wslproxy` = the k3s1 ingress
+# class the WSL Proxy edge routes to — identical to the working beacon
+# (monitoring-go) *.workstation.co.uk hosts (e.g. grafana/prometheus.workstation
+# .co.uk). The edge proxies to the shared k3s ingress entry 193.237.176.232:8888
+# (see the opsapi-prod-default rule backend), which serves this release's Host
+# over plain HTTP. NO cert-manager / NO tls block: TLS is terminated at the WSL
+# Proxy edge (ssl_enabled in the committed server JSON); traefik serves plain
+# HTTP :80 behind it, routing by Host header. The pod is pinned to a debian node
+# (nodeSelector below) — placement is independent of routing.
 ingress:
   enabled: true
-  className: traefik-edge
+  className: wslproxy
   annotations: {}
   hosts:
     - host: int-opsapi.workstation.co.uk

--- a/devops/helm-charts/diytaxreturn-lapis/values-workstation-prod.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/values-workstation-prod.yaml
@@ -31,7 +31,7 @@ service:
 # no cert-manager on k3s1). See values-workstation-int.yaml.
 ingress:
   enabled: true
-  className: traefik-edge
+  className: wslproxy
   annotations: {}
   hosts:
     - host: opsapi.workstation.co.uk

--- a/devops/helm-charts/diytaxreturn-lapis/values-workstation-test.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/values-workstation-test.yaml
@@ -30,7 +30,7 @@ service:
 # no cert-manager on k3s1). See values-workstation-int.yaml.
 ingress:
   enabled: true
-  className: traefik-edge
+  className: wslproxy
   annotations: {}
   hosts:
     - host: test-opsapi.workstation.co.uk


### PR DESCRIPTION
## TL;DR
Make `*-opsapi.workstation.co.uk` identical to the **working beacon (monitoring-go)** `*.workstation.co.uk` hosts — same cluster, same WSL Proxy infra, same everything, just opsapi instead of beacon.

## What beacon does (and we now match)
Verified against `monitoring-go` + live: `http://193.237.176.232:8888` with `Host: int-opsapi.workstation.co.uk` already returns **`200`** (ingress class `wslproxy`).

| Aspect | beacon (works) | opsapi before | opsapi now |
|---|---|---|---|
| rule backend | `193.237.176.232:8888` | `13.42.188.136:80` (ELB → 301 loop) then #541 `cloud001` | **`193.237.176.232:8888`** |
| vhost | **stub** (`config_status:false`, no `config`, `match_cases:{}`, string `rules`) | #541 "compiled" config + array `rules` | **stub, string `rules`** |
| ingress class | `wslproxy` | #541 `traefik-edge` | **`wslproxy`** |

## Changes
- `rules/prod/opsapi-prod-default.json` → backend `193.237.176.232:8888`
- `servers/prod/host:*-opsapi.workstation.co.uk.json` (×4) → beacon-style stubs (same shape as `host:grafana.workstation.co.uk.json`)
- `values-workstation-{int,acc,test,prod}.yaml` → `className: wslproxy` (kept `nodeSelector: debworker00` on int+prod)

## Verified
- `193.237.176.232:8888` + wslproxy class serves `int-opsapi` → `200` (healthy JSON), pod on `debworker00`.
- Register validator passes (`jq -r '.rules'` → `opsapi-prod-default` → rule file exists) for all 4.
- `helm template` renders `ingressClassName: wslproxy` + `nodeSelector: debworker00`; `helm lint` clean.

Supersedes #541's edge changes and **#542** (close it). On merge, the deploy-k3s **Register WSL Proxy** step pushes the corrected rule + stub vhosts automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)