### PR TITLE
feat(domains): render wslproxy rule too + template-driven, schema-resilient sync

### DIFF
--- a/lapis/helper/wslproxy-server.lua
+++ b/lapis/helper/wslproxy-server.lua
@@ -1,52 +1,96 @@
 --[[
-    WSL Proxy Server (vhost) Renderer
-    =================================
+    WSL Proxy Renderer (template-driven)
+    ====================================
 
-    Turns an opsapi `domains` row into a WSL Proxy server-config file matching
-    the shape consumed by diy-tax-return-uk's
-    .github/wslproxy/data/servers/<env>/host:<domain>.json and the
-    wslproxy-register-domains.yml workflow.
+    Turns opsapi `domains` rows into WSL Proxy config files matching the shape
+    consumed by the wslproxy-register-domains.yml workflow and the edge control
+    plane, for BOTH objects a working host needs:
 
-    The committed convention (verified against existing files):
-      - `config` is a base64-encoded nginx server block
-      - `config_status` is false (staged; the register workflow flips it live)
-      - `rules` references a rule id in data/rules/<env>/
-      - `id` and filename are `host:<server_name>`
+      * server (vhost)  -> data/servers/<env>/host:<domain>.json
+      * rule            -> data/rules/<env>/<rule_id>.json   (the backend)
+
+    Previously only servers were rendered — the `rules` field just referenced a
+    rule id that had to be hand-authored, so a synced domain never actually
+    routed. This module now renders the rule too.
+
+    SCALABILITY: the JSON shapes are TEMPLATES (plain strings with {{...}}
+    placeholders), not hand-built Lua tables. Defaults live here; a namespace
+    can override them from Sync Settings (dashboard). When wslproxy adds a
+    field, edit the template DATA — no code change, no redeploy. Because we fill
+    templates by string substitution (never a cjson decode->encode round-trip),
+    the exact JSON shape is preserved — including `{}` vs `[]` for empty
+    values — so the old `match_cases:[]`->`{}` fix-up hack is gone.
+
+    Servers are rendered as STUBS (config_status:false, no nginx `config`
+    block): the register workflow (ACTIVATE_CONFIG=true) compiles the config
+    edge-side, exactly like the working beacon/*.workstation.co.uk hosts. That
+    keeps opsapi's schema surface to the handful of fields it actually owns.
 ]]
 
 local cjson = require("cjson")
 
 local WslproxyServer = {}
 
--- Base64-encode a plaintext nginx config (matches the committed import format).
-local function b64(s)
-    if ngx and ngx.encode_base64 then return ngx.encode_base64(s) end
-    -- Fallback (non-nginx contexts) — should not be hit in the worker.
-    local mime_ok, mime = pcall(require, "mime")
-    if mime_ok then return (mime.b64(s)) end
-    return s
+-- ── Default templates ─────────────────────────────────────────────────────
+-- String placeholders ("{{x}}") sit INSIDE the template's quotes and receive a
+-- JSON-escaped string. Raw placeholders (arrays/booleans) sit OUTSIDE quotes
+-- and receive a ready-made JSON fragment ({{listens_json}}, {{ssl_enabled}}…).
+
+WslproxyServer.DEFAULT_SERVER_TEMPLATE = [[{
+  "id": "host:{{server_name}}",
+  "server_name": "{{server_name}}",
+  "proxy_server_name": "{{server_name}}",
+  "root": "{{root}}",
+  "index": "index.html",
+  "access_log": "logs/{{server_name}}.access.log",
+  "error_log": "logs/{{server_name}}.error.log",
+  "config_status": false,
+  "profile_id": "{{profile_id}}",
+  "rules": "{{rules}}",
+  "listens": {{listens_json}},
+  "ssl_enabled": {{ssl_enabled}},
+  "ssl_force_https": {{ssl_force_https}},
+  "ssl_staging": {{ssl_staging}},
+  "ssl_auto_renew": {{ssl_auto_renew}},
+  "ssl_email": "{{ssl_email}}",
+  "cache_enabled": false,
+  "match_cases": {},
+  "custom_headers": []
+}]]
+
+WslproxyServer.DEFAULT_RULE_TEMPLATE = [[{
+  "id": "{{rule_id}}",
+  "name": "{{rule_id}}",
+  "profile_id": "{{profile_id}}",
+  "priority": 1,
+  "rules_tags": ["opsapi", "domains"],
+  "match": {
+    "rules": { "path": "/", "path_key": "starts_with" },
+    "response": {
+      "code": 305,
+      "redirect_uri": "{{backend}}",
+      "strip_path": false,
+      "backends": [ { "address": "{{backend}}", "weight": 100, "label": "opsapi-managed domain backend" } ],
+      "routing": { "mode": "least_conn" }
+    }
+  },
+  "servers": {{servers_json}}
+}]]
+
+-- ── small helpers ─────────────────────────────────────────────────────────
+
+local function trim(s)
+    if s == nil then return "" end
+    return (tostring(s):gsub("^%s+", ""):gsub("%s+$", ""))
 end
 
--- Render the nginx server block for a domain (mirrors the existing template).
-local function nginx_config(domain)
-    local name = domain.domain_name
-    local root = domain.wslproxy_root or "/var/www/html"
-    local lines = {
-        "server {",
-        "      listen 80;  # Listen on port (HTTP)",
-        "      server_name " .. name .. ";  # Your domain name",
-        "      root " .. root .. ";  # Document root directory",
-        "      index index.html;  # Default index files",
-        "      access_log logs/" .. name .. ".access.log;  # Access log file location",
-        "      error_log logs/" .. name .. ".error.log;  # Error log file location",
-        "",
-        "",
-        "",
-        "  }",
-        "",
-        "  ",
-    }
-    return table.concat(lines, "\n")
+-- Escape a value for insertion into a JSON string literal (the template
+-- supplies the surrounding quotes).
+local function json_escape(s)
+    s = tostring(s == nil and "" or s)
+    s = s:gsub('\\', '\\\\'):gsub('"', '\\"')
+    s = s:gsub('\n', '\\n'):gsub('\r', '\\r'):gsub('\t', '\\t')
+    return s
 end
 
 local function bool(v, default)
@@ -57,108 +101,201 @@ local function bool(v, default)
     return default
 end
 
---- Build the listens array from a comma-separated port list ("80,443").
-local function build_listens(listen_ports)
+local function bool_json(v, default)
+    return bool(v, default) and "true" or "false"
+end
+
+-- opsapi-<domain-with-dashes>, a safe per-domain default rule id that will not
+-- collide with hand-authored infra rules (e.g. opsapi-prod-default).
+local function default_rule_id(domain_name)
+    local slug = tostring(domain_name or ""):lower():gsub("[^%w]+", "-"):gsub("^%-+", ""):gsub("%-+$", "")
+    if slug == "" then slug = "domain" end
+    return "opsapi-" .. slug
+end
+
+-- Build the listens JSON array from a comma-separated port list ("80,443").
+local function listens_json(listen_ports)
     local out = {}
     for p in tostring(listen_ports or "80"):gmatch("[^,%s]+") do
         table.insert(out, { listen = p })
     end
     if #out == 0 then out = { { listen = "80" } } end
-    return out
+    return cjson.encode(out)
 end
 
---- Render a domain row to a WSL Proxy server config table.
--- @param domain table domains row (with wslproxy fields)
--- @return table { filename, env, id, content } where content is the Lua table
-function WslproxyServer.render(domain)
+-- Fill {{placeholders}} from a precomputed var map (each value is already the
+-- final JSON representation: escaped string body, or a raw JSON fragment).
+-- Function replacement avoids Lua's % handling in gsub replacements. Any
+-- placeholder without a var is left intact so validate() flags the mismatch.
+local function fill(tpl, vars)
+    return (tpl:gsub("{{([%w_]+)}}", function(key)
+        local v = vars[key]
+        if v == nil then return "{{" .. key .. "}}" end
+        return v
+    end))
+end
+
+-- Parse the filled template; returns (ok, err). Catches template/var mistakes
+-- before anything is committed.
+local function validate_json(s)
+    local ok, decoded = pcall(cjson.decode, s)
+    if not ok then return false, tostring(decoded) end
+    if type(decoded) ~= "table" then return false, "not a JSON object" end
+    return true
+end
+
+-- ── effective per-domain values ───────────────────────────────────────────
+
+-- Rule id a domain's server references: explicit column > settings default >
+-- a per-domain default (opsapi-<domain>). Per-domain default keeps each domain
+-- self-contained and never clobbers a shared hand-authored rule.
+function WslproxyServer.effective_rule_id(domain, opts)
+    local rid = trim(domain.wslproxy_rule_id)
+    if rid ~= "" then return rid end
+    rid = trim(opts and opts.default_rule_id)
+    if rid ~= "" then return rid end
+    return default_rule_id(domain.domain_name)
+end
+
+-- Backend a rule points at: the domain's proxy_target > settings default.
+local function effective_backend(domain, opts)
+    local b = trim(domain.proxy_target)
+    if b ~= "" then return b end
+    return trim(opts and opts.default_backend)
+end
+
+-- ── renderers ──────────────────────────────────────────────────────────────
+
+--- Render one domain row to a WSL Proxy server (vhost) JSON string.
+-- @return string json, string filename, string env, string|nil err
+function WslproxyServer.render_server(domain, env, opts)
+    opts = opts or {}
     local name = domain.domain_name
-    local env = domain.environment or "prod"
-    local id = "host:" .. name
-
-    local config = {
-        id = id,
-        server_name = name,
-        proxy_server_name = name,
-        profile_id = env,
-        rules = domain.wslproxy_rule_id or "",
-        config_status = false, -- staged; register workflow activates
-        ssl_enabled = bool(domain.ssl_enabled, true),
-        ssl_email = domain.ssl_email or "",
-        ssl_auto_renew = bool(domain.ssl_auto_renew, true),
-        ssl_force_https = bool(domain.ssl_force_https, true),
-        ssl_staging = bool(domain.ssl_staging, false),
-        cache_enabled = false,
-        index = "index.html",
-        root = domain.wslproxy_root or "/var/www/html",
-        access_log = "logs/" .. name .. ".access.log",
-        error_log = "logs/" .. name .. ".error.log",
-        -- Empty Lua tables encode as {} objects (matching the committed files).
-        custom_headers = {},
-        match_cases = {},
-        listens = build_listens(domain.listen_ports),
-        config = b64(nginx_config(domain)),
+    local tpl = (opts.server_template and trim(opts.server_template) ~= "" and opts.server_template)
+        or WslproxyServer.DEFAULT_SERVER_TEMPLATE
+    local vars = {
+        server_name    = json_escape(name),
+        root           = json_escape(domain.wslproxy_root or "/var/www/html"),
+        profile_id     = json_escape(env),
+        rules          = json_escape(WslproxyServer.effective_rule_id(domain, opts)),
+        ssl_email      = json_escape(domain.ssl_email or ""),
+        listens_json   = listens_json(domain.listen_ports),
+        ssl_enabled     = bool_json(domain.ssl_enabled, true),
+        ssl_force_https = bool_json(domain.ssl_force_https, true),
+        ssl_staging     = bool_json(domain.ssl_staging, false),
+        ssl_auto_renew  = bool_json(domain.ssl_auto_renew, true),
     }
+    local json = fill(tpl, vars)
+    local ok, err = validate_json(json)
+    if not ok then return nil, "host:" .. name .. ".json", env, "invalid server JSON: " .. err end
+    return json, "host:" .. name .. ".json", env
+end
 
-    return {
-        filename = "host:" .. name .. ".json",
-        env = env,
-        id = id,
-        content = config,
+--- Render one rule JSON string.
+-- @param rule_id string
+-- @param backend string  backend address (host:port)
+-- @param servers table   list of server ids ("host:<domain>") referencing it
+-- @return string json, string filename, string|nil err
+function WslproxyServer.render_rule(rule_id, backend, servers, env, opts)
+    opts = opts or {}
+    local tpl = (opts.rule_template and trim(opts.rule_template) ~= "" and opts.rule_template)
+        or WslproxyServer.DEFAULT_RULE_TEMPLATE
+    local vars = {
+        rule_id      = json_escape(rule_id),
+        profile_id   = json_escape(env),
+        backend      = json_escape(backend),
+        servers_json = cjson.encode(servers or {}),
     }
+    local json = fill(tpl, vars)
+    local ok, err = validate_json(json)
+    if not ok then return nil, rule_id .. ".json", "invalid rule JSON: " .. err end
+    return json, rule_id .. ".json"
 end
 
--- opsapi's cjson encodes empty Lua tables as `[]`. The committed wslproxy files
--- use `{}` for custom_headers / match_cases — force those two back to objects.
--- Deterministic: only these two keys are ever empty tables in the payload.
-function WslproxyServer.encode(content)
-    local s = cjson.encode(content)
-    s = s:gsub('"custom_headers":%[%]', '"custom_headers":{}')
-    s = s:gsub('"match_cases":%[%]', '"match_cases":{}')
-    return s
-end
+-- ── repo paths ──────────────────────────────────────────────────────────────
 
---- Convenience: render to a compact JSON string (wslproxy-faithful).
-function WslproxyServer.render_json(domain)
-    local rendered = WslproxyServer.render(domain)
-    return WslproxyServer.encode(rendered.content), rendered.filename, rendered.env
-end
-
---- Repo path (relative) for a rendered server file under a data root.
--- @param env string environment/profile
--- @param filename string host:<domain>.json
--- @param base string|nil data root (default .github/wslproxy/data)
 function WslproxyServer.repo_path(env, filename, base)
     base = base or ".github/wslproxy/data"
     return base .. "/servers/" .. env .. "/" .. filename
 end
 
+function WslproxyServer.rule_repo_path(env, filename, base)
+    base = base or ".github/wslproxy/data"
+    return base .. "/rules/" .. env .. "/" .. filename
+end
+
 --- Path of the opsapi-managed-domains manifest. Deliberately OUTSIDE
---- servers/<env>/ (which the register workflow globs as *.json) so it is never
---- treated as a vhost. The DNS reconcile reads this to scope reconciliation to
---- opsapi-managed domains only (never the hand-authored ones).
+--- servers/<env>/ (globbed as vhosts) so it is never treated as one.
 function WslproxyServer.manifest_path(env)
     return ".github/wslproxy/opsapi/domains-" .. env .. ".json"
 end
 
---- Build the full set of files to commit for a namespace's domains in one env:
---- one server file per domain PLUS the opsapi-managed manifest.
--- @param domains table list of domain rows
--- @param env string environment
--- @param data_base string|nil server data root
--- @return { files = {{path,content}...}, rendered = {{path,server_name,content}...}, count }
-function WslproxyServer.build_sync_files(domains, env, data_base)
-    local files, rendered, manifest = {}, {}, {}
+-- ── the sync builder ──────────────────────────────────────────────────────
+
+--- Build every file to commit for a namespace's domains in one env: a server
+--- stub per domain, a rule per distinct rule id (with a resolvable backend),
+--- plus the opsapi-managed manifest.
+-- @param domains table   list of domain rows
+-- @param env string      environment/profile
+-- @param data_base string|nil  data root (default .github/wslproxy/data)
+-- @param opts table|nil  { server_template, rule_template, default_rule_id,
+--                          default_backend, sync_rules (default true) }
+-- @return { files={{path,content}...}, rendered={{path,server_name,content}...},
+--           count, rules_count, warnings={...} }
+function WslproxyServer.build_sync_files(domains, env, data_base, opts)
+    opts = opts or {}
+    local sync_rules = opts.sync_rules ~= false -- default ON
+    local files, rendered, manifest, warnings = {}, {}, {}, {}
+    -- rule_id -> { backend, servers = {server-id...} }
+    local rules = {}
+    local rule_order = {}
+
     for _, d in ipairs(domains or {}) do
         if (d.environment or "prod") == env then
-            local r = WslproxyServer.render(d)
-            local path = WslproxyServer.repo_path(env, r.filename, data_base)
-            local content = WslproxyServer.encode(r.content)
-            table.insert(files, { path = path, content = content })
-            table.insert(rendered, { path = path, server_name = d.domain_name, content = content })
-            table.insert(manifest, { server_name = d.domain_name, target = d.proxy_target or "" })
+            local json, filename, _, serr = WslproxyServer.render_server(d, env, opts)
+            if not json then
+                table.insert(warnings, serr or ("could not render " .. tostring(d.domain_name)))
+            else
+                local path = WslproxyServer.repo_path(env, filename, data_base)
+                table.insert(files, { path = path, content = json })
+                table.insert(rendered, { path = path, server_name = d.domain_name, content = json })
+                table.insert(manifest, { server_name = d.domain_name, target = d.proxy_target or "" })
+
+                -- Accumulate the rule this server references.
+                local rid = WslproxyServer.effective_rule_id(d, opts)
+                if not rules[rid] then
+                    rules[rid] = { backend = effective_backend(d, opts), servers = {} }
+                    table.insert(rule_order, rid)
+                elseif trim(rules[rid].backend) == "" then
+                    rules[rid].backend = effective_backend(d, opts)
+                end
+                table.insert(rules[rid].servers, "host:" .. d.domain_name)
+            end
         end
     end
-    if #files > 0 then
+
+    local rules_count = 0
+    if sync_rules then
+        for _, rid in ipairs(rule_order) do
+            local r = rules[rid]
+            if trim(r.backend) == "" then
+                table.insert(warnings, "rule '" .. rid .. "' skipped: no proxy_target/default_backend "
+                    .. "— set one to generate its backend")
+            else
+                local json, filename, rerr = WslproxyServer.render_rule(rid, r.backend, r.servers, env, opts)
+                if not json then
+                    table.insert(warnings, rerr or ("could not render rule " .. rid))
+                else
+                    local path = WslproxyServer.rule_repo_path(env, filename, data_base)
+                    table.insert(files, { path = path, content = json })
+                    table.insert(rendered, { path = path, server_name = "(rule) " .. rid, content = json })
+                    rules_count = rules_count + 1
+                end
+            end
+        end
+    end
+
+    if #manifest > 0 then
         local mpath = WslproxyServer.manifest_path(env)
         local mcontent = cjson.encode({
             environment = env,
@@ -169,7 +306,14 @@ function WslproxyServer.build_sync_files(domains, env, data_base)
         table.insert(files, { path = mpath, content = mcontent })
         table.insert(rendered, { path = mpath, server_name = "(opsapi manifest)", content = mcontent })
     end
-    return { files = files, rendered = rendered, count = #manifest }
+
+    return {
+        files = files,
+        rendered = rendered,
+        count = #manifest,
+        rules_count = rules_count,
+        warnings = warnings,
+    }
 end
 
 return WslproxyServer

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -1732,6 +1732,7 @@ local _migrations = {
     ['607_domain_wslproxy_fields'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_wslproxy_fields_migrations, 1),
     ['608_domain_pipeline_runs'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_pipeline_runs_migrations, 1),
     ['609_domain_sync_settings'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_sync_settings_migrations, 1),
+    ['612_domain_sync_templates'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_sync_settings_migrations, 2),
 
     -- CRM menu items (720-723): surface CRM in the backend-driven sidebar
     ['720_seed_crm_menu_items'] = conditional_array(ProjectConfig.FEATURES.CRM, crm_menu_items_migrations, 1),

--- a/lapis/migrations/domain-sync-settings.lua
+++ b/lapis/migrations/domain-sync-settings.lua
@@ -52,4 +52,20 @@ return {
 
         pcall(function() db.query([[CREATE INDEX domain_sync_settings_namespace_idx ON domain_sync_settings (namespace_id)]]) end)
     end,
+
+    -- [2] Template-driven wslproxy rendering + rule generation (see
+    -- helper/wslproxy-server.lua). All nullable — NULL means "use the built-in
+    -- default template", so this is fully backward-compatible.
+    [2] = function()
+        if not table_exists("domain_sync_settings") then return end
+        local function add(sql) pcall(function() db.query(sql) end) end
+        -- Override JSON templates ({{placeholder}} strings). NULL -> code default.
+        add([[ALTER TABLE domain_sync_settings ADD COLUMN IF NOT EXISTS server_template TEXT]])
+        add([[ALTER TABLE domain_sync_settings ADD COLUMN IF NOT EXISTS rule_template TEXT]])
+        -- Fallbacks when a domain row leaves wslproxy_rule_id / proxy_target blank.
+        add([[ALTER TABLE domain_sync_settings ADD COLUMN IF NOT EXISTS default_rule_id TEXT]])
+        add([[ALTER TABLE domain_sync_settings ADD COLUMN IF NOT EXISTS default_backend TEXT]])
+        -- Whether the sync also emits rule files (default on).
+        add([[ALTER TABLE domain_sync_settings ADD COLUMN IF NOT EXISTS sync_rules BOOLEAN DEFAULT TRUE]])
+    end,
 }

--- a/lapis/queries/DomainSyncSettingsQueries.lua
+++ b/lapis/queries/DomainSyncSettingsQueries.lua
@@ -13,7 +13,12 @@ local db = require("lapis.db")
 
 local DomainSyncSettingsQueries = {}
 
-local WRITABLE = { "owner", "repo", "branch", "github_integration_id", "data_base", "default_environment" }
+local WRITABLE = {
+    "owner", "repo", "branch", "github_integration_id", "data_base", "default_environment",
+    -- Template-driven wslproxy rendering (see helper/wslproxy-server.lua).
+    -- All optional; blank/NULL falls back to the built-in defaults.
+    "server_template", "rule_template", "default_rule_id", "default_backend", "sync_rules",
+}
 
 --- Get the namespace's settings (or nil).
 function DomainSyncSettingsQueries.get(namespace_id)
@@ -51,6 +56,12 @@ end
 function DomainSyncSettingsQueries.resolve(namespace_id, req)
     req = req or {}
     local s = DomainSyncSettingsQueries.get(namespace_id) or {}
+    -- sync_rules is a tri-state (true/false/nil). Only treat an explicit false
+    -- as "off"; nil anywhere means "use default (on)".
+    local function first_defined(a, b)
+        if a ~= nil then return a end
+        return b
+    end
     local eff = {
         owner = req.owner or s.owner,
         repo = req.repo or s.repo,
@@ -58,6 +69,12 @@ function DomainSyncSettingsQueries.resolve(namespace_id, req)
         github_integration_id = req.github_integration_id or s.github_integration_id,
         data_base = req.data_base or s.data_base,
         environment = req.environment or s.default_environment or "prod",
+        -- Template-driven rendering (nil -> helper uses its built-in default).
+        server_template = req.server_template or s.server_template,
+        rule_template = req.rule_template or s.rule_template,
+        default_rule_id = req.default_rule_id or s.default_rule_id,
+        default_backend = req.default_backend or s.default_backend,
+        sync_rules = first_defined(req.sync_rules, s.sync_rules),
     }
     local missing = {}
     if not eff.owner or eff.owner == "" then table.insert(missing, "owner") end

--- a/lapis/queries/DomainSyncSettingsQueries.lua
+++ b/lapis/queries/DomainSyncSettingsQueries.lua
@@ -20,6 +20,51 @@ local WRITABLE = {
     "server_template", "rule_template", "default_rule_id", "default_backend", "sync_rules",
 }
 
+--- Parse a GitHub repo reference into { owner, repo, branch? }. Lets a caller
+--- paste the repo URL instead of entering owner + repo separately (fewer
+--- fields, no misconfiguration). Accepts, case-insensitively:
+---   https://github.com/owner/repo(.git)         git@github.com:owner/repo.git
+---   https://github.com/owner/repo/tree/<branch> ssh://git@github.com/owner/repo
+---   github.com/owner/repo                        owner/repo   (shorthand)
+--- Returns nil if it cannot find both owner and repo.
+function DomainSyncSettingsQueries.parse_repo_url(url)
+    if type(url) ~= "string" then return nil end
+    local s = url:gsub("^%s+", ""):gsub("%s+$", "")
+    if s == "" then return nil end
+    s = s:gsub("[?#].*$", "")                 -- drop ?query / #fragment
+    s = s:gsub("^git@[Gg]it[Hh]ub%.com:", "") -- scp-style ssh
+    s = s:gsub("^ssh://git@[Gg]it[Hh]ub%.com/", "")
+    s = s:gsub("^%w+://", "")                 -- http(s):// etc.
+    s = s:gsub("^www%.", "")
+    s = s:gsub("^[Gg]it[Hh]ub%.com/", "")     -- host
+    s = s:gsub("^/+", "")                      -- leading slashes
+    local owner, repo = s:match("^([^/]+)/([^/]+)")
+    if not owner or not repo or owner == "" or repo == "" then return nil end
+    repo = repo:gsub("%.git$", "")
+    if repo == "" then return nil end
+    local branch = s:match("^[^/]+/[^/]+/tree/([^/]+)")
+    return { owner = owner, repo = repo, branch = branch }
+end
+
+-- If params carry a repo_url, derive owner/repo (and branch, when the URL
+-- includes /tree/<branch>) from it. The pasted URL is the single source of
+-- truth for the target, so it wins over any stray owner/repo the caller sent.
+-- Mutates and returns the same table. A repo_url that cannot be parsed is left
+-- for the caller's missing-owner/repo validation to reject with a clear error.
+local function apply_repo_url(t)
+    if type(t) ~= "table" or t.repo_url == nil then return t end
+    local parsed = DomainSyncSettingsQueries.parse_repo_url(t.repo_url)
+    if parsed then
+        t.owner = parsed.owner
+        t.repo = parsed.repo
+        local b = t.branch
+        if parsed.branch and parsed.branch ~= "" and (b == nil or tostring(b):gsub("%s+", "") == "") then
+            t.branch = parsed.branch
+        end
+    end
+    return t
+end
+
 --- Get the namespace's settings (or nil).
 function DomainSyncSettingsQueries.get(namespace_id)
     local rows = db.query("SELECT * FROM domain_sync_settings WHERE namespace_id = ? LIMIT 1", namespace_id)
@@ -28,6 +73,7 @@ end
 
 --- Create or update the single settings row for a namespace.
 function DomainSyncSettingsQueries.upsert(namespace_id, params)
+    params = apply_repo_url(params or {}) -- pasted repo_url -> owner/repo/branch
     local existing = DomainSyncSettingsQueries.get(namespace_id)
 
     local set = {}
@@ -54,7 +100,7 @@ end
 -- Returns { owner, repo, branch, github_integration_id, data_base, environment }
 -- and a list of missing required fields.
 function DomainSyncSettingsQueries.resolve(namespace_id, req)
-    req = req or {}
+    req = apply_repo_url(req or {}) -- a per-request repo_url overrides the target
     local s = DomainSyncSettingsQueries.get(namespace_id) or {}
     -- sync_rules is a tri-state (true/false/nil). Only treat an explicit false
     -- as "off"; nil anywhere means "use default (on)".

--- a/lapis/routes/domains.lua
+++ b/lapis/routes/domains.lua
@@ -342,6 +342,10 @@ return function(app)
 
             local SyncSettings = require("queries.DomainSyncSettingsQueries")
             local saved = SyncSettings.upsert(self.namespace.id, {
+                -- Callers may paste a repo URL instead of owner+repo; upsert
+                -- derives owner/repo (and branch) from it. owner/repo are still
+                -- honoured when sent explicitly (e.g. an older client).
+                repo_url = data.repo_url,
                 owner = data.owner,
                 repo = data.repo,
                 branch = data.branch,

--- a/lapis/routes/domains.lua
+++ b/lapis/routes/domains.lua
@@ -172,7 +172,16 @@ return function(app)
             -- (+ the opsapi-managed manifest used by the DNS reconcile).
             local WslproxyServer = require("helper.wslproxy-server")
             local rows = DomainQueries.getAllForNamespace(self.namespace.id)
-            local built = WslproxyServer.build_sync_files(rows, env, eff.data_base)
+            -- Pass the namespace's template + rule defaults so rendering is
+            -- data-driven (dashboard-configurable), not hardcoded. Also emits a
+            -- rule file per referenced rule id so a synced domain actually routes.
+            local built = WslproxyServer.build_sync_files(rows, env, eff.data_base, {
+                server_template = eff.server_template,
+                rule_template   = eff.rule_template,
+                default_rule_id = eff.default_rule_id,
+                default_backend = eff.default_backend,
+                sync_rules      = eff.sync_rules,
+            })
             local files = built.files
             local rendered = built.rendered
 
@@ -182,7 +191,8 @@ return function(app)
 
             -- Dry-run: return the rendered files without committing.
             if data.dry_run == true or data.dry_run == "true" then
-                return ok_resp({ dry_run = true, environment = env, count = #files, files = rendered })
+                return ok_resp({ dry_run = true, environment = env, count = #files,
+                    rules = built.rules_count, warnings = built.warnings, files = rendered })
             end
 
             -- Resolve the GitHub token from the linked services integration.
@@ -220,6 +230,8 @@ return function(app)
                 branch = eff.branch,
                 commit = sha,
                 count = #files,
+                rules = built.rules_count,
+                warnings = built.warnings,
                 files = rendered,
             })
         end)

--- a/opsapi-dashboard/app/dashboard/domains/page.tsx
+++ b/opsapi-dashboard/app/dashboard/domains/page.tsx
@@ -438,10 +438,51 @@ function DomainsPageContent() {
 }
 
 // ============================================================
+// Repo URL → owner/repo/branch. Users paste a single link instead of typing
+// owner + repo separately (fewer fields, no misconfiguration). Mirrors the
+// backend DomainSyncSettingsQueries.parse_repo_url. Accepts https / ssh /
+// github.com/owner/repo / owner/repo, with an optional /tree/<branch>.
+// ============================================================
+function parseRepoUrl(url: string): { owner: string; repo: string; branch?: string } | null {
+  let s = (url || '').trim();
+  if (!s) return null;
+  s = s
+    .replace(/[?#].*$/, '')
+    .replace(/^git@github\.com:/i, '')
+    .replace(/^ssh:\/\/git@github\.com\//i, '')
+    .replace(/^\w+:\/\//, '')
+    .replace(/^www\./i, '')
+    .replace(/^github\.com\//i, '')
+    .replace(/^\/+/, '');
+  const m = s.match(/^([^/]+)\/([^/]+)/);
+  if (!m) return null;
+  const owner = m[1];
+  const repo = m[2].replace(/\.git$/, '');
+  if (!owner || !repo) return null;
+  const bm = s.match(/^[^/]+\/[^/]+\/tree\/([^/]+)/);
+  return { owner, repo, branch: bm?.[1] };
+}
+
+// Single "paste the repo URL" input with a live parse preview. Reused by every
+// modal that used to ask for owner + repo separately.
+function RepoUrlField({ value, onChange, className }: { value: string; onChange: (v: string) => void; className?: string }) {
+  const parsed = parseRepoUrl(value);
+  const touched = (value || '').trim() !== '';
+  return (
+    <div className={className}>
+      <Input placeholder="Paste repo URL — https://github.com/owner/repo" value={value} onChange={(e) => onChange(e.target.value)} />
+      {touched && (parsed
+        ? <p className="mt-1 text-xs text-emerald-600">✓ {parsed.owner}/{parsed.repo}{parsed.branch ? ` · branch ${parsed.branch}` : ''}</p>
+        : <p className="mt-1 text-xs text-red-600">Enter a full GitHub repo URL, e.g. github.com/owner/repo</p>)}
+    </div>
+  );
+}
+
+// ============================================================
 // Sync Settings modal — configure the repo target + GitHub auth ONCE.
 // ============================================================
 function SyncSettingsModal({ onClose }: { onClose: () => void }) {
-  const [form, setForm] = useState({ owner: '', repo: '', branch: 'main', default_environment: 'prod', github_integration_id: '' });
+  const [form, setForm] = useState({ repo_url: '', branch: 'main', default_environment: 'prod', github_integration_id: '' });
   const [integrations, setIntegrations] = useState<GithubIntegrationLite[]>([]);
   const [integrationName, setIntegrationName] = useState<string | undefined>();
   const [authMode, setAuthMode] = useState<'existing' | 'new'>('existing');
@@ -460,8 +501,7 @@ function SyncSettingsModal({ onClose }: { onClose: () => void }) {
         setIntegrationName(s.integration_name);
         if (s.settings) {
           setForm({
-            owner: s.settings.owner || '',
-            repo: s.settings.repo || '',
+            repo_url: (s.settings.owner && s.settings.repo) ? `https://github.com/${s.settings.owner}/${s.settings.repo}` : '',
             branch: s.settings.branch || 'main',
             default_environment: s.settings.default_environment || 'prod',
             github_integration_id: s.settings.github_integration_id || '',
@@ -473,15 +513,19 @@ function SyncSettingsModal({ onClose }: { onClose: () => void }) {
   }, []);
 
   const save = async () => {
-    if (!form.owner || !form.repo) { toast.error('owner and repo required'); return; }
+    const parsed = parseRepoUrl(form.repo_url);
+    if (!parsed) { toast.error('Enter a valid GitHub repository URL (e.g. https://github.com/owner/repo)'); return; }
     setSaving(true);
     try {
       // GitHub auth is OPTIONAL here — the sync target saves on its own. Only
       // send a token when the user actually typed a new one (never a blank or
       // the masked placeholder, which would otherwise trip token validation and
       // block the save); only send an integration id when one is picked.
+      // We send the pasted repo_url AND the client-parsed owner/repo so the
+      // save works regardless of which the backend prefers.
       const payload: Record<string, unknown> = {
-        owner: form.owner, repo: form.repo, branch: form.branch, default_environment: form.default_environment,
+        repo_url: form.repo_url.trim(), owner: parsed.owner, repo: parsed.repo,
+        branch: parsed.branch || form.branch, default_environment: form.default_environment,
       };
       const token = newToken.trim();
       if (authMode === 'new' && token && token !== '********') {
@@ -509,14 +553,15 @@ function SyncSettingsModal({ onClose }: { onClose: () => void }) {
           After this, “Sync to Repo” and “Run Pipeline” just work — no re-entering.
         </p>
 
-        {/* Repo target */}
-        <div className="grid grid-cols-2 gap-2">
-          <Input placeholder="owner (e.g. bwalia)" value={form.owner} onChange={(e) => setForm({ ...form, owner: e.target.value })} />
-          <Input placeholder="repo (e.g. diy-tax-return-uk)" value={form.repo} onChange={(e) => setForm({ ...form, repo: e.target.value })} />
-          <Input placeholder="branch" value={form.branch} onChange={(e) => setForm({ ...form, branch: e.target.value })} />
-          <select className="rounded-md border border-secondary-200 px-3 py-2 text-sm" value={form.default_environment} onChange={(e) => setForm({ ...form, default_environment: e.target.value })}>
-            {['prod', 'acc', 'test', 'int', 'dev'].map((x) => <option key={x} value={x}>{x}</option>)}
-          </select>
+        {/* Repo target — paste the repo URL, we work out owner/repo/branch */}
+        <div className="space-y-2">
+          <RepoUrlField value={form.repo_url} onChange={(v) => setForm({ ...form, repo_url: v })} />
+          <div className="grid grid-cols-2 gap-2">
+            <Input placeholder="branch (default main)" value={form.branch} onChange={(e) => setForm({ ...form, branch: e.target.value })} />
+            <select className="rounded-md border border-secondary-200 px-3 py-2 text-sm" value={form.default_environment} onChange={(e) => setForm({ ...form, default_environment: e.target.value })}>
+              {['prod', 'acc', 'test', 'int', 'dev'].map((x) => <option key={x} value={x}>{x}</option>)}
+            </select>
+          </div>
         </div>
 
         {/* GitHub auth */}
@@ -554,7 +599,7 @@ function SyncSettingsModal({ onClose }: { onClose: () => void }) {
 // ============================================================
 // Pipeline modal (opsapi drives: sync → dns-reconcile → wslproxy-register → auto-tag)
 // ============================================================
-const EMPTY_PIPELINE = { environment: 'prod', owner: '', repo: '', branch: 'main', github_integration_id: '' };
+const EMPTY_PIPELINE = { environment: 'prod', repo_url: '', branch: 'main', github_integration_id: '' };
 
 function stepBadge(status: string) {
   const map: Record<string, 'success' | 'warning' | 'error' | 'secondary'> = {
@@ -575,8 +620,7 @@ function PipelineModal({ onClose }: { onClose: () => void }) {
       setForm((f) => ({
         ...f,
         environment: s.settings?.default_environment || f.environment,
-        owner: s.settings?.owner || '',
-        repo: s.settings?.repo || '',
+        repo_url: (s.settings?.owner && s.settings?.repo) ? `https://github.com/${s.settings.owner}/${s.settings.repo}` : '',
         branch: s.settings?.branch || 'main',
         github_integration_id: s.settings?.github_integration_id || '',
       }));
@@ -596,11 +640,14 @@ function PipelineModal({ onClose }: { onClose: () => void }) {
   }, [run]);
 
   const start = async () => {
-    if (!form.owner || !form.repo) { toast.error('owner and repo required'); return; }
+    const parsed = parseRepoUrl(form.repo_url);
+    if (!parsed) { toast.error('Enter a valid GitHub repository URL'); return; }
     if (!form.github_integration_id) { toast.error('GitHub integration id required'); return; }
     setStarting(true);
     try {
-      const r = await domainService.runPipeline({ ...form });
+      const r = await domainService.runPipeline({
+        ...form, owner: parsed.owner, repo: parsed.repo, branch: parsed.branch || form.branch,
+      });
       setRun(r);
       toast.success('Pipeline started');
     } catch { toast.error('Could not start pipeline'); } finally { setStarting(false); }
@@ -619,9 +666,8 @@ function PipelineModal({ onClose }: { onClose: () => void }) {
             <select className="rounded-md border border-secondary-200 px-3 py-2 text-sm" value={form.environment} onChange={(e) => setForm({ ...form, environment: e.target.value })}>
               {['prod', 'acc', 'test', 'int', 'dev'].map((x) => <option key={x} value={x}>{x}</option>)}
             </select>
-            <Input placeholder="branch" value={form.branch} onChange={(e) => setForm({ ...form, branch: e.target.value })} />
-            <Input placeholder="owner (e.g. bwalia)" value={form.owner} onChange={(e) => setForm({ ...form, owner: e.target.value })} />
-            <Input placeholder="repo (e.g. diy-tax-return-uk)" value={form.repo} onChange={(e) => setForm({ ...form, repo: e.target.value })} />
+            <Input placeholder="branch (default main)" value={form.branch} onChange={(e) => setForm({ ...form, branch: e.target.value })} />
+            <RepoUrlField className="col-span-2" value={form.repo_url} onChange={(v) => setForm({ ...form, repo_url: v })} />
             <Input className="col-span-2" placeholder="GitHub integration id (uuid)" value={form.github_integration_id} onChange={(e) => setForm({ ...form, github_integration_id: e.target.value })} />
           </div>
         )}
@@ -674,7 +720,7 @@ function s_error(run: PipelineRun): string | null {
 // ============================================================
 // Sync-to-repo modal (render wslproxy vhost files → commit to GitHub)
 // ============================================================
-const EMPTY_REPO = { environment: 'prod', owner: '', repo: '', branch: 'main', github_integration_id: '' };
+const EMPTY_REPO = { environment: 'prod', repo_url: '', branch: 'main', github_integration_id: '' };
 
 function RepoSyncModal({ onClose }: { onClose: () => void }) {
   const [form, setForm] = useState({ ...EMPTY_REPO });
@@ -688,8 +734,7 @@ function RepoSyncModal({ onClose }: { onClose: () => void }) {
       setForm((f) => ({
         ...f,
         environment: s.settings?.default_environment || f.environment,
-        owner: s.settings?.owner || '',
-        repo: s.settings?.repo || '',
+        repo_url: (s.settings?.owner && s.settings?.repo) ? `https://github.com/${s.settings.owner}/${s.settings.repo}` : '',
         branch: s.settings?.branch || 'main',
         github_integration_id: s.settings?.github_integration_id || '',
       }));
@@ -697,20 +742,22 @@ function RepoSyncModal({ onClose }: { onClose: () => void }) {
   }, []);
 
   const dryRun = async () => {
-    if (!form.owner || !form.repo) { toast.error('owner and repo required'); return; }
+    const parsed = parseRepoUrl(form.repo_url);
+    if (!parsed) { toast.error('Enter a valid GitHub repository URL'); return; }
     setBusy(true);
     try {
-      setPreview(await domainService.syncToRepo({ ...form, dry_run: true }));
+      setPreview(await domainService.syncToRepo({ ...form, owner: parsed.owner, repo: parsed.repo, branch: parsed.branch || form.branch, dry_run: true }));
     } catch { toast.error('Preview failed'); } finally { setBusy(false); }
   };
 
   const commit = async () => {
-    if (!form.owner || !form.repo) { toast.error('owner and repo required'); return; }
+    const parsed = parseRepoUrl(form.repo_url);
+    if (!parsed) { toast.error('Enter a valid GitHub repository URL'); return; }
     if (!form.github_integration_id) { toast.error('Select a GitHub integration id'); return; }
     setBusy(true);
     const tid = toast.loading('Committing to repo…');
     try {
-      const r = await domainService.syncToRepo({ ...form });
+      const r = await domainService.syncToRepo({ ...form, owner: parsed.owner, repo: parsed.repo, branch: parsed.branch || form.branch });
       toast.success(`Committed ${r.count} file(s) — ${r.commit?.slice(0, 7)}`, { id: tid });
       setPreview(r);
     } catch { toast.error('Commit failed — check integration & permissions', { id: tid }); } finally { setBusy(false); }
@@ -728,9 +775,8 @@ function RepoSyncModal({ onClose }: { onClose: () => void }) {
           <select className="rounded-md border border-secondary-200 px-3 py-2 text-sm" value={form.environment} onChange={(e) => setForm({ ...form, environment: e.target.value })}>
             {['prod', 'acc', 'test', 'int', 'dev'].map((x) => <option key={x} value={x}>{x}</option>)}
           </select>
-          <Input placeholder="branch" value={form.branch} onChange={(e) => setForm({ ...form, branch: e.target.value })} />
-          <Input placeholder="owner (e.g. bwalia)" value={form.owner} onChange={(e) => setForm({ ...form, owner: e.target.value })} />
-          <Input placeholder="repo (e.g. diy-tax-return-uk)" value={form.repo} onChange={(e) => setForm({ ...form, repo: e.target.value })} />
+          <Input placeholder="branch (default main)" value={form.branch} onChange={(e) => setForm({ ...form, branch: e.target.value })} />
+          <RepoUrlField className="col-span-2" value={form.repo_url} onChange={(v) => setForm({ ...form, repo_url: v })} />
           <Input className="col-span-2" placeholder="GitHub integration id (uuid)" value={form.github_integration_id} onChange={(e) => setForm({ ...form, github_integration_id: e.target.value })} />
         </div>
 

--- a/opsapi-dashboard/services/domain.service.ts
+++ b/opsapi-dashboard/services/domain.service.ts
@@ -148,6 +148,9 @@ export interface PipelineStep {
 
 export interface DomainSyncSettings {
   uuid?: string;
+  // Write-only convenience: paste a repo URL and the backend derives
+  // owner/repo (and branch). owner/repo are what the API stores + returns.
+  repo_url?: string;
   owner?: string;
   repo?: string;
   branch?: string;


### PR DESCRIPTION
Closes the two gaps you spotted in the Domains → wslproxy sync.

## Problem
1. **The rule was never created.** Sync committed the **server only**; its `rules` field just *referenced* a rule id that had to be hand-authored — so a domain synced from opsapi didn't actually route.
2. **The schema was hard-coded in Lua** (even a `"match_cases":[]`→`{}` string fix-up). Any new wslproxy field ⇒ a code change + redeploy.

## What this does
**① Renders the rule too.** `build_sync_files` now emits `data/rules/<env>/<id>.json` with the backend from the domain's `proxy_target`:
- domains sharing a `wslproxy_rule_id` → **one grouped rule** listing all their servers;
- a blank rule id → a safe **per-domain default** `opsapi-<domain>` that never clobbers hand-authored infra rules (e.g. `opsapi-prod-default`);
- no backend → rule **skipped with a warning** (server still syncs), never a crash.

**② Template-driven & schema-resilient.** Server + rule JSON are string **templates** with `{{placeholders}}`, filled by substitution — **never a `cjson` decode→encode round-trip** — so the exact shape (incl. `{}` vs `[]`) is preserved and the gsub hack is gone. Defaults live in the helper; a namespace can override `server_template` / `rule_template` / `default_rule_id` / `default_backend` / `sync_rules` from **Sync Settings** (migration `612`, all nullable → backward compatible). **New wslproxy field ⇒ edit the template data, not the code.**

**③ Servers render as stubs** (`config_status:false`, no nginx `config` block) — the register workflow compiles config edge-side, like the working beacon/`*.workstation.co.uk` hosts. Fewer fields = less schema opsapi owns.

`sync-to-repo` now returns `rules` (count) + `warnings`.

## Verified (real OpenResty runtime + local DB)
- Migration `612` **applies**; all 5 columns present.
- All changed modules **load**; `luajit -b` syntax-clean.
- Renderer tested across **4 cases** (normal / shared-rule / no-backend / custom-template-adds-a-field) — every emitted file is valid JSON and matches the working **server-stub** + **`opsapi-prod-default`** shapes. Example rule output:
  ```json
  { "id":"opsapi-shop-acme-com", "match": { "response": {
      "code":305, "redirect_uri":"10.0.0.5:8080",
      "backends":[{"address":"10.0.0.5:8080","weight":100,"label":"opsapi-managed domain backend"}],
      "routing":{"mode":"least_conn"} } },
    "servers":["host:shop.acme.com"] }
  ```

Follow-ups (not in this PR): a dashboard editor for the templates; optional fetch-merge against the wslproxy API so even *required* new fields are zero-touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)