### PR TITLE
fix(tenancy): parse PROJECT_CODE as the module list it is — signup 400s on int, acc and prod

### DIFF
--- a/lapis/helper/namespace_assignment.lua
+++ b/lapis/helper/namespace_assignment.lua
@@ -11,11 +11,20 @@
     Tenant resolution — the caller passes `project_code` (from the browser's
     `X-Project-Code` header at register.lua, or a query param at the OAuth
     callback). If the caller doesn't provide it, we fall back to the pod's
-    `PROJECT_CODE` env var. If BOTH are missing (or the value doesn't match
-    any active namespace) we return `nil, reason` and the caller MUST 400 —
-    we deliberately do NOT fall back to "first active tenant" any more, as
-    that was the exact silent-mis-routing behavior that put self-registered
-    tax-copilot users into the `system` namespace on int.
+    `PROJECT_CODE` env var, which is a comma-separated list of enabled
+    feature modules ("tax_copilot,services") and is parsed as such — each
+    listed code is tried in order and the first matching an active namespace
+    wins. If BOTH are missing (or nothing matches an active namespace) we
+    return `nil, reason` and the caller MUST 400 — we deliberately do NOT
+    fall back to "first active tenant" any more, as that was the exact
+    silent-mis-routing behavior that put self-registered tax-copilot users
+    into the `system` namespace on int.
+
+    Reading PROJECT_CODE as one atomic tenant key (rather than as the list it
+    is) meant every multi-module deploy 400'd every registration — email/
+    password and Google OAuth alike — on int, acc and production. Keep this
+    path going through ProjectConfig.parseProjectCodes, the single place that
+    knows the variable's format.
 
     Idempotent — every INSERT carries an `ON CONFLICT … DO NOTHING/UPDATE`
     clause, so repeating the call (e.g. after a partial earlier failure)
@@ -34,43 +43,92 @@
 ]]
 
 local db = require("lapis.db")
+local ProjectConfig = require("helper.project-config")
 
 local M = {}
+
+--- Build the ordered list of candidate tenant codes to try.
+-- A per-request hint (X-Project-Code header / OAuth query param) is taken
+-- verbatim and is the only candidate — the caller named a tenant, so we do
+-- not silently widen the search past it.
+--
+-- Otherwise we fall back to the pod's PROJECT_CODE. That variable is a
+-- comma-separated list of enabled FEATURE MODULES ("tax_copilot,services"),
+-- not a single tenant key — see ProjectConfig.parseProjectCodes, which is how
+-- every other consumer in this codebase reads it. Matching the raw string
+-- against `namespaces.project_code` can therefore never hit a row on any
+-- multi-module deploy, which is what broke registration outright.
+--
+-- "all" is dropped: it is the "no project selected" sentinel that
+-- ProjectConfig.getProjectCode returns when the env var is unset, never a
+-- real tenant.
+-- @param project_code string|nil per-request tenant hint
+-- @return table list of candidate codes (possibly empty)
+local function candidateProjectCodes(project_code)
+    if project_code then
+        local trimmed = tostring(project_code):match("^%s*(.-)%s*$")
+        if trimmed ~= "" and trimmed ~= "all" then
+            return { trimmed }
+        end
+    end
+
+    local codes = {}
+    for _, code in ipairs(ProjectConfig.parseProjectCodes()) do
+        if code ~= "all" then
+            table.insert(codes, code)
+        end
+    end
+    return codes
+end
+
+--- Resolve a project_code hint to an active namespace id.
+-- Tries each candidate in priority order and returns the first that matches
+-- an active namespace. Only codes the deploy explicitly declares are ever
+-- tried — there is deliberately no "first active tenant" fallback, which was
+-- the silent mis-routing this resolution path exists to prevent.
+-- @param project_code string|nil per-request tenant hint
+-- @return integer|nil namespace_id
+-- @return string|nil reason ("no_project_code" / "project_code_not_found:<codes>")
+function M.resolveProjectNamespaceId(project_code)
+    local codes = candidateProjectCodes(project_code)
+    if #codes == 0 then
+        return nil, "no_project_code"
+    end
+
+    for _, code in ipairs(codes) do
+        local ns = db.query([[
+            SELECT id FROM namespaces
+            WHERE status = 'active' AND project_code = ?
+            ORDER BY id ASC LIMIT 1
+        ]], code)
+        if ns and #ns > 0 then
+            return ns[1].id
+        end
+    end
+
+    return nil, "project_code_not_found:" .. table.concat(codes, ",")
+end
 
 --- Auto-assign a newly-created user to the tenant identified by project_code.
 -- @param user_id integer  users.id of the freshly-created user
 -- @param user_uuid string users.uuid of the same user (for log breadcrumbs)
 -- @param project_code string|nil  per-request tenant hint (from X-Project-Code
 --                                 header, or OAuth query param). If nil or
