### PR TITLE
fix(domains): stop create 500 on duplicate / re-add of a deleted domain

### DIFF
--- a/lapis/migrations/domain-wslproxy-fields.lua
+++ b/lapis/migrations/domain-wslproxy-fields.lua
@@ -38,4 +38,13 @@ return {
         -- Index by environment for per-env export.
         add_column([[CREATE INDEX IF NOT EXISTS domains_namespace_env_idx ON domains (namespace_id, environment)]])
     end,
+
+    -- [2] The WSL Proxy rule's match path (default "/"). Lets a user build
+    -- path-based rules from the domain form instead of the path being hardcoded
+    -- to "/" in the renderer. See helper/wslproxy-server.lua (rule template).
+    [2] = function()
+        local exists = db.query("SELECT to_regclass('public.domains') IS NOT NULL AS ok")
+        if not (exists and exists[1] and exists[1].ok) then return end
+        add_column([[ALTER TABLE domains ADD COLUMN IF NOT EXISTS rule_path TEXT DEFAULT '/']])
+    end,
 }

--- a/lapis/queries/DomainQueries.lua
+++ b/lapis/queries/DomainQueries.lua
@@ -23,19 +23,95 @@ local WRITABLE_FIELDS = {
     -- WSL Proxy vhost rendering fields (see helper/wslproxy-server.lua)
     "environment", "wslproxy_rule_id", "ssl_email", "ssl_enabled",
     "ssl_auto_renew", "ssl_force_https", "ssl_staging", "wslproxy_root",
-    "listen_ports", "proxy_target",
+    "listen_ports", "proxy_target", "rule_path",
 }
 
 --------------------------------------------------------------------------------
 -- Create
+--
+-- Guards the UNIQUE(namespace_id, domain_name) constraint explicitly so a
+-- collision returns a clean, typed error instead of bubbling up as a 500:
+--   * an ACTIVE row of the same name  -> returns nil, { code = "duplicate" }
+--   * a SOFT-DELETED row of the same name -> revived in place (delete only sets
+--     deleted_at, but the unique constraint still counts that hidden row, so a
+--     naive re-insert would violate it). Deleting then re-adding a domain now
+--     just works, and returns the revived row.
+-- The final INSERT is wrapped in pcall so any residual DB error (e.g. a unique
+-- race, or a schema/column issue) is surfaced as a typed error, never a raw 500.
+--
+-- Returns: domain            on success (created or revived)
+--          nil, err_table    on failure, where err_table = { code, message }
+--                            and code is "duplicate" | "db_error".
 --------------------------------------------------------------------------------
 function DomainQueries.createDomain(params)
     if not params.uuid then
         params.uuid = Global.generateUUID()
     end
+
+    if params.namespace_id and params.domain_name then
+        local existing = db.query([[
+            SELECT uuid, deleted_at FROM domains
+            WHERE namespace_id = ? AND domain_name = ?
+            LIMIT 1
+        ]], params.namespace_id, params.domain_name)
+        existing = existing and existing[1] or nil
+        if existing then
+            if existing.deleted_at == nil then
+                return nil, {
+                    code = "duplicate",
+                    message = "A domain with this name already exists in this namespace",
+                }
+            end
+            -- Revive the previously soft-deleted domain with the new details.
+            local revived = DomainQueries.reviveDomain(existing.uuid, params)
+            if revived then return revived end
+            -- If revive unexpectedly failed, fall through to a fresh insert.
+        end
+    end
+
     params.created_at = db.raw("NOW()")
     params.updated_at = db.raw("NOW()")
