### PR TITLE
feat(workstation-opsapi): isolate DB + deploy admin UI dashboard

### DIFF
--- a/.github/workflows/deploy-workstation-dashboard.yml
+++ b/.github/workflows/deploy-workstation-dashboard.yml
@@ -1,0 +1,225 @@
+name: Deploy Workstation Dashboard
+
+# Builds and deploys the OpsAPI admin UI (opsapi-dashboard/, Next.js) to
+# https://int-opsapi-ui.workstation.co.uk, fully from GitHub. The UI calls the
+# workstation-opsapi API at https://int-opsapi.workstation.co.uk.
+#
+# Mirrors deploy-k3s.yml (which deploys the API): same k3s1 cluster
+# (KUBE_CONFIG_DATA_K3S), same WSL Proxy edge (DNS CNAME -> pop0.wslproxy.com +
+# a stub vhost/rule registered on the control plane), same Docker Hub registry.
+#
+# Next.js inlines NEXT_PUBLIC_API_URL into the browser bundle at BUILD time, so
+# the image is built with the API URL baked in (one image -> one API host). The
+# API URL is read from the chart's `apiUrl:` so it can never drift from what the
+# Deployment serves.
+#
+# Flow:  build (image) -> dns (Cloudflare CNAME) -> wslproxy (edge vhost/rule)
+#        -> deploy (helm upgrade + rollout)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "opsapi-dashboard/**"
+      - "devops/helm-charts/opsapi-dashboard/**"
+      - ".github/workflows/deploy-workstation-dashboard.yml"
+      - ".github/wslproxy/data/servers/prod/host:*-opsapi-ui.workstation.co.uk.json"
+  workflow_dispatch:
+    inputs:
+      TARGET_ENV:
+        description: "Environment (values-workstation-<env>.yaml)"
+        required: false
+        default: "int"
+        type: string
+
+concurrency:
+  group: deploy-workstation-dashboard-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  IMAGE_REGISTRY: bwalia
+  IMAGE_NAME: opsapi-dashboard
+  HELM_CHART_PATH: ./devops/helm-charts/opsapi-dashboard
+  RELEASE_NAME: workstation-opsapi-dashboard
+  TARGET_ENV: ${{ github.event.inputs.TARGET_ENV || 'int' }}
+  # DNS: the UI host is a DNS-only CNAME to the WSL Proxy edge, which terminates
+  # TLS and proxies to the k3s ingress entry (same as the API host).
+  DNS_ZONE: workstation.co.uk
+  DNS_TARGET: pop0.wslproxy.com
+  DNS_PROXIED: "false"
+
+jobs:
+  # =========================================================================
+  # 1. BUILD — build + push the dashboard image with the API URL baked in.
+  # =========================================================================
+  build:
+    name: Build dashboard image
+    runs-on: [self-hosted, Linux, X64]
+    outputs:
+      image_tag: ${{ steps.meta.outputs.IMAGE_TAG }}
+      api_url: ${{ steps.meta.outputs.API_URL }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Determine build metadata + API URL
+        id: meta
+        run: |
+          set -euo pipefail
+          VALUES="${HELM_CHART_PATH}/values-workstation-${TARGET_ENV}.yaml"
+          [ -f "$VALUES" ] || { echo "::error::no values file ($VALUES)"; exit 1; }
+
+          # Single source of truth: the API URL the chart deploys with. Baking
+          # a different URL than the runtime env would silently break the UI.
+          API_URL="$(awk '/^apiUrl:/{print $2; exit}' "$VALUES")"
+          [ -n "$API_URL" ] || { echo "::error::no 'apiUrl:' in $VALUES"; exit 1; }
+
+          APP_VERSION=$(git describe --tags --always 2>/dev/null || echo 'dev')
+          SAFE_VERSION=$(echo "$APP_VERSION" | tr -c 'A-Za-z0-9_.-' '-' | sed 's/-\+$//')
+          IMAGE_TAG="${SAFE_VERSION}-${GITHUB_RUN_NUMBER:-local}"
+          echo "API_URL=$API_URL"     >> "$GITHUB_OUTPUT"
+          echo "IMAGE_TAG=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          echo "Building ${IMAGE_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} (API=${API_URL})"
+
+      - name: Build & push (NEXT_PUBLIC_API_URL baked in)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./opsapi-dashboard
+          file: ./opsapi-dashboard/Dockerfile
+          push: true
+          build-args: |
+            NEXT_PUBLIC_API_URL=${{ steps.meta.outputs.API_URL }}
+          tags: |
+            ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.IMAGE_TAG }}
+          # Registry layer cache — reuses the npm-ci deps stage unless the
+          # lockfile changed (see the Dockerfile), so most builds skip the
+          # heavy install. mode=max also caches the Next.js build cache.
+          cache-from: type=registry,ref=${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
+          provenance: false
+
+  # =========================================================================
+  # 2. DNS — ensure the Cloudflare CNAME for the UI host -> the WSL Proxy edge.
+  # =========================================================================
+  dns:
+    name: Ensure Cloudflare DNS
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Ensure the CNAME for the UI host
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE: ${{ env.DNS_ZONE }}
+        run: |
+          set -euo pipefail
+          VALUES="${HELM_CHART_PATH}/values-workstation-${TARGET_ENV}.yaml"
+          [ -f "$VALUES" ] || { echo "::error::no values file ($VALUES)"; exit 1; }
+          HOST="$(awk '/^host:/{print $2; exit}' "$VALUES")"
+          [ -n "$HOST" ] || { echo "::error::no 'host:' in $VALUES"; exit 1; }
+          echo "Ensuring ${HOST} -> ${DNS_TARGET} (proxied=${DNS_PROXIED})"
+          chmod +x devops/scripts/cloudflare-dns.sh
+          ./devops/scripts/cloudflare-dns.sh \
+            --name "$HOST" \
+            --content "$DNS_TARGET" \
+            --proxied "$DNS_PROXIED"
+
+  # =========================================================================
+  # 3. WSL PROXY — register the edge vhost + rule for the UI host. The UI vhost
+  #    (host:*-opsapi-ui.workstation.co.uk) reuses the opsapi-prod-default rule,
+  #    so it routes to the same k3s ingress entry and traefik picks it by Host.
+  # =========================================================================
+  wslproxy:
+    name: Register WSL Proxy vhost
+    needs: [dns]
+    uses: ./.github/workflows/wslproxy-register-domains.yml
+    with:
+      TARGET_ENV: prod
+      ACTIVATE_CONFIG: true
+      DRY_RUN: false
+    secrets: inherit
+
+  # =========================================================================
+  # 4. DEPLOY — helm upgrade the workstation-opsapi-dashboard release to k3s1.
+  # =========================================================================
+  deploy:
+    name: Deploy dashboard to K3s (${{ github.event.inputs.TARGET_ENV || 'int' }})
+    needs: [build, dns, wslproxy]
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 15
+    if: >-
+      ${{ always()
+          && needs.build.result == 'success'
+          && needs.dns.result == 'success'
+          && needs.wslproxy.result == 'success' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Decode kubeconfig (k3s1)
+        env:
+          KUBECONFIG_BASE64: ${{ secrets.KUBE_CONFIG_DATA_K3S }}
+        run: |
+          set -euo pipefail
+          [ -n "$KUBECONFIG_BASE64" ] || { echo "::error::secret KUBE_CONFIG_DATA_K3S is empty"; exit 1; }
+          echo "$KUBECONFIG_BASE64" | base64 -d > kubeconfig
+          chmod 600 kubeconfig
+          echo "KUBECONFIG=$(pwd)/kubeconfig" >> "$GITHUB_ENV"
+
+      - name: Ensure kubectl + helm
+        run: |
+          command -v kubectl >/dev/null 2>&1 || {
+            curl -sLO "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+            chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+          }
+          command -v helm >/dev/null 2>&1 || {
+            curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          }
+          kubectl version --client=true 2>/dev/null | head -1 || true
+          helm version --short || true
+
+      - name: Deploy dashboard
+        env:
+          TAG: ${{ needs.build.outputs.image_tag }}
+          API_URL: ${{ needs.build.outputs.api_url }}
+        run: |
+          set -euo pipefail
+          VALUES="${HELM_CHART_PATH}/values-workstation-${TARGET_ENV}.yaml"
+          [ -f "$VALUES" ] || { echo "::error::no values file ($VALUES)"; exit 1; }
+          kubectl create namespace "${TARGET_ENV}" --dry-run=client -o yaml | kubectl apply -f -
+          helm upgrade --install "${RELEASE_NAME}" "${HELM_CHART_PATH}" \
+            -f "$VALUES" \
+            --namespace "${TARGET_ENV}" --create-namespace \
+            --set image.repository="${IMAGE_REGISTRY}/${IMAGE_NAME}" \
+            --set image.tag="${TAG}" \
+            --set apiUrl="${API_URL}" \
+            --set deployedAt="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --wait --timeout 8m
+          kubectl -n "${TARGET_ENV}" rollout status "deploy/${RELEASE_NAME}" --timeout=300s || true
+          kubectl -n "${TARGET_ENV}" get pods -o wide -l app="${RELEASE_NAME}"
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "### Workstation Dashboard deployed"
+            echo "- URL: https://$(awk '/^host:/{print $2; exit}' "${HELM_CHART_PATH}/values-workstation-${TARGET_ENV}.yaml")"
+            echo "- image: \`${IMAGE_REGISTRY}/${IMAGE_NAME}:${{ needs.build.outputs.image_tag }}\`"
+            echo "- API (baked): \`${{ needs.build.outputs.api_url }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/wslproxy/data/rules/prod/opsapi-prod-default.json
+++ b/.github/wslproxy/data/rules/prod/opsapi-prod-default.json
@@ -33,6 +33,7 @@
     "host:opsapi.workstation.co.uk",
     "host:int-opsapi.workstation.co.uk",
     "host:test-opsapi.workstation.co.uk",
-    "host:acc-opsapi.workstation.co.uk"
+    "host:acc-opsapi.workstation.co.uk",
+    "host:int-opsapi-ui.workstation.co.uk"
   ]
 }

--- a/.github/wslproxy/data/servers/prod/host:int-opsapi-ui.workstation.co.uk.json
+++ b/.github/wslproxy/data/servers/prod/host:int-opsapi-ui.workstation.co.uk.json
@@ -1,0 +1,25 @@
+{
+  "id": "host:int-opsapi-ui.workstation.co.uk",
+  "server_name": "int-opsapi-ui.workstation.co.uk",
+  "proxy_server_name": "int-opsapi-ui.workstation.co.uk",
+  "root": "/var/www/html",
+  "index": "index.html",
+  "access_log": "logs/int-opsapi-ui.workstation.co.uk.access.log",
+  "error_log": "logs/int-opsapi-ui.workstation.co.uk.error.log",
+  "config_status": false,
+  "profile_id": "prod",
+  "rules": "opsapi-prod-default",
+  "listens": [
+    {
+      "listen": "80"
+    }
+  ],
+  "ssl_enabled": true,
+  "ssl_force_https": true,
+  "ssl_staging": false,
+  "ssl_auto_renew": true,
+  "ssl_email": "admin@workstation.co.uk",
+  "cache_enabled": false,
+  "match_cases": {},
+  "custom_headers": []
+}

--- a/devops/helm-charts/diytaxreturn-lapis/templates/cronjob.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/templates/cronjob.yaml
@@ -114,10 +114,18 @@ spec:
                       name: {{ .Release.Name }}-secrets
                       key: POSTGRES_PORT
                 - name: POSTGRES_DB
+                  {{- if and .Values.database .Values.database.name }}
+                  # Isolation: back up THIS release's own database (see the
+                  # POSTGRES_DB override in deployment.yaml), not the shared
+                  # secret's POSTGRES_DB — otherwise this release would dump the
+                  # co-tenant's database instead of its own.
+                  value: {{ .Values.database.name | quote }}
+                  {{- else }}
                   valueFrom:
                     secretKeyRef:
                       name: {{ .Release.Name }}-secrets
                       key: POSTGRES_DB
+                  {{- end }}
           volumes:
             - name: {{ .Release.Name }}-backup-script
               configMap:
@@ -241,10 +249,18 @@ spec:
                       name: {{ .Release.Name }}-secrets
                       key: POSTGRES_PORT
                 - name: POSTGRES_DB
+                  {{- if and .Values.database .Values.database.name }}
+                  # Isolation: back up THIS release's own database (see the
+                  # POSTGRES_DB override in deployment.yaml), not the shared
+                  # secret's POSTGRES_DB — otherwise this release would dump the
+                  # co-tenant's database instead of its own.
+                  value: {{ .Values.database.name | quote }}
+                  {{- else }}
                   valueFrom:
                     secretKeyRef:
                       name: {{ .Release.Name }}-secrets
                       key: POSTGRES_DB
+                  {{- end }}
           volumes:
             - name: {{ .Release.Name }}-backup-script
               configMap:

--- a/devops/helm-charts/diytaxreturn-lapis/templates/deployment.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/templates/deployment.yaml
@@ -108,6 +108,23 @@ spec:
             # "no encryption" and the whole API 500s.
             - name: POSTGRES_SSL
               value: {{ .Values.postgresSsl | default "true" | quote }}
+            {{- if and .Values.database .Values.database.name }}
+            # DATABASE ISOLATION. By default this release inherits POSTGRES_DB
+            # from the shared Vault ExternalSecret (envFrom above) — which is
+            # the SAME `opsapi` database the legacy diytaxreturn-lapis release
+            # uses. Setting `database.name` points THIS release at its own
+            # database on the same Postgres server, so its data (users,
+            # namespaces, tenants) is fully isolated from diytaxreturn's. An
+            # explicit container `env` WINS over the `envFrom` secretRef for the
+            # same key, and config.lua + `lapis migrate` both read
+            # os.getenv("POSTGRES_DB"), so the app and the postStart migration
+            # hook agree. The target database MUST already exist on the server
+            # (pguser lacks CREATEDB) — provision it once before first deploy:
+            #   CREATE DATABASE <name> OWNER pguser;
+            # then the postStart bootstrap migrates it fresh + seeds the admin.
+            - name: POSTGRES_DB
+              value: {{ .Values.database.name | quote }}
+            {{- end }}
             # PCRE pattern (matched via ngx.re.match) of recipients
             # whose SMTP delivery must be silently skipped. Used by
             # helper/mail.lua + helper/otp.lua; gated internally on

--- a/devops/helm-charts/diytaxreturn-lapis/values-workstation-int.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/values-workstation-int.yaml
@@ -16,9 +16,14 @@ app: workstation-opsapi
 # this `host:` via awk). MUST equal ingress.hosts[0].host below.
 host: int-opsapi.workstation.co.uk
 
-# Scope migrations to the tax app only — see values-int.yaml for the full
-# rationale (a CRM migration drift took acc down for 22h once).
-projectCode: tax_copilot
+# Full opsapi product on its OWN isolated database (see `database` below), so
+# `all` is safe here: every migration runs against the dedicated
+# workstation_opsapi DB and cannot affect diytaxreturn's data. `all` enables
+# every feature module (incl. SERVICES/Domains) so the admin dashboard shows
+# the complete product. The "CRM drift took acc down 22h" caveat in
+# values-int.yaml applied to the SHARED diytaxreturn DB — it does not apply to
+# this isolated release.
+projectCode: all
 
 # Password-reset email link target (the Next.js dashboard, unchanged — the
 # API moving to workstation.co.uk does not move the frontend). Migration 489
@@ -63,20 +68,45 @@ ingress:
 nodeSelector:
   kubernetes.io/hostname: debworker00
 
-# Empty map (NOT unset): the chart's ExternalSecret reads
-# `.Values.database.host | default <Vault POSTGRES_HOST>`, which nil-pointers
-# if `database` is absent entirely. `{}` leaves `.host` unset so the Vault
-# fallback fires — the correct in-cluster address for diytaxreturn-pg on k3s1.
-# The legacy 10.96.x IP in values-int.yaml is a dead k3s0-era ClusterIP.
-database: {}
+# DATABASE ISOLATION.
+#   `host` is intentionally left UNSET so the chart's ExternalSecret falls back
+#   to the Vault POSTGRES_HOST (diy-tax-db.int.svc — the correct in-cluster
+#   Postgres). `name` points this release at its OWN database on that same
+#   server, isolating its data from the diytaxreturn-lapis release which shares
+#   the Vault secret. Without `name`, both releases would read/write the single
+#   `opsapi` database (verified 2026-08-10: identical 810-user DB). The chart
+#   turns `name` into a POSTGRES_DB env override (see deployment.yaml).
+#   PREREQUISITE: the database must exist before deploy (pguser has no CREATEDB):
+#     kubectl exec -n int diy-tax-db-0 -- psql -U postgres \
+#       -c 'CREATE DATABASE workstation_opsapi OWNER pguser'
+#   The postStart bootstrap then migrates it fresh (projectCode=all) and seeds
+#   the admin below. Other envs (acc/test/prod) need their own DB + this same
+#   block before they are stood up, or they will share that env's diytax DB.
+database:
+  name: workstation_opsapi
 
 externalSecret:
   enabled: true
 
+# Bootstrap super-admin for the fresh workstation_opsapi DB (created on first
+# boot by scripts/setup-namespace). Email is safe to commit; the password is
+# NOT set here (this repo is public) — it defaults to the setup-namespace
+# default on a fresh seed and should be rotated after first login. The seeded
+# admin owns the `workstation` namespace and holds the platform `administrative`
+# role. Once the admin exists, setup-namespace is idempotent and never rewrites
+# the password, so redeploys are safe.
 setup:
-  adminEmail: ""
+  adminEmail: "tenthmatrix.mailer@gmail.com"
   adminPassword: ""
-  namespaceSlug: ""
+  namespaceSlug: "workstation"
+
+# Browser CORS allow-list (consumed by middleware/cors.lua). The admin UI
+# dashboard is served from *-opsapi-ui.workstation.co.uk and calls this API
+# cross-origin; without an allow-list match the middleware emits no
+# Access-Control-Allow-Origin and the browser blocks every call. The bare
+# domain matches the apex AND every subdomain (http/https, any port), so it
+# covers int-opsapi-ui.workstation.co.uk and the other env UI hosts.
+corsAllowedDomains: "workstation.co.uk"
 
 autoscaling:
   enabled: false

--- a/devops/helm-charts/opsapi-dashboard/Chart.yaml
+++ b/devops/helm-charts/opsapi-dashboard/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: opsapi-dashboard
+description: >-
+  OpsAPI admin dashboard (Next.js) for workstation.co.uk — the UI that talks to
+  the workstation-opsapi backend. The image is built from opsapi-dashboard/ with
+  NEXT_PUBLIC_API_URL baked in at build time (Next.js inlines NEXT_PUBLIC_* into
+  the browser bundle), so one image maps to exactly one API host.
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/devops/helm-charts/opsapi-dashboard/README.md
+++ b/devops/helm-charts/opsapi-dashboard/README.md
@@ -1,0 +1,35 @@
+# opsapi-dashboard chart
+
+Deploys the OpsAPI admin UI (Next.js, `opsapi-dashboard/`) for
+`*.workstation.co.uk`, talking to the `workstation-opsapi` API.
+
+- **Release:** `workstation-opsapi-dashboard` (namespace `int`)
+- **Public host:** https://int-opsapi-ui.workstation.co.uk → API
+  https://int-opsapi.workstation.co.uk
+- **Deployed by:** `.github/workflows/deploy-workstation-dashboard.yml`
+  (build image → Cloudflare DNS → WSL Proxy vhost → helm upgrade). No manual
+  steps.
+
+## Build-time API URL (important)
+
+Next.js inlines `NEXT_PUBLIC_*` into the browser bundle **at build time**, so
+the image is built with `--build-arg NEXT_PUBLIC_API_URL=<apiUrl>`. The workflow
+reads `apiUrl:` from `values-workstation-<env>.yaml` and uses it both as the
+build arg and the runtime env, so they can never drift. Changing the API host
+means a **rebuild**, not just a values edit.
+
+## Routing (mirrors the API)
+
+`ingress.className: wslproxy` — identical to the `workstation-opsapi` API and the
+working beacon `*.workstation.co.uk` hosts. TLS terminates at the WSL Proxy edge;
+traefik serves plain HTTP :80 behind it and routes by Host header. The edge
+vhost is a stub under `.github/wslproxy/data/servers/prod/` reusing the
+`opsapi-prod-default` rule (same k3s ingress backend as the API).
+
+## Adding an environment
+
+1. Add `values-workstation-<env>.yaml` (set `env`, `apiUrl`, `host`,
+   `ingress.hostname`).
+2. Add the stub vhost `host:<env>-opsapi-ui.workstation.co.uk.json` and append
+   it to the `opsapi-prod-default` rule's `servers`.
+3. Deploy via the workflow with that `TARGET_ENV`.

--- a/devops/helm-charts/opsapi-dashboard/templates/deployment.yaml
+++ b/devops/helm-charts/opsapi-dashboard/templates/deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: {{ .Values.autoscaling.minReplicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+      annotations:
+        # Bump on every helm upgrade so the :latest image is re-pulled even when
+        # the tag is unchanged (the deploy workflow sets this to build time).
+        deployed-at: {{ .Values.deployedAt | default "unset" | quote }}
+    spec:
+      {{- if .Values.imagePullSecretName }}
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecretName }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Release.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.targetPort }}
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: NEXT_PUBLIC_DEPLOY_ENV
+              value: {{ .Values.env | quote }}
+            # Server-side reads only. The browser bundle uses the value baked in
+            # at BUILD time (--build-arg NEXT_PUBLIC_API_URL). See README.
+            - name: NEXT_PUBLIC_API_URL
+              value: {{ .Values.apiUrl | quote }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.path }}
+              port: {{ .Values.livenessProbe.port }}
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.path }}
+              port: {{ .Values.readinessProbe.port }}
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/devops/helm-charts/opsapi-dashboard/templates/ingress.yaml
+++ b/devops/helm-charts/opsapi-dashboard/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+# Ingress for the dashboard UI host. className `wslproxy` — identical to the
+# workstation-opsapi API Ingress and the working beacon *.workstation.co.uk
+# hosts. TLS is terminated at the WSL Proxy edge (ssl_enabled in the committed
+# server JSON); traefik serves plain HTTP :80 behind it and routes by Host
+# header, so NO tls block / NO cert-manager here. DNS (host → pop0.wslproxy.com)
+# and the edge vhost/rule are wired by the deploy workflow, not external-dns.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    - host: {{ .Values.ingress.hostname }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}
+                port:
+                  number: {{ .Values.service.port }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/devops/helm-charts/opsapi-dashboard/templates/service.yaml
+++ b/devops/helm-charts/opsapi-dashboard/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+  selector:
+    app: {{ .Release.Name }}
+  type: {{ .Values.service.type }}

--- a/devops/helm-charts/opsapi-dashboard/values-workstation-int.yaml
+++ b/devops/helm-charts/opsapi-dashboard/values-workstation-int.yaml
@@ -1,0 +1,26 @@
+# ── OpsAPI Dashboard on workstation.co.uk — INTEGRATION ─────────────────────
+# Helm RELEASE: workstation-opsapi-dashboard   Namespace: int   Cluster: k3s1
+# Public host: https://int-opsapi-ui.workstation.co.uk
+#   → calls the API at https://int-opsapi.workstation.co.uk (workstation-opsapi)
+#
+# Layered on top of values.yaml by deploy-workstation-dashboard.yml. Only the
+# fields that differ from the base defaults (or that other jobs read) live here.
+env: int
+
+# The API this UI calls. Baked into the browser bundle at BUILD time
+# (--build-arg NEXT_PUBLIC_API_URL) by the deploy workflow.
+apiUrl: https://int-opsapi.workstation.co.uk
+
+# Single source of truth for the DNS + wslproxy jobs (read via awk). MUST equal
+# ingress.hostname below.
+host: int-opsapi-ui.workstation.co.uk
+
+ingress:
+  enabled: true
+  className: wslproxy
+  hostname: int-opsapi-ui.workstation.co.uk
+  annotations: {}
+  tls: []
+
+nodeSelector:
+  kubernetes.io/hostname: debworker00

--- a/devops/helm-charts/opsapi-dashboard/values.yaml
+++ b/devops/helm-charts/opsapi-dashboard/values.yaml
@@ -1,0 +1,62 @@
+# Base defaults for the opsapi-dashboard chart. Per-env overrides live in
+# values-workstation-<env>.yaml and are layered on top by the deploy workflow.
+env: int
+
+# The opsapi backend this dashboard talks to. NOTE: Next.js inlines
+# NEXT_PUBLIC_* at BUILD time, so the image must be BUILT with
+#   --build-arg NEXT_PUBLIC_API_URL=<this value>
+# (the deploy workflow does this from `apiUrl`). The runtime env below is for
+# server-side reads only; the browser bundle uses the build-time value.
+apiUrl: https://int-opsapi.workstation.co.uk
+
+# Bumped by the deploy workflow (build timestamp) to force a re-pull of :latest.
+deployedAt: "unset"
+
+# opsapi-dashboard image, built from opsapi-dashboard/ and pushed to public
+# Docker Hub by .github/workflows/deploy-workstation-dashboard.yml. Public repo
+# → no imagePullSecret needed.
+image:
+  repository: bwalia/opsapi-dashboard
+  tag: latest
+  pullPolicy: Always
+imagePullSecretName: ""
+
+service:
+  type: ClusterIP
+  port: 8039
+  targetPort: 8039
+
+ingress:
+  enabled: true
+  className: wslproxy
+  hostname: int-opsapi-ui.workstation.co.uk
+  annotations: {}
+  tls: []
+
+# The Next.js standalone server serves the /login page (200) before auth — a
+# cheap, dependency-free readiness signal.
+livenessProbe:
+  enabled: true
+  path: /login
+  port: 8039
+readinessProbe:
+  enabled: true
+  path: /login
+  port: 8039
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+  limits:
+    memory: 512Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 2
+
+# Pin to debworker00 (debian node with disk headroom), matching the API pod.
+nodeSelector:
+  kubernetes.io/hostname: debworker00
+tolerations: []


### PR DESCRIPTION
Two related productionisation changes for the workstation-opsapi stack.

## 1. Database isolation 🔒
`workstation-opsapi` was sharing **diytaxreturn-lapis's live `opsapi` database** — verified 2026-08-10: byte-identical `database_size_bytes`, same 810 users, same `POSTGRES_HOST/DB/USER`. Both releases pull `POSTGRES_*` from the same Vault ExternalSecret. **No data isolation.**

It now runs on its **own `workstation_opsapi` database** on the same Postgres server.

| | before | after |
|---|---|---|
| POSTGRES_DB | `opsapi` (shared) | **`workstation_opsapi`** |
| users visible | 810 (diytax) | **2** (own admin + migration seed) |
| projectCode | `tax_copilot` | **`all`** (full product incl. Domains) |
| super admin | — | **tenthmatrix.mailer@gmail.com** (+ `workstation` namespace) |

- `deployment.yaml`: `database.name` → explicit `POSTGRES_DB` env that wins over the shared ExternalSecret (config.lua + `lapis migrate` both read `os.getenv("POSTGRES_DB")`).
- `cronjob.yaml`: the pg_dump backups now target the release's own DB, not the co-tenant's.
- `values-workstation-int.yaml`: isolated `database.name`, `projectCode: all`, admin seed, and `corsAllowedDomains: workstation.co.uk` (so the UI can call the API cross-origin).
- **Prerequisite** (documented in values): `CREATE DATABASE workstation_opsapi OWNER pguser` once before deploy (pguser lacks CREATEDB); the postStart bootstrap migrates it fresh + seeds the admin. **Already provisioned + verified live** (246 tables, `opsapi` untouched at 137).

## 2. Admin UI dashboard 🖥️
New `opsapi-dashboard` chart + `deploy-workstation-dashboard.yml` serve the Next.js admin UI at **https://int-opsapi-ui.workstation.co.uk**, calling the API at https://int-opsapi.workstation.co.uk.

Same infra as the API + the working beacon `*.workstation.co.uk` hosts:
- `ingress.className: wslproxy`; TLS terminated at the WSL Proxy edge.
- Stub edge vhost `host:int-opsapi-ui.workstation.co.uk` reusing the `opsapi-prod-default` rule (same k3s ingress backend, routed by Host).
- `NEXT_PUBLIC_API_URL` **baked at build time** (read from the chart's `apiUrl:` so build ↔ runtime can't drift).
- Fully automated: **build → Cloudflare DNS → wslproxy register → helm upgrade**, mirroring deploy-k3s.yml (self-hosted runner, `KUBE_CONFIG_DATA_K3S`, `DOCKER_USERNAME`/`DOCKER_PASSWD`, `cloudflare-dns.sh`).

## On merge
- `deploy-k3s.yml` redeploys the API with the isolated DB + CORS (no-op migration; DB already isolated).
- `deploy-workstation-dashboard.yml` builds `bwalia/opsapi-dashboard`, wires DNS + edge, and rolls out the UI.

## Verified
- Chart lint clean; `helm template` renders `POSTGRES_DB=workstation_opsapi` (deployment + both cronjobs), `PROJECT_CODE=all`, `CORS_ALLOWED_DOMAINS=workstation.co.uk`; dashboard renders `ingressClassName: wslproxy`, host `int-opsapi-ui`, `NEXT_PUBLIC_API_URL=https://int-opsapi.workstation.co.uk`.
- UI vhost passes the register validator (`rules` → `opsapi-prod-default`).
- Live isolation confirmed: `int-opsapi` health → `workstation_opsapi` (2 users); diytaxreturn `opsapi` untouched.

⚠️ Note: a migration seeds a default platform admin `diytaxreturnmail@gmail.com` on every fresh DB (shared code). Flagging for a follow-up to disable it on the workstation instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)