### PR TITLE
fix(ci): skip Cypress binary download in dashboard image build

### DIFF
--- a/opsapi-dashboard/Dockerfile
+++ b/opsapi-dashboard/Dockerfile
@@ -15,6 +15,14 @@
 FROM node:24.14-alpine AS deps
 WORKDIR /app
 COPY package.json package-lock.json ./
+# Cypress is an e2e-only devDependency (used by `npm run cy:*` on a dev/CI box),
+# never inside this image. Its post-install otherwise downloads a ~200 MB binary
+# from download.cypress.io on every deps cache-miss — slow, and a single CDN
+# hiccup fails the whole build (as it did on the #554 deploy). Skip that binary
+# download: the npm package still installs so the lockfile stays valid and
+# `next build` is unaffected; the final runner image ships only the Next.js
+# standalone output, so nothing dev-only reaches production anyway.
+ENV CYPRESS_INSTALL_BINARY=0
 RUN --mount=type=cache,target=/root/.npm \
     npm ci --no-audit --no-fund
 


### PR DESCRIPTION
## Problem

The **Deploy Workstation Dashboard** build failed at `npm ci` in the Dockerfile `deps` stage ([run 31575614170](https://github.com/bwalia/opsapi/actions/runs/31575614170/job/94046932017)):

```
npm error path /app/node_modules/cypress
npm error The Cypress App could not be downloaded.
URL: https://download.cypress.io/desktop/14.5.4?platform=linux&arch=x64
AggregateError
```

Cypress's post-install downloads a ~200 MB app binary from its CDN on every `deps` cache-miss. That download flaked and failed the whole image build. It's **not** related to the code that triggered the deploy — it's a transient external-download problem that can hit any build.

## Fix

Set `CYPRESS_INSTALL_BINARY=0` in the `deps` stage before `npm ci`.

- Cypress is an **e2e-only devDependency** (`npm run cy:*`), never needed inside the image.
- The **runner** stage ships only the Next.js `standalone` output, so no dev dependency reaches production regardless.
- The npm package still installs (lockfile stays valid; `next build` unaffected) — only the fragile binary download is skipped.
- Bonus: the build is deterministic and a bit faster (no 200 MB download).

Local e2e (`npm run cy:*` on a dev/CI box, outside this image) is unaffected — Cypress fetches its binary there as usual.

## Verification

`docker build --target deps` now completes where it previously failed:

```
#10 [deps 4/4] RUN ... npm ci --no-audit --no-fund
#10 82.29 added 663 packages in 1m
#10 DONE
```

No Cypress download step, no error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)