### PR TITLE
feat(domains): set-once default backend for rules + surface sync warnings

### DIFF
--- a/lapis/routes/domains.lua
+++ b/lapis/routes/domains.lua
@@ -352,6 +352,11 @@ return function(app)
                 github_integration_id = integration_id,
                 data_base = data.data_base,
                 default_environment = data.default_environment,
+                -- Rule generation: a set-once backend (used when a domain has no
+                -- proxy_target), an optional shared rule id, and a toggle.
+                default_backend = data.default_backend,
+                default_rule_id = data.default_rule_id,
+                sync_rules = data.sync_rules,
             })
             if not saved then return err_resp(500, "Failed to save sync settings") end
             return ok_resp(saved)

--- a/opsapi-dashboard/app/dashboard/domains/page.tsx
+++ b/opsapi-dashboard/app/dashboard/domains/page.tsx
@@ -482,7 +482,7 @@ function RepoUrlField({ value, onChange, className }: { value: string; onChange:
 // Sync Settings modal — configure the repo target + GitHub auth ONCE.
 // ============================================================
 function SyncSettingsModal({ onClose }: { onClose: () => void }) {
-  const [form, setForm] = useState({ repo_url: '', branch: 'main', default_environment: 'prod', github_integration_id: '' });
+  const [form, setForm] = useState({ repo_url: '', branch: 'main', default_environment: 'prod', github_integration_id: '', default_backend: '', sync_rules: true });
   const [integrations, setIntegrations] = useState<GithubIntegrationLite[]>([]);
   const [integrationName, setIntegrationName] = useState<string | undefined>();
   const [authMode, setAuthMode] = useState<'existing' | 'new'>('existing');
@@ -505,6 +505,8 @@ function SyncSettingsModal({ onClose }: { onClose: () => void }) {
             branch: s.settings.branch || 'main',
             default_environment: s.settings.default_environment || 'prod',
             github_integration_id: s.settings.github_integration_id || '',
+            default_backend: s.settings.default_backend || '',
+            sync_rules: s.settings.sync_rules !== false,
           });
         }
         if ((list?.length ?? 0) === 0) setAuthMode('new');
@@ -526,6 +528,7 @@ function SyncSettingsModal({ onClose }: { onClose: () => void }) {
       const payload: Record<string, unknown> = {
         repo_url: form.repo_url.trim(), owner: parsed.owner, repo: parsed.repo,
         branch: parsed.branch || form.branch, default_environment: form.default_environment,
+        default_backend: form.default_backend.trim(), sync_rules: form.sync_rules,
       };
       const token = newToken.trim();
       if (authMode === 'new' && token && token !== '********') {
@@ -562,6 +565,24 @@ function SyncSettingsModal({ onClose }: { onClose: () => void }) {
               {['prod', 'acc', 'test', 'int', 'dev'].map((x) => <option key={x} value={x}>{x}</option>)}
             </select>
           </div>
+        </div>
+
+        {/* Rules — a synced domain needs a backend to route to. Without a
+            per-domain Proxy target, this default backend is used to generate
+            the rule; leave blank + no Proxy target = server synced, no rule. */}
+        <div className="rounded border border-secondary-200 p-3 space-y-2">
+          <label className="flex items-center gap-2 text-sm font-medium">
+            <input type="checkbox" checked={form.sync_rules} onChange={(e) => setForm({ ...form, sync_rules: e.target.checked })} />
+            Generate WSL Proxy rule files
+          </label>
+          {form.sync_rules && (
+            <>
+              <Input placeholder="Default backend — e.g. 193.237.176.232:8888" value={form.default_backend} onChange={(e) => setForm({ ...form, default_backend: e.target.value })} />
+              <p className="text-xs text-secondary-500">
+                Used for any domain that has no <span className="font-medium">Proxy target</span> of its own. A rule needs a backend to point at — without one the rule is skipped (the server still syncs).
+              </p>
+            </>
+          )}
         </div>
 
         {/* GitHub auth */}
@@ -784,10 +805,19 @@ function RepoSyncModal({ onClose }: { onClose: () => void }) {
           <div className="rounded border border-secondary-200 p-2 text-sm">
             <div className="mb-1 font-medium">
               {preview.dry_run ? 'Preview' : `Committed ${preview.commit?.slice(0, 7)}`} — {preview.count} file(s)
+              {typeof preview.rules === 'number' && <span className="ml-1 font-normal text-secondary-500">({preview.rules} rule{preview.rules === 1 ? '' : 's'})</span>}
             </div>
             <ul className="max-h-40 overflow-auto text-xs text-secondary-600">
               {preview.files.map((f) => <li key={f.path}>{f.path}</li>)}
             </ul>
+            {preview.warnings && preview.warnings.length > 0 && (
+              <div className="mt-2 rounded bg-amber-50 border border-amber-200 p-2 text-xs text-amber-800">
+                <div className="font-medium">⚠ {preview.warnings.length} warning{preview.warnings.length === 1 ? '' : 's'}</div>
+                <ul className="mt-1 list-disc pl-4">
+                  {preview.warnings.map((w, i) => <li key={i}>{w}</li>)}
+                </ul>
+              </div>
+            )}
           </div>
         )}
 

--- a/opsapi-dashboard/services/domain.service.ts
+++ b/opsapi-dashboard/services/domain.service.ts
@@ -45,6 +45,8 @@ export interface SyncToRepoResult {
   branch?: string;
   commit?: string;
   count: number;
+  rules?: number;
+  warnings?: string[];
   dry_run?: boolean;
   files: { path: string; server_name: string; content?: string }[];
 }
@@ -157,6 +159,11 @@ export interface DomainSyncSettings {
   github_integration_id?: string;
   data_base?: string;
   default_environment?: string;
+  // Rule generation. default_backend is used when a domain has no proxy_target;
+  // sync_rules toggles emitting rule files at all.
+  default_backend?: string;
+  default_rule_id?: string;
+  sync_rules?: boolean;
 }
 
 export interface GithubIntegrationLite {


### PR DESCRIPTION
Follow-up to #546 — you hit exactly the case it was meant to handle, but the UI hid the reason.

## What you saw
You added two domains and synced, but **no rule file appeared** — only the servers + manifest. Diagnosed on the live API: your domains have **no `proxy_target`**, so the renderer skipped the rule with a warning:
> `rule 'opsapi-…' skipped: no proxy_target/default_backend — set one to generate its backend`

A rule's job is *"route this host → backend X"*; with no backend there's nothing to point at. That's correct behavior — but the **Preview silently dropped the warning**, so it looked broken.

## Fixes
1. **Set-once "Default backend" in Sync Settings** (+ a "Generate rule files" toggle). Used to build the rule for any domain with no per-domain Proxy target — so a namespace whose domains all route to the same ingress (e.g. `193.237.176.232:8888`) gets rules without touching each domain. (The route now forwards `default_backend`/`default_rule_id`/`sync_rules` to `upsert`.)
2. **Preview/Commit now shows the rule count + warnings** (amber list), so a skipped rule is never silent.

## Two ways to get rules now
- **Per-domain:** open a domain → set **Proxy target** → sync.
- **Set-once:** Sync Settings → **Default backend** = `193.237.176.232:8888` → every backend-less domain gets a rule.

## Verified locally
`build_sync_files` on your two domains:
- no default_backend → **0 rules, 2 warnings**
- `default_backend=193.237.176.232:8888` → **2 rules, 0 warnings** (`opsapi-int-opsapi-diytaxreturn-co-uk.json`, `opsapi-int-opsapi-ui-diytaxreturn-co-uk.json`)

`tsc --noEmit` 0 errors, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)