### PR TITLE
feat(domains): auto rule id + Backend/Path fields (drop the confusing "rule id")

### DIFF
--- a/lapis/helper/wslproxy-server.lua
+++ b/lapis/helper/wslproxy-server.lua
@@ -65,7 +65,7 @@ WslproxyServer.DEFAULT_RULE_TEMPLATE = [[{
   "priority": 1,
   "rules_tags": ["opsapi", "domains"],
   "match": {
-    "rules": { "path": "/", "path_key": "starts_with" },
+    "rules": { "path": "{{rule_path}}", "path_key": "starts_with" },
     "response": {
       "code": 305,
       "redirect_uri": "{{backend}}",
@@ -196,14 +196,17 @@ end
 -- @param backend string  backend address (host:port)
 -- @param servers table   list of server ids ("host:<domain>") referencing it
 -- @return string json, string filename, string|nil err
-function WslproxyServer.render_rule(rule_id, backend, servers, env, opts)
+function WslproxyServer.render_rule(rule_id, backend, servers, env, opts, rule_path)
     opts = opts or {}
     local tpl = (opts.rule_template and trim(opts.rule_template) ~= "" and opts.rule_template)
         or WslproxyServer.DEFAULT_RULE_TEMPLATE
+    local path = trim(rule_path)
+    if path == "" then path = "/" end
     local vars = {
         rule_id      = json_escape(rule_id),
         profile_id   = json_escape(env),
         backend      = json_escape(backend),
+        rule_path    = json_escape(path),
         servers_json = cjson.encode(servers or {}),
     }
     local json = fill(tpl, vars)
@@ -264,10 +267,15 @@ function WslproxyServer.build_sync_files(domains, env, data_base, opts)
                 -- Accumulate the rule this server references.
                 local rid = WslproxyServer.effective_rule_id(d, opts)
                 if not rules[rid] then
-                    rules[rid] = { backend = effective_backend(d, opts), servers = {} }
+                    rules[rid] = { backend = effective_backend(d, opts), servers = {}, path = trim(d.rule_path) }
                     table.insert(rule_order, rid)
-                elseif trim(rules[rid].backend) == "" then
-                    rules[rid].backend = effective_backend(d, opts)
+                else
+                    if trim(rules[rid].backend) == "" then
+                        rules[rid].backend = effective_backend(d, opts)
+                    end
+                    if trim(rules[rid].path) == "" then
+                        rules[rid].path = trim(d.rule_path)
+                    end
                 end
                 table.insert(rules[rid].servers, "host:" .. d.domain_name)
             end
@@ -282,7 +290,7 @@ function WslproxyServer.build_sync_files(domains, env, data_base, opts)
                 table.insert(warnings, "rule '" .. rid .. "' skipped: no proxy_target/default_backend "
                     .. "— set one to generate its backend")
             else
-                local json, filename, rerr = WslproxyServer.render_rule(rid, r.backend, r.servers, env, opts)
+                local json, filename, rerr = WslproxyServer.render_rule(rid, r.backend, r.servers, env, opts, r.path)
                 if not json then
                     table.insert(warnings, rerr or ("could not render rule " .. rid))
                 else

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -1730,6 +1730,7 @@ local _migrations = {
     ['605_grant_domain_permissions'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_menu_items_migrations, 3),
     ['606_enable_domain_menu_for_namespaces'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_menu_items_migrations, 4),
     ['607_domain_wslproxy_fields'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_wslproxy_fields_migrations, 1),
+    ['613_domain_rule_path'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_wslproxy_fields_migrations, 2),
     ['608_domain_pipeline_runs'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_pipeline_runs_migrations, 1),
     ['609_domain_sync_settings'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_sync_settings_migrations, 1),
     ['612_domain_sync_templates'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_sync_settings_migrations, 2),

--- a/lapis/migrations/domain-wslproxy-fields.lua
+++ b/lapis/migrations/domain-wslproxy-fields.lua
@@ -38,4 +38,13 @@ return {
         -- Index by environment for per-env export.
         add_column([[CREATE INDEX IF NOT EXISTS domains_namespace_env_idx ON domains (namespace_id, environment)]])
     end,
+
+    -- [2] The WSL Proxy rule's match path (default "/"). Lets a user build
+    -- path-based rules from the domain form instead of the path being hardcoded
+    -- to "/" in the renderer. See helper/wslproxy-server.lua (rule template).
+    [2] = function()
+        local exists = db.query("SELECT to_regclass('public.domains') IS NOT NULL AS ok")
+        if not (exists and exists[1] and exists[1].ok) then return end
+        add_column([[ALTER TABLE domains ADD COLUMN IF NOT EXISTS rule_path TEXT DEFAULT '/']])
+    end,
 }

--- a/lapis/queries/DomainQueries.lua
+++ b/lapis/queries/DomainQueries.lua
@@ -23,7 +23,7 @@ local WRITABLE_FIELDS = {
     -- WSL Proxy vhost rendering fields (see helper/wslproxy-server.lua)
     "environment", "wslproxy_rule_id", "ssl_email", "ssl_enabled",
     "ssl_auto_renew", "ssl_force_https", "ssl_staging", "wslproxy_root",
-    "listen_ports", "proxy_target",
+    "listen_ports", "proxy_target", "rule_path",
 }
 
 --------------------------------------------------------------------------------

--- a/lapis/routes/domains.lua
+++ b/lapis/routes/domains.lua
@@ -599,6 +599,9 @@ return function(app)
                 wslproxy_root = data.wslproxy_root or "/var/www/html",
                 listen_ports = data.listen_ports or "80",
                 proxy_target = data.proxy_target,
+                -- WSL Proxy rule match path (default "/"). The rule id itself is
+                -- auto-generated (opsapi-<domain>) by the renderer.
+                rule_path = data.rule_path or "/",
                 metadata = metadata or "{}",
             })
             if not created then return err_resp(500, "Failed to create domain") end

--- a/opsapi-dashboard/app/dashboard/domains/page.tsx
+++ b/opsapi-dashboard/app/dashboard/domains/page.tsx
@@ -72,6 +72,14 @@ function StatCard({ icon, label, value, tone }: { icon: React.ReactNode; label: 
   );
 }
 
+// Mirror of the backend auto rule id (helper/wslproxy-server.lua): a domain with
+// no explicit rule id gets rule "opsapi-<sanitized-domain>" — so the user never
+// has to know or type a "rule id".
+function ruleSlug(domainName: string): string {
+  const slug = (domainName || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  return 'opsapi-' + (slug || 'domain');
+}
+
 const EMPTY_FORM = {
   domain_name: '',
   registrar: '',
@@ -79,11 +87,11 @@ const EMPTY_FORM = {
   cloudflare_zone_id: '',
   alert_threshold_days: 30,
   notes: '',
-  // WSL Proxy vhost fields
+  // WSL Proxy routing fields (the rule id is auto-generated: opsapi-<domain>)
   environment: 'prod',
-  wslproxy_rule_id: '',
   ssl_email: '',
   proxy_target: '',
+  rule_path: '/',
 };
 
 function DomainsPageContent() {
@@ -150,9 +158,9 @@ function DomainsPageContent() {
       alert_threshold_days: d.alert_threshold_days || 30,
       notes: d.notes || '',
       environment: d.environment || 'prod',
-      wslproxy_rule_id: d.wslproxy_rule_id || '',
       ssl_email: d.ssl_email || '',
       proxy_target: d.proxy_target || '',
+      rule_path: d.rule_path || '/',
     });
     setFormOpen(true);
   };
@@ -381,7 +389,7 @@ function DomainsPageContent() {
             </div>
           </div>
           <div className="rounded border border-secondary-200 p-3 space-y-3">
-            <div className="text-xs font-semibold uppercase text-secondary-500">WSL Proxy vhost (for repo sync)</div>
+            <div className="text-xs font-semibold uppercase text-secondary-500">WSL Proxy routing (repo sync)</div>
             <div className="grid grid-cols-2 gap-3">
               <div>
                 <label className="text-sm font-medium">Environment</label>
@@ -390,19 +398,27 @@ function DomainsPageContent() {
                 </select>
               </div>
               <div>
-                <label className="text-sm font-medium">WSL Proxy rule id</label>
-                <Input placeholder="e.g. academy-prod-default" value={form.wslproxy_rule_id} onChange={(e) => setForm({ ...form, wslproxy_rule_id: e.target.value })} />
+                <label className="text-sm font-medium">Backend</label>
+                <Input placeholder="193.237.176.232:8888" value={form.proxy_target} onChange={(e) => setForm({ ...form, proxy_target: e.target.value })} />
+                <p className="mt-1 text-xs text-secondary-500">Where this domain routes — the rule&apos;s backend. Blank = the Sync Settings default backend.</p>
               </div>
             </div>
             <div className="grid grid-cols-2 gap-3">
               <div>
+                <label className="text-sm font-medium">Path</label>
+                <Input placeholder="/" value={form.rule_path} onChange={(e) => setForm({ ...form, rule_path: e.target.value })} />
+              </div>
+              <div>
                 <label className="text-sm font-medium">SSL email</label>
                 <Input placeholder="admin@example.com" value={form.ssl_email} onChange={(e) => setForm({ ...form, ssl_email: e.target.value })} />
               </div>
-              <div>
-                <label className="text-sm font-medium">Proxy / DNS target</label>
-                <Input placeholder="pop1.diytaxreturn.co.uk" value={form.proxy_target} onChange={(e) => setForm({ ...form, proxy_target: e.target.value })} />
-              </div>
+            </div>
+            {/* Live preview of the rule that will be auto-created on sync — the
+                user never types a "rule id". */}
+            <div className="rounded bg-secondary-50 border border-secondary-200 p-2 text-xs text-secondary-600">
+              Auto-created rule: <span className="font-mono text-secondary-800">{ruleSlug(form.domain_name)}</span>
+              {' '}— path <span className="font-mono text-secondary-800">{form.rule_path || '/'}</span>
+              {' '}→ <span className="font-mono text-secondary-800">{form.proxy_target || '(Sync Settings default backend)'}</span>
             </div>
           </div>
           <div>

--- a/opsapi-dashboard/services/domain.service.ts
+++ b/opsapi-dashboard/services/domain.service.ts
@@ -35,6 +35,7 @@ export interface Domain {
   wslproxy_root?: string;
   listen_ports?: string;
   proxy_target?: string;
+  rule_path?: string;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
You flagged that **"WSL Proxy rule id"** in the domain form is jargon users don't understand. Traced the flow: the rule id was *already* auto-generated (`opsapi-<domain>`) when left blank — but the form still showed the field as if required, and the rule's path was hardcoded to `/`.

## Changes
- **Drop the "rule id" field.** The rule id is always auto = `opsapi-<domain>`. Users never type it.
- **Relabel "Proxy / DNS target" → "Backend"** with a clear placeholder (`193.237.176.232:8888`) + one-line help. Blank falls back to the Sync Settings **default backend**.
- **New "Path" field** → `rule_path` column (default `/`, migration `613`). The renderer's hardcoded `"path": "/"` becomes a `{{rule_path}}` template placeholder.
- **Live preview** in the form: *"Auto-created rule: `opsapi-yourdomain-com` — path `/` → `193.237.176.232:8888`"* — so it's obvious what sync will produce.

## Flow now (what you asked for)
Add/Edit a domain → set **Backend** + **Path** (rule id is automatic) → Sync to Repo writes the vhost **and** its rule.

## Verified
- Render test: custom path `/api` → rule `"path": "/api"`; no path → `/`; empty → `/`.
- Migration `613` applies (`rule_path` default `/`).
- `tsc --noEmit` 0 errors; local dashboard rebuilt — new form shows, no "rule id" field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)