-    return DomainModel:create(params, { returning = "*" })
+
+    local ok, created = pcall(function()
+        return DomainModel:create(params, { returning = "*" })
+    end)
+    if not ok then
+        local msg = tostring(created)
+        if msg:find("domains_namespace_domain_unique") or msg:lower():find("duplicate key") then
+            return nil, {
+                code = "duplicate",
+                message = "A domain with this name already exists in this namespace",
+            }
+        end
+        return nil, { code = "db_error", message = "Failed to create domain", detail = msg }
+    end
+    return created
+end
+
+--------------------------------------------------------------------------------
+-- Revive a soft-deleted domain: clear deleted_at and overwrite its details with
+-- the supplied (whitelisted) fields, so re-adding a deleted domain behaves like
+-- a fresh create.
+--------------------------------------------------------------------------------
+function DomainQueries.reviveDomain(uuid, params)
+    local domain = DomainModel:find({ uuid = uuid })
+    if not domain then return nil end
+
+    local update_params = {}
+    for _, field in ipairs(WRITABLE_FIELDS) do
+        if params[field] ~= nil then
+            update_params[field] = params[field]
+        end
+    end
+    if params.metadata ~= nil then update_params.metadata = params.metadata end
+    update_params.status = params.status or "active"
+    update_params.deleted_at = db.NULL
+    update_params.updated_at = db.raw("NOW()")
+
+    domain:update(update_params, { returning = "*" })
+    -- Return the full refreshed row (instance:update yields a boolean), so the
+    -- create path hands back a domain object just like a fresh insert.
+    return DomainModel:find({ uuid = uuid })
 end
 
 --------------------------------------------------------------------------------

--- a/lapis/routes/domains.lua
+++ b/lapis/routes/domains.lua
@@ -577,7 +577,7 @@ return function(app)
             local metadata = data.metadata
             if metadata and type(metadata) == "table" then metadata = cjson.encode(metadata) end
 
-            local created = DomainQueries.createDomain({
+            local created, cerr = DomainQueries.createDomain({
                 namespace_id = self.namespace.id,
                 domain_name = (data.domain_name):lower(),
                 registrar = data.registrar,
@@ -599,9 +599,18 @@ return function(app)
                 wslproxy_root = data.wslproxy_root or "/var/www/html",
                 listen_ports = data.listen_ports or "80",
                 proxy_target = data.proxy_target,
+                -- WSL Proxy rule match path (default "/"). The rule id itself is
+                -- auto-generated (opsapi-<domain>) by the renderer.
+                rule_path = data.rule_path or "/",
                 metadata = metadata or "{}",
             })
-            if not created then return err_resp(500, "Failed to create domain") end
+            if not created then
+                -- A same-name collision is a client error (409), not a 500.
+                if cerr and cerr.code == "duplicate" then
+                    return err_resp(409, cerr.message)
+                end
+                return err_resp(500, (cerr and cerr.message) or "Failed to create domain")
+            end
             return { status = 201, json = { success = true, data = created } }
         end)
     ))

--- a/opsapi-dashboard/app/dashboard/domains/page.tsx
+++ b/opsapi-dashboard/app/dashboard/domains/page.tsx
@@ -72,6 +72,14 @@ function StatCard({ icon, label, value, tone }: { icon: React.ReactNode; label: 
   );
 }
 
+// Mirror of the backend auto rule id (helper/wslproxy-server.lua): a domain with
+// no explicit rule id gets rule "opsapi-<sanitized-domain>" — so the user never
+// has to know or type a "rule id".
+function ruleSlug(domainName: string): string {
+  const slug = (domainName || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  return 'opsapi-' + (slug || 'domain');
+}
+
 const EMPTY_FORM = {
   domain_name: '',
   registrar: '',
@@ -79,11 +87,11 @@ const EMPTY_FORM = {
   cloudflare_zone_id: '',
   alert_threshold_days: 30,
   notes: '',
-  // WSL Proxy vhost fields
+  // WSL Proxy routing fields (the rule id is auto-generated: opsapi-<domain>)
   environment: 'prod',
-  wslproxy_rule_id: '',
   ssl_email: '',
   proxy_target: '',
+  rule_path: '/',
 };
 
 function DomainsPageContent() {
@@ -150,9 +158,9 @@ function DomainsPageContent() {
       alert_threshold_days: d.alert_threshold_days || 30,
       notes: d.notes || '',
       environment: d.environment || 'prod',
-      wslproxy_rule_id: d.wslproxy_rule_id || '',
       ssl_email: d.ssl_email || '',
       proxy_target: d.proxy_target || '',
+      rule_path: d.rule_path || '/',
     });
     setFormOpen(true);
   };
@@ -169,8 +177,12 @@ function DomainsPageContent() {
       }
       setFormOpen(false);
       load(); loadStats();
-    } catch {
-      toast.error('Save failed');
+    } catch (err) {
+      // Surface the backend message (e.g. the 409 "A domain with this name
+      // already exists in this namespace") instead of a generic failure.
+      const serverMsg = (err as { response?: { data?: { error?: string } } })
+        ?.response?.data?.error;
+      toast.error(serverMsg || (err instanceof Error ? err.message : 'Save failed'));
     }
   };
 
