### PR TITLE
perf(dashboard-ci): persistent buildx builder + inline cache (cut push time)

### DIFF
--- a/.github/workflows/deploy-workstation-dashboard.yml
+++ b/.github/workflows/deploy-workstation-dashboard.yml
@@ -73,8 +73,19 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWD }}
 
-      - name: Set up Docker Buildx
+      - name: Set up Docker Buildx (persistent builder)
         uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+          # FIXED builder name + keep-state: on this self-hosted runner the
+          # BuildKit instance and its cache are NOT torn down between runs, so
+          # the Dockerfile's RUN --mount=type=cache mounts (npm cache, Next.js
+          # build cache) AND the multi-stage layer cache persist locally.
+          # Unchanged package-lock.json => the whole `npm ci` deps layer is a
+          # cache HIT: not rebuilt, and never re-uploaded. This is the main win
+          # — no registry round-trip for the ~682 MB deps stage.
+          name: opsapi-dashboard-builder
+          keep-state: true
 
       - name: Determine build metadata + API URL
         id: meta
@@ -106,11 +117,18 @@ jobs:
           tags: |
             ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
             ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.IMAGE_TAG }}
-          # Registry layer cache — reuses the npm-ci deps stage unless the
-          # lockfile changed (see the Dockerfile), so most builds skip the
-          # heavy install. mode=max also caches the Next.js build cache.
-          cache-from: type=registry,ref=${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
-          cache-to: type=registry,ref=${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
+          # UPLOAD OPTIMISATION. The old `cache-to mode=max` re-exported every
+          # stage (incl. the ~682 MB node_modules) to a registry :buildcache tag
+          # on EVERY run — that was the slow "push". Instead we now:
+          #   • rely on the persistent builder above for the deps/build cache
+          #     (local, zero upload), and
+          #   • embed cache metadata INLINE in the pushed :latest image
+          #     (cache-to type=inline) — so there is NO separate cache blob to
+          #     upload; only the final image's own layers are pushed.
+          # cache-from reads that inline cache from :latest to warm a cold
+          # builder (e.g. after a runner reset) without a mode=max blob.
+          cache-from: type=registry,ref=${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          cache-to: type=inline
           provenance: false
 
   # =========================================================================


### PR DESCRIPTION
Re-PR of a commit that missed the #544 merge (the PR was merged at its first commit, before this optimization was pushed to the branch — main still has the old `mode=max` cache).

## Problem
`deploy-workstation-dashboard.yml`'s build used `cache-to: mode=max`, which re-exported **every** stage — including the ~682 MB `npm ci` node_modules — to a registry `:buildcache` tag on **every run**. That export is the slow "push" the deploy spends time on.

## Fix
- **Persistent buildx builder** (`name:` + `keep-state: true`): on the self-hosted runner the BuildKit instance and its cache (the Dockerfile's `RUN --mount=type=cache` npm + Next.js caches, plus the multi-stage layer cache) survive between runs. Unchanged `package-lock.json` → the whole `npm ci` layer is a cache **HIT** (not rebuilt, not uploaded).
- **`cache-to: type=inline`** instead of registry `mode=max`: cache metadata is embedded in the pushed `:latest` image, so there is **no separate cache blob to upload** — only the final image's own layers are pushed. `cache-from` reads that inline cache from `:latest` to warm a cold builder.

## Effect
| unchanged-deps rebuild | before | after |
|---|---|---|
| deps (node_modules) upload | ~682 MB every run | **0** (local cache hit) |
| separate cache blob | pushed every run | **none** (inline) |
| pushed per run | cache blob + app layers | **only app layers** |

Chart/app unaffected — CI-only. YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)