### PR TITLE
perf(ci): split OpsAPI deps into prebuilt base image (~14min → ~1-2min build)

### DIFF
--- a/.github/workflows/build-opsapi-base.yml
+++ b/.github/workflows/build-opsapi-base.yml
@@ -1,0 +1,56 @@
+name: Build OpsAPI Base Image
+
+# Builds the OpsAPI dependency base image (lapis/Dockerfile.base): OpenResty +
+# luarocks + all Lua rocks + runtime system packages. This is the slow,
+# rarely-changing part of the build (~12 min of luarocks compilation), so it is
+# split out and rebuilt ONLY when its inputs change — the app image
+# (lapis/Dockerfile) then does `FROM bwalia/opsapi-base:latest` and builds in
+# seconds.
+#
+# Triggers:
+#   - push touching lapis/Dockerfile.base or this workflow (ANY branch, so a PR
+#     that introduces/edits the base publishes it BEFORE the app build needs it)
+#   - manual dispatch (rebuild on demand, e.g. to pick up a new upstream rock)
+on:
+  push:
+    paths:
+      - 'lapis/Dockerfile.base'
+      - '.github/workflows/build-opsapi-base.yml'
+  workflow_dispatch:
+
+env:
+  IMAGE_REGISTRY: bwalia
+  IMAGE_NAME: opsapi-base
+
+jobs:
+  build-base:
+    name: Build & push opsapi-base
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push opsapi-base
+        uses: docker/build-push-action@v5
+        with:
+          context: ./lapis
+          file: ./lapis/Dockerfile.base
+          push: true
+          # :latest is what lapis/Dockerfile's `FROM` defaults to; the
+          # commit-SHA tag lets you pin/roll back a specific dependency set.
+          tags: |
+            ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          # Registry cache (durable, no GHA 10 GB eviction) so an unchanged
+          # base rebuilds from cached layers in ~1 min instead of recompiling.
+          cache-from: type=registry,ref=${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max,ignore-error=true

--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -244,21 +244,21 @@ jobs:
           # `TAG=latest` retained for existing consumers. New APP_VERSION /
           # BUILD_NUMBER / BUILD_TIME args are what app.lua reads via
           # os.getenv() so `/`, `/health`, `/metrics` surface the same
-          # version string in every environment.
+          # version string in every environment. OPSAPI_BASE points the app
+          # image at the prebuilt dependency base (built by the "Build OpsAPI
+          # Base Image" workflow) so this build skips the ~12 min luarocks compile.
           build-args: |
             TAG=latest
+            OPSAPI_BASE=${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}-base:latest
             APP_VERSION=${{ steps.version.outputs.APP_VERSION }}
             BUILD_NUMBER=${{ steps.version.outputs.BUILD_NUMBER }}
             BUILD_TIME=${{ steps.version.outputs.BUILD_TIME }}
-          cache-from: type=gha
-          # ignore-error: the GitHub Actions Cache export is a pure build-speed
-          # optimisation. When that service has a blip it returns an HTML error
-          # page instead of JSON, buildx fails to parse it, and the WHOLE build
-          # aborts (cancelling the already-successful image push) — which then
-          # skips smoke + deploy. A build whose image built and pushed fine must
-          # not fail because the cache backend was briefly unavailable, so make
-          # the export non-fatal: on error it logs a warning and continues.
-          cache-to: type=gha,mode=max,ignore-error=true
+          # No layer cache here on purpose. With the heavy dependencies now in
+          # bwalia/opsapi-base, this image is just a handful of tiny COPY layers
+          # on top — it rebuilds in seconds. The old `type=gha` cache was pure
+          # overhead: ~6 min importing a manifest that produced ZERO cache hits
+          # plus ~4 min exporting mode=max every run. Dropping it is what makes
+          # the app build fast; the base image is where dependency caching lives.
 
   # =========================================================================
   # 2. SMOKE TEST

--- a/lapis/Dockerfile
+++ b/lapis/Dockerfile
@@ -1,4 +1,18 @@
-FROM openresty/openresty:1.31-alpine-fat
+# syntax=docker/dockerfile:1.7
+# ===========================================================================
+# OpsAPI APP image — thin layer on top of the prebuilt dependency base.
+# ===========================================================================
+# The heavy, rarely-changing dependencies (OpenResty + luarocks + all rocks +
+# system packages) live in bwalia/opsapi-base, built separately by the
+# "Build OpsAPI Base Image" workflow. This image just COPYs the Lua source on
+# top, so a normal deploy is a handful of tiny COPY layers + push (~1 min)
+# instead of a ~12 min luarocks recompile every time.
+#
+# OPSAPI_BASE is overridable (e.g. pin a digest for reproducibility); it
+# defaults to the :latest base. Declared before FROM so it can parameterise it.
+# ===========================================================================
+ARG OPSAPI_BASE=bwalia/opsapi-base:latest
+FROM ${OPSAPI_BASE}
 
 ARG TARGET_NGINX_CONF=nginx.conf
 ARG TAG=latest
@@ -23,40 +37,11 @@ LABEL org.opencontainers.image.version="${APP_VERSION}" \
       org.opencontainers.image.created="${BUILD_TIME}" \
       opsapi.build.number="${BUILD_NUMBER}"
 
-RUN apk add --no-cache wget make gcc libc-dev \
-    && wget https://luarocks.github.io/luarocks/releases/luarocks-3.12.0.tar.gz \
-    && tar zxpf luarocks-3.12.0.tar.gz \
-    && cd luarocks-3.12.0 \
-    && ./configure \
-    && make \
-    && make install \
-    && cd .. \
-    && rm -rf luarocks-3.12.0 luarocks.tar.gz
-
-RUN apk add --no-cache openssl-dev
-RUN luarocks install luaossl
-RUN luarocks install luasec
-RUN luarocks install lapis
-RUN luarocks install bcrypt
-RUN luarocks install tableshape
-RUN luarocks install lua-resty-http
-RUN luarocks install lua-resty-openidc
-RUN luarocks install lua-resty-string
-RUN luarocks install base64
-RUN luarocks install lua-resty-jwt
-RUN luarocks install payments
-RUN luarocks install lua-resty-mail
-
-RUN apk add mysql-client
-RUN apk add postgresql-client
-RUN apk add curl
-# poppler-utils provides pdftotext + pdftoppm, used by lib/tax-extraction.lua to
-# pull transactions out of uploaded PDF bank statements (and rasterise scanned
-# PDFs for the Vision fallback). Without it, the "Extract" action fails on PDFs.
-RUN apk add --no-cache poppler-utils
-RUN wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc \
-    --tries=3 --timeout=30 && \
-    chmod +x /usr/local/bin/mc
+# NOTE: OpenResty, luarocks + all Lua rocks (luaossl, luasec, lapis, bcrypt,
+# tableshape, lua-resty-*, base64, payments, lua-resty-mail) and the runtime
+# system tools (mysql-client, postgresql-client, curl, poppler-utils, MinIO mc)
+# are all provided by the bwalia/opsapi-base image this builds FROM. To change
+# a dependency, edit lapis/Dockerfile.base (which rebuilds the base image).
 
 WORKDIR /app
 

--- a/lapis/Dockerfile.base
+++ b/lapis/Dockerfile.base
@@ -1,0 +1,58 @@
+# syntax=docker/dockerfile:1.7
+# ===========================================================================
+# OpsAPI dependency BASE image
+# ===========================================================================
+# OpenResty + luarocks + every Lua rock + the runtime system packages OpsAPI
+# needs. These are ~600 MB that essentially NEVER change with app work, yet the
+# old single-stage lapis/Dockerfile recompiled all of it (luarocks-from-source
+# + 12 `luarocks install` C builds) on EVERY deploy — ~12 min per build.
+#
+# This image is built ONLY when its inputs change (via the "Build OpsAPI Base
+# Image" workflow, triggered on edits to this file). The app image
+# (lapis/Dockerfile) does `FROM bwalia/opsapi-base:latest` and just COPYs the
+# Lua source in, so a normal deploy skips the whole compile step.
+#
+# When you add/remove a rock or system package: edit this file and push — the
+# base workflow rebuilds & pushes bwalia/opsapi-base:latest, then the next app
+# build picks it up automatically.
+# ===========================================================================
+FROM openresty/openresty:1.31-alpine-fat
+
+# --- luarocks (built from source) + all Lua rocks ------------------------
+# Kept as two RUN layers (toolchain, then rocks) so the rock list can change
+# without re-fetching/building luarocks itself. The build toolchain (gcc etc.)
+# is only needed to COMPILE the rocks; it stays in this base image, which is
+# acceptable — the base is a build/runtime dependency layer, not the shipped
+# app surface, and keeping it means the app image needs no compiler.
+RUN apk add --no-cache wget make gcc libc-dev openssl-dev \
+    && wget https://luarocks.github.io/luarocks/releases/luarocks-3.12.0.tar.gz \
+    && tar zxpf luarocks-3.12.0.tar.gz \
+    && cd luarocks-3.12.0 \
+    && ./configure \
+    && make \
+    && make install \
+    && cd .. \
+    && rm -rf luarocks-3.12.0 luarocks-3.12.0.tar.gz
+
+RUN luarocks install luaossl \
+    && luarocks install luasec \
+    && luarocks install lapis \
+    && luarocks install bcrypt \
+    && luarocks install tableshape \
+    && luarocks install lua-resty-http \
+    && luarocks install lua-resty-openidc \
+    && luarocks install lua-resty-string \
+    && luarocks install base64 \
+    && luarocks install lua-resty-jwt \
+    && luarocks install payments \
+    && luarocks install lua-resty-mail
+
+# --- runtime system tools ------------------------------------------------
+# DB clients, curl, poppler-utils (pdftotext/pdftoppm for lib/tax-extraction.lua
+# PDF bank-statement parsing), and the MinIO `mc` client.
+RUN apk add --no-cache mysql-client postgresql-client curl poppler-utils \
+    && wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc \
+       --tries=3 --timeout=30 \
+    && chmod +x /usr/local/bin/mc
+
+WORKDIR /app


### PR DESCRIPTION
## Problem

The backend image build took **~14 min** on every deploy ([run 31575614171](https://github.com/bwalia/opsapi/actions/runs/31575614171/job/94047198155)). Two causes, from the build log:

1. **Dependencies recompiled every time.** `CACHED` count was **0** — luarocks was built from source and all **12 `luarocks install` C builds** (luaossl, luasec, lapis, bcrypt, …) ran from scratch on each deploy. That's ~600 MB of deps that never change with app work.
2. **The `type=gha` cache was pure overhead.** It imported a stale manifest (~6 min) that produced **zero** cache hits, then exported `mode=max` (~4 min, `#58 … 228.2s`). ~10 min of cache I/O for no benefit — the GitHub Actions cache (10 GB, LRU) is shared across ~6 workflows and keeps evicting these layers.

## Fix — prebuilt dependency base image

- **`lapis/Dockerfile.base`** (new) — OpenResty + luarocks + all rocks + runtime tools (mysql/postgresql clients, curl, poppler-utils, MinIO `mc`). The heavy, rarely-changing layer.
- **`lapis/Dockerfile`** — now `FROM bwalia/opsapi-base:latest` + only the tiny Lua-source `COPY` layers. `OPSAPI_BASE` is an overridable build-arg (pin a digest for reproducibility).
- **`.github/workflows/build-opsapi-base.yml`** (new) — builds & pushes `opsapi-base` **only when `Dockerfile.base` changes** (or manual dispatch), with **durable registry cache** (no GHA eviction). Triggers on any branch, so this PR publishes the base before the app build needs it.
- **`deploy-k3s.yml`** — passes `OPSAPI_BASE` and **drops the `type=gha` cache** (0 hits, ~10 min overhead). The app image is now just COPY layers.

## Result

Normal deploys become **pull-base + COPY + push** instead of a ~12 min recompile.

**Verified locally:**
- Base image builds with **all 12 rocks + tools present** (588 MB).
- App image then builds **`FROM` the base in ~11 s**.
- Both Dockerfiles pass BuildKit `--check`; both workflow YAMLs validate.

## Rollout / ordering

- Pushing this branch triggers **Build OpsAPI Base Image**, publishing `bwalia/opsapi-base:latest` **before** merge — so the app build finds it immediately.
- After merge, the base rebuilds **only** when `lapis/Dockerfile.base` changes; day-to-day app deploys skip it entirely.
- To change a dependency later: edit `lapis/Dockerfile.base`, push → base republishes → next app build picks it up.

Note: local dev (`start.sh`) builds `lapis/Dockerfile`, which now pulls `bwalia/opsapi-base:latest` from Docker Hub (public), so no local change needed once the base is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)