### PR TITLE
feat(cms): website Pages + Blog module (namespace-scoped, WYSIWYG)

### DIFF
--- a/lapis/app.lua
+++ b/lapis/app.lua
@@ -587,6 +587,13 @@ load_if("academy", "routes.academy-stripe-webhook")
 load_if("academy", "routes.academy-admin")
 
 -- ============================================
+-- CMS (website pages + blog: articles, categories, tags)
+-- ============================================
+load_if("cms", "routes.cms-posts")
+load_if("cms", "routes.cms-pages")
+load_if("cms", "routes.cms-taxonomy")
+
+-- ============================================
 -- PROJECT MODULE ROUTES (auto-loaded from /projects/)
 -- ============================================
 local ok_loader, ProjectLoader = pcall(require, "helper.project-loader")

--- a/lapis/helper/cms-http.lua
+++ b/lapis/helper/cms-http.lua
@@ -1,0 +1,109 @@
+--[[
+    CMS HTTP helpers
+    ================
+    Shared request/response utilities for the CMS routes (posts, pages,
+    taxonomy). Kept small and dependency-light; mirrors the inline helpers in
+    routes/academy.lua but factored out so the three CMS route files agree.
+]]
+
+local cJson = require("cjson")
+local NamespaceQueries = require "queries.NamespaceQueries"
+
+local CmsHttp = {}
+
+--- Parse a JSON or form-encoded body into a table.
+--- Large bodies (a post's rich content_html) exceed client_body_buffer_size, so
+--- nginx spills them to a temp file — in that case get_body_data() is empty and
+--- we read the body file ourselves. JSON is tried first, then urlencoded.
+function CmsHttp.parse_body()
+    ngx.req.read_body()
+
+    local ctype = ngx.var.content_type or ""
+    local is_json = ctype:find("application/json", 1, true) ~= nil
+
+    if not is_json then
+        local post_args = ngx.req.get_post_args()
+        if post_args and next(post_args) then return post_args end
+    end
+
+    local body = ngx.req.get_body_data()
+    if not body or body == "" then
+        local path = ngx.req.get_body_file()
+        if path then
+            local f = io.open(path, "rb")
+            if f then
+                body = f:read("*a")
+                f:close()
+            end
+        end
+    end
+    if not body or body == "" then return {} end
+
+    local ok, decoded = pcall(cJson.decode, body)
+    if ok and type(decoded) == "table" then return decoded end
+
+    local args = ngx.decode_args(body)
+    if type(args) == "table" then return args end
+    return {}
+end
+
+--- House response shape: { success, data } or { success=false, error }.
+function CmsHttp.api_response(status, data, error_msg)
+    if error_msg then
+        return { status = status, json = { success = false, error = error_msg } }
+    end
+    return { status = status, json = { success = true, data = data } }
+end
+
+--- Coerce loose truthy values (forms send strings).
+function CmsHttp.to_bool(v, default)
+    if v == nil then return default end
+    if type(v) == "boolean" then return v end
+    if type(v) == "number" then return v ~= 0 end
+    local s = tostring(v):lower()
+    return s == "true" or s == "1" or s == "yes" or s == "on"
+end
+
+--- Normalise a tag list from any transport into a clean Lua array of strings.
+--- Accepts a real JSON array, a JSON-array string, a comma-separated string, or
+--- a single string. Each entry is trimmed and capped at 60 chars; empties and
+--- duplicates (case-insensitive) are dropped.
+function CmsHttp.coerce_list(v)
+    if v == nil then return nil end
+    local raw = {}
+    if type(v) == "table" then
+        for _, item in ipairs(v) do raw[#raw + 1] = item end
+    elseif type(v) == "string" then
+        local s = v:gsub("^%s+", ""):gsub("%s+$", "")
+        if s == "" then return {} end
+        if s:sub(1, 1) == "[" then
+            local ok, decoded = pcall(cJson.decode, s)
+            if ok and type(decoded) == "table" then
+                for _, item in ipairs(decoded) do raw[#raw + 1] = item end
+            end
+        else
+            for part in s:gmatch("[^,]+") do raw[#raw + 1] = part end
+        end
+    else
+        return {}
+    end
+
+    local out, seen = {}, {}
+    for _, item in ipairs(raw) do
+        local str = tostring(item):gsub("^%s+", ""):gsub("%s+$", "")
+        if #str > 60 then str = str:sub(1, 60) end
+        local key = str:lower()
+        if str ~= "" and not seen[key] then
+            seen[key] = true
+            out[#out + 1] = str
+        end
+    end
+    return out
+end
+
+--- Resolve the public namespace from :namespace (slug) in the URL.
+function CmsHttp.resolve_namespace(self)
+    return NamespaceQueries.findBySlug(self.params.namespace)
+end
+
+return CmsHttp

--- a/lapis/helper/project-config.lua
+++ b/lapis/helper/project-config.lua
@@ -40,6 +40,7 @@ ProjectConfig.FEATURES = {
     INVOICING = "invoicing",           -- Invoice generation and payments
     ACCOUNTING = "accounting",         -- Bookkeeping, VAT returns, trial balance, AI-powered
     ACADEMY = "academy",               -- LMS: courses, lessons, rich (WYSIWYG) content
+    CMS = "cms",                       -- Content: website pages + blog (articles, categories, tags)
 
     -- Platform-level features (always-on for every preset)
     THEMES = "themes",                 -- Multi-tenant theme system (WordPress-style)
@@ -67,6 +68,17 @@ ProjectConfig.PROJECT_FEATURES = {
         ProjectConfig.FEATURES.INVOICING,
         ProjectConfig.FEATURES.ACCOUNTING,
         ProjectConfig.FEATURES.ACADEMY,
+        ProjectConfig.FEATURES.CMS,
+        ProjectConfig.FEATURES.THEMES,
+    },
+
+    -- CMS - Website content (static pages + blog). Installs only the cms tables;
+    -- tenants are isolated by namespace, so it can safely share a database with
+    -- any other project. Also included in the `all` preset.
+    cms = {
+        ProjectConfig.FEATURES.CORE,
+        ProjectConfig.FEATURES.CMS,
+        ProjectConfig.FEATURES.MENU,
         ProjectConfig.FEATURES.THEMES,
     },
 
@@ -465,6 +477,11 @@ ProjectConfig.PROJECT_MODULES = {
     -- Academy (LMS) modules — RBAC module that routes/academy.lua gates on ("courses")
     academy = {
         { machine_name = "courses", name = "Courses", description = "Course and lesson content management (rich WYSIWYG)", category = "Academy" },
+    },
+
+    -- CMS modules — RBAC module the routes/cms-*.lua gate on ("cms")
+    cms = {
+        { machine_name = "cms", name = "Content", description = "Website pages, blog articles, categories and tags (rich WYSIWYG)", category = "Content" },
     },
 
     -- Theme system (platform-level; always on)

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -142,6 +142,10 @@ local academy_enrollment_migrations = load_if_enabled(ProjectConfig.FEATURES.ACA
 local academy_payment_migrations = load_if_enabled(ProjectConfig.FEATURES.ACADEMY, "migrations.academy-payments") or {}
 local academy_progress_migrations = load_if_enabled(ProjectConfig.FEATURES.ACADEMY, "migrations.academy-progress") or {}
 
+-- CMS (website pages + blog: articles, categories, tags — namespace-scoped)
+local cms_migrations = load_if_enabled(ProjectConfig.FEATURES.CMS, "migrations.cms-system") or {}
+local cms_menu_migrations = load_if_enabled(ProjectConfig.FEATURES.CMS, "migrations.cms-menu-items") or {}
+
 -- Core enhancements (always load for namespace/rbac)
 local rbac_enhancements_migrations = require("migrations.rbac-enhancements")
 local namespace_system_migrations = require("migrations.namespace-system")
@@ -2275,6 +2279,23 @@ local _migrations = {
     -- Academy learner progress (completed lessons -> dashboard progress bars)
     ['819_create_academy_lesson_progress'] = conditional_array(ProjectConfig.FEATURES.ACADEMY, academy_progress_migrations, 1),
     ['820_academy_lesson_progress_indexes'] = conditional_array(ProjectConfig.FEATURES.ACADEMY, academy_progress_migrations, 2),
+
+    -- =========================================================================
+    -- CMS (website pages + blog). Feature-gated, so these only run when
+    -- PROJECT_CODE enables `cms`. Tables are ordered so FK targets exist first:
+    -- categories -> tags -> posts -> pages -> post_tags.
+    -- =========================================================================
+    ['833_create_cms_categories'] = conditional_array(ProjectConfig.FEATURES.CMS, cms_migrations, 1),
+    ['834_create_cms_tags'] = conditional_array(ProjectConfig.FEATURES.CMS, cms_migrations, 2),
+    ['835_create_cms_posts'] = conditional_array(ProjectConfig.FEATURES.CMS, cms_migrations, 3),
+    ['836_cms_posts_indexes'] = conditional_array(ProjectConfig.FEATURES.CMS, cms_migrations, 4),
+    ['837_create_cms_pages'] = conditional_array(ProjectConfig.FEATURES.CMS, cms_migrations, 5),
+    ['838_create_cms_post_tags'] = conditional_array(ProjectConfig.FEATURES.CMS, cms_migrations, 6),
+    -- CMS sidebar menu item + RBAC module ("cms") + role grants + enable for namespaces
+    ['839_seed_cms_menu_items'] = conditional_array(ProjectConfig.FEATURES.CMS, cms_menu_migrations, 1),
+    ['840_register_cms_modules'] = conditional_array(ProjectConfig.FEATURES.CMS, cms_menu_migrations, 2),
+    ['841_grant_cms_permissions'] = conditional_array(ProjectConfig.FEATURES.CMS, cms_menu_migrations, 3),
+    ['842_enable_cms_menu_for_namespaces'] = conditional_array(ProjectConfig.FEATURES.CMS, cms_menu_migrations, 4),
 
     -- Theme system foundation (Phase 0): drop obsolete scaffold.
     -- Replaced by new tables in Phase 1 migration 621_create_theme_system.

--- a/lapis/migrations/cms-menu-items.lua
+++ b/lapis/migrations/cms-menu-items.lua
@@ -1,0 +1,151 @@
+--[[
+    CMS Menu Items Seeding Migration
+
+    CMS has a backend (routes/cms-*.lua), DB tables (cms_pages / cms_posts /
+    cms_categories / cms_tags), an RBAC module ("cms") and a dashboard page
+    (/dashboard/cms). This seeds the sidebar menu_items row, registers the RBAC
+    module, grants permissions to owner/admin namespace roles, and enables the
+    menu item for existing namespaces. Mirrors academy-menu-items.
+    Feature-gated under FEATURES.CMS.
+]]
+
+local db = require("lapis.db")
+
+return {
+    -- [1] Insert the Content (CMS) menu item
+    [1] = function()
+        local MigrationUtils = require("helper.migration-utils")
+        local timestamp = MigrationUtils.getCurrentTimestamp()
+
+        local items = {
+            {
+                key = "cms",
+                name = "Content",
+                icon = "FileText",
+                path = "/dashboard/cms",
+                module = "cms",
+                required_action = "read",
+                priority = 46,
+            },
+        }
+
+        for _, item in ipairs(items) do
+            local existing = db.select("* FROM menu_items WHERE key = ?", item.key)
+            if #existing == 0 then
+                db.insert("menu_items", {
+                    uuid = MigrationUtils.generateUUID(),
+                    key = item.key,
+                    name = item.name,
+                    icon = item.icon,
+                    path = item.path,
+                    module = item.module,
+                    required_action = item.required_action,
+                    priority = item.priority,
+                    is_active = true,
+                    is_admin_only = false,
+                    always_show = false,
+                    settings = "{}",
+                    created_at = timestamp,
+                    updated_at = timestamp,
+                })
+                print("[CMS] Added menu item: " .. item.key)
+            end
+        end
+    end,
+
+    -- [2] Register the CMS RBAC module ("cms")
+    [2] = function()
+        local MigrationUtils = require("helper.migration-utils")
+        local timestamp = MigrationUtils.getCurrentTimestamp()
+
+        local modules = {
+            { machine_name = "cms", name = "Content", description = "Website pages, blog articles, categories and tags (rich WYSIWYG)", priority = 46 },
+        }
+
+        for _, mod in ipairs(modules) do
+            local existing = db.select("* FROM modules WHERE machine_name = ?", mod.machine_name)
+            if #existing == 0 then
+                db.insert("modules", {
+                    uuid = MigrationUtils.generateUUID(),
+                    machine_name = mod.machine_name,
+                    name = mod.name,
+                    description = mod.description,
+                    priority = mod.priority,
+                    created_at = timestamp,
+                    updated_at = timestamp,
+                })
+                print("[CMS] Registered module: " .. mod.machine_name)
+            end
+        end
+    end,
+
+    -- [3] Grant "cms" permissions to owner + admin roles
+    [3] = function()
+        local cjson_ok, cjson = pcall(require, "cjson")
+        if not cjson_ok then return end
+
+        local full_modules = { "cms" }
+
+        local owner_roles = db.select(
+            "* FROM namespace_roles WHERE role_name IN ('Owner', 'owner', 'Namespace Owner')"
+        )
+        local owner_actions = { "create", "read", "update", "delete", "manage" }
+        for _, role in ipairs(owner_roles) do
+            local perms = {}
+            if role.permissions and role.permissions ~= "" then
+                local ok, decoded = pcall(cjson.decode, role.permissions)
+                if ok and type(decoded) == "table" then perms = decoded end
+            end
+            for _, mod_name in ipairs(full_modules) do
+                if not perms[mod_name] then perms[mod_name] = owner_actions end
+            end
+            db.update("namespace_roles", { permissions = cjson.encode(perms) }, { id = role.id })
+        end
+
+        local admin_roles = db.select(
+            "* FROM namespace_roles WHERE role_name IN ('Admin', 'admin', 'Namespace Admin')"
+        )
+        local admin_actions = { "create", "read", "update", "delete" }
+        for _, role in ipairs(admin_roles) do
+            local perms = {}
+            if role.permissions and role.permissions ~= "" then
+                local ok, decoded = pcall(cjson.decode, role.permissions)
+                if ok and type(decoded) == "table" then perms = decoded end
+            end
+            for _, mod_name in ipairs(full_modules) do
+                if not perms[mod_name] then perms[mod_name] = admin_actions end
+            end
+            db.update("namespace_roles", { permissions = cjson.encode(perms) }, { id = role.id })
+        end
+    end,
+
+    -- [4] Enable the menu item for all existing namespaces
+    [4] = function()
+        local MigrationUtils = require("helper.migration-utils")
+        local timestamp = MigrationUtils.getCurrentTimestamp()
+
+        for _, key in ipairs({ "cms" }) do
+            local menu_rows = db.select("* FROM menu_items WHERE key = ?", key)
+            if #menu_rows > 0 then
+                local menu_item = menu_rows[1]
+                local namespaces = db.select("* FROM namespaces")
+                for _, ns in ipairs(namespaces) do
+                    local exists = db.select([[
+                        * FROM namespace_menu_config
+                        WHERE namespace_id = ? AND menu_item_id = ?
+                    ]], ns.id, menu_item.id)
+                    if #exists == 0 then
+                        db.insert("namespace_menu_config", {
+                            uuid = MigrationUtils.generateUUID(),
+                            namespace_id = ns.id,
+                            menu_item_id = menu_item.id,
+                            is_enabled = true,
+                            created_at = timestamp,
+                            updated_at = timestamp,
+                        })
+                    end
+                end
+            end
+        end
+    end,
+}

--- a/lapis/migrations/cms-system.lua
+++ b/lapis/migrations/cms-system.lua
@@ -1,0 +1,405 @@
+--[[
+    CMS (Content Management) System Migrations
+    ==========================================
+
+    A multi-tenant Content Management System powering the public-facing website
+    of a namespace: static **Pages** (About, Contact, ...) and a proper **Blog**
+    (articles with categories + tags). Rich WYSIWYG content, mirroring the
+    academy module's storage model.
+
+    Tables:
+    =======
+    1. cms_categories - Blog categories (hierarchical, namespace-scoped)
+    2. cms_tags       - Blog tags (flat, namespace-scoped)
+    3. cms_posts      - Blog articles (rich HTML + editor JSON, SEO, publishing)
+    4. cms_pages      - Static site pages (rich HTML + editor JSON, SEO, nav)
+    5. cms_post_tags  - Post <-> Tag join (many-to-many)
+
+    Notes:
+    ======
+    - Every content table is namespace-scoped (FK -> namespaces ON DELETE CASCADE)
+      so tenants are fully isolated and it can share a DB with any other project.
+    - Soft deletes (deleted_at) everywhere; unique slug per namespace applies only
+      to live rows (partial index WHERE deleted_at IS NULL), so a deleted slug can
+      be reused / revived.
+    - Body is stored as sanitized `content_html` (rendered) plus `content_json`
+      (the editor document, for re-editing) — same contract as academy_lessons.
+]]
+
+local schema = require("lapis.db.schema")
+local types = schema.types
+local db = require("lapis.db")
+
+local function table_exists(table_name)
+    local result = db.query([[
+        SELECT EXISTS (
+            SELECT FROM information_schema.tables WHERE table_name = ?
+        ) as exists
+    ]], table_name)
+    return result[1] and result[1].exists
+end
+
+local function index_exists(index_name)
+    local result = db.query([[
+        SELECT EXISTS (SELECT FROM pg_indexes WHERE indexname = ?) as exists
+    ]], index_name)
+    return result[1] and result[1].exists
+end
+
+return {
+    -- ========================================================================
+    -- [1] Create cms_categories (hierarchical blog categories)
+    -- ========================================================================
+    [1] = function()
+        if table_exists("cms_categories") then return end
+
+        schema.create_table("cms_categories", {
+            { "id", types.serial },
+            { "uuid", types.varchar({ unique = true }) },
+            { "namespace_id", types.integer },
+            { "name", types.varchar },
+            { "slug", types.varchar },
+            { "description", types.text({ null = true }) },
+            { "parent_id", types.integer({ null = true }) },
+            { "position", types.integer({ default = 0 }) },
+            { "created_at", types.time({ default = db.raw("NOW()") }) },
+            { "updated_at", types.time({ default = db.raw("NOW()") }) },
+            { "deleted_at", types.time({ null = true }) },
+            "PRIMARY KEY (id)"
+        })
+
+        pcall(function()
+            db.query([[
+                ALTER TABLE cms_categories
+                ADD CONSTRAINT cms_categories_namespace_fk
+                FOREIGN KEY (namespace_id) REFERENCES namespaces(id) ON DELETE CASCADE
+            ]])
+        end)
+
+        -- lapis types.integer gives the column a DEFAULT 0; for a nullable FK
+        -- that means an omitted parent inserts 0 and breaks the FK. Drop it so
+        -- an unspecified parent is NULL.
+        pcall(function()
+            db.query("ALTER TABLE cms_categories ALTER COLUMN parent_id DROP DEFAULT")
+        end)
+
+        -- Self-reference for nesting; a deleted parent orphans children (SET NULL)
+        -- rather than cascading — a child category should survive its parent.
+        pcall(function()
+            db.query([[
+                ALTER TABLE cms_categories
+                ADD CONSTRAINT cms_categories_parent_fk
+                FOREIGN KEY (parent_id) REFERENCES cms_categories(id) ON DELETE SET NULL
+            ]])
+        end)
+
+        pcall(function()
+            db.query([[
+                CREATE UNIQUE INDEX cms_categories_namespace_slug_unique
+                ON cms_categories (namespace_id, slug)
+                WHERE deleted_at IS NULL
+            ]])
+        end)
+
+        if not index_exists("idx_cms_categories_uuid") then
+            db.query("CREATE UNIQUE INDEX idx_cms_categories_uuid ON cms_categories (uuid)")
+        end
+        if not index_exists("idx_cms_categories_ns") then
+            db.query([[
+                CREATE INDEX idx_cms_categories_ns
+                ON cms_categories (namespace_id)
+                WHERE deleted_at IS NULL
+            ]])
+        end
+    end,
+
+    -- ========================================================================
+    -- [2] Create cms_tags (flat blog tags)
+    -- ========================================================================
+    [2] = function()
+        if table_exists("cms_tags") then return end
+
+        schema.create_table("cms_tags", {
+            { "id", types.serial },
+            { "uuid", types.varchar({ unique = true }) },
+            { "namespace_id", types.integer },
+            { "name", types.varchar },
+            { "slug", types.varchar },
+            { "created_at", types.time({ default = db.raw("NOW()") }) },
+            { "updated_at", types.time({ default = db.raw("NOW()") }) },
+            { "deleted_at", types.time({ null = true }) },
+            "PRIMARY KEY (id)"
+        })
+
+        pcall(function()
+            db.query([[
+                ALTER TABLE cms_tags
+                ADD CONSTRAINT cms_tags_namespace_fk
+                FOREIGN KEY (namespace_id) REFERENCES namespaces(id) ON DELETE CASCADE
+            ]])
+        end)
+
+        pcall(function()
+            db.query([[
+                CREATE UNIQUE INDEX cms_tags_namespace_slug_unique
+                ON cms_tags (namespace_id, slug)
+                WHERE deleted_at IS NULL
+            ]])
+        end)
+
+        if not index_exists("idx_cms_tags_uuid") then
+            db.query("CREATE UNIQUE INDEX idx_cms_tags_uuid ON cms_tags (uuid)")
+        end
+        if not index_exists("idx_cms_tags_ns") then
+            db.query([[
+                CREATE INDEX idx_cms_tags_ns
+                ON cms_tags (namespace_id)
+                WHERE deleted_at IS NULL
+            ]])
+        end
+    end,
+
+    -- ========================================================================
+    -- [3] Create cms_posts (blog articles)
+    -- ========================================================================
+    [3] = function()
+        if table_exists("cms_posts") then return end
+
+        schema.create_table("cms_posts", {
+            { "id", types.serial },
+            { "uuid", types.varchar({ unique = true }) },
+            { "namespace_id", types.integer },
+            { "category_id", types.integer({ null = true }) },
+            { "title", types.varchar },
+            { "slug", types.varchar },
+            { "excerpt", types.text({ null = true }) },
+            { "content_html", types.text({ null = true }) },   -- sanitized, rendered
+            { "content_json", types.text({ null = true }) },   -- editor document (re-editing)
+            { "featured_image_url", types.varchar({ null = true }) },
+            { "status", types.varchar({ default = "draft" }) },      -- draft|published|scheduled|archived
+            { "visibility", types.varchar({ default = "public" }) }, -- public|private
+            { "is_featured", types.boolean({ default = false }) },
+            { "author_uuid", types.varchar({ null = true }) },
+            { "author_name", types.varchar({ null = true }) },
+            { "published_at", types.time({ null = true }) },
+            { "scheduled_at", types.time({ null = true }) },
+            { "seo_title", types.varchar({ null = true }) },
+            { "seo_description", types.text({ null = true }) },
+            { "seo_keywords", types.varchar({ null = true }) },
+            { "reading_minutes", types.integer({ default = 0 }) },
+            { "view_count", types.integer({ default = 0 }) },
+            { "created_at", types.time({ default = db.raw("NOW()") }) },
+            { "updated_at", types.time({ default = db.raw("NOW()") }) },
+            { "deleted_at", types.time({ null = true }) },
+            "PRIMARY KEY (id)"
+        })
+
+        pcall(function()
+            db.query([[
+                ALTER TABLE cms_posts
+                ADD CONSTRAINT cms_posts_namespace_fk
+                FOREIGN KEY (namespace_id) REFERENCES namespaces(id) ON DELETE CASCADE
+            ]])
+        end)
+
+        -- Nullable FK: drop the DEFAULT 0 so an uncategorised post inserts NULL.
+        pcall(function()
+            db.query("ALTER TABLE cms_posts ALTER COLUMN category_id DROP DEFAULT")
+        end)
+
+        -- Deleting a category detaches its posts (SET NULL) — posts outlive
+        -- their category.
+        pcall(function()
+            db.query([[
+                ALTER TABLE cms_posts
+                ADD CONSTRAINT cms_posts_category_fk
+                FOREIGN KEY (category_id) REFERENCES cms_categories(id) ON DELETE SET NULL
+            ]])
+        end)
+
+        pcall(function()
+            db.query([[
+                ALTER TABLE cms_posts
+                ADD CONSTRAINT cms_posts_status_check
+                CHECK (status IN ('draft', 'published', 'scheduled', 'archived'))
+            ]])
+        end)
+
+        pcall(function()
+            db.query([[
+                ALTER TABLE cms_posts
+                ADD CONSTRAINT cms_posts_visibility_check
+                CHECK (visibility IN ('public', 'private'))
+            ]])
+        end)
+
+        pcall(function()
+            db.query([[
+                CREATE UNIQUE INDEX cms_posts_namespace_slug_unique
+                ON cms_posts (namespace_id, slug)
+                WHERE deleted_at IS NULL
+            ]])
+        end)
+    end,
+
+    -- ========================================================================
+    -- [4] cms_posts indexes
+    -- ========================================================================
+    [4] = function()
+        if not index_exists("idx_cms_posts_uuid") then
+            db.query("CREATE UNIQUE INDEX idx_cms_posts_uuid ON cms_posts (uuid)")
+        end
+        -- Catalogue listing: newest published first per namespace.
+        if not index_exists("idx_cms_posts_ns_status_pub") then
+            db.query([[
+                CREATE INDEX idx_cms_posts_ns_status_pub
+                ON cms_posts (namespace_id, status, published_at DESC)
+                WHERE deleted_at IS NULL
+            ]])
+        end
+        if not index_exists("idx_cms_posts_ns_category") then
+            db.query([[
+                CREATE INDEX idx_cms_posts_ns_category
+                ON cms_posts (namespace_id, category_id)
+                WHERE deleted_at IS NULL
+            ]])
+        end
+        if not index_exists("idx_cms_posts_ns_featured") then
+            db.query([[
+                CREATE INDEX idx_cms_posts_ns_featured
+                ON cms_posts (namespace_id, is_featured)
+                WHERE deleted_at IS NULL
+            ]])
+        end
+    end,
+
+    -- ========================================================================
+    -- [5] Create cms_pages (static site pages)
+    -- ========================================================================
+    [5] = function()
+        if table_exists("cms_pages") then return end
+
+        schema.create_table("cms_pages", {
+            { "id", types.serial },
+            { "uuid", types.varchar({ unique = true }) },
+            { "namespace_id", types.integer },
+            { "parent_id", types.integer({ null = true }) },
+            { "title", types.varchar },
+            { "slug", types.varchar },
+            { "excerpt", types.text({ null = true }) },
+            { "content_html", types.text({ null = true }) },   -- sanitized, rendered
+            { "content_json", types.text({ null = true }) },   -- editor document (re-editing)
+            { "featured_image_url", types.varchar({ null = true }) },
+            { "status", types.varchar({ default = "draft" }) },     -- draft|published|archived
+            { "template", types.varchar({ default = "default" }) }, -- theme template hint
+            { "menu_order", types.integer({ default = 0 }) },
+            { "show_in_nav", types.boolean({ default = false }) },
+            { "author_uuid", types.varchar({ null = true }) },
+            { "published_at", types.time({ null = true }) },
+            { "seo_title", types.varchar({ null = true }) },
+            { "seo_description", types.text({ null = true }) },
+            { "seo_keywords", types.varchar({ null = true }) },
+            { "created_at", types.time({ default = db.raw("NOW()") }) },
+            { "updated_at", types.time({ default = db.raw("NOW()") }) },
+            { "deleted_at", types.time({ null = true }) },
+            "PRIMARY KEY (id)"
+        })
+
+        pcall(function()
+            db.query([[
+                ALTER TABLE cms_pages
+                ADD CONSTRAINT cms_pages_namespace_fk
+                FOREIGN KEY (namespace_id) REFERENCES namespaces(id) ON DELETE CASCADE
+            ]])
+        end)
+
+        -- Nullable FK: drop the DEFAULT 0 so a top-level page inserts NULL.
+        pcall(function()
+            db.query("ALTER TABLE cms_pages ALTER COLUMN parent_id DROP DEFAULT")
+        end)
+
+        pcall(function()
+            db.query([[
+                ALTER TABLE cms_pages
+                ADD CONSTRAINT cms_pages_parent_fk
+                FOREIGN KEY (parent_id) REFERENCES cms_pages(id) ON DELETE SET NULL
+            ]])
+        end)
+
+        pcall(function()
+            db.query([[
+                ALTER TABLE cms_pages
+                ADD CONSTRAINT cms_pages_status_check
+                CHECK (status IN ('draft', 'published', 'archived'))
+            ]])
+        end)
+
+        pcall(function()
+            db.query([[
+                CREATE UNIQUE INDEX cms_pages_namespace_slug_unique
+                ON cms_pages (namespace_id, slug)
+                WHERE deleted_at IS NULL
+            ]])
+        end)
+
+        if not index_exists("idx_cms_pages_uuid") then
+            db.query("CREATE UNIQUE INDEX idx_cms_pages_uuid ON cms_pages (uuid)")
+        end
+        if not index_exists("idx_cms_pages_ns_status") then
+            db.query([[
+                CREATE INDEX idx_cms_pages_ns_status
+                ON cms_pages (namespace_id, status)
+                WHERE deleted_at IS NULL
+            ]])
+        end
+        if not index_exists("idx_cms_pages_ns_nav") then
+            db.query([[
+                CREATE INDEX idx_cms_pages_ns_nav
+                ON cms_pages (namespace_id, show_in_nav, menu_order)
+                WHERE deleted_at IS NULL
+            ]])
+        end
+    end,
+
+    -- ========================================================================
+    -- [6] Create cms_post_tags (post <-> tag many-to-many)
+    -- ========================================================================
+    [6] = function()
+        if table_exists("cms_post_tags") then return end
+
+        schema.create_table("cms_post_tags", {
+            { "id", types.serial },
+            { "post_id", types.integer },
+            { "tag_id", types.integer },
+            { "created_at", types.time({ default = db.raw("NOW()") }) },
+            "PRIMARY KEY (id)"
+        })
+
+        pcall(function()
+            db.query([[
+                ALTER TABLE cms_post_tags
+                ADD CONSTRAINT cms_post_tags_post_fk
+                FOREIGN KEY (post_id) REFERENCES cms_posts(id) ON DELETE CASCADE
+            ]])
+        end)
+
+        pcall(function()
+            db.query([[
+                ALTER TABLE cms_post_tags
+                ADD CONSTRAINT cms_post_tags_tag_fk
+                FOREIGN KEY (tag_id) REFERENCES cms_tags(id) ON DELETE CASCADE
+            ]])
+        end)
+
+        pcall(function()
+            db.query([[
+                CREATE UNIQUE INDEX cms_post_tags_unique
+                ON cms_post_tags (post_id, tag_id)
+            ]])
+        end)
+
+        if not index_exists("idx_cms_post_tags_tag") then
+            db.query("CREATE INDEX idx_cms_post_tags_tag ON cms_post_tags (tag_id)")
+        end
+    end,
+}

--- a/lapis/models/CmsCategoryModel.lua
+++ b/lapis/models/CmsCategoryModel.lua
@@ -1,0 +1,12 @@
+local Model = require("lapis.db.model").Model
+
+local CmsCategory = Model:extend("cms_categories", {
+    timestamp = true,
+    relations = {
+        { "namespace", belongs_to = "NamespaceModel", key = "namespace_id" },
+        { "parent",    belongs_to = "CmsCategoryModel", key = "parent_id" },
+        { "posts",     has_many = "CmsPostModel", key = "category_id" },
+    }
+})
+
+return CmsCategory

--- a/lapis/models/CmsPageModel.lua
+++ b/lapis/models/CmsPageModel.lua
@@ -1,0 +1,11 @@
+local Model = require("lapis.db.model").Model
+
+local CmsPage = Model:extend("cms_pages", {
+    timestamp = true,
+    relations = {
+        { "namespace", belongs_to = "NamespaceModel", key = "namespace_id" },
+        { "parent",    belongs_to = "CmsPageModel", key = "parent_id" },
+    }
+})
+
+return CmsPage

--- a/lapis/models/CmsPostModel.lua
+++ b/lapis/models/CmsPostModel.lua
@@ -1,0 +1,11 @@
+local Model = require("lapis.db.model").Model
+
+local CmsPost = Model:extend("cms_posts", {
+    timestamp = true,
+    relations = {
+        { "namespace", belongs_to = "NamespaceModel", key = "namespace_id" },
+        { "category",  belongs_to = "CmsCategoryModel", key = "category_id" },
+    }
+})
+
+return CmsPost

--- a/lapis/models/CmsPostTagModel.lua
+++ b/lapis/models/CmsPostTagModel.lua
@@ -1,0 +1,12 @@
+local Model = require("lapis.db.model").Model
+
+-- Join row between a blog post and a tag. No `updated_at` on this table, so
+-- `timestamp` is left off (the model would try to set a column that isn't there).
+local CmsPostTag = Model:extend("cms_post_tags", {
+    relations = {
+        { "post", belongs_to = "CmsPostModel", key = "post_id" },
+        { "tag",  belongs_to = "CmsTagModel", key = "tag_id" },
+    }
+})
+
+return CmsPostTag

--- a/lapis/models/CmsTagModel.lua
+++ b/lapis/models/CmsTagModel.lua
@@ -1,0 +1,10 @@
+local Model = require("lapis.db.model").Model
+
+local CmsTag = Model:extend("cms_tags", {
+    timestamp = true,
+    relations = {
+        { "namespace", belongs_to = "NamespaceModel", key = "namespace_id" },
+    }
+})
+
+return CmsTag

--- a/lapis/queries/CmsCategoryQueries.lua
+++ b/lapis/queries/CmsCategoryQueries.lua
@@ -1,0 +1,124 @@
+--[[
+    CMS Category Queries
+    ====================
+    Namespace-scoped CRUD for cms_categories (hierarchical blog categories).
+    Soft-deleted; slug is unique per namespace among live rows.
+]]
+
+local CmsCategoryModel = require "models.CmsCategoryModel"
+local Global = require "helper.global"
+local db = require("lapis.db")
+
+local CmsCategoryQueries = {}
+
+local function slugify(text)
+    if not text or text == "" then return "" end
+    return (text:lower():gsub("%s+", "-"):gsub("[^%w%-]", ""):gsub("%-+", "-"):gsub("^%-", ""):gsub("%-$", ""))
+end
+CmsCategoryQueries.slugify = slugify
+
+--- Produce a slug unique among live rows in the namespace. Appends -2, -3, ...
+--- `ignore_id` lets an update keep its own slug.
+local function uniqueSlug(namespace_id, base, ignore_id)
+    base = (base and base ~= "") and base or "category"
+    local slug = base
+    local n = 1
+    while true do
+        local rows = db.query(
+            "SELECT id FROM cms_categories WHERE namespace_id = ? AND slug = ? AND deleted_at IS NULL LIMIT 1",
+            namespace_id, slug)
+        local clash = rows and rows[1]
+        if not clash or (ignore_id and tonumber(clash.id) == tonumber(ignore_id)) then
+            return slug
+        end
+        n = n + 1
+        slug = base .. "-" .. n
+    end
+end
+
+local function findScoped(namespace_id, uuid)
+    local row = CmsCategoryModel:find({ uuid = uuid, namespace_id = namespace_id })
+    if not row or row.deleted_at then return nil end
+    return row
+end
+CmsCategoryQueries.findScoped = findScoped
+
+--- Resolve a parent uuid to its internal id (scoped); nil if absent/invalid.
+local function resolveParentId(namespace_id, parent_uuid)
+    if not parent_uuid or parent_uuid == "" then return nil end
+    local parent = findScoped(namespace_id, parent_uuid)
+    return parent and parent.id or nil
+end
+
+function CmsCategoryQueries.create(namespace_id, params)
+    local base = slugify(params.slug ~= "" and params.slug or params.name)
+    local insert = {
+        uuid = Global.generateUUID(),
+        namespace_id = namespace_id,
+        name = params.name,
+        slug = uniqueSlug(namespace_id, base),
+        description = params.description,
+        -- Nullable FK: pass an explicit NULL when unset (the column carries a
+        -- DEFAULT 0 from lapis types.integer, which would break the FK).
+        parent_id = resolveParentId(namespace_id, params.parent_uuid) or db.NULL,
+        position = tonumber(params.position) or 0,
+        created_at = db.raw("NOW()"),
+        updated_at = db.raw("NOW()"),
+    }
+    return CmsCategoryModel:create(insert, { returning = "*" })
+end
+
+--- List categories in a namespace (with post counts). `search` optional.
+function CmsCategoryQueries.list(namespace_id, params)
+    params = params or {}
+    local where = { "c.namespace_id = ?", "c.deleted_at IS NULL" }
+    local values = { namespace_id }
+    if params.search and params.search ~= "" then
+        table.insert(where, "(c.name ILIKE ? OR c.slug ILIKE ?)")
+        local p = "%" .. params.search .. "%"
+        table.insert(values, p); table.insert(values, p)
+    end
+    local rows = db.query([[
+        SELECT c.*, (
+            SELECT COUNT(*) FROM cms_posts p
+            WHERE p.category_id = c.id AND p.deleted_at IS NULL
+        ) AS post_count
+        FROM cms_categories c
+        WHERE ]] .. table.concat(where, " AND ") .. [[
+        ORDER BY c.position ASC, c.name ASC
+    ]], table.unpack(values))
+    return rows or {}
+end
+
+function CmsCategoryQueries.getByUuid(namespace_id, uuid)
+    return findScoped(namespace_id, uuid)
+end
+
+function CmsCategoryQueries.update(namespace_id, uuid, params)
+    local row = findScoped(namespace_id, uuid)
+    if not row then return nil end
+    local fields = { updated_at = db.raw("NOW()") }
+    if params.name ~= nil then fields.name = params.name end
+    if params.description ~= nil then fields.description = params.description end
+    if params.position ~= nil then fields.position = tonumber(params.position) or 0 end
+    if params.slug ~= nil and params.slug ~= "" then
+        fields.slug = uniqueSlug(namespace_id, slugify(params.slug), row.id)
+    end
+    if params.parent_uuid ~= nil then
+        local pid = resolveParentId(namespace_id, params.parent_uuid)
+        -- guard against self-parenting
+        if pid == row.id then pid = nil end
+        fields.parent_id = pid or db.NULL
+    end
+    row:update(fields)
+    return findScoped(namespace_id, uuid)
+end
+
+function CmsCategoryQueries.softDelete(namespace_id, uuid)
+    local row = findScoped(namespace_id, uuid)
+    if not row then return nil end
+    row:update({ deleted_at = db.raw("NOW()"), updated_at = db.raw("NOW()") })
+    return row
+end
+
+return CmsCategoryQueries

--- a/lapis/queries/CmsPageQueries.lua
+++ b/lapis/queries/CmsPageQueries.lua
@@ -1,0 +1,181 @@
+--[[
+    CMS Page (Static Site Page) Queries
+    ===================================
+    Namespace-scoped CRUD + public reads for cms_pages.
+    - Soft-deleted; slug unique per namespace among live rows.
+    - Optional parent (nesting) resolved by uuid.
+    - Publishing stamps published_at once (first time it goes live).
+]]
+
+local CmsPageModel = require "models.CmsPageModel"
+local Global = require "helper.global"
+local db = require("lapis.db")
+
+local CmsPageQueries = {}
+
+local function slugify(text)
+    if not text or text == "" then return "" end
+    return (text:lower():gsub("%s+", "-"):gsub("[^%w%-]", ""):gsub("%-+", "-"):gsub("^%-", ""):gsub("%-$", ""))
+end
+CmsPageQueries.slugify = slugify
+
+local function uniqueSlug(namespace_id, base, ignore_id)
+    base = (base and base ~= "") and base or "page"
+    local slug = base
+    local n = 1
+    while true do
+        local rows = db.query(
+            "SELECT id FROM cms_pages WHERE namespace_id = ? AND slug = ? AND deleted_at IS NULL LIMIT 1",
+            namespace_id, slug)
+        local clash = rows and rows[1]
+        if not clash or (ignore_id and tonumber(clash.id) == tonumber(ignore_id)) then
+            return slug
+        end
+        n = n + 1
+        slug = base .. "-" .. n
+    end
+end
+
+local function findScoped(namespace_id, uuid)
+    local row = CmsPageModel:find({ uuid = uuid, namespace_id = namespace_id })
+    if not row or row.deleted_at then return nil end
+    return row
+end
+CmsPageQueries.findScoped = findScoped
+
+local function resolveParentId(namespace_id, parent_uuid)
+    if not parent_uuid or parent_uuid == "" then return nil end
+    local p = findScoped(namespace_id, parent_uuid)
+    return p and p.id or nil
+end
+
+function CmsPageQueries.create(namespace_id, params)
+    local base = slugify((params.slug and params.slug ~= "") and params.slug or params.title)
+    local status = params.status or "draft"
+    local insert = {
+        uuid = Global.generateUUID(),
+        namespace_id = namespace_id,
+        -- Nullable FK: explicit NULL when unset (column has a DEFAULT 0 from
+        -- lapis types.integer, which would violate the self-parent FK).
+        parent_id = resolveParentId(namespace_id, params.parent_uuid) or db.NULL,
+        title = params.title,
+        slug = uniqueSlug(namespace_id, base),
+        excerpt = params.excerpt,
+        content_html = params.content_html,
+        content_json = params.content_json,
+        featured_image_url = params.featured_image_url,
+        status = status,
+        template = params.template or "default",
+        menu_order = tonumber(params.menu_order) or 0,
+        show_in_nav = params.show_in_nav and true or false,
+        author_uuid = params.author_uuid,
+        seo_title = params.seo_title,
+        seo_description = params.seo_description,
+        seo_keywords = params.seo_keywords,
+        created_at = db.raw("NOW()"),
+        updated_at = db.raw("NOW()"),
+    }
+    if status == "published" then
+        insert.published_at = db.raw("NOW()")
+    end
+    return CmsPageModel:create(insert, { returning = "*" })
+end
+
+function CmsPageQueries.list(namespace_id, params)
+    params = params or {}
+    local where = { "namespace_id = ?", "deleted_at IS NULL" }
+    local values = { namespace_id }
+    if params.status and params.status ~= "" then
+        table.insert(where, "status = ?"); table.insert(values, params.status)
+    end
+    if params.search and params.search ~= "" then
+        table.insert(where, "(title ILIKE ? OR slug ILIKE ?)")
+        local pat = "%" .. params.search .. "%"
+        table.insert(values, pat); table.insert(values, pat)
+    end
+    local rows = db.query([[
+        SELECT * FROM cms_pages
+        WHERE ]] .. table.concat(where, " AND ") .. [[
+        ORDER BY menu_order ASC, title ASC
+    ]], table.unpack(values))
+    return rows or {}
+end
+
+function CmsPageQueries.getByUuid(namespace_id, uuid)
+    return findScoped(namespace_id, uuid)
+end
+
+function CmsPageQueries.update(namespace_id, uuid, params)
+    local row = findScoped(namespace_id, uuid)
+    if not row then return nil end
+
+    local fields = { updated_at = db.raw("NOW()") }
+    for _, k in ipairs({ "title", "excerpt", "content_html", "content_json",
+        "featured_image_url", "template", "seo_title", "seo_description", "seo_keywords" }) do
+        if params[k] ~= nil then fields[k] = params[k] end
+    end
+    if params.slug ~= nil and params.slug ~= "" then
+        fields.slug = uniqueSlug(namespace_id, slugify(params.slug), row.id)
+    end
+    if params.menu_order ~= nil then fields.menu_order = tonumber(params.menu_order) or 0 end
+    if params.show_in_nav ~= nil then fields.show_in_nav = params.show_in_nav and true or false end
+    if params.parent_uuid ~= nil then
+        local pid = resolveParentId(namespace_id, params.parent_uuid)
+        if pid == row.id then pid = nil end
+        fields.parent_id = pid or db.NULL
+    end
+    if params.status ~= nil then
+        fields.status = params.status
+        if params.status == "published" and (row.published_at == nil or row.published_at == db.NULL) then
+            fields.published_at = db.raw("NOW()")
+        end
+    end
+
+    row:update(fields)
+    return findScoped(namespace_id, uuid)
+end
+
+function CmsPageQueries.softDelete(namespace_id, uuid)
+    local row = findScoped(namespace_id, uuid)
+    if not row then return nil end
+    row:update({ deleted_at = db.raw("NOW()"), updated_at = db.raw("NOW()") })
+    return row
+end
+
+-- ---------------------------------------------------------------------------
+-- PUBLIC reads (published only)
+-- ---------------------------------------------------------------------------
+
+--- Published pages flagged for nav, ordered — for the public site menu.
+function CmsPageQueries.listPublishedNav(namespace_id)
+    local rows = db.query([[
+        SELECT uuid, title, slug, menu_order, parent_id FROM cms_pages
+        WHERE namespace_id = ? AND deleted_at IS NULL
+          AND status = 'published' AND show_in_nav = TRUE
+        ORDER BY menu_order ASC, title ASC
+    ]], namespace_id)
+    return rows or {}
+end
+
+--- All published pages (for a public sitemap/listing).
+function CmsPageQueries.listPublished(namespace_id)
+    local rows = db.query([[
+        SELECT uuid, title, slug, excerpt, featured_image_url, published_at, updated_at
+        FROM cms_pages
+        WHERE namespace_id = ? AND deleted_at IS NULL AND status = 'published'
+        ORDER BY menu_order ASC, title ASC
+    ]], namespace_id)
+    return rows or {}
+end
+
+--- A single published page by slug for the public site.
+function CmsPageQueries.getPublishedBySlug(namespace_id, slug)
+    local rows = db.query([[
+        SELECT * FROM cms_pages
+        WHERE namespace_id = ? AND slug = ? AND deleted_at IS NULL AND status = 'published'
+        LIMIT 1
+    ]], namespace_id, slug)
+    return rows and rows[1] or nil
+end
+
+return CmsPageQueries

--- a/lapis/queries/CmsPostQueries.lua
+++ b/lapis/queries/CmsPostQueries.lua
@@ -1,0 +1,372 @@
+--[[
+    CMS Post (Blog Article) Queries
+    ===============================
+    Namespace-scoped CRUD + public catalogue reads for cms_posts.
+
+    - Soft-deleted; slug unique per namespace among live rows.
+    - Tags are a many-to-many via cms_post_tags; the route hands us tag *names*
+      and we resolve/create them (CmsTagQueries.getOrCreateByName) then re-sync
+      the join rows.
+    - Publishing: moving to `published` stamps published_at once (first time).
+]]
+
+local CmsPostModel = require "models.CmsPostModel"
+local CmsTagQueries = require "queries.CmsTagQueries"
+local Global = require "helper.global"
+local db = require("lapis.db")
+
+local CmsPostQueries = {}
+
+local function slugify(text)
+    if not text or text == "" then return "" end
+    return (text:lower():gsub("%s+", "-"):gsub("[^%w%-]", ""):gsub("%-+", "-"):gsub("^%-", ""):gsub("%-$", ""))
+end
+CmsPostQueries.slugify = slugify
+
+local function uniqueSlug(namespace_id, base, ignore_id)
+    base = (base and base ~= "") and base or "post"
+    local slug = base
+    local n = 1
+    while true do
+        local rows = db.query(
+            "SELECT id FROM cms_posts WHERE namespace_id = ? AND slug = ? AND deleted_at IS NULL LIMIT 1",
+            namespace_id, slug)
+        local clash = rows and rows[1]
+        if not clash or (ignore_id and tonumber(clash.id) == tonumber(ignore_id)) then
+            return slug
+        end
+        n = n + 1
+        slug = base .. "-" .. n
+    end
+end
+
+--- Rough reading time from rendered HTML: strip tags, count words, /200 wpm.
+local function readingMinutes(html)
+    if not html or html == "" then return 0 end
+    local text = html:gsub("<[^>]->", " ")
+    local words = 0
+    for _ in text:gmatch("%S+") do words = words + 1 end
+    local mins = math.floor(words / 200)
+    return mins < 1 and 1 or mins
+end
+
+local function findScoped(namespace_id, uuid)
+    local row = CmsPostModel:find({ uuid = uuid, namespace_id = namespace_id })
+    if not row or row.deleted_at then return nil end
+    return row
+end
+CmsPostQueries.findScoped = findScoped
+
+--- Resolve a category uuid to internal id (scoped); nil clears the category.
+local function resolveCategoryId(namespace_id, category_uuid)
+    if category_uuid == nil or category_uuid == "" then return nil end
+    local rows = db.query(
+        "SELECT id FROM cms_categories WHERE namespace_id = ? AND uuid = ? AND deleted_at IS NULL LIMIT 1",
+        namespace_id, category_uuid)
+    return rows and rows[1] and rows[1].id or nil
+end
+
+--- Fetch tag rows ({name, slug, uuid}) attached to a set of post ids.
+--- Returns a map post_id -> array of tags.
+local function tagsForPosts(post_ids)
+    local map = {}
+    for _, id in ipairs(post_ids) do map[id] = {} end
+    if #post_ids == 0 then return map end
+    local ph = {}
+    for i = 1, #post_ids do ph[i] = "?" end
+    local rows = db.query([[
+        SELECT pt.post_id, t.uuid, t.name, t.slug
+        FROM cms_post_tags pt
+        JOIN cms_tags t ON t.id = pt.tag_id AND t.deleted_at IS NULL
+        WHERE pt.post_id IN (]] .. table.concat(ph, ", ") .. [[)
+        ORDER BY t.name ASC
+    ]], table.unpack(post_ids)) or {}
+    for _, r in ipairs(rows) do
+        local bucket = map[r.post_id]
+        if bucket then
+            table.insert(bucket, { uuid = r.uuid, name = r.name, slug = r.slug })
+        end
+    end
+    return map
+end
+CmsPostQueries.tagsForPosts = tagsForPosts
+
+--- Attach hydrated tags[] (and category slug/name) to a list of post rows.
+local function hydrate(namespace_id, posts)
+    if #posts == 0 then return posts end
+    local ids = {}
+    for _, p in ipairs(posts) do ids[#ids + 1] = p.id end
+    local tagMap = tagsForPosts(ids)
+
+    -- Category lookup (one query for the referenced categories).
+    local catRows = db.query([[
+        SELECT id, uuid, name, slug FROM cms_categories
+        WHERE namespace_id = ? AND deleted_at IS NULL
+    ]], namespace_id) or {}
+    local catById = {}
+    for _, c in ipairs(catRows) do catById[c.id] = c end
+
+    for _, p in ipairs(posts) do
+        p.tags = tagMap[p.id] or {}
+        if p.category_id and catById[p.category_id] then
+            local c = catById[p.category_id]
+            p.category = { uuid = c.uuid, name = c.name, slug = c.slug }
+        else
+            p.category = nil
+        end
+    end
+    return posts
+end
+
+--- Re-sync a post's tag join rows from an array of tag names.
+local function syncTags(namespace_id, post_id, tag_names)
+    if type(tag_names) ~= "table" then return end
+    local wanted = {}       -- tag_id -> true
+    for _, name in ipairs(tag_names) do
+        local tag = CmsTagQueries.getOrCreateByName(namespace_id, name)
+        if tag then wanted[tag.id] = true end
+    end
+
+    -- Existing join rows.
+    local existing = db.query("SELECT tag_id FROM cms_post_tags WHERE post_id = ?", post_id) or {}
+    local have = {}
+    for _, r in ipairs(existing) do have[r.tag_id] = true end
+
+    -- Insert missing.
+    for tag_id in pairs(wanted) do
+        if not have[tag_id] then
+            db.query("INSERT INTO cms_post_tags (post_id, tag_id, created_at) VALUES (?, ?, NOW()) " ..
+                "ON CONFLICT (post_id, tag_id) DO NOTHING", post_id, tag_id)
+        end
+    end
+    -- Remove stale.
+    for tag_id in pairs(have) do
+        if not wanted[tag_id] then
+            db.query("DELETE FROM cms_post_tags WHERE post_id = ? AND tag_id = ?", post_id, tag_id)
+        end
+    end
+end
+CmsPostQueries.syncTags = syncTags
+
+function CmsPostQueries.create(namespace_id, params)
+    local base = slugify((params.slug and params.slug ~= "") and params.slug or params.title)
+    local status = params.status or "draft"
+    local insert = {
+        uuid = Global.generateUUID(),
+        namespace_id = namespace_id,
+        -- Nullable FK: explicit NULL when unset (column has a DEFAULT 0 from
+        -- lapis types.integer, which would violate the category FK).
+        category_id = resolveCategoryId(namespace_id, params.category_uuid) or db.NULL,
+        title = params.title,
+        slug = uniqueSlug(namespace_id, base),
+        excerpt = params.excerpt,
+        content_html = params.content_html,
+        content_json = params.content_json,
+        featured_image_url = params.featured_image_url,
+        status = status,
+        visibility = params.visibility or "public",
+        is_featured = params.is_featured and true or false,
+        author_uuid = params.author_uuid,
+        author_name = params.author_name,
+        seo_title = params.seo_title,
+        seo_description = params.seo_description,
+        seo_keywords = params.seo_keywords,
+        reading_minutes = readingMinutes(params.content_html),
+        view_count = 0,
+        created_at = db.raw("NOW()"),
+        updated_at = db.raw("NOW()"),
+    }
+    if status == "published" then
+        insert.published_at = db.raw("NOW()")
+    elseif status == "scheduled" and params.scheduled_at then
+        insert.scheduled_at = params.scheduled_at
+    end
+
+    local post = CmsPostModel:create(insert, { returning = "*" })
+    if params.tags ~= nil then syncTags(namespace_id, post.id, params.tags) end
+    return hydrate(namespace_id, { post })[1]
+end
+
+--- List posts in a namespace with filters + pagination. Admin view (all
+--- statuses unless filtered).
+function CmsPostQueries.list(namespace_id, params)
+    params = params or {}
+    local page = tonumber(params.page) or 1
+    local perPage = tonumber(params.perPage) or 20
+    local offset = (page - 1) * perPage
+
+    local where = { "p.namespace_id = ?", "p.deleted_at IS NULL" }
+    local values = { namespace_id }
+
+    if params.status and params.status ~= "" then
+        table.insert(where, "p.status = ?"); table.insert(values, params.status)
+    end
+    if params.category_uuid and params.category_uuid ~= "" then
+        table.insert(where, "p.category_id = (SELECT id FROM cms_categories WHERE namespace_id = ? AND uuid = ? LIMIT 1)")
+        table.insert(values, namespace_id); table.insert(values, params.category_uuid)
+    end
+    if params.is_featured ~= nil then
+        table.insert(where, "p.is_featured = ?"); table.insert(values, params.is_featured and true or false)
+    end
+    if params.tag and params.tag ~= "" then
+        table.insert(where, [[p.id IN (
+            SELECT pt.post_id FROM cms_post_tags pt
+            JOIN cms_tags t ON t.id = pt.tag_id
+            WHERE t.namespace_id = ? AND t.slug = ?
+        )]])
+        table.insert(values, namespace_id); table.insert(values, params.tag)
+    end
+    if params.search and params.search ~= "" then
+        table.insert(where, "(p.title ILIKE ? OR p.excerpt ILIKE ?)")
+        local pat = "%" .. params.search .. "%"
+        table.insert(values, pat); table.insert(values, pat)
+    end
+
+    local whereSql = table.concat(where, " AND ")
+
+    local countRows = db.query("SELECT COUNT(*) AS n FROM cms_posts p WHERE " .. whereSql, table.unpack(values))
+    local total = countRows and countRows[1] and tonumber(countRows[1].n) or 0
+
+    local listValues = {}
+    for _, v in ipairs(values) do listValues[#listValues + 1] = v end
+    listValues[#listValues + 1] = perPage
+    listValues[#listValues + 1] = offset
+
+    -- NULLS LAST so drafts (no published_at) sort by created_at fallback.
+    local rows = db.query([[
+        SELECT * FROM cms_posts p
+        WHERE ]] .. whereSql .. [[
+        ORDER BY COALESCE(p.published_at, p.created_at) DESC
+        LIMIT ? OFFSET ?
+    ]], table.unpack(listValues)) or {}
+
+    hydrate(namespace_id, rows)
+    return {
+        data = rows,
+        meta = { total = total, page = page, perPage = perPage,
+                 totalPages = math.ceil(total / perPage) }
+    }
+end
+
+function CmsPostQueries.getByUuid(namespace_id, uuid)
+    local row = findScoped(namespace_id, uuid)
+    if not row then return nil end
+    return hydrate(namespace_id, { row })[1]
+end
+
+function CmsPostQueries.update(namespace_id, uuid, params)
+    local row = findScoped(namespace_id, uuid)
+    if not row then return nil end
+
+    local fields = { updated_at = db.raw("NOW()") }
+    for _, k in ipairs({ "title", "excerpt", "content_html", "content_json",
+        "featured_image_url", "author_name", "seo_title", "seo_description", "seo_keywords" }) do
+        if params[k] ~= nil then fields[k] = params[k] end
+    end
+    if params.slug ~= nil and params.slug ~= "" then
+        fields.slug = uniqueSlug(namespace_id, slugify(params.slug), row.id)
+    end
+    if params.visibility ~= nil then fields.visibility = params.visibility end
+    if params.is_featured ~= nil then fields.is_featured = params.is_featured and true or false end
+    if params.category_uuid ~= nil then
+        fields.category_id = resolveCategoryId(namespace_id, params.category_uuid) or db.NULL
+    end
+    if params.content_html ~= nil then
+        fields.reading_minutes = readingMinutes(params.content_html)
+    end
+    if params.status ~= nil then
+        fields.status = params.status
+        -- Stamp published_at the first time it goes live; keep it thereafter.
+        if params.status == "published" and (row.published_at == nil or row.published_at == db.NULL) then
+            fields.published_at = db.raw("NOW()")
+        end
+        if params.status == "scheduled" and params.scheduled_at then
+            fields.scheduled_at = params.scheduled_at
+        end
+    end
+
+    row:update(fields)
+    if params.tags ~= nil then syncTags(namespace_id, row.id, params.tags) end
+    return CmsPostQueries.getByUuid(namespace_id, uuid)
+end
+
+function CmsPostQueries.softDelete(namespace_id, uuid)
+    local row = findScoped(namespace_id, uuid)
+    if not row then return nil end
+    row:update({ deleted_at = db.raw("NOW()"), updated_at = db.raw("NOW()") })
+    return row
+end
+
+-- ---------------------------------------------------------------------------
+-- PUBLIC catalogue reads (published only)
+-- ---------------------------------------------------------------------------
+
+--- Published posts for the public site (namespace-scoped, paginated).
+function CmsPostQueries.listPublished(namespace_id, params)
+    params = params or {}
+    local page = tonumber(params.page) or 1
+    local perPage = tonumber(params.perPage) or 12
+    local offset = (page - 1) * perPage
+
+    local where = { "p.namespace_id = ?", "p.deleted_at IS NULL",
+        "p.status = 'published'", "p.visibility = 'public'" }
+    local values = { namespace_id }
+
+    if params.category and params.category ~= "" then
+        table.insert(where, "p.category_id = (SELECT id FROM cms_categories WHERE namespace_id = ? AND slug = ? LIMIT 1)")
+        table.insert(values, namespace_id); table.insert(values, params.category)
+    end
+    if params.tag and params.tag ~= "" then
+        table.insert(where, [[p.id IN (
+            SELECT pt.post_id FROM cms_post_tags pt
+            JOIN cms_tags t ON t.id = pt.tag_id
+            WHERE t.namespace_id = ? AND t.slug = ?
+        )]])
+        table.insert(values, namespace_id); table.insert(values, params.tag)
+    end
+    if params.search and params.search ~= "" then
+        table.insert(where, "(p.title ILIKE ? OR p.excerpt ILIKE ?)")
+        local pat = "%" .. params.search .. "%"
+        table.insert(values, pat); table.insert(values, pat)
+    end
+
+    local whereSql = table.concat(where, " AND ")
+    local countRows = db.query("SELECT COUNT(*) AS n FROM cms_posts p WHERE " .. whereSql, table.unpack(values))
+    local total = countRows and countRows[1] and tonumber(countRows[1].n) or 0
+
+    local listValues = {}
+    for _, v in ipairs(values) do listValues[#listValues + 1] = v end
+    listValues[#listValues + 1] = perPage
+    listValues[#listValues + 1] = offset
+
+    local rows = db.query([[
+        SELECT * FROM cms_posts p
+        WHERE ]] .. whereSql .. [[
+        ORDER BY p.published_at DESC NULLS LAST
+        LIMIT ? OFFSET ?
+    ]], table.unpack(listValues)) or {}
+
+    hydrate(namespace_id, rows)
+    return {
+        data = rows,
+        meta = { total = total, page = page, perPage = perPage,
+                 totalPages = math.ceil(total / perPage) }
+    }
+end
+
+--- A single published post by slug for the public site; increments view_count.
+function CmsPostQueries.getPublishedBySlug(namespace_id, slug)
+    local rows = db.query([[
+        SELECT * FROM cms_posts
+        WHERE namespace_id = ? AND slug = ? AND deleted_at IS NULL
+          AND status = 'published' AND visibility = 'public'
+        LIMIT 1
+    ]], namespace_id, slug)
+    local post = rows and rows[1]
+    if not post then return nil end
+    db.query("UPDATE cms_posts SET view_count = view_count + 1 WHERE id = ?", post.id)
+    post.view_count = (tonumber(post.view_count) or 0) + 1
+    return hydrate(namespace_id, { post })[1]
+end
+
+return CmsPostQueries

--- a/lapis/queries/CmsTagQueries.lua
+++ b/lapis/queries/CmsTagQueries.lua
@@ -1,0 +1,135 @@
+--[[
+    CMS Tag Queries
+    ===============
+    Namespace-scoped CRUD for cms_tags (flat blog tags). Soft-deleted; slug is
+    unique per namespace among live rows. Includes getOrCreate for attaching
+    tags to posts by name.
+]]
+
+local CmsTagModel = require "models.CmsTagModel"
+local Global = require "helper.global"
+local db = require("lapis.db")
+
+local CmsTagQueries = {}
+
+local function slugify(text)
+    if not text or text == "" then return "" end
+    return (text:lower():gsub("%s+", "-"):gsub("[^%w%-]", ""):gsub("%-+", "-"):gsub("^%-", ""):gsub("%-$", ""))
+end
+CmsTagQueries.slugify = slugify
+
+local function findScoped(namespace_id, uuid)
+    local row = CmsTagModel:find({ uuid = uuid, namespace_id = namespace_id })
+    if not row or row.deleted_at then return nil end
+    return row
+end
+CmsTagQueries.findScoped = findScoped
+
+--- Find a live tag row by slug within a namespace (internal use).
+local function findLiveBySlug(namespace_id, slug)
+    local rows = db.query(
+        "SELECT * FROM cms_tags WHERE namespace_id = ? AND slug = ? AND deleted_at IS NULL LIMIT 1",
+        namespace_id, slug)
+    return rows and rows[1] or nil
+end
+
+function CmsTagQueries.create(namespace_id, params)
+    local slug = slugify(params.slug ~= "" and params.slug or params.name)
+    local existing = findLiveBySlug(namespace_id, slug)
+    if existing then return existing end
+    return CmsTagModel:create({
+        uuid = Global.generateUUID(),
+        namespace_id = namespace_id,
+        name = params.name,
+        slug = slug,
+        created_at = db.raw("NOW()"),
+        updated_at = db.raw("NOW()"),
+    }, { returning = "*" })
+end
+
+--- Return an existing live tag by name/slug, or create one. Also revives a
+--- previously soft-deleted tag with the same slug. Used when saving a post's
+--- tag list — the client sends tag *names*, we resolve them to ids.
+function CmsTagQueries.getOrCreateByName(namespace_id, name)
+    if not name or name == "" then return nil end
+    local slug = slugify(name)
+    if slug == "" then return nil end
+
+    local live = findLiveBySlug(namespace_id, slug)
+    if live then return live end
+
+    -- Revive a soft-deleted tag with the same slug (keeps its uuid/id stable).
+    local dead = db.query(
+        "SELECT * FROM cms_tags WHERE namespace_id = ? AND slug = ? AND deleted_at IS NOT NULL LIMIT 1",
+        namespace_id, slug)
+    dead = dead and dead[1] or nil
+    if dead then
+        db.query("UPDATE cms_tags SET deleted_at = NULL, name = ?, updated_at = NOW() WHERE id = ?",
+            name, dead.id)
+        dead.deleted_at = nil
+        dead.name = name
+        return dead
+    end
+
+    return CmsTagModel:create({
+        uuid = Global.generateUUID(),
+        namespace_id = namespace_id,
+        name = name,
+        slug = slug,
+        created_at = db.raw("NOW()"),
+        updated_at = db.raw("NOW()"),
+    }, { returning = "*" })
+end
+
+--- List tags in a namespace (with post counts). `search` optional.
+function CmsTagQueries.list(namespace_id, params)
+    params = params or {}
+    local where = { "t.namespace_id = ?", "t.deleted_at IS NULL" }
+    local values = { namespace_id }
+    if params.search and params.search ~= "" then
+        table.insert(where, "(t.name ILIKE ? OR t.slug ILIKE ?)")
+        local p = "%" .. params.search .. "%"
+        table.insert(values, p); table.insert(values, p)
+    end
+    local rows = db.query([[
+        SELECT t.*, (
+            SELECT COUNT(*) FROM cms_post_tags pt
+            JOIN cms_posts p ON p.id = pt.post_id AND p.deleted_at IS NULL
+            WHERE pt.tag_id = t.id
+        ) AS post_count
+        FROM cms_tags t
+        WHERE ]] .. table.concat(where, " AND ") .. [[
+        ORDER BY t.name ASC
+    ]], table.unpack(values))
+    return rows or {}
+end
+
+function CmsTagQueries.getByUuid(namespace_id, uuid)
+    return findScoped(namespace_id, uuid)
+end
+
+function CmsTagQueries.update(namespace_id, uuid, params)
+    local row = findScoped(namespace_id, uuid)
+    if not row then return nil end
+    local fields = { updated_at = db.raw("NOW()") }
+    if params.name ~= nil then fields.name = params.name end
+    if params.slug ~= nil and params.slug ~= "" then
+        local slug = slugify(params.slug)
+        local clash = findLiveBySlug(namespace_id, slug)
+        if clash and tonumber(clash.id) ~= tonumber(row.id) then
+            return nil, "slug_taken"
+        end
+        fields.slug = slug
+    end
+    row:update(fields)
+    return findScoped(namespace_id, uuid)
+end
+
+function CmsTagQueries.softDelete(namespace_id, uuid)
+    local row = findScoped(namespace_id, uuid)
+    if not row then return nil end
+    row:update({ deleted_at = db.raw("NOW()"), updated_at = db.raw("NOW()") })
+    return row
+end
+
+return CmsTagQueries

--- a/lapis/routes/cms-pages.lua
+++ b/lapis/routes/cms-pages.lua
@@ -1,0 +1,154 @@
+--[[
+    CMS Static Page API Routes
+    ==========================
+
+    Multi-tenant static website pages (About, Contact, ...) with rich WYSIWYG
+    content. Admin endpoints are namespace-scoped and RBAC-gated (module "cms");
+    public endpoints expose published pages for a namespace to its website.
+
+    Admin (auth + namespace + RBAC module "cms"):
+      GET    /api/v2/cms/pages
+      POST   /api/v2/cms/pages
+      GET    /api/v2/cms/pages/:uuid
+      PUT    /api/v2/cms/pages/:uuid
+      DELETE /api/v2/cms/pages/:uuid
+
+    Public (no auth; namespace by slug):
+      GET    /api/v2/public/cms/:namespace/pages            (all published)
+      GET    /api/v2/public/cms/:namespace/nav              (nav-flagged pages)
+      GET    /api/v2/public/cms/:namespace/pages/:slug
+]]
+
+local CmsPageQueries = require "queries.CmsPageQueries"
+local CmsHttp = require "helper.cms-http"
+local AuthMiddleware = require("middleware.auth")
+local NamespaceMiddleware = require("middleware.namespace")
+
+local parse_body = CmsHttp.parse_body
+local api_response = CmsHttp.api_response
+local to_bool = CmsHttp.to_bool
+local resolve_namespace = CmsHttp.resolve_namespace
+
+local PAGE_STATUS = { draft = true, published = true, archived = true }
+
+local function public_page(p)
+    return {
+        uuid = p.uuid,
+        title = p.title,
+        slug = p.slug,
+        excerpt = p.excerpt,
+        content_html = p.content_html,
+        featured_image_url = p.featured_image_url,
+        template = p.template,
+        published_at = p.published_at,
+        updated_at = p.updated_at,
+        seo_title = p.seo_title,
+        seo_description = p.seo_description,
+        seo_keywords = p.seo_keywords,
+    }
+end
+
+return function(app)
+    -------------------------------------------------------------------------
+    -- ADMIN
+    -------------------------------------------------------------------------
+    app:get("/api/v2/cms/pages", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("cms", "read", function(self)
+            local pages = CmsPageQueries.list(self.namespace.id, {
+                status = self.params.status,
+                search = self.params.search,
+            })
+            return { status = 200, json = { success = true, data = pages } }
+        end)))
+
+    app:post("/api/v2/cms/pages", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("cms", "create", function(self)
+            local body = parse_body()
+            if not body.title or body.title == "" then
+                return api_response(400, nil, "title is required")
+            end
+            local status = body.status or "draft"
+            if not PAGE_STATUS[status] then
+                return api_response(400, nil, "Invalid status (draft|published|archived)")
+            end
+
+            local user = self.current_user or {}
+            local page = CmsPageQueries.create(self.namespace.id, {
+                title = body.title,
+                slug = body.slug,
+                excerpt = body.excerpt,
+                content_html = body.content_html,
+                content_json = body.content_json,
+                featured_image_url = body.featured_image_url,
+                status = status,
+                template = body.template,
+                menu_order = body.menu_order,
+                show_in_nav = to_bool(body.show_in_nav, false),
+                parent_uuid = body.parent_uuid,
+                author_uuid = user.uuid,
+                seo_title = body.seo_title,
+                seo_description = body.seo_description,
+                seo_keywords = body.seo_keywords,
+            })
+            return api_response(201, page)
+        end)))
+
+    app:get("/api/v2/cms/pages/:uuid", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("cms", "read", function(self)
+            local page = CmsPageQueries.getByUuid(self.namespace.id, self.params.uuid)
+            if not page then return api_response(404, nil, "Page not found") end
+            return api_response(200, page)
+        end)))
+
+    app:put("/api/v2/cms/pages/:uuid", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("cms", "update", function(self)
+            local body = parse_body()
+            if body.status and not PAGE_STATUS[body.status] then
+                return api_response(400, nil, "Invalid status")
+            end
+            local fields = {}
+            for _, k in ipairs({ "title", "slug", "excerpt", "content_html", "content_json",
+                "featured_image_url", "status", "template", "parent_uuid",
+                "seo_title", "seo_description", "seo_keywords" }) do
+                if body[k] ~= nil then fields[k] = body[k] end
+            end
+            if body.menu_order ~= nil then fields.menu_order = body.menu_order end
+            if body.show_in_nav ~= nil then fields.show_in_nav = to_bool(body.show_in_nav, false) end
+
+            local page = CmsPageQueries.update(self.namespace.id, self.params.uuid, fields)
+            if not page then return api_response(404, nil, "Page not found") end
+            return api_response(200, page)
+        end)))
+
+    app:delete("/api/v2/cms/pages/:uuid", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("cms", "delete", function(self)
+            local page = CmsPageQueries.softDelete(self.namespace.id, self.params.uuid)
+            if not page then return api_response(404, nil, "Page not found") end
+            return api_response(200, { deleted = true })
+        end)))
+
+    -------------------------------------------------------------------------
+    -- PUBLIC (no auth; namespace by slug)
+    -------------------------------------------------------------------------
+    app:get("/api/v2/public/cms/:namespace/pages", function(self)
+        local ns = resolve_namespace(self)
+        if not ns then return api_response(404, nil, "Namespace not found") end
+        local pages = CmsPageQueries.listPublished(ns.id)
+        return { status = 200, json = { success = true, data = pages } }
+    end)
+
+    app:get("/api/v2/public/cms/:namespace/nav", function(self)
+        local ns = resolve_namespace(self)
+        if not ns then return api_response(404, nil, "Namespace not found") end
+        local nav = CmsPageQueries.listPublishedNav(ns.id)
+        return { status = 200, json = { success = true, data = nav } }
+    end)
+
+    app:get("/api/v2/public/cms/:namespace/pages/:slug", function(self)
+        local ns = resolve_namespace(self)
+        if not ns then return api_response(404, nil, "Namespace not found") end
+        local page = CmsPageQueries.getPublishedBySlug(ns.id, self.params.slug)
+        if not page then return api_response(404, nil, "Page not found") end
+        return { status = 200, json = { success = true, data = public_page(page) } }
+    end)
+end

--- a/lapis/routes/cms-posts.lua
+++ b/lapis/routes/cms-posts.lua
@@ -1,0 +1,200 @@
+--[[
+    CMS Blog Post API Routes
+    ========================
+
+    Multi-tenant blog articles with rich WYSIWYG content, categories and tags.
+    Admin endpoints are namespace-scoped and RBAC-gated (module "cms"); public
+    endpoints expose published posts for a namespace to its public website.
+
+    Admin (auth + namespace + RBAC module "cms"):
+      GET    /api/v2/cms/posts
+      POST   /api/v2/cms/posts
+      GET    /api/v2/cms/posts/:uuid
+      PUT    /api/v2/cms/posts/:uuid
+      DELETE /api/v2/cms/posts/:uuid
+
+    Public (no auth; namespace by slug):
+      GET    /api/v2/public/cms/:namespace/posts
+      GET    /api/v2/public/cms/:namespace/posts/:slug
+]]
+
+local CmsPostQueries = require "queries.CmsPostQueries"
+local CmsHttp = require "helper.cms-http"
+local AuthMiddleware = require("middleware.auth")
+local NamespaceMiddleware = require("middleware.namespace")
+
+local parse_body = CmsHttp.parse_body
+local api_response = CmsHttp.api_response
+local to_bool = CmsHttp.to_bool
+local coerce_list = CmsHttp.coerce_list
+local resolve_namespace = CmsHttp.resolve_namespace
+
+local POST_STATUS = { draft = true, published = true, scheduled = true, archived = true }
+local VISIBILITY = { public = true, private = true }
+
+--- Shape a post row for the public site (omit internal/private fields).
+local function public_post(p)
+    return {
+        uuid = p.uuid,
+        title = p.title,
+        slug = p.slug,
+        excerpt = p.excerpt,
+        content_html = p.content_html,
+        featured_image_url = p.featured_image_url,
+        author_name = p.author_name,
+        published_at = p.published_at,
+        reading_minutes = p.reading_minutes,
+        view_count = p.view_count,
+        is_featured = p.is_featured,
+        category = p.category,
+        tags = p.tags or {},
+        seo_title = p.seo_title,
+        seo_description = p.seo_description,
+        seo_keywords = p.seo_keywords,
+    }
+end
+
+--- Shape a post-list item for the public site (no full body).
+local function public_post_summary(p)
+    return {
+        uuid = p.uuid,
+        title = p.title,
+        slug = p.slug,
+        excerpt = p.excerpt,
+        featured_image_url = p.featured_image_url,
+        author_name = p.author_name,
+        published_at = p.published_at,
+        reading_minutes = p.reading_minutes,
+        is_featured = p.is_featured,
+        category = p.category,
+        tags = p.tags or {},
+    }
+end
+
+return function(app)
+    -------------------------------------------------------------------------
+    -- ADMIN
+    -------------------------------------------------------------------------
+    app:get("/api/v2/cms/posts", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("cms", "read", function(self)
+            local result = CmsPostQueries.list(self.namespace.id, {
+                page = self.params.page,
+                perPage = self.params.perPage,
+                status = self.params.status,
+                category_uuid = self.params.category,
+                tag = self.params.tag,
+                search = self.params.search,
+                is_featured = self.params.featured == "true" and true or nil,
+            })
+            return { status = 200, json = { success = true, data = result.data, meta = result.meta } }
+        end)))
+
+    app:post("/api/v2/cms/posts", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("cms", "create", function(self)
+            local body = parse_body()
+            if not body.title or body.title == "" then
+                return api_response(400, nil, "title is required")
+            end
+            local status = body.status or "draft"
+            if not POST_STATUS[status] then
+                return api_response(400, nil, "Invalid status (draft|published|scheduled|archived)")
+            end
+            local visibility = body.visibility or "public"
+            if not VISIBILITY[visibility] then
+                return api_response(400, nil, "Invalid visibility (public|private)")
+            end
+
+            local user = self.current_user or {}
+            local author_name = body.author_name
+            if not author_name or author_name == "" then
+                author_name = user.first_name and (user.first_name .. " " .. (user.last_name or "")) or user.username
+            end
+
+            local post = CmsPostQueries.create(self.namespace.id, {
+                title = body.title,
+                slug = body.slug,
+                excerpt = body.excerpt,
+                content_html = body.content_html,
+                content_json = body.content_json,
+                featured_image_url = body.featured_image_url,
+                status = status,
+                visibility = visibility,
+                is_featured = to_bool(body.is_featured, false),
+                category_uuid = body.category_uuid,
+                tags = coerce_list(body.tags),
+                author_uuid = user.uuid,
+                author_name = author_name,
+                scheduled_at = body.scheduled_at,
+                seo_title = body.seo_title,
+                seo_description = body.seo_description,
+                seo_keywords = body.seo_keywords,
+            })
+            return api_response(201, post)
+        end)))
+
+    app:get("/api/v2/cms/posts/:uuid", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("cms", "read", function(self)
+            local post = CmsPostQueries.getByUuid(self.namespace.id, self.params.uuid)
+            if not post then return api_response(404, nil, "Post not found") end
+            return api_response(200, post)
+        end)))
+
+    app:put("/api/v2/cms/posts/:uuid", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("cms", "update", function(self)
+            local body = parse_body()
+            if body.status and not POST_STATUS[body.status] then
+                return api_response(400, nil, "Invalid status")
+            end
+            if body.visibility and not VISIBILITY[body.visibility] then
+                return api_response(400, nil, "Invalid visibility")
+            end
+
+            local fields = {}
+            for _, k in ipairs({ "title", "slug", "excerpt", "content_html", "content_json",
+                "featured_image_url", "status", "visibility", "category_uuid", "author_name",
+                "scheduled_at", "seo_title", "seo_description", "seo_keywords" }) do
+                if body[k] ~= nil then fields[k] = body[k] end
+            end
+            if body.is_featured ~= nil then fields.is_featured = to_bool(body.is_featured, false) end
+            if body.tags ~= nil then fields.tags = coerce_list(body.tags) end
+
+            local post = CmsPostQueries.update(self.namespace.id, self.params.uuid, fields)
+            if not post then return api_response(404, nil, "Post not found") end
+            return api_response(200, post)
+        end)))
+
+    app:delete("/api/v2/cms/posts/:uuid", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("cms", "delete", function(self)
+            local post = CmsPostQueries.softDelete(self.namespace.id, self.params.uuid)
+            if not post then return api_response(404, nil, "Post not found") end
+            return api_response(200, { deleted = true })
+        end)))
+
+    -------------------------------------------------------------------------
+    -- PUBLIC (no auth; namespace by slug)
+    -------------------------------------------------------------------------
+    app:get("/api/v2/public/cms/:namespace/posts", function(self)
+        local ns = resolve_namespace(self)
+        if not ns then return api_response(404, nil, "Namespace not found") end
+
+        local result = CmsPostQueries.listPublished(ns.id, {
+            page = self.params.page,
+            perPage = self.params.perPage,
+            category = self.params.category,
+            tag = self.params.tag,
+            search = self.params.search,
+        })
+        local out = {}
+        for _, p in ipairs(result.data) do out[#out + 1] = public_post_summary(p) end
+        return { status = 200, json = { success = true, data = out, meta = result.meta } }
+    end)
+
+    app:get("/api/v2/public/cms/:namespace/posts/:slug", function(self)
+        local ns = resolve_namespace(self)
+        if not ns then return api_response(404, nil, "Namespace not found") end
+
+        local post = CmsPostQueries.getPublishedBySlug(ns.id, self.params.slug)
+        if not post then return api_response(404, nil, "Post not found") end
+        return { status = 200, json = { success = true, data = public_post(post) } }
+    end)
+end

--- a/lapis/routes/cms-taxonomy.lua
+++ b/lapis/routes/cms-taxonomy.lua
@@ -1,0 +1,150 @@
+--[[
+    CMS Taxonomy API Routes (Categories + Tags)
+    ===========================================
+
+    Namespace-scoped, RBAC-gated (module "cms") management of blog categories
+    and tags, plus public reads for the website's category/tag navigation.
+
+    Admin (auth + namespace + RBAC module "cms"):
+      Categories:
+        GET    /api/v2/cms/categories
+        POST   /api/v2/cms/categories
+        PUT    /api/v2/cms/categories/:uuid
+        DELETE /api/v2/cms/categories/:uuid
+      Tags:
+        GET    /api/v2/cms/tags
+        POST   /api/v2/cms/tags
+        PUT    /api/v2/cms/tags/:uuid
+        DELETE /api/v2/cms/tags/:uuid
+
+    Public (no auth; namespace by slug):
+      GET    /api/v2/public/cms/:namespace/categories
+      GET    /api/v2/public/cms/:namespace/tags
+]]
+
+local CmsCategoryQueries = require "queries.CmsCategoryQueries"
+local CmsTagQueries = require "queries.CmsTagQueries"
+local CmsHttp = require "helper.cms-http"
+local AuthMiddleware = require("middleware.auth")
+local NamespaceMiddleware = require("middleware.namespace")
+
+local parse_body = CmsHttp.parse_body
+local api_response = CmsHttp.api_response
+local resolve_namespace = CmsHttp.resolve_namespace
+
+return function(app)
+    -------------------------------------------------------------------------
+    -- CATEGORIES (admin)
+    -------------------------------------------------------------------------
+    app:get("/api/v2/cms/categories", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("cms", "read", function(self)
+            local cats = CmsCategoryQueries.list(self.namespace.id, { search = self.params.search })
+            return { status = 200, json = { success = true, data = cats } }
+        end)))
+
+    app:post("/api/v2/cms/categories", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("cms", "create", function(self)
+            local body = parse_body()
+            if not body.name or body.name == "" then
+                return api_response(400, nil, "name is required")
+            end
+            local cat = CmsCategoryQueries.create(self.namespace.id, {
+                name = body.name,
+                slug = body.slug or "",
+                description = body.description,
+                parent_uuid = body.parent_uuid,
+                position = body.position,
+            })
+            return api_response(201, cat)
+        end)))
+
+    app:put("/api/v2/cms/categories/:uuid", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("cms", "update", function(self)
+            local body = parse_body()
+            local cat = CmsCategoryQueries.update(self.namespace.id, self.params.uuid, {
+                name = body.name,
+                slug = body.slug,
+                description = body.description,
+                parent_uuid = body.parent_uuid,
+                position = body.position,
+            })
+            if not cat then return api_response(404, nil, "Category not found") end
+            return api_response(200, cat)
+        end)))
+
+    app:delete("/api/v2/cms/categories/:uuid", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("cms", "delete", function(self)
+            local cat = CmsCategoryQueries.softDelete(self.namespace.id, self.params.uuid)
+            if not cat then return api_response(404, nil, "Category not found") end
+            return api_response(200, { deleted = true })
+        end)))
+
+    -------------------------------------------------------------------------
+    -- TAGS (admin)
+    -------------------------------------------------------------------------
+    app:get("/api/v2/cms/tags", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("cms", "read", function(self)
+            local tags = CmsTagQueries.list(self.namespace.id, { search = self.params.search })
+            return { status = 200, json = { success = true, data = tags } }
+        end)))
+
+    app:post("/api/v2/cms/tags", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("cms", "create", function(self)
+            local body = parse_body()
+            if not body.name or body.name == "" then
+                return api_response(400, nil, "name is required")
+            end
+            local tag = CmsTagQueries.create(self.namespace.id, {
+                name = body.name,
+                slug = body.slug or "",
+            })
+            return api_response(201, tag)
+        end)))
+
+    app:put("/api/v2/cms/tags/:uuid", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("cms", "update", function(self)
+            local body = parse_body()
+            local tag, errcode = CmsTagQueries.update(self.namespace.id, self.params.uuid, {
+                name = body.name,
+                slug = body.slug,
+            })
+            if errcode == "slug_taken" then
+                return api_response(409, nil, "A tag with this slug already exists")
+            end
+            if not tag then return api_response(404, nil, "Tag not found") end
+            return api_response(200, tag)
+        end)))
+
+    app:delete("/api/v2/cms/tags/:uuid", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("cms", "delete", function(self)
+            local tag = CmsTagQueries.softDelete(self.namespace.id, self.params.uuid)
+            if not tag then return api_response(404, nil, "Tag not found") end
+            return api_response(200, { deleted = true })
+        end)))
+
+    -------------------------------------------------------------------------
+    -- PUBLIC (no auth; namespace by slug)
+    -------------------------------------------------------------------------
+    app:get("/api/v2/public/cms/:namespace/categories", function(self)
+        local ns = resolve_namespace(self)
+        if not ns then return api_response(404, nil, "Namespace not found") end
+        local cats = CmsCategoryQueries.list(ns.id, {})
+        local out = {}
+        for _, c in ipairs(cats) do
+            out[#out + 1] = { uuid = c.uuid, name = c.name, slug = c.slug,
+                description = c.description, post_count = c.post_count }
+        end
+        return { status = 200, json = { success = true, data = out } }
+    end)
+
+    app:get("/api/v2/public/cms/:namespace/tags", function(self)
+        local ns = resolve_namespace(self)
+        if not ns then return api_response(404, nil, "Namespace not found") end
+        local tags = CmsTagQueries.list(ns.id, {})
+        local out = {}
+        for _, t in ipairs(tags) do
+            out[#out + 1] = { uuid = t.uuid, name = t.name, slug = t.slug, post_count = t.post_count }
+        end
+        return { status = 200, json = { success = true, data = out } }
+    end)
+end

--- a/opsapi-dashboard/app/dashboard/cms/page.tsx
+++ b/opsapi-dashboard/app/dashboard/cms/page.tsx
@@ -1,0 +1,765 @@
+'use client';
+
+import React, { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import {
+  FileText,
+  Plus,
+  Search,
+  Edit,
+  Trash2,
+  Loader2,
+  Star,
+  Eye,
+  FolderTree,
+  Tag as TagIcon,
+  Newspaper,
+  Files,
+} from 'lucide-react';
+import { PageHeader } from '@/components/layout/PageHeader';
+import { ProtectedPage } from '@/components/permissions';
+import { usePermissions } from '@/contexts/PermissionsContext';
+import {
+  Table,
+  Badge,
+  Button,
+  Input,
+  Select,
+  Pagination,
+  Modal,
+  ConfirmDialog,
+  Card,
+} from '@/components/ui';
+import {
+  cmsService,
+  type CmsPost,
+  type CmsPage,
+  type CmsCategory,
+  type CmsTag,
+  type PostStatus,
+} from '@/services/cms.service';
+import { formatDate } from '@/lib/utils';
+import type { TableColumn } from '@/types';
+import toast from 'react-hot-toast';
+
+const PER_PAGE = 20;
+type TabKey = 'posts' | 'pages' | 'categories' | 'tags';
+
+const TABS: { key: TabKey; label: string; icon: React.ReactNode }[] = [
+  { key: 'posts', label: 'Blog Posts', icon: <Newspaper className="h-4 w-4" /> },
+  { key: 'pages', label: 'Pages', icon: <Files className="h-4 w-4" /> },
+  { key: 'categories', label: 'Categories', icon: <FolderTree className="h-4 w-4" /> },
+  { key: 'tags', label: 'Tags', icon: <TagIcon className="h-4 w-4" /> },
+];
+
+function statusVariant(status: string): 'success' | 'warning' | 'secondary' | 'info' | 'default' {
+  switch (status) {
+    case 'published':
+      return 'success';
+    case 'scheduled':
+      return 'info';
+    case 'draft':
+      return 'warning';
+    case 'archived':
+      return 'secondary';
+    default:
+      return 'default';
+  }
+}
+
+// ============================================================
+// Posts tab
+// ============================================================
+function PostsTab() {
+  const router = useRouter();
+  const { hasPermission } = usePermissions();
+  const canWrite = hasPermission('cms', 'update');
+  const canDelete = hasPermission('cms', 'delete');
+
+  const [posts, setPosts] = useState<CmsPost[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
+  const [totalPages, setTotalPages] = useState(1);
+  const [status, setStatus] = useState<PostStatus | ''>('');
+  const [search, setSearch] = useState('');
+  const [confirmDelete, setConfirmDelete] = useState<CmsPost | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await cmsService.getPosts({ page, perPage: PER_PAGE, status, search });
+      setPosts(res.data);
+      setTotal(res.meta.total);
+      setTotalPages(res.meta.totalPages || 1);
+    } catch {
+      toast.error('Failed to load posts');
+    } finally {
+      setLoading(false);
+    }
+  }, [page, status, search]);
+
+  useEffect(() => {
+    const t = setTimeout(load, search ? 300 : 0);
+    return () => clearTimeout(t);
+  }, [load, search]);
+
+  const doDelete = async () => {
+    if (!confirmDelete) return;
+    setDeleting(true);
+    try {
+      await cmsService.deletePost(confirmDelete.uuid);
+      toast.success('Post deleted');
+      setConfirmDelete(null);
+      load();
+    } catch {
+      toast.error('Failed to delete post');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const columns: TableColumn<CmsPost>[] = [
+    {
+      key: 'title',
+      header: 'Title',
+      render: (p) => (
+        <div className="min-w-0">
+          <div className="flex items-center gap-1.5 font-medium text-secondary-900">
+            {p.is_featured && <Star className="h-3.5 w-3.5 shrink-0 text-amber-500" />}
+            <span className="truncate">{p.title}</span>
+          </div>
+          <div className="truncate text-xs text-secondary-400">/{p.slug}</div>
+        </div>
+      ),
+    },
+    {
+      key: 'category',
+      header: 'Category',
+      render: (p) => (p.category ? <Badge variant="secondary" size="sm">{p.category.name}</Badge> : <span className="text-secondary-300">—</span>),
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      render: (p) => (
+        <Badge variant={statusVariant(p.status)} size="sm">
+          {p.status}
+        </Badge>
+      ),
+    },
+    {
+      key: 'view_count',
+      header: 'Views',
+      render: (p) => (
+        <span className="inline-flex items-center gap-1 text-sm text-secondary-500">
+          <Eye className="h-3.5 w-3.5" /> {p.view_count ?? 0}
+        </span>
+      ),
+    },
+    {
+      key: 'published_at',
+      header: 'Date',
+      render: (p) => (
+        <span className="text-sm text-secondary-500">
+          {p.published_at ? formatDate(p.published_at) : formatDate(p.created_at || '')}
+        </span>
+      ),
+    },
+    {
+      key: 'actions',
+      header: '',
+      width: '90px',
+      render: (p) => (
+        <div className="flex items-center justify-end gap-1">
+          {canWrite && (
+            <button
+              onClick={() => router.push(`/dashboard/cms/posts/${p.uuid}`)}
+              className="rounded p-1.5 text-secondary-500 hover:bg-secondary-100 hover:text-primary-600"
+              aria-label="Edit"
+            >
+              <Edit className="h-4 w-4" />
+            </button>
+          )}
+          {canDelete && (
+            <button
+              onClick={() => setConfirmDelete(p)}
+              className="rounded p-1.5 text-secondary-500 hover:bg-error-50 hover:text-error-600"
+              aria-label="Delete"
+            >
+              <Trash2 className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <div className="w-full sm:w-72">
+            <Input
+              leftIcon={<Search className="h-4 w-4" />}
+              value={search}
+              onChange={(e) => {
+                setPage(1);
+                setSearch(e.target.value);
+              }}
+              placeholder="Search posts…"
+            />
+          </div>
+          <div className="w-full sm:w-48">
+            <Select
+              value={status}
+              onChange={(e) => {
+                setPage(1);
+                setStatus(e.target.value as PostStatus | '');
+              }}
+            >
+              <option value="">All statuses</option>
+              <option value="draft">Draft</option>
+              <option value="published">Published</option>
+              <option value="scheduled">Scheduled</option>
+              <option value="archived">Archived</option>
+            </Select>
+          </div>
+        </div>
+        {canWrite && (
+          <Button onClick={() => router.push('/dashboard/cms/posts/new')}>
+            <Plus className="mr-1 h-4 w-4" /> New Post
+          </Button>
+        )}
+      </div>
+
+      <Table
+        columns={columns}
+        data={posts}
+        keyExtractor={(p) => p.uuid}
+        isLoading={loading}
+        emptyMessage="No posts yet. Create your first article."
+      />
+
+      {totalPages > 1 && (
+        <Pagination
+          currentPage={page}
+          totalPages={totalPages}
+          totalItems={total}
+          perPage={PER_PAGE}
+          onPageChange={setPage}
+        />
+      )}
+
+      <ConfirmDialog
+        isOpen={Boolean(confirmDelete)}
+        onClose={() => setConfirmDelete(null)}
+        onConfirm={doDelete}
+        title="Delete post"
+        message={`Delete "${confirmDelete?.title}"? This can be recovered by support but will disappear from your site.`}
+        confirmText="Delete"
+        variant="danger"
+        isLoading={deleting}
+      />
+    </div>
+  );
+}
+
+// ============================================================
+// Pages tab
+// ============================================================
+function PagesTab() {
+  const router = useRouter();
+  const { hasPermission } = usePermissions();
+  const canWrite = hasPermission('cms', 'update');
+  const canDelete = hasPermission('cms', 'delete');
+
+  const [pages, setPages] = useState<CmsPage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+  const [confirmDelete, setConfirmDelete] = useState<CmsPage | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      setPages(await cmsService.getPages({ search }));
+    } catch {
+      toast.error('Failed to load pages');
+    } finally {
+      setLoading(false);
+    }
+  }, [search]);
+
+  useEffect(() => {
+    const t = setTimeout(load, search ? 300 : 0);
+    return () => clearTimeout(t);
+  }, [load, search]);
+
+  const doDelete = async () => {
+    if (!confirmDelete) return;
+    setDeleting(true);
+    try {
+      await cmsService.deletePage(confirmDelete.uuid);
+      toast.success('Page deleted');
+      setConfirmDelete(null);
+      load();
+    } catch {
+      toast.error('Failed to delete page');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const columns: TableColumn<CmsPage>[] = [
+    {
+      key: 'title',
+      header: 'Title',
+      render: (p) => (
+        <div className="min-w-0">
+          <div className="truncate font-medium text-secondary-900">{p.title}</div>
+          <div className="truncate text-xs text-secondary-400">/{p.slug}</div>
+        </div>
+      ),
+    },
+    {
+      key: 'show_in_nav',
+      header: 'In nav',
+      render: (p) => (p.show_in_nav ? <Badge variant="info" size="sm">Nav</Badge> : <span className="text-secondary-300">—</span>),
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      render: (p) => (
+        <Badge variant={statusVariant(p.status)} size="sm">
+          {p.status}
+        </Badge>
+      ),
+    },
+    {
+      key: 'updated_at',
+      header: 'Updated',
+      render: (p) => <span className="text-sm text-secondary-500">{formatDate(p.updated_at || '')}</span>,
+    },
+    {
+      key: 'actions',
+      header: '',
+      width: '90px',
+      render: (p) => (
+        <div className="flex items-center justify-end gap-1">
+          {canWrite && (
+            <button
+              onClick={() => router.push(`/dashboard/cms/pages/${p.uuid}`)}
+              className="rounded p-1.5 text-secondary-500 hover:bg-secondary-100 hover:text-primary-600"
+              aria-label="Edit"
+            >
+              <Edit className="h-4 w-4" />
+            </button>
+          )}
+          {canDelete && (
+            <button
+              onClick={() => setConfirmDelete(p)}
+              className="rounded p-1.5 text-secondary-500 hover:bg-error-50 hover:text-error-600"
+              aria-label="Delete"
+            >
+              <Trash2 className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="w-full sm:w-72">
+          <Input
+            leftIcon={<Search className="h-4 w-4" />}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search pages…"
+          />
+        </div>
+        {canWrite && (
+          <Button onClick={() => router.push('/dashboard/cms/pages/new')}>
+            <Plus className="mr-1 h-4 w-4" /> New Page
+          </Button>
+        )}
+      </div>
+
+      <Table
+        columns={columns}
+        data={pages}
+        keyExtractor={(p) => p.uuid}
+        isLoading={loading}
+        emptyMessage="No pages yet. Create your first page (About, Contact, …)."
+      />
+
+      <ConfirmDialog
+        isOpen={Boolean(confirmDelete)}
+        onClose={() => setConfirmDelete(null)}
+        onConfirm={doDelete}
+        title="Delete page"
+        message={`Delete "${confirmDelete?.title}"?`}
+        confirmText="Delete"
+        variant="danger"
+        isLoading={deleting}
+      />
+    </div>
+  );
+}
+
+// ============================================================
+// Categories tab
+// ============================================================
+function CategoriesTab() {
+  const { hasPermission } = usePermissions();
+  const canWrite = hasPermission('cms', 'update');
+  const canDelete = hasPermission('cms', 'delete');
+
+  const [cats, setCats] = useState<CmsCategory[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [editing, setEditing] = useState<CmsCategory | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState<CmsCategory | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      setCats(await cmsService.getCategories());
+    } catch {
+      toast.error('Failed to load categories');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const openNew = () => {
+    setEditing(null);
+    setName('');
+    setDescription('');
+    setShowForm(true);
+  };
+  const openEdit = (c: CmsCategory) => {
+    setEditing(c);
+    setName(c.name);
+    setDescription(c.description ?? '');
+    setShowForm(true);
+  };
+
+  const save = async () => {
+    if (!name.trim()) {
+      toast.error('Name is required');
+      return;
+    }
+    setSaving(true);
+    try {
+      if (editing) {
+        await cmsService.updateCategory(editing.uuid, { name, description });
+        toast.success('Category updated');
+      } else {
+        await cmsService.createCategory({ name, description });
+        toast.success('Category created');
+      }
+      setShowForm(false);
+      load();
+    } catch {
+      toast.error('Failed to save category');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const doDelete = async () => {
+    if (!confirmDelete) return;
+    setDeleting(true);
+    try {
+      await cmsService.deleteCategory(confirmDelete.uuid);
+      toast.success('Category deleted');
+      setConfirmDelete(null);
+      load();
+    } catch {
+      toast.error('Failed to delete category');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-secondary-500">Group blog posts into browsable categories.</p>
+        {canWrite && (
+          <Button onClick={openNew}>
+            <Plus className="mr-1 h-4 w-4" /> New Category
+          </Button>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-secondary-400" />
+        </div>
+      ) : cats.length === 0 ? (
+        <Card>
+          <p className="py-8 text-center text-secondary-500">No categories yet.</p>
+        </Card>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {cats.map((c) => (
+            <Card key={c.uuid} className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <div className="truncate font-medium text-secondary-900">{c.name}</div>
+                <div className="truncate text-xs text-secondary-400">/{c.slug}</div>
+                {c.description && <p className="mt-1 line-clamp-2 text-sm text-secondary-500">{c.description}</p>}
+                <Badge variant="secondary" size="sm" className="mt-2">
+                  {c.post_count ?? 0} posts
+                </Badge>
+              </div>
+              <div className="flex shrink-0 items-center gap-1">
+                {canWrite && (
+                  <button onClick={() => openEdit(c)} className="rounded p-1.5 text-secondary-500 hover:bg-secondary-100 hover:text-primary-600" aria-label="Edit">
+                    <Edit className="h-4 w-4" />
+                  </button>
+                )}
+                {canDelete && (
+                  <button onClick={() => setConfirmDelete(c)} className="rounded p-1.5 text-secondary-500 hover:bg-error-50 hover:text-error-600" aria-label="Delete">
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                )}
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      <Modal isOpen={showForm} onClose={() => setShowForm(false)} title={editing ? 'Edit category' : 'New category'}>
+        <div className="space-y-4">
+          <Input label="Name" value={name} onChange={(e) => setName(e.target.value)} placeholder="Announcements" />
+          <Input label="Description" value={description} onChange={(e) => setDescription(e.target.value)} placeholder="Optional" />
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" onClick={() => setShowForm(false)}>
+              Cancel
+            </Button>
+            <Button onClick={save} disabled={saving}>
+              {saving && <Loader2 className="mr-1 h-4 w-4 animate-spin" />}
+              {editing ? 'Save' : 'Create'}
+            </Button>
+          </div>
+        </div>
+      </Modal>
+
+      <ConfirmDialog
+        isOpen={Boolean(confirmDelete)}
+        onClose={() => setConfirmDelete(null)}
+        onConfirm={doDelete}
+        title="Delete category"
+        message={`Delete "${confirmDelete?.name}"? Posts in it become uncategorised.`}
+        confirmText="Delete"
+        variant="danger"
+        isLoading={deleting}
+      />
+    </div>
+  );
+}
+
+// ============================================================
+// Tags tab
+// ============================================================
+function TagsTab() {
+  const { hasPermission } = usePermissions();
+  const canWrite = hasPermission('cms', 'update');
+  const canDelete = hasPermission('cms', 'delete');
+
+  const [tags, setTags] = useState<CmsTag[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [newTag, setNewTag] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState<CmsTag | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      setTags(await cmsService.getTags());
+    } catch {
+      toast.error('Failed to load tags');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const create = async () => {
+    if (!newTag.trim()) return;
+    setCreating(true);
+    try {
+      await cmsService.createTag({ name: newTag.trim() });
+      setNewTag('');
+      load();
+    } catch {
+      toast.error('Failed to create tag');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const doDelete = async () => {
+    if (!confirmDelete) return;
+    setDeleting(true);
+    try {
+      await cmsService.deleteTag(confirmDelete.uuid);
+      toast.success('Tag deleted');
+      setConfirmDelete(null);
+      load();
+    } catch {
+      toast.error('Failed to delete tag');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-secondary-500">Lightweight labels for cross-cutting topics.</p>
+
+      {canWrite && (
+        <div className="flex max-w-md gap-2">
+          <Input
+            value={newTag}
+            onChange={(e) => setNewTag(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && create()}
+            placeholder="Add a tag…"
+          />
+          <Button onClick={create} disabled={creating}>
+            {creating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+          </Button>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-secondary-400" />
+        </div>
+      ) : tags.length === 0 ? (
+        <Card>
+          <p className="py-8 text-center text-secondary-500">No tags yet.</p>
+        </Card>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          {tags.map((t) => (
+            <span
+              key={t.uuid}
+              className="inline-flex items-center gap-2 rounded-full border border-secondary-200 bg-surface px-3 py-1.5 text-sm text-secondary-700"
+            >
+              <TagIcon className="h-3.5 w-3.5 text-secondary-400" />
+              {t.name}
+              <span className="text-xs text-secondary-400">{t.post_count ?? 0}</span>
+              {canDelete && (
+                <button onClick={() => setConfirmDelete(t)} className="text-secondary-400 hover:text-error-600" aria-label={`Delete ${t.name}`}>
+                  <Trash2 className="h-3.5 w-3.5" />
+                </button>
+              )}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <ConfirmDialog
+        isOpen={Boolean(confirmDelete)}
+        onClose={() => setConfirmDelete(null)}
+        onConfirm={doDelete}
+        title="Delete tag"
+        message={`Delete "${confirmDelete?.name}"? It will be removed from all posts.`}
+        confirmText="Delete"
+        variant="danger"
+        isLoading={deleting}
+      />
+    </div>
+  );
+}
+
+// ============================================================
+// Hub
+// ============================================================
+function CmsHub() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const initial = (searchParams.get('tab') as TabKey) || 'posts';
+  const [tab, setTab] = useState<TabKey>(
+    TABS.some((t) => t.key === initial) ? initial : 'posts',
+  );
+
+  const setActive = (key: TabKey) => {
+    setTab(key);
+    router.replace(`/dashboard/cms?tab=${key}`);
+  };
+
+  const activeLabel = useMemo(() => TABS.find((t) => t.key === tab)?.label, [tab]);
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Content"
+        description="Manage your website pages and blog — articles, categories and tags."
+        icon={<FileText className="h-6 w-6" />}
+      />
+
+      {/* Tabs */}
+      <div className="border-b border-secondary-200">
+        <nav className="-mb-px flex flex-wrap gap-1" aria-label="CMS sections">
+          {TABS.map((t) => (
+            <button
+              key={t.key}
+              onClick={() => setActive(t.key)}
+              className={`inline-flex items-center gap-2 border-b-2 px-4 py-2.5 text-sm font-medium transition-colors ${
+                tab === t.key
+                  ? 'border-primary-500 text-primary-600'
+                  : 'border-transparent text-secondary-500 hover:border-secondary-300 hover:text-secondary-700'
+              }`}
+              aria-current={tab === t.key ? 'page' : undefined}
+            >
+              {t.icon}
+              {t.label}
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      <div role="tabpanel" aria-label={activeLabel}>
+        {tab === 'posts' && <PostsTab />}
+        {tab === 'pages' && <PagesTab />}
+        {tab === 'categories' && <CategoriesTab />}
+        {tab === 'tags' && <TagsTab />}
+      </div>
+    </div>
+  );
+}
+
+export default function CmsContentPage() {
+  return (
+    <ProtectedPage module="cms" action="read" title="Content">
+      <Suspense
+        fallback={
+          <div className="flex justify-center py-24">
+            <Loader2 className="h-6 w-6 animate-spin text-secondary-400" />
+          </div>
+        }
+      >
+        <CmsHub />
+      </Suspense>
+    </ProtectedPage>
+  );
+}

--- a/opsapi-dashboard/app/dashboard/cms/pages/[uuid]/page.tsx
+++ b/opsapi-dashboard/app/dashboard/cms/pages/[uuid]/page.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { Loader2 } from 'lucide-react';
+import { ProtectedPage } from '@/components/permissions';
+import { PageEditor } from '@/components/cms';
+import { cmsService, type CmsPage } from '@/services/cms.service';
+import { Button } from '@/components/ui';
+import toast from 'react-hot-toast';
+
+export default function EditCmsPage() {
+  const params = useParams();
+  const router = useRouter();
+  const uuid = String(params?.uuid ?? '');
+
+  const [page, setPage] = useState<CmsPage | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    cmsService
+      .getPage(uuid)
+      .then((p) => {
+        if (active) setPage(p);
+      })
+      .catch(() => {
+        if (active) {
+          setError(true);
+          toast.error('Page not found');
+        }
+      })
+      .finally(() => active && setLoading(false));
+    return () => {
+      active = false;
+    };
+  }, [uuid]);
+
+  return (
+    <ProtectedPage module="cms" action="update" title="Edit Page">
+      {loading ? (
+        <div className="flex items-center justify-center py-24">
+          <Loader2 className="h-6 w-6 animate-spin text-secondary-400" />
+        </div>
+      ) : error || !page ? (
+        <div className="flex flex-col items-center justify-center gap-4 py-24">
+          <p className="text-secondary-600">This page could not be loaded.</p>
+          <Button variant="outline" onClick={() => router.push('/dashboard/cms?tab=pages')}>
+            Back to pages
+          </Button>
+        </div>
+      ) : (
+        <PageEditor page={page} />
+      )}
+    </ProtectedPage>
+  );
+}

--- a/opsapi-dashboard/app/dashboard/cms/pages/new/page.tsx
+++ b/opsapi-dashboard/app/dashboard/cms/pages/new/page.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import React from 'react';
+import { ProtectedPage } from '@/components/permissions';
+import { PageEditor } from '@/components/cms';
+
+export default function NewCmsPage() {
+  return (
+    <ProtectedPage module="cms" action="create" title="New Page">
+      <PageEditor />
+    </ProtectedPage>
+  );
+}

--- a/opsapi-dashboard/app/dashboard/cms/posts/[uuid]/page.tsx
+++ b/opsapi-dashboard/app/dashboard/cms/posts/[uuid]/page.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { Loader2 } from 'lucide-react';
+import { ProtectedPage } from '@/components/permissions';
+import { PostEditor } from '@/components/cms';
+import { cmsService, type CmsPost } from '@/services/cms.service';
+import { Button } from '@/components/ui';
+import toast from 'react-hot-toast';
+
+export default function EditPostPage() {
+  const params = useParams();
+  const router = useRouter();
+  const uuid = String(params?.uuid ?? '');
+
+  const [post, setPost] = useState<CmsPost | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    cmsService
+      .getPost(uuid)
+      .then((p) => {
+        if (active) setPost(p);
+      })
+      .catch(() => {
+        if (active) {
+          setError(true);
+          toast.error('Post not found');
+        }
+      })
+      .finally(() => active && setLoading(false));
+    return () => {
+      active = false;
+    };
+  }, [uuid]);
+
+  return (
+    <ProtectedPage module="cms" action="update" title="Edit Post">
+      {loading ? (
+        <div className="flex items-center justify-center py-24">
+          <Loader2 className="h-6 w-6 animate-spin text-secondary-400" />
+        </div>
+      ) : error || !post ? (
+        <div className="flex flex-col items-center justify-center gap-4 py-24">
+          <p className="text-secondary-600">This post could not be loaded.</p>
+          <Button variant="outline" onClick={() => router.push('/dashboard/cms?tab=posts')}>
+            Back to posts
+          </Button>
+        </div>
+      ) : (
+        <PostEditor post={post} />
+      )}
+    </ProtectedPage>
+  );
+}

--- a/opsapi-dashboard/app/dashboard/cms/posts/new/page.tsx
+++ b/opsapi-dashboard/app/dashboard/cms/posts/new/page.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import React from 'react';
+import { ProtectedPage } from '@/components/permissions';
+import { PostEditor } from '@/components/cms';
+
+export default function NewPostPage() {
+  return (
+    <ProtectedPage module="cms" action="create" title="New Post">
+      <PostEditor />
+    </ProtectedPage>
+  );
+}

--- a/opsapi-dashboard/components/academy/RichTextEditor.tsx
+++ b/opsapi-dashboard/components/academy/RichTextEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useEditor, EditorContent, type Editor } from '@tiptap/react';
 import { Node, mergeAttributes } from '@tiptap/core';
 import StarterKit from '@tiptap/starter-kit';
@@ -155,7 +155,11 @@ const Divider: React.FC = () => <span className={styles.divider} aria-hidden="tr
 // Toolbar
 // ------------------------------------------------------------
 
-const Toolbar: React.FC<{ editor: Editor }> = ({ editor }) => {
+const Toolbar: React.FC<{
+  editor: Editor;
+  sourceMode?: boolean;
+  onToggleSource?: () => void;
+}> = ({ editor, sourceMode, onToggleSource }) => {
   const setLink = useCallback(() => {
     const previous = editor.getAttributes('link').href as string | undefined;
     const url = window.prompt('Link URL', previous ?? 'https://');
@@ -215,6 +219,20 @@ const Toolbar: React.FC<{ editor: Editor }> = ({ editor }) => {
   };
 
   const currentColor = (editor.getAttributes('textStyle').color as string) || '#111827';
+
+  // In HTML source mode the rich buttons would act on a hidden editor, so show
+  // a slim toolbar with just the toggle back to the visual editor. (Placed after
+  // all hooks above so the Rules of Hooks are respected.)
+  if (sourceMode) {
+    return (
+      <div className={styles.toolbar} role="toolbar" aria-label="HTML source">
+        <TbButton title="Back to visual editor" active onClick={() => onToggleSource?.()}>
+          <Code2 size={16} />
+        </TbButton>
+        <span className="ml-2 text-xs font-medium text-secondary-500">Editing HTML source</span>
+      </div>
+    );
+  }
 
   return (
     <div className={styles.toolbar} role="toolbar" aria-label="Formatting">
@@ -341,6 +359,15 @@ const Toolbar: React.FC<{ editor: Editor }> = ({ editor }) => {
       >
         <RemoveFormatting size={16} />
       </TbButton>
+
+      {onToggleSource && (
+        <>
+          <Divider />
+          <TbButton title="View / edit HTML source" onClick={() => onToggleSource()}>
+            <Code2 size={16} />
+          </TbButton>
+        </>
+      )}
     </div>
   );
 };
@@ -383,18 +410,55 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({
     },
   });
 
-  // Sync external value changes (e.g. async-loaded lesson) without disrupting typing.
-  useEffect(() => {
+  // HTML source ("code view") mode — lets you paste/edit raw HTML directly, the
+  // way CKEditor's source view does. sourceValue holds the raw textarea text.
+  const [sourceMode, setSourceMode] = useState(false);
+  const [sourceValue, setSourceValue] = useState('');
+
+  const toggleSource = useCallback(() => {
     if (!editor) return;
+    if (sourceMode) {
+      // Leaving source view: push the edited HTML back into the editor. TipTap
+      // parses/sanitises it and emitUpdate fires onChange with normalised HTML+JSON.
+      editor.commands.setContent(sourceValue || '', { emitUpdate: true });
+      setSourceMode(false);
+    } else {
+      setSourceValue(editor.getHTML());
+      setSourceMode(true);
+    }
+  }, [editor, sourceMode, sourceValue]);
+
+  // Sync external value changes (e.g. async-loaded content) without disrupting
+  // typing — and never while the user is hand-editing HTML in source view.
+  useEffect(() => {
+    if (!editor || sourceMode) return;
     if (value !== editor.getHTML() && !editor.isFocused) {
       editor.commands.setContent(value || '', { emitUpdate: false });
     }
-  }, [value, editor]);
+  }, [value, editor, sourceMode]);
 
   return (
     <div className={styles.editorShell}>
-      {editor && <Toolbar editor={editor} />}
-      <EditorContent editor={editor} className={styles.editorContent} />
+      {editor && <Toolbar editor={editor} sourceMode={sourceMode} onToggleSource={toggleSource} />}
+      {sourceMode ? (
+        <textarea
+          className="block w-full min-h-80 resize-y bg-surface p-4 font-mono text-[13px] leading-relaxed text-secondary-900 focus:outline-none"
+          value={sourceValue}
+          spellCheck={false}
+          readOnly={!editable}
+          aria-label="HTML source"
+          placeholder="<p>Paste or write raw HTML here…</p>"
+          onChange={(e) => {
+            const html = e.target.value;
+            setSourceValue(html);
+            // Keep the parent form in sync as you type raw HTML. content_json is
+            // rebuilt from HTML on load, so an empty JSON here is fine.
+            onChange?.(html, '');
+          }}
+        />
+      ) : (
+        <EditorContent editor={editor} className={styles.editorContent} />
+      )}
     </div>
   );
 };

--- a/opsapi-dashboard/components/cms/PageEditor.tsx
+++ b/opsapi-dashboard/components/cms/PageEditor.tsx
@@ -1,0 +1,262 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { ArrowLeft, Save, Loader2 } from 'lucide-react';
+import { Button, Input, Textarea, Select, Card } from '@/components/ui';
+import { RichTextEditor } from '@/components/academy';
+import { cmsService, type CmsPage, type PageInput, type PageStatus } from '@/services/cms.service';
+import toast from 'react-hot-toast';
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+// Gentle normalisation while typing in the slug field (keeps a trailing hyphen
+// so hyphenated slugs are actually typable); full slugify runs on blur.
+function normalizeSlugInput(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+/, '');
+}
+
+const STATUS_OPTIONS: { value: PageStatus; label: string }[] = [
+  { value: 'draft', label: 'Draft' },
+  { value: 'published', label: 'Published' },
+  { value: 'archived', label: 'Archived' },
+];
+
+interface PageEditorProps {
+  page?: CmsPage;
+}
+
+export default function PageEditor({ page }: PageEditorProps) {
+  const router = useRouter();
+  const isEdit = Boolean(page);
+
+  const [saving, setSaving] = useState(false);
+  const [title, setTitle] = useState(page?.title ?? '');
+  const [slug, setSlug] = useState(page?.slug ?? '');
+  const [slugTouched, setSlugTouched] = useState(isEdit);
+  const [excerpt, setExcerpt] = useState(page?.excerpt ?? '');
+  const [contentHtml, setContentHtml] = useState(page?.content_html ?? '');
+  const [contentJson, setContentJson] = useState(page?.content_json ?? '');
+  const [status, setStatus] = useState<PageStatus>(page?.status ?? 'draft');
+  const [template, setTemplate] = useState(page?.template ?? 'default');
+  const [menuOrder, setMenuOrder] = useState<number>(page?.menu_order ?? 0);
+  const [showInNav, setShowInNav] = useState<boolean>(page?.show_in_nav ?? false);
+  const [featuredImage, setFeaturedImage] = useState(page?.featured_image_url ?? '');
+
+  const [seoTitle, setSeoTitle] = useState(page?.seo_title ?? '');
+  const [seoDescription, setSeoDescription] = useState(page?.seo_description ?? '');
+  const [seoKeywords, setSeoKeywords] = useState(page?.seo_keywords ?? '');
+  const [showSeo, setShowSeo] = useState(false);
+
+  // Auto-derive the slug from the title until the user edits the slug directly.
+  const handleTitleChange = (v: string) => {
+    setTitle(v);
+    if (!slugTouched) setSlug(slugify(v));
+  };
+  const handleSlugChange = (v: string) => {
+    setSlugTouched(true);
+    setSlug(normalizeSlugInput(v));
+  };
+  const handleSlugBlur = () => setSlug((s) => slugify(s));
+
+  const buildPayload = (): PageInput => ({
+    title: title.trim(),
+    slug: slug.trim() || undefined,
+    excerpt: excerpt.trim() || undefined,
+    content_html: contentHtml,
+    content_json: contentJson,
+    featured_image_url: featuredImage.trim() || undefined,
+    status,
+    template: template.trim() || 'default',
+    menu_order: Number.isFinite(menuOrder) ? menuOrder : 0,
+    show_in_nav: showInNav,
+    seo_title: seoTitle.trim() || undefined,
+    seo_description: seoDescription.trim() || undefined,
+    seo_keywords: seoKeywords.trim() || undefined,
+  });
+
+  const save = async (overrideStatus?: PageStatus) => {
+    if (!title.trim()) {
+      toast.error('Title is required');
+      return;
+    }
+    setSaving(true);
+    try {
+      const payload = buildPayload();
+      if (overrideStatus) payload.status = overrideStatus;
+      if (isEdit && page) {
+        await cmsService.updatePage(page.uuid, payload);
+        toast.success('Page updated');
+      } else {
+        await cmsService.createPage(payload);
+        toast.success('Page created');
+      }
+      router.push('/dashboard/cms?tab=pages');
+    } catch (err) {
+      const serverMsg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
+      toast.error(serverMsg || (err instanceof Error ? err.message : 'Save failed'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" size="sm" onClick={() => router.push('/dashboard/cms?tab=pages')}>
+            <ArrowLeft className="mr-1 h-4 w-4" /> Back
+          </Button>
+          <h1 className="text-xl font-bold text-secondary-900 sm:text-2xl">
+            {isEdit ? 'Edit Page' : 'New Page'}
+          </h1>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={() => save('draft')} disabled={saving}>
+            Save draft
+          </Button>
+          <Button size="sm" onClick={() => save()} disabled={saving}>
+            {saving ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Save className="mr-1 h-4 w-4" />}
+            {status === 'published' ? 'Publish' : 'Save'}
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <div className="space-y-4 lg:col-span-2">
+          <Card>
+            <div className="space-y-4">
+              <Input label="Title" value={title} onChange={(e) => handleTitleChange(e.target.value)} placeholder="About Us" />
+              <Input
+                label="Slug"
+                value={slug}
+                onChange={(e) => handleSlugChange(e.target.value)}
+                onBlur={handleSlugBlur}
+                helperText="Auto-generated from the title. Edit it to set your own URL."
+                placeholder="about-us"
+              />
+              <Textarea
+                label="Excerpt"
+                value={excerpt}
+                onChange={(e) => setExcerpt(e.target.value)}
+                placeholder="Short summary (optional)."
+                rows={2}
+              />
+            </div>
+          </Card>
+
+          <Card>
+            <label className="mb-2 block text-sm font-medium text-secondary-700">Content</label>
+            <RichTextEditor
+              value={contentHtml}
+              placeholder="Write your page content…"
+              onChange={(html, json) => {
+                setContentHtml(html);
+                setContentJson(json);
+              }}
+            />
+          </Card>
+
+          <Card>
+            <button
+              type="button"
+              onClick={() => setShowSeo((s) => !s)}
+              className="flex w-full items-center justify-between text-left"
+            >
+              <span className="font-semibold text-secondary-900">SEO settings</span>
+              <span className="text-sm text-secondary-500">{showSeo ? 'Hide' : 'Show'}</span>
+            </button>
+            {showSeo && (
+              <div className="mt-4 space-y-4">
+                <Input label="SEO title" value={seoTitle} onChange={(e) => setSeoTitle(e.target.value)} />
+                <Textarea
+                  label="Meta description"
+                  value={seoDescription}
+                  onChange={(e) => setSeoDescription(e.target.value)}
+                  rows={2}
+                />
+                <Input
+                  label="Keywords"
+                  value={seoKeywords}
+                  onChange={(e) => setSeoKeywords(e.target.value)}
+                  helperText="Comma-separated"
+                />
+              </div>
+            )}
+          </Card>
+        </div>
+
+        <div className="space-y-4">
+          <Card>
+            <h3 className="mb-3 font-semibold text-secondary-900">Publish</h3>
+            <div className="space-y-3">
+              <Select label="Status" value={status} onChange={(e) => setStatus(e.target.value as PageStatus)}>
+                {STATUS_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </Select>
+              <label className="flex cursor-pointer items-center gap-2 text-sm text-secondary-700">
+                <input
+                  type="checkbox"
+                  checked={showInNav}
+                  onChange={(e) => setShowInNav(e.target.checked)}
+                  className="h-4 w-4 rounded border-secondary-300 text-primary-600"
+                />
+                Show in site navigation
+              </label>
+              <Input
+                label="Menu order"
+                type="number"
+                value={String(menuOrder)}
+                onChange={(e) => setMenuOrder(parseInt(e.target.value, 10) || 0)}
+              />
+            </div>
+          </Card>
+
+          <Card>
+            <h3 className="mb-3 font-semibold text-secondary-900">Template</h3>
+            <Input
+              value={template}
+              onChange={(e) => setTemplate(e.target.value)}
+              placeholder="default"
+              helperText="Theme template hint for the public site."
+            />
+          </Card>
+
+          <Card>
+            <h3 className="mb-3 font-semibold text-secondary-900">Featured image</h3>
+            <Input
+              value={featuredImage}
+              onChange={(e) => setFeaturedImage(e.target.value)}
+              placeholder="https://…/image.jpg"
+            />
+            {featuredImage && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={featuredImage}
+                alt="Featured preview"
+                className="mt-3 h-32 w-full rounded-lg object-cover"
+                onError={(e) => ((e.target as HTMLImageElement).style.display = 'none')}
+              />
+            )}
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/opsapi-dashboard/components/cms/PostEditor.tsx
+++ b/opsapi-dashboard/components/cms/PostEditor.tsx
@@ -1,0 +1,374 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { ArrowLeft, Save, X, Eye, Star, Loader2 } from 'lucide-react';
+import { Button, Input, Textarea, Select, Card } from '@/components/ui';
+import { RichTextEditor } from '@/components/academy';
+import {
+  cmsService,
+  type CmsPost,
+  type CmsCategory,
+  type PostInput,
+  type PostStatus,
+  type PostVisibility,
+} from '@/services/cms.service';
+import toast from 'react-hot-toast';
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+// Gentle normalisation while the user is typing IN the slug field: keeps a
+// trailing hyphen so "my-post" can actually be typed (full slugify strips it and
+// makes hyphens impossible to enter). The final clean happens on blur.
+function normalizeSlugInput(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+/, '');
+}
+
+const STATUS_OPTIONS: { value: PostStatus; label: string }[] = [
+  { value: 'draft', label: 'Draft' },
+  { value: 'published', label: 'Published' },
+  { value: 'scheduled', label: 'Scheduled' },
+  { value: 'archived', label: 'Archived' },
+];
+
+interface PostEditorProps {
+  /** Existing post (edit mode). Omit for create mode. */
+  post?: CmsPost;
+}
+
+export default function PostEditor({ post }: PostEditorProps) {
+  const router = useRouter();
+  const isEdit = Boolean(post);
+
+  const [categories, setCategories] = useState<CmsCategory[]>([]);
+  const [saving, setSaving] = useState(false);
+
+  const [title, setTitle] = useState(post?.title ?? '');
+  const [slug, setSlug] = useState(post?.slug ?? '');
+  const [slugTouched, setSlugTouched] = useState(isEdit);
+  const [excerpt, setExcerpt] = useState(post?.excerpt ?? '');
+  const [contentHtml, setContentHtml] = useState(post?.content_html ?? '');
+  const [contentJson, setContentJson] = useState(post?.content_json ?? '');
+  const [status, setStatus] = useState<PostStatus>(post?.status ?? 'draft');
+  const [visibility, setVisibility] = useState<PostVisibility>(post?.visibility ?? 'public');
+  const [isFeatured, setIsFeatured] = useState<boolean>(post?.is_featured ?? false);
+  const [categoryUuid, setCategoryUuid] = useState<string>(post?.category?.uuid ?? '');
+  const [featuredImage, setFeaturedImage] = useState(post?.featured_image_url ?? '');
+  const [authorName, setAuthorName] = useState(post?.author_name ?? '');
+  const [scheduledAt, setScheduledAt] = useState(post?.scheduled_at ?? '');
+
+  const [tags, setTags] = useState<string[]>(post?.tags?.map((t) => t.name) ?? []);
+  const [tagInput, setTagInput] = useState('');
+
+  const [seoTitle, setSeoTitle] = useState(post?.seo_title ?? '');
+  const [seoDescription, setSeoDescription] = useState(post?.seo_description ?? '');
+  const [seoKeywords, setSeoKeywords] = useState(post?.seo_keywords ?? '');
+  const [showSeo, setShowSeo] = useState(false);
+
+  useEffect(() => {
+    cmsService
+      .getCategories()
+      .then(setCategories)
+      .catch(() => setCategories([]));
+  }, []);
+
+  // Auto-derive the slug from the title until the user edits the slug directly.
+  // Done inline (not in an effect) so it's predictable and avoids a re-render loop.
+  const handleTitleChange = (v: string) => {
+    setTitle(v);
+    if (!slugTouched) setSlug(slugify(v));
+  };
+  const handleSlugChange = (v: string) => {
+    setSlugTouched(true);
+    setSlug(normalizeSlugInput(v));
+  };
+  const handleSlugBlur = () => setSlug((s) => slugify(s));
+
+  const addTag = useCallback(
+    (raw: string) => {
+      const name = raw.trim();
+      if (!name) return;
+      setTags((prev) => (prev.some((t) => t.toLowerCase() === name.toLowerCase()) ? prev : [...prev, name]));
+      setTagInput('');
+    },
+    [],
+  );
+
+  const removeTag = useCallback((name: string) => {
+    setTags((prev) => prev.filter((t) => t !== name));
+  }, []);
+
+  const onTagKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      addTag(tagInput);
+    } else if (e.key === 'Backspace' && !tagInput && tags.length) {
+      removeTag(tags[tags.length - 1]);
+    }
+  };
+
+  const categoryOptions = useMemo(
+    () => [{ value: '', label: 'No category' }, ...categories.map((c) => ({ value: c.uuid, label: c.name }))],
+    [categories],
+  );
+
+  const buildPayload = (): PostInput => ({
+    title: title.trim(),
+    slug: slug.trim() || undefined,
+    excerpt: excerpt.trim() || undefined,
+    content_html: contentHtml,
+    content_json: contentJson,
+    featured_image_url: featuredImage.trim() || undefined,
+    status,
+    visibility,
+    is_featured: isFeatured,
+    category_uuid: categoryUuid || '',
+    tags,
+    author_name: authorName.trim() || undefined,
+    scheduled_at: status === 'scheduled' ? scheduledAt || undefined : undefined,
+    seo_title: seoTitle.trim() || undefined,
+    seo_description: seoDescription.trim() || undefined,
+    seo_keywords: seoKeywords.trim() || undefined,
+  });
+
+  const save = async (overrideStatus?: PostStatus) => {
+    if (!title.trim()) {
+      toast.error('Title is required');
+      return;
+    }
+    setSaving(true);
+    try {
+      const payload = buildPayload();
+      if (overrideStatus) payload.status = overrideStatus;
+      if (isEdit && post) {
+        await cmsService.updatePost(post.uuid, payload);
+        toast.success('Post updated');
+      } else {
+        await cmsService.createPost(payload);
+        toast.success('Post created');
+      }
+      router.push('/dashboard/cms?tab=posts');
+    } catch (err) {
+      const serverMsg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
+      toast.error(serverMsg || (err instanceof Error ? err.message : 'Save failed'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Top bar */}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" size="sm" onClick={() => router.push('/dashboard/cms?tab=posts')}>
+            <ArrowLeft className="mr-1 h-4 w-4" /> Back
+          </Button>
+          <h1 className="text-xl font-bold text-secondary-900 sm:text-2xl">
+            {isEdit ? 'Edit Post' : 'New Post'}
+          </h1>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={() => save('draft')} disabled={saving}>
+            Save draft
+          </Button>
+          <Button size="sm" onClick={() => save()} disabled={saving}>
+            {saving ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Save className="mr-1 h-4 w-4" />}
+            {status === 'published' ? 'Publish' : 'Save'}
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        {/* Main column */}
+        <div className="space-y-4 lg:col-span-2">
+          <Card>
+            <div className="space-y-4">
+              <Input
+                label="Title"
+                value={title}
+                onChange={(e) => handleTitleChange(e.target.value)}
+                placeholder="Your post title"
+              />
+              <Input
+                label="Slug"
+                value={slug}
+                onChange={(e) => handleSlugChange(e.target.value)}
+                onBlur={handleSlugBlur}
+                helperText="Auto-generated from the title. Edit it to set your own URL."
+                placeholder="your-post-title"
+              />
+              <Textarea
+                label="Excerpt"
+                value={excerpt}
+                onChange={(e) => setExcerpt(e.target.value)}
+                placeholder="Short summary shown in listings and search results."
+                rows={3}
+              />
+            </div>
+          </Card>
+
+          <Card>
+            <label className="mb-2 block text-sm font-medium text-secondary-700">Content</label>
+            <RichTextEditor
+              value={contentHtml}
+              placeholder="Write your article…"
+              onChange={(html, json) => {
+                setContentHtml(html);
+                setContentJson(json);
+              }}
+            />
+          </Card>
+
+          {/* SEO */}
+          <Card>
+            <button
+              type="button"
+              onClick={() => setShowSeo((s) => !s)}
+              className="flex w-full items-center justify-between text-left"
+            >
+              <span className="font-semibold text-secondary-900">SEO settings</span>
+              <span className="text-sm text-secondary-500">{showSeo ? 'Hide' : 'Show'}</span>
+            </button>
+            {showSeo && (
+              <div className="mt-4 space-y-4">
+                <Input label="SEO title" value={seoTitle} onChange={(e) => setSeoTitle(e.target.value)} />
+                <Textarea
+                  label="Meta description"
+                  value={seoDescription}
+                  onChange={(e) => setSeoDescription(e.target.value)}
+                  rows={2}
+                />
+                <Input
+                  label="Keywords"
+                  value={seoKeywords}
+                  onChange={(e) => setSeoKeywords(e.target.value)}
+                  helperText="Comma-separated"
+                />
+              </div>
+            )}
+          </Card>
+        </div>
+
+        {/* Sidebar */}
+        <div className="space-y-4">
+          <Card>
+            <h3 className="mb-3 font-semibold text-secondary-900">Publish</h3>
+            <div className="space-y-3">
+              <Select label="Status" value={status} onChange={(e) => setStatus(e.target.value as PostStatus)}>
+                {STATUS_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </Select>
+              {status === 'scheduled' && (
+                <Input
+                  label="Publish date"
+                  type="datetime-local"
+                  value={scheduledAt ? scheduledAt.slice(0, 16) : ''}
+                  onChange={(e) => setScheduledAt(e.target.value)}
+                />
+              )}
+              <Select
+                label="Visibility"
+                value={visibility}
+                onChange={(e) => setVisibility(e.target.value as PostVisibility)}
+              >
+                <option value="public">Public</option>
+                <option value="private">Private</option>
+              </Select>
+              <label className="flex cursor-pointer items-center gap-2 text-sm text-secondary-700">
+                <input
+                  type="checkbox"
+                  checked={isFeatured}
+                  onChange={(e) => setIsFeatured(e.target.checked)}
+                  className="h-4 w-4 rounded border-secondary-300 text-primary-600"
+                />
+                <Star className="h-4 w-4" /> Featured post
+              </label>
+            </div>
+          </Card>
+
+          <Card>
+            <h3 className="mb-3 font-semibold text-secondary-900">Category</h3>
+            <Select value={categoryUuid} onChange={(e) => setCategoryUuid(e.target.value)}>
+              {categoryOptions.map((o) => (
+                <option key={o.value || 'none'} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </Select>
+          </Card>
+
+          <Card>
+            <h3 className="mb-3 font-semibold text-secondary-900">Tags</h3>
+            <Input
+              value={tagInput}
+              onChange={(e) => setTagInput(e.target.value)}
+              onKeyDown={onTagKeyDown}
+              onBlur={() => addTag(tagInput)}
+              placeholder="Type a tag and press Enter"
+            />
+            {tags.length > 0 && (
+              <div className="mt-3 flex flex-wrap gap-2">
+                {tags.map((t) => (
+                  <span
+                    key={t}
+                    className="inline-flex items-center gap-1 rounded-full bg-primary-500/10 px-2.5 py-1 text-xs font-medium text-primary-600"
+                  >
+                    {t}
+                    <button type="button" onClick={() => removeTag(t)} aria-label={`Remove ${t}`}>
+                      <X className="h-3 w-3" />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+          </Card>
+
+          <Card>
+            <h3 className="mb-3 font-semibold text-secondary-900">Featured image</h3>
+            <Input
+              value={featuredImage}
+              onChange={(e) => setFeaturedImage(e.target.value)}
+              placeholder="https://…/image.jpg"
+              leftIcon={<Eye className="h-4 w-4" />}
+            />
+            {featuredImage && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={featuredImage}
+                alt="Featured preview"
+                className="mt-3 h-32 w-full rounded-lg object-cover"
+                onError={(e) => ((e.target as HTMLImageElement).style.display = 'none')}
+              />
+            )}
+          </Card>
+
+          <Card>
+            <h3 className="mb-3 font-semibold text-secondary-900">Author</h3>
+            <Input
+              value={authorName}
+              onChange={(e) => setAuthorName(e.target.value)}
+              placeholder="Defaults to you"
+            />
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/opsapi-dashboard/components/cms/index.ts
+++ b/opsapi-dashboard/components/cms/index.ts
@@ -1,0 +1,2 @@
+export { default as PostEditor } from './PostEditor';
+export { default as PageEditor } from './PageEditor';

--- a/opsapi-dashboard/services/cms.service.ts
+++ b/opsapi-dashboard/services/cms.service.ts
@@ -1,0 +1,281 @@
+import apiClient, { toFormData, buildQueryString } from '@/lib/api-client';
+
+// ============================================================
+// Types
+// ============================================================
+
+export type PostStatus = 'draft' | 'published' | 'scheduled' | 'archived';
+export type PostVisibility = 'public' | 'private';
+export type PageStatus = 'draft' | 'published' | 'archived';
+
+export interface CmsTaxonomyRef {
+  uuid: string;
+  name: string;
+  slug: string;
+}
+
+export interface CmsCategory {
+  uuid: string;
+  name: string;
+  slug: string;
+  description?: string;
+  parent_id?: number | null;
+  position?: number;
+  post_count?: number;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface CmsTag {
+  uuid: string;
+  name: string;
+  slug: string;
+  post_count?: number;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface CmsPost {
+  uuid: string;
+  title: string;
+  slug: string;
+  excerpt?: string;
+  content_html?: string;
+  content_json?: string;
+  featured_image_url?: string;
+  status: PostStatus;
+  visibility: PostVisibility;
+  is_featured: boolean;
+  author_uuid?: string;
+  author_name?: string;
+  published_at?: string | null;
+  scheduled_at?: string | null;
+  seo_title?: string;
+  seo_description?: string;
+  seo_keywords?: string;
+  reading_minutes?: number;
+  view_count?: number;
+  category_id?: number | null;
+  category?: CmsTaxonomyRef | null;
+  tags?: CmsTaxonomyRef[];
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface CmsPage {
+  uuid: string;
+  title: string;
+  slug: string;
+  excerpt?: string;
+  content_html?: string;
+  content_json?: string;
+  featured_image_url?: string;
+  status: PageStatus;
+  template?: string;
+  menu_order?: number;
+  show_in_nav?: boolean;
+  parent_id?: number | null;
+  author_uuid?: string;
+  published_at?: string | null;
+  seo_title?: string;
+  seo_description?: string;
+  seo_keywords?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface ListMeta {
+  total: number;
+  page: number;
+  perPage: number;
+  totalPages: number;
+}
+
+export interface PostListParams {
+  page?: number;
+  perPage?: number;
+  status?: PostStatus | '';
+  category?: string; // category uuid
+  tag?: string; // tag slug
+  search?: string;
+  featured?: boolean;
+}
+
+export interface PostListResult {
+  data: CmsPost[];
+  meta: ListMeta;
+}
+
+export interface PostInput {
+  title: string;
+  slug?: string;
+  excerpt?: string;
+  content_html?: string;
+  content_json?: string;
+  featured_image_url?: string;
+  status?: PostStatus;
+  visibility?: PostVisibility;
+  is_featured?: boolean;
+  category_uuid?: string;
+  tags?: string[];
+  author_name?: string;
+  scheduled_at?: string;
+  seo_title?: string;
+  seo_description?: string;
+  seo_keywords?: string;
+}
+
+export interface PageInput {
+  title: string;
+  slug?: string;
+  excerpt?: string;
+  content_html?: string;
+  content_json?: string;
+  featured_image_url?: string;
+  status?: PageStatus;
+  template?: string;
+  menu_order?: number;
+  show_in_nav?: boolean;
+  parent_uuid?: string;
+  seo_title?: string;
+  seo_description?: string;
+  seo_keywords?: string;
+}
+
+// ============================================================
+// Helpers
+// ============================================================
+
+function unwrapData<T>(response: { data?: unknown }): T {
+  const body = response.data as { data?: T } | undefined;
+  return (body?.data as T) ?? ([] as unknown as T);
+}
+
+// Serialize a post payload for the form-encoded body. `tags` is JSON-encoded so
+// the backend's coerce_list gets a clean array (an empty [] clears the tags).
+function serializePost(data: Partial<PostInput>): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...data };
+  if (data.tags !== undefined) out.tags = JSON.stringify(data.tags ?? []);
+  if (data.is_featured !== undefined) out.is_featured = data.is_featured ? 'true' : 'false';
+  return out;
+}
+
+function serializePage(data: Partial<PageInput>): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...data };
+  if (data.show_in_nav !== undefined) out.show_in_nav = data.show_in_nav ? 'true' : 'false';
+  return out;
+}
+
+// ============================================================
+// Service
+// ============================================================
+
+export const cmsService = {
+  // ---------------- Posts (blog articles) ----------------
+  async getPosts(params: PostListParams = {}): Promise<PostListResult> {
+    const qs = buildQueryString({
+      page: params.page,
+      perPage: params.perPage,
+      status: params.status,
+      category: params.category,
+      tag: params.tag,
+      search: params.search,
+      featured: params.featured ? 'true' : undefined,
+    });
+    const response = await apiClient.get(`/api/v2/cms/posts${qs}`);
+    const body = response.data as { data?: CmsPost[]; meta?: ListMeta };
+    return {
+      data: Array.isArray(body?.data) ? body.data : [],
+      meta: body?.meta ?? { total: 0, page: 1, perPage: 20, totalPages: 1 },
+    };
+  },
+
+  async getPost(uuid: string): Promise<CmsPost> {
+    const response = await apiClient.get(`/api/v2/cms/posts/${uuid}`);
+    return unwrapData<CmsPost>(response);
+  },
+
+  async createPost(data: PostInput): Promise<CmsPost> {
+    const response = await apiClient.post('/api/v2/cms/posts', toFormData(serializePost(data)));
+    return unwrapData<CmsPost>(response);
+  },
+
+  async updatePost(uuid: string, data: Partial<PostInput>): Promise<CmsPost> {
+    const response = await apiClient.put(`/api/v2/cms/posts/${uuid}`, toFormData(serializePost(data)));
+    return unwrapData<CmsPost>(response);
+  },
+
+  async deletePost(uuid: string): Promise<void> {
+    await apiClient.delete(`/api/v2/cms/posts/${uuid}`);
+  },
+
+  // ---------------- Pages (static site pages) ----------------
+  async getPages(params: { status?: PageStatus | ''; search?: string } = {}): Promise<CmsPage[]> {
+    const qs = buildQueryString({ status: params.status, search: params.search });
+    const response = await apiClient.get(`/api/v2/cms/pages${qs}`);
+    return unwrapData<CmsPage[]>(response);
+  },
+
+  async getPage(uuid: string): Promise<CmsPage> {
+    const response = await apiClient.get(`/api/v2/cms/pages/${uuid}`);
+    return unwrapData<CmsPage>(response);
+  },
+
+  async createPage(data: PageInput): Promise<CmsPage> {
+    const response = await apiClient.post('/api/v2/cms/pages', toFormData(serializePage(data)));
+    return unwrapData<CmsPage>(response);
+  },
+
+  async updatePage(uuid: string, data: Partial<PageInput>): Promise<CmsPage> {
+    const response = await apiClient.put(`/api/v2/cms/pages/${uuid}`, toFormData(serializePage(data)));
+    return unwrapData<CmsPage>(response);
+  },
+
+  async deletePage(uuid: string): Promise<void> {
+    await apiClient.delete(`/api/v2/cms/pages/${uuid}`);
+  },
+
+  // ---------------- Categories ----------------
+  async getCategories(search?: string): Promise<CmsCategory[]> {
+    const qs = buildQueryString({ search });
+    const response = await apiClient.get(`/api/v2/cms/categories${qs}`);
+    return unwrapData<CmsCategory[]>(response);
+  },
+
+  async createCategory(data: { name: string; slug?: string; description?: string; parent_uuid?: string; position?: number }): Promise<CmsCategory> {
+    const response = await apiClient.post('/api/v2/cms/categories', toFormData(data));
+    return unwrapData<CmsCategory>(response);
+  },
+
+  async updateCategory(uuid: string, data: { name?: string; slug?: string; description?: string; parent_uuid?: string; position?: number }): Promise<CmsCategory> {
+    const response = await apiClient.put(`/api/v2/cms/categories/${uuid}`, toFormData(data));
+    return unwrapData<CmsCategory>(response);
+  },
+
+  async deleteCategory(uuid: string): Promise<void> {
+    await apiClient.delete(`/api/v2/cms/categories/${uuid}`);
+  },
+
+  // ---------------- Tags ----------------
+  async getTags(search?: string): Promise<CmsTag[]> {
+    const qs = buildQueryString({ search });
+    const response = await apiClient.get(`/api/v2/cms/tags${qs}`);
+    return unwrapData<CmsTag[]>(response);
+  },
+
+  async createTag(data: { name: string; slug?: string }): Promise<CmsTag> {
+    const response = await apiClient.post('/api/v2/cms/tags', toFormData(data));
+    return unwrapData<CmsTag>(response);
+  },
+
+  async updateTag(uuid: string, data: { name?: string; slug?: string }): Promise<CmsTag> {
+    const response = await apiClient.put(`/api/v2/cms/tags/${uuid}`, toFormData(data));
+    return unwrapData<CmsTag>(response);
+  },
+
+  async deleteTag(uuid: string): Promise<void> {
+    await apiClient.delete(`/api/v2/cms/tags/${uuid}`);
+  },
+};
+
+export default cmsService;

--- a/opsapi-dashboard/services/index.ts
+++ b/opsapi-dashboard/services/index.ts
@@ -80,6 +80,23 @@ export {
   type LessonStatus,
 } from './academy.service';
 
+// CMS (website pages + blog: articles, categories, tags)
+export {
+  cmsService,
+  type CmsPost,
+  type CmsPage,
+  type CmsCategory,
+  type CmsTag,
+  type CmsTaxonomyRef,
+  type PostStatus,
+  type PostVisibility,
+  type PageStatus,
+  type PostInput,
+  type PageInput,
+  type PostListParams,
+  type PostListResult,
+} from './cms.service';
+
 // Hospital & Care Home Management
 export { hospitalsService } from './hospitals.service';
 export { patientsService } from './patients.service';


### PR DESCRIPTION
## What & why

Adds a multi-tenant **CMS** so each namespace can run its public site: static **Pages** (About, Contact, …) and a proper **Blog** (articles with **categories** + **tags**), with a rich WYSIWYG editor. Follows the existing academy module's layered pattern (`routes → queries → models → PostgreSQL`), fully namespace-scoped and feature-gated (`cms`).

## Backend (`lapis/`)

- **Migration** `migrations/cms-system.lua` — `cms_categories`, `cms_tags`, `cms_posts`, `cms_pages`, `cms_post_tags`. All `namespace_id`-scoped (FK → `namespaces ON DELETE CASCADE`), soft-deleted, unique-slug-per-namespace via partial index (deleted slugs reusable). Drops the `DEFAULT 0` lapis gives nullable FK columns so an omitted parent/category inserts `NULL`.
- **Migration** `migrations/cms-menu-items.lua` — sidebar item + `cms` RBAC module + owner/admin grants + enable for existing namespaces.
- **Models** (5), **Queries** (4 — namespace-scoped slug uniqueness, tag re-sync, publish stamping, reading-time, public published-only reads), **Routes** `cms-posts` / `cms-pages` / `cms-taxonomy` — admin CRUD (RBAC module `cms`) + public `\/api\/v2\/public\/cms\/:namespace\/...` reads.
- `helper/cms-http.lua` — shared body parsing (handles large content spilled to temp files), house response shape, tag-list coercion, namespace resolve.
- **Wire-up** — `FEATURES.CMS` + a `cms` preset (also added to `all`), `PROJECT_MODULES.cms`, `load_if` in `app.lua`, migration registry entries `833`–`842`.

## Frontend (`opsapi-dashboard/`)

- `services/cms.service.ts` typed client + index export.
- `/dashboard/cms` hub with tabs: **Blog Posts · Pages · Categories · Tags**; WordPress-style post/page editors reusing the TipTap `RichTextEditor`.
- `RichTextEditor`: adds an **HTML source ("code view") toggle** so raw HTML can be pasted/edited (also benefits academy lessons).
- Slug **auto-generates from the title** and stays editable (gentle normalise while typing, full slugify on blur).

## Verification

- Migrations run clean → 5 tables + indexes + menu item + RBAC module + owner grants.
- Live API (minted JWT, `system` namespace): create / list (paginated) / update (publish + edit HTML + tags) / delete / public published-only reads / view-count increment — all pass.
- `\/api\/v2\/user\/menu` serves the **Content** item → appears in the sidebar.
- Frontend `tsc --noEmit` **0 errors**, ESLint clean.

## Notes

- Public read endpoints are in place for a public site to consume; the public-facing site templates themselves (theme layer) are out of scope here.
- Enable on a narrower deploy with `PROJECT_CODE=cms` (already on under `all`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)