---                                 empty, falls back to the PROJECT_CODE env
---                                 var. If both are missing / unresolvable,
+--                                 empty, falls back to the codes listed in the
+--                                 PROJECT_CODE env var. If nothing resolves,
 --                                 returns nil + reason and does NOT insert.
+--                                 See M.resolveProjectNamespaceId.
 -- @return integer|nil resolved namespace_id (nil on failure)
--- @return string|nil reason ("no_project_code" / "project_code_not_found:<code>"
+-- @return string|nil reason ("no_project_code" / "project_code_not_found:<codes>"
 --                             / "internal_error:<err>"), nil on success
 function M.assignUserToProjectNamespace(user_id, user_uuid, project_code)
     local resolved_ns_id, resolved_reason
     local ok, err = pcall(function()
-        local effective_code = project_code
-        if not effective_code or effective_code == "" then
-            effective_code = os.getenv("PROJECT_CODE")
-        end
-        if not effective_code or effective_code == "" or effective_code == "all" then
-            resolved_reason = "no_project_code"
+        local namespace_id, reason = M.resolveProjectNamespaceId(project_code)
+        if not namespace_id then
+            resolved_reason = reason
             return
         end
-
-        local ns = db.query([[
-            SELECT id FROM namespaces
-            WHERE status = 'active' AND project_code = ?
-            ORDER BY id ASC LIMIT 1
-        ]], effective_code)
-
-        if not ns or #ns == 0 then
-            resolved_reason = "project_code_not_found:" .. tostring(effective_code)
-            return
-        end
-        local namespace_id = ns[1].id
 
         -- Membership (status = 'active', is_owner = false).
         db.query([[

--- a/lapis/queries/UserQueries.lua
+++ b/lapis/queries/UserQueries.lua
@@ -54,8 +54,9 @@ function UserQueries.create(params)
     --   2. Per-request `params.project_code` (from X-Project-Code header on
     --      register.lua). Matches on `namespaces.project_code` — the SAME
     --      column NamespaceAssignment uses, so both writes hit one tenant.
-    --   3. Pod-level `PROJECT_CODE` env var. Legacy fallback for server-side
-    --      user creation that doesn't ride HTTP (CLI, background jobs).
+    --   3. The codes listed in the pod-level `PROJECT_CODE` env var (a
+    --      comma-separated module list), tried in order. Legacy fallback for
+    --      server-side user creation that doesn't ride HTTP (CLI, jobs).
     --
     -- No `slug='system'` fallback. No "first active namespace" fallback.
     -- If none of the above resolves, we leave `target_namespace_id` nil
@@ -65,19 +66,13 @@ function UserQueries.create(params)
     -- silent mis-routing into a loud failure.
     local target_namespace_id = namespace_id
     if not target_namespace_id then
-        local project_code = override_project_code
-        if not project_code or project_code == "" then
-            project_code = os.getenv("PROJECT_CODE")
-        end
-        if project_code and project_code ~= "" and project_code ~= "all" then
-            local project_ns = db.select(
-                "id FROM namespaces WHERE project_code = ? AND status = 'active' ORDER BY id ASC LIMIT 1",
-                project_code
-            )
-            if project_ns and #project_ns > 0 then
-                target_namespace_id = project_ns[1].id
-            end
-        end
+        -- Delegated to NamespaceAssignment so the two paths cannot drift:
+        -- this used to carry its own copy of the lookup, and when that copy
+        -- read PROJECT_CODE as a single tenant key instead of the comma-
+        -- separated module list it is, both copies had to be fixed to fix
+        -- registration. One resolver now, not two.
+        local NamespaceAssignment = require "helper.namespace_assignment"
+        target_namespace_id = NamespaceAssignment.resolveProjectNamespaceId(override_project_code)
     end
 
     if target_namespace_id then


### PR DESCRIPTION
## Signup is returning 400 for every user, on every environment

```
VALIDATION_400  field=project_code  reason=namespace_unresolvable
detail=project_code_not_found:tax_copilot,services
```

Reproduced with a plain `curl` against all three:

| Env | `POST /opsapi/api/v2/register` |
|---|---|
| int | 400 `project_code_not_found:tax_copilot,services` |
| acc | 400 `project_code_not_found:tax_copilot,services` |
| **production** | 400 `project_code_not_found:tax_copilot,services` |

## In one sentence

`PROJECT_CODE` is a **list**, and two places read it as a single value.

Every new user must be filed under a tenant. The tenant is resolved from the `X-Project-Code` request header, falling back to the pod's `PROJECT_CODE`. That env var is a comma-separated list of enabled feature modules — its documented contract (`migrations.lua`: *"Supports comma-separated PROJECT_CODE (e.g. `tax_copilot,ecommerce`)"*), and every other consumer in the codebase reads it through `ProjectConfig.parseProjectCodes()`.

These two did not:

- `lapis/helper/namespace_assignment.lua` — email/password **and** Google OAuth sign-up
- `lapis/queries/UserQueries.lua` — a second, duplicated copy of the same lookup

Both matched the raw string against `namespaces.project_code`. No namespace is literally named `tax_copilot,services`, so on any deploy with more than one module enabled the lookup could never hit a row — the registration transaction rolled back and `register.lua` surfaced the unresolvable-tenant 400. All three environments run a multi-module `PROJECT_CODE`, hence all three are down.

## The fix

One resolver, `M.resolveProjectNamespaceId`, parsing via `ProjectConfig.parseProjectCodes()` and returning the first listed code that matches an active namespace. `UserQueries` now delegates to it instead of carrying a copy that can drift again — that duplication is why this needed fixing in two places at once.

**Deliberately preserved** — this does not loosen the tenancy guarantees from `c4afcc8`:

- An explicit `X-Project-Code` hint is still the *only* candidate tried. A bad hint 400s; it never silently widens to the pod's list.
- Still no `slug='system'` and no "first active tenant" fallback — the silent mis-routing `c4afcc8` set out to remove.
- The 400 reason string keeps its shape, so no client contract change.

## Verification

A harness drives `resolveProjectNamespaceId` over the **real** `ProjectConfig` parser with a stubbed `namespaces` table (one active `tax_copilot` row), asserting the returned id, the reason string, *and* which codes were queried:

```
=== the production bug ===
PASS  comma list, no hint (int/acc/prod today)  -> id=7   reason=nil  queried=[tax_copilot]

=== regressions guarded ===
PASS  single code, no hint            -> id=7    queried=[tax_copilot]
PASS  hint wins over env              -> id=7    queried=[tax_copilot]
PASS  bad hint is NOT widened to env  -> nil, project_code_not_found:nope    queried=[nope]
PASS  spaces in list                  -> id=7    queried=[services|tax_copilot]
PASS  env unset -> 'all' sentinel     -> nil, no_project_code               queried=[]
PASS  env literally 'all'             -> nil, no_project_code               queried=[]
PASS  hint 'all' falls through to env -> id=7    queried=[tax_copilot]
PASS  empty hint falls through to env -> id=7    queried=[tax_copilot]
PASS  no code resolves                -> nil, project_code_not_found:services,ecommerce
ALL PASS
```

The `queried=[...]` column is the part that matters for the security properties: a bad hint queries only `nope` and stops, and nothing ever falls back to an unlisted tenant.

## Note on the earlier attempt

`54141bf` ("DEFAULT_PROJECT_CODE=tax_copilot as final resolution tier") was reverted in `571346d` with no stated reason. Its diagnosis — *"a misconfigured pod would 400 every registration"* — was the right symptom, but the cause was this parse bug rather than a missing default. Fixing the parse removes the need for a hardcoded tenant, so none is reintroduced here.

## How this surfaced

The nightly `ios_functional_tests.yml` provisions a throwaway account before running Maestro, and has failed every night since 2026-08-07 — the deploy window for `c4afcc8`. It reported only `HTTP 400` because the check discards the response body; that's fixed separately in the app repo. Signup being down in production was the larger finding underneath it.

## Suggested follow-up (not in this PR)

The Flutter app never sends `X-Project-Code` — no `.dart` file references it, and `/api/v2/register` sits on the `noAuthPaths` list in `api_service.dart` where no tenant headers are attached. It works after this fix because the pod-level fallback resolves again, but the app relying entirely on server env for its tenant is worth a deliberate decision.