@@ -381,7 +393,7 @@ function DomainsPageContent() {
             </div>
           </div>
           <div className="rounded border border-secondary-200 p-3 space-y-3">
-            <div className="text-xs font-semibold uppercase text-secondary-500">WSL Proxy vhost (for repo sync)</div>
+            <div className="text-xs font-semibold uppercase text-secondary-500">WSL Proxy routing (repo sync)</div>
             <div className="grid grid-cols-2 gap-3">
               <div>
                 <label className="text-sm font-medium">Environment</label>
@@ -390,19 +402,27 @@ function DomainsPageContent() {
                 </select>
               </div>
               <div>
-                <label className="text-sm font-medium">WSL Proxy rule id</label>
-                <Input placeholder="e.g. academy-prod-default" value={form.wslproxy_rule_id} onChange={(e) => setForm({ ...form, wslproxy_rule_id: e.target.value })} />
+                <label className="text-sm font-medium">Backend</label>
+                <Input placeholder="193.237.176.232:8888" value={form.proxy_target} onChange={(e) => setForm({ ...form, proxy_target: e.target.value })} />
+                <p className="mt-1 text-xs text-secondary-500">Where this domain routes — the rule&apos;s backend. Blank = the Sync Settings default backend.</p>
               </div>
             </div>
             <div className="grid grid-cols-2 gap-3">
               <div>
+                <label className="text-sm font-medium">Path</label>
+                <Input placeholder="/" value={form.rule_path} onChange={(e) => setForm({ ...form, rule_path: e.target.value })} />
+              </div>
+              <div>
                 <label className="text-sm font-medium">SSL email</label>
                 <Input placeholder="admin@example.com" value={form.ssl_email} onChange={(e) => setForm({ ...form, ssl_email: e.target.value })} />
               </div>
-              <div>
-                <label className="text-sm font-medium">Proxy / DNS target</label>
-                <Input placeholder="pop1.diytaxreturn.co.uk" value={form.proxy_target} onChange={(e) => setForm({ ...form, proxy_target: e.target.value })} />
-              </div>
+            </div>
+            {/* Live preview of the rule that will be auto-created on sync — the
+                user never types a "rule id". */}
+            <div className="rounded bg-secondary-50 border border-secondary-200 p-2 text-xs text-secondary-600">
+              Auto-created rule: <span className="font-mono text-secondary-800">{ruleSlug(form.domain_name)}</span>
+              {' '}— path <span className="font-mono text-secondary-800">{form.rule_path || '/'}</span>
+              {' '}→ <span className="font-mono text-secondary-800">{form.proxy_target || '(Sync Settings default backend)'}</span>
             </div>
           </div>
           <div>

--- a/opsapi-dashboard/services/domain.service.ts
+++ b/opsapi-dashboard/services/domain.service.ts
@@ -35,6 +35,7 @@ export interface Domain {
   wslproxy_root?: string;
   listen_ports?: string;
   proxy_target?: string;
+  rule_path?: string;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
Creating a domain whose (namespace_id, domain_name) already existed threw a raw unique-constraint violation -> SYSTEM_500. Worse, because delete is a soft delete (sets deleted_at) while the UNIQUE(namespace_id, domain_name) constraint still counts the hidden row, deleting a domain and re-adding it also 500'd — and the row was invisible in the UI, so it looked like nothing was there.

DomainQueries.createDomain now guards the constraint explicitly:
  * active same-name row      -> returns { code = "duplicate" } -> route 409
  * soft-deleted same-name row -> revived in place (clears deleted_at, overwrites
    details) so re-adding a deleted domain just works and returns the row
  * the final INSERT is pcall-wrapped, so any residual DB error is a typed error
    instead of a raw 500
The dashboard now surfaces the server message (the 409 "already exists") on the
create/update form instead of a generic "Save failed".

Verified locally: create 201, duplicate 409, delete 200, re-create-after-delete 201 (single row, revived with new details).

Also includes the in-tree rule_path work these files carried: the rule_path column migration (domain-wslproxy-fields.lua step [2], already referenced by migrations.lua) + rule_path on the Domain type and form.