### PR TITLE
feat(templates): namespace {{slot}} template library for CMS pages + domains

### DIFF
--- a/lapis/app.lua
+++ b/lapis/app.lua
@@ -355,6 +355,9 @@ safe_load_routes("routes.groups")
 safe_load_routes("routes.roles")
 safe_load_routes("routes.permissions")
 safe_load_routes("routes.module")
+-- Namespace template library ({{slot}} templates for CMS pages + domain sync).
+-- Always on (core): namespace-scoped, RBAC-gated on the "templates" module.
+safe_load_routes("routes.render-templates")
 safe_load_routes("routes.documents")
 safe_load_routes("routes.secrets")
 safe_load_routes("routes.tags")

--- a/lapis/helper/project-config.lua
+++ b/lapis/helper/project-config.lua
@@ -394,6 +394,7 @@ ProjectConfig.PROJECT_MODULES = {
         { machine_name = "roles", name = "Roles", description = "Role management within namespace", category = "Core", is_system = true },
         { machine_name = "settings", name = "Settings", description = "Namespace settings", category = "Core", is_system = true },
         { machine_name = "reports", name = "Reports", description = "Analytics and reports", category = "Core", allowed_actions = {"access"} },
+        { machine_name = "templates", name = "Templates", description = "Reusable {{slot}} templates for CMS pages and domain sync formats", category = "Content" },
     },
 
     -- Ecommerce modules

--- a/lapis/helper/template-render.lua
+++ b/lapis/helper/template-render.lua
@@ -1,0 +1,61 @@
+--[[
+    Template Render helper
+    ======================
+    The shared "{{slot}}" engine behind the namespace Templates library. A
+    template is a plain string (HTML for a page layout, JSON for a domain sync
+    format, …) with `{{placeholder}}` slots; render() fills them from a data
+    table. Mirrors the mechanism already used by helper/wslproxy-server.lua, so
+    the whole platform speaks one template dialect.
+
+    - Placeholders are `{{ key }}` where key is [%w_.] — dots allow nested
+      lookups (`{{author.name}}`).
+    - A missing/nil value renders as an empty string (never the literal
+      "{{key}}"), so a partially-populated template degrades cleanly.
+    - render() does NOT escape — the caller owns escaping for its target format
+      (CMS HTML is already sanitised upstream; the domain JSON path uses
+      wslproxy-server's JSON-aware renderer).
+]]
+
+local TemplateRender = {}
+
+-- Resolve a possibly-dotted key ("a.b.c") against a data table.
+local function lookup(data, key)
+    if data == nil then return nil end
+    if data[key] ~= nil then return data[key] end -- fast path: exact key
+    local cur = data
+    for part in key:gmatch("[^%.]+") do
+        if type(cur) ~= "table" then return nil end
+        cur = cur[part]
+    end
+    return cur
+end
+
+--- Fill every {{placeholder}} in `template` from `data`. Function replacement
+--- avoids Lua's `%` handling in gsub replacement strings.
+function TemplateRender.render(template, data)
+    if type(template) ~= "string" then return "" end
+    data = data or {}
+    return (template:gsub("{{%s*([%w_%.]+)%s*}}", function(key)
+        local val = lookup(data, key)
+        if val == nil then return "" end
+        if type(val) == "boolean" then return val and "true" or "false" end
+        if type(val) == "table" then return "" end
+        return tostring(val)
+    end))
+end
+
+--- Unique placeholder names in `template`, in first-seen order (for the editor
+--- to show which variables a template expects).
+function TemplateRender.placeholders(template)
+    if type(template) ~= "string" then return {} end
+    local seen, out = {}, {}
+    for key in template:gmatch("{{%s*([%w_%.]+)%s*}}") do
+        if not seen[key] then
+            seen[key] = true
+            out[#out + 1] = key
+        end
+    end
+    return out
+end
+
+return TemplateRender

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -146,6 +146,10 @@ local academy_progress_migrations = load_if_enabled(ProjectConfig.FEATURES.ACADE
 local cms_migrations = load_if_enabled(ProjectConfig.FEATURES.CMS, "migrations.cms-system") or {}
 local cms_menu_migrations = load_if_enabled(ProjectConfig.FEATURES.CMS, "migrations.cms-menu-items") or {}
 
+-- Render Templates (namespace {{slot}} template library). Core/always-on:
+-- namespace-scoped, used by CMS pages + domains, so it isn't feature-gated.
+local render_template_migrations = require("migrations.render-templates")
+
 -- Core enhancements (always load for namespace/rbac)
 local rbac_enhancements_migrations = require("migrations.rbac-enhancements")
 local namespace_system_migrations = require("migrations.namespace-system")
@@ -2296,6 +2300,11 @@ local _migrations = {
     ['840_register_cms_modules'] = conditional_array(ProjectConfig.FEATURES.CMS, cms_menu_migrations, 2),
     ['841_grant_cms_permissions'] = conditional_array(ProjectConfig.FEATURES.CMS, cms_menu_migrations, 3),
     ['842_enable_cms_menu_for_namespaces'] = conditional_array(ProjectConfig.FEATURES.CMS, cms_menu_migrations, 4),
+
+    -- Render Templates library (namespace-scoped {{slot}} templates). Always-run
+    -- (core): table + the "templates" RBAC module + owner/admin grants.
+    ['843_create_render_templates'] = render_template_migrations[1],
+    ['844_register_templates_module'] = render_template_migrations[2],
 
     -- Theme system foundation (Phase 0): drop obsolete scaffold.
     -- Replaced by new tables in Phase 1 migration 621_create_theme_system.

--- a/lapis/migrations/render-templates.lua
+++ b/lapis/migrations/render-templates.lua
@@ -1,0 +1,143 @@
+--[[
+    Render Templates (namespace Template Library) Migrations
+    ========================================================
+
+    A namespace-scoped library of reusable "{{slot}}" templates. One template is
+    a plain string with `{{placeholder}}` slots + an optional sample_data JSON.
+    `template_type` discriminates what a template is for:
+       - 'cms_page'        HTML page layout ({{title}}, {{content}}, …) chosen in
+                           the CMS page editor.
+       - 'domain_wslproxy' WSL Proxy vhost JSON format for the domains sync.
+
+    Tables:
+      1. render_templates  (namespace-scoped, soft-deleted)
+
+    Also registers the "templates" RBAC module and grants it to owner/admin so
+    the CMS "Templates" tab and the domain template picker are permissioned.
+]]
+
+local schema = require("lapis.db.schema")
+local types = schema.types
+local db = require("lapis.db")
+
+local function table_exists(name)
+    local r = db.query([[SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = ?) as exists]], name)
+    return r[1] and r[1].exists
+end
+local function index_exists(name)
+    local r = db.query([[SELECT EXISTS (SELECT FROM pg_indexes WHERE indexname = ?) as exists]], name)
+    return r[1] and r[1].exists
+end
+
+return {
+    -- ========================================================================
+    -- [1] Create render_templates
+    -- ========================================================================
+    [1] = function()
+        if table_exists("render_templates") then return end
+
+        schema.create_table("render_templates", {
+            { "id", types.serial },
+            { "uuid", types.varchar({ unique = true }) },
+            { "namespace_id", types.integer },
+            { "name", types.varchar },
+            { "slug", types.varchar },
+            { "template_type", types.varchar({ default = "cms_page" }) },
+            { "content", types.text({ null = true }) },       -- the template body ({{slots}})
+            { "sample_data", types.text({ null = true }) },   -- JSON sample for preview
+            { "description", types.text({ null = true }) },
+            { "is_default", types.boolean({ default = false }) },
+            { "created_at", types.time({ default = db.raw("NOW()") }) },
+            { "updated_at", types.time({ default = db.raw("NOW()") }) },
+            { "deleted_at", types.time({ null = true }) },
+            "PRIMARY KEY (id)"
+        })
+
+        pcall(function()
+            db.query([[
+                ALTER TABLE render_templates
+                ADD CONSTRAINT render_templates_namespace_fk
+                FOREIGN KEY (namespace_id) REFERENCES namespaces(id) ON DELETE CASCADE
+            ]])
+        end)
+
+        pcall(function()
+            db.query([[
+                ALTER TABLE render_templates
+                ADD CONSTRAINT render_templates_type_check
+                CHECK (template_type IN ('cms_page', 'domain_wslproxy'))
+            ]])
+        end)
+
+        -- Unique slug per (namespace, type) among live rows.
+        pcall(function()
+            db.query([[
+                CREATE UNIQUE INDEX render_templates_ns_type_slug_unique
+                ON render_templates (namespace_id, template_type, slug)
+                WHERE deleted_at IS NULL
+            ]])
+        end)
+
+        if not index_exists("idx_render_templates_uuid") then
+            db.query("CREATE UNIQUE INDEX idx_render_templates_uuid ON render_templates (uuid)")
+        end
+        if not index_exists("idx_render_templates_ns_type") then
+            db.query([[
+                CREATE INDEX idx_render_templates_ns_type
+                ON render_templates (namespace_id, template_type)
+                WHERE deleted_at IS NULL
+            ]])
+        end
+    end,
+
+    -- ========================================================================
+    -- [2] Register the "templates" RBAC module + grant to owner/admin roles
+    -- ========================================================================
+    [2] = function()
+        local MigrationUtils = require("helper.migration-utils")
+        local ts = MigrationUtils.getCurrentTimestamp()
+
+        local existing = db.select("* FROM modules WHERE machine_name = ?", "templates")
+        if #existing == 0 then
+            db.insert("modules", {
+                uuid = MigrationUtils.generateUUID(),
+                machine_name = "templates",
+                name = "Templates",
+                description = "Reusable {{slot}} templates for CMS pages and domain sync formats",
+                priority = 47,
+                created_at = ts,
+                updated_at = ts,
+            })
+            print("[Templates] Registered module: templates")
+        end
+
+        local cjson_ok, cjson = pcall(require, "cjson")
+        if not cjson_ok then return end
+
+        local owner_roles = db.select(
+            "* FROM namespace_roles WHERE role_name IN ('Owner', 'owner', 'Namespace Owner')")
+        local owner_actions = { "create", "read", "update", "delete", "manage" }
+        for _, role in ipairs(owner_roles) do
+            local perms = {}
+            if role.permissions and role.permissions ~= "" then
+                local ok, decoded = pcall(cjson.decode, role.permissions)
+                if ok and type(decoded) == "table" then perms = decoded end
+            end
+            if not perms["templates"] then perms["templates"] = owner_actions end
+            db.update("namespace_roles", { permissions = cjson.encode(perms) }, { id = role.id })
+        end
+
+        local admin_roles = db.select(
+            "* FROM namespace_roles WHERE role_name IN ('Admin', 'admin', 'Namespace Admin')")
+        local admin_actions = { "create", "read", "update", "delete" }
+        for _, role in ipairs(admin_roles) do
+            local perms = {}
+            if role.permissions and role.permissions ~= "" then
+                local ok, decoded = pcall(cjson.decode, role.permissions)
+                if ok and type(decoded) == "table" then perms = decoded end
+            end
+            if not perms["templates"] then perms["templates"] = admin_actions end
+            db.update("namespace_roles", { permissions = cjson.encode(perms) }, { id = role.id })
+        end
+    end,
+}

--- a/lapis/models/RenderTemplateModel.lua
+++ b/lapis/models/RenderTemplateModel.lua
@@ -1,0 +1,10 @@
+local Model = require("lapis.db.model").Model
+
+local RenderTemplate = Model:extend("render_templates", {
+    timestamp = true,
+    relations = {
+        { "namespace", belongs_to = "NamespaceModel", key = "namespace_id" },
+    }
+})
+
+return RenderTemplate

--- a/lapis/queries/RenderTemplateQueries.lua
+++ b/lapis/queries/RenderTemplateQueries.lua
@@ -1,0 +1,174 @@
+--[[
+    Render Template Queries
+    =======================
+    Namespace-scoped CRUD for the render_templates library. Soft-deleted; slug is
+    unique per (namespace, template_type) among live rows. Exactly one row per
+    (namespace, type) may be is_default.
+]]
+
+local RenderTemplateModel = require "models.RenderTemplateModel"
+local TemplateRender = require "helper.template-render"
+local Global = require "helper.global"
+local db = require("lapis.db")
+
+local RenderTemplateQueries = {}
+
+local VALID_TYPES = { cms_page = true, domain_wslproxy = true }
+RenderTemplateQueries.VALID_TYPES = VALID_TYPES
+
+local function slugify(text)
+    if not text or text == "" then return "" end
+    return (text:lower():gsub("%s+", "-"):gsub("[^%w%-]", ""):gsub("%-+", "-"):gsub("^%-", ""):gsub("%-$", ""))
+end
+RenderTemplateQueries.slugify = slugify
+
+--- Unique slug within (namespace, type) among live rows; appends -2, -3, …
+local function uniqueSlug(namespace_id, ttype, base, ignore_id)
+    base = (base and base ~= "") and base or "template"
+    local slug, n = base, 1
+    while true do
+        local rows = db.query([[
+            SELECT id FROM render_templates
+            WHERE namespace_id = ? AND template_type = ? AND slug = ? AND deleted_at IS NULL LIMIT 1
+        ]], namespace_id, ttype, slug)
+        local clash = rows and rows[1]
+        if not clash or (ignore_id and tonumber(clash.id) == tonumber(ignore_id)) then return slug end
+        n = n + 1
+        slug = base .. "-" .. n
+    end
+end
+
+local function findScoped(namespace_id, uuid)
+    local row = RenderTemplateModel:find({ uuid = uuid, namespace_id = namespace_id })
+    if not row or row.deleted_at then return nil end
+    return row
+end
+RenderTemplateQueries.findScoped = findScoped
+
+--- Clear is_default on every other live template of the same (namespace, type).
+local function clearOtherDefaults(namespace_id, ttype, keep_id)
+    db.query([[
+        UPDATE render_templates SET is_default = FALSE, updated_at = NOW()
+        WHERE namespace_id = ? AND template_type = ? AND is_default = TRUE
+          AND deleted_at IS NULL AND id <> ?
+    ]], namespace_id, ttype, keep_id or -1)
+end
+
+--- Attach the parsed placeholder list to a row (for the editor).
+local function withMeta(row)
+    if not row then return row end
+    row.placeholders = TemplateRender.placeholders(row.content or "")
+    return row
+end
+RenderTemplateQueries.withMeta = withMeta
+
+function RenderTemplateQueries.create(namespace_id, params)
+    local ttype = VALID_TYPES[params.template_type] and params.template_type or "cms_page"
+    local base = slugify((params.slug and params.slug ~= "") and params.slug or params.name)
+    local row = RenderTemplateModel:create({
+        uuid = Global.generateUUID(),
+        namespace_id = namespace_id,
+        name = params.name,
+        slug = uniqueSlug(namespace_id, ttype, base),
+        template_type = ttype,
+        content = params.content,
+        sample_data = params.sample_data,
+        description = params.description,
+        is_default = params.is_default and true or false,
+        created_at = db.raw("NOW()"),
+        updated_at = db.raw("NOW()"),
+    }, { returning = "*" })
+    if row.is_default then clearOtherDefaults(namespace_id, ttype, row.id) end
+    return withMeta(row)
+end
+
+--- List templates in a namespace, optionally filtered by type. `search` optional.
+function RenderTemplateQueries.list(namespace_id, params)
+    params = params or {}
+    local where = { "namespace_id = ?", "deleted_at IS NULL" }
+    local values = { namespace_id }
+    if params.template_type and params.template_type ~= "" then
+        table.insert(where, "template_type = ?"); table.insert(values, params.template_type)
+    end
+    if params.search and params.search ~= "" then
+        table.insert(where, "(name ILIKE ? OR slug ILIKE ?)")
+        local p = "%" .. params.search .. "%"
+        table.insert(values, p); table.insert(values, p)
+    end
+    local rows = db.query([[
+        SELECT * FROM render_templates
+        WHERE ]] .. table.concat(where, " AND ") .. [[
+        ORDER BY template_type ASC, is_default DESC, name ASC
+    ]], table.unpack(values)) or {}
+    for _, r in ipairs(rows) do withMeta(r) end
+    return rows
+end
+
+function RenderTemplateQueries.getByUuid(namespace_id, uuid)
+    return withMeta(findScoped(namespace_id, uuid))
+end
+
+--- Default template for a (namespace, type), or nil.
+function RenderTemplateQueries.getDefault(namespace_id, ttype)
+    local rows = db.query([[
+        SELECT * FROM render_templates
+        WHERE namespace_id = ? AND template_type = ? AND is_default = TRUE AND deleted_at IS NULL
+        LIMIT 1
+    ]], namespace_id, ttype)
+    return rows and rows[1] and withMeta(rows[1]) or nil
+end
+
+function RenderTemplateQueries.update(namespace_id, uuid, params)
+    local row = findScoped(namespace_id, uuid)
+    if not row then return nil end
+    local fields = { updated_at = db.raw("NOW()") }
+    for _, k in ipairs({ "name", "content", "sample_data", "description" }) do
+        if params[k] ~= nil then fields[k] = params[k] end
+    end
+    if params.slug ~= nil and params.slug ~= "" then
+        fields.slug = uniqueSlug(namespace_id, row.template_type, slugify(params.slug), row.id)
+    end
+    if params.is_default ~= nil then fields.is_default = params.is_default and true or false end
+    row:update(fields)
+    if fields.is_default == true then clearOtherDefaults(namespace_id, row.template_type, row.id) end
+    return withMeta(findScoped(namespace_id, uuid))
+end
+
+function RenderTemplateQueries.softDelete(namespace_id, uuid)
+    local row = findScoped(namespace_id, uuid)
+    if not row then return nil end
+    row:update({ deleted_at = db.raw("NOW()"), updated_at = db.raw("NOW()") })
+    return row
+end
+
+--- Render the (namespace, type) template identified by `slug` with `data`.
+--- Returns the rendered string, or nil when there's no template to apply
+--- (slug empty/"default"/unknown) so the caller can fall back to raw content.
+function RenderTemplateQueries.renderBySlug(namespace_id, ttype, slug, data)
+    if not slug or slug == "" or slug == "default" then return nil end
+    local rows = db.query([[
+        SELECT content FROM render_templates
+        WHERE namespace_id = ? AND template_type = ? AND slug = ? AND deleted_at IS NULL
+        LIMIT 1
+    ]], namespace_id, ttype, slug)
+    local row = rows and rows[1]
+    if not row then return nil end
+    return TemplateRender.render(row.content or "", data or {})
+end
+
+--- Render a template's content with the given data (for the preview endpoint).
+--- Falls back to the stored sample_data when no data is supplied.
+function RenderTemplateQueries.preview(namespace_id, uuid, data)
+    local row = findScoped(namespace_id, uuid)
+    if not row then return nil end
+    if data == nil and row.sample_data and row.sample_data ~= "" then
+        local ok, decoded = pcall(require("cjson").decode, row.sample_data)
+        if ok and type(decoded) == "table" then data = decoded end
+    end
+    return {
+        rendered = TemplateRender.render(row.content or "", data or {}),
+        placeholders = TemplateRender.placeholders(row.content or ""),
+    }
+end
+
+return RenderTemplateQueries

--- a/lapis/routes/cms-pages.lua
+++ b/lapis/routes/cms-pages.lua
@@ -20,6 +20,7 @@
 ]]
 
 local CmsPageQueries = require "queries.CmsPageQueries"
+local RenderTemplateQueries = require "queries.RenderTemplateQueries"
 local CmsHttp = require "helper.cms-http"
 local AuthMiddleware = require("middleware.auth")
 local NamespaceMiddleware = require("middleware.namespace")
@@ -149,6 +150,21 @@ return function(app)
         if not ns then return api_response(404, nil, "Namespace not found") end
         local page = CmsPageQueries.getPublishedBySlug(ns.id, self.params.slug)
         if not page then return api_response(404, nil, "Page not found") end
-        return { status = 200, json = { success = true, data = public_page(page) } }
+
+        local out = public_page(page)
+        -- Compose the page into its chosen layout template (if any). `template`
+        -- holds a render_templates slug; "default"/unknown -> raw content_html.
+        local rendered = RenderTemplateQueries.renderBySlug(ns.id, "cms_page", page.template, {
+            title = page.title or "",
+            slug = page.slug or "",
+            excerpt = page.excerpt or "",
+            content = page.content_html or "",
+            featured_image_url = page.featured_image_url or "",
+            seo_title = page.seo_title or "",
+            seo_description = page.seo_description or "",
+        })
+        out.template = page.template
+        out.rendered_html = rendered or page.content_html
+        return { status = 200, json = { success = true, data = out } }
     end)
 end

--- a/lapis/routes/domains.lua
+++ b/lapis/routes/domains.lua
@@ -172,11 +172,25 @@ return function(app)
             -- (+ the opsapi-managed manifest used by the DNS reconcile).
             local WslproxyServer = require("helper.wslproxy-server")
             local rows = DomainQueries.getAllForNamespace(self.namespace.id)
+
+            -- A chosen Template (type domain_wslproxy) from the library overrides
+            -- the raw server_template string, so the JSON format is picked from a
+            -- named, reusable template instead of pasted inline.
+            local server_template = eff.server_template
+            if data.template_uuid and data.template_uuid ~= "" then
+                local RTQ = require("queries.RenderTemplateQueries")
+                local tpl = RTQ.getByUuid(self.namespace.id, data.template_uuid)
+                if tpl and tpl.template_type == "domain_wslproxy"
+                    and tpl.content and tpl.content ~= "" then
+                    server_template = tpl.content
+                end
+            end
+
             -- Pass the namespace's template + rule defaults so rendering is
             -- data-driven (dashboard-configurable), not hardcoded. Also emits a
             -- rule file per referenced rule id so a synced domain actually routes.
             local built = WslproxyServer.build_sync_files(rows, env, eff.data_base, {
-                server_template = eff.server_template,
+                server_template = server_template,
                 rule_template   = eff.rule_template,
                 default_rule_id = eff.default_rule_id,
                 default_backend = eff.default_backend,

--- a/lapis/routes/render-templates.lua
+++ b/lapis/routes/render-templates.lua
@@ -1,0 +1,105 @@
+--[[
+    Render Templates API (namespace Template Library)
+    =================================================
+
+    Namespace-scoped, RBAC-gated (module "templates") CRUD for the reusable
+    "{{slot}}" templates used by CMS pages (type cms_page) and the domains sync
+    (type domain_wslproxy), plus preview endpoints that fill a template with data.
+
+      GET    /api/v2/render-templates?type=cms_page
+      POST   /api/v2/render-templates
+      GET    /api/v2/render-templates/:uuid
+      PUT    /api/v2/render-templates/:uuid
+      DELETE /api/v2/render-templates/:uuid
+      POST   /api/v2/render-templates/:uuid/preview   (render saved template)
+      POST   /api/v2/render-templates/preview         (render ad-hoc content+data)
+]]
+
+local RenderTemplateQueries = require "queries.RenderTemplateQueries"
+local TemplateRender = require "helper.template-render"
+local CmsHttp = require "helper.cms-http"
+local AuthMiddleware = require("middleware.auth")
+local NamespaceMiddleware = require("middleware.namespace")
+
+local parse_body = CmsHttp.parse_body
+local api_response = CmsHttp.api_response
+local to_bool = CmsHttp.to_bool
+
+return function(app)
+    app:get("/api/v2/render-templates", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("templates", "read", function(self)
+            local rows = RenderTemplateQueries.list(self.namespace.id, {
+                template_type = self.params.type,
+                search = self.params.search,
+            })
+            return { status = 200, json = { success = true, data = rows } }
+        end)))
+
+    app:post("/api/v2/render-templates", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("templates", "create", function(self)
+            local body = parse_body()
+            if not body.name or body.name == "" then
+                return api_response(400, nil, "name is required")
+            end
+            local ttype = body.template_type or "cms_page"
+            if not RenderTemplateQueries.VALID_TYPES[ttype] then
+                return api_response(400, nil, "Invalid template_type (cms_page|domain_wslproxy)")
+            end
+            local tpl = RenderTemplateQueries.create(self.namespace.id, {
+                name = body.name,
+                slug = body.slug,
+                template_type = ttype,
+                content = body.content,
+                sample_data = body.sample_data,
+                description = body.description,
+                is_default = to_bool(body.is_default, false),
+            })
+            return api_response(201, tpl)
+        end)))
+
+    app:get("/api/v2/render-templates/:uuid", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("templates", "read", function(self)
+            local tpl = RenderTemplateQueries.getByUuid(self.namespace.id, self.params.uuid)
+            if not tpl then return api_response(404, nil, "Template not found") end
+            return api_response(200, tpl)
+        end)))
+
+    app:put("/api/v2/render-templates/:uuid", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("templates", "update", function(self)
+            local body = parse_body()
+            local fields = {}
+            for _, k in ipairs({ "name", "slug", "content", "sample_data", "description" }) do
+                if body[k] ~= nil then fields[k] = body[k] end
+            end
+            if body.is_default ~= nil then fields.is_default = to_bool(body.is_default, false) end
+            local tpl = RenderTemplateQueries.update(self.namespace.id, self.params.uuid, fields)
+            if not tpl then return api_response(404, nil, "Template not found") end
+            return api_response(200, tpl)
+        end)))
+
+    app:delete("/api/v2/render-templates/:uuid", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("templates", "delete", function(self)
+            local tpl = RenderTemplateQueries.softDelete(self.namespace.id, self.params.uuid)
+            if not tpl then return api_response(404, nil, "Template not found") end
+            return api_response(200, { deleted = true })
+        end)))
+
+    -- Render a SAVED template with provided data (or its stored sample_data).
+    app:post("/api/v2/render-templates/:uuid/preview", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("templates", "read", function(self)
+            local body = parse_body()
+            local result = RenderTemplateQueries.preview(self.namespace.id, self.params.uuid, body.data)
+            if not result then return api_response(404, nil, "Template not found") end
+            return api_response(200, result)
+        end)))
+
+    -- Render AD-HOC content + data (live editor preview, nothing saved).
+    app:post("/api/v2/render-templates/preview", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("templates", "read", function(self)
+            local body = parse_body()
+            return api_response(200, {
+                rendered = TemplateRender.render(body.content or "", body.data or {}),
+                placeholders = TemplateRender.placeholders(body.content or ""),
+            })
+        end)))
+end

--- a/opsapi-dashboard/app/dashboard/cms/page.tsx
+++ b/opsapi-dashboard/app/dashboard/cms/page.tsx
@@ -15,7 +15,9 @@ import {
   Tag as TagIcon,
   Newspaper,
   Files,
+  LayoutTemplate,
 } from 'lucide-react';
+import TemplatesTab from '@/components/cms/TemplatesTab';
 import { PageHeader } from '@/components/layout/PageHeader';
 import { ProtectedPage } from '@/components/permissions';
 import { usePermissions } from '@/contexts/PermissionsContext';
@@ -43,13 +45,14 @@ import type { TableColumn } from '@/types';
 import toast from 'react-hot-toast';
 
 const PER_PAGE = 20;
-type TabKey = 'posts' | 'pages' | 'categories' | 'tags';
+type TabKey = 'posts' | 'pages' | 'categories' | 'tags' | 'templates';
 
 const TABS: { key: TabKey; label: string; icon: React.ReactNode }[] = [
   { key: 'posts', label: 'Blog Posts', icon: <Newspaper className="h-4 w-4" /> },
   { key: 'pages', label: 'Pages', icon: <Files className="h-4 w-4" /> },
   { key: 'categories', label: 'Categories', icon: <FolderTree className="h-4 w-4" /> },
   { key: 'tags', label: 'Tags', icon: <TagIcon className="h-4 w-4" /> },
+  { key: 'templates', label: 'Templates', icon: <LayoutTemplate className="h-4 w-4" /> },
 ];
 
 function statusVariant(status: string): 'success' | 'warning' | 'secondary' | 'info' | 'default' {
@@ -743,6 +746,7 @@ function CmsHub() {
         {tab === 'pages' && <PagesTab />}
         {tab === 'categories' && <CategoriesTab />}
         {tab === 'tags' && <TagsTab />}
+        {tab === 'templates' && <TemplatesTab />}
       </div>
     </div>
   );

--- a/opsapi-dashboard/app/dashboard/domains/page.tsx
+++ b/opsapi-dashboard/app/dashboard/domains/page.tsx
@@ -5,7 +5,7 @@ import {
   Search, Plus, Trash2, Edit, RefreshCw, Globe, ShieldCheck, AlertTriangle,
   Clock, X, Cloud, GitBranch, Download, Play, KeyRound, Settings,
 } from 'lucide-react';
-import { Input, Table, Badge, Pagination, Card, Modal, Button, ConfirmDialog } from '@/components/ui';
+import { Input, Table, Badge, Pagination, Card, Modal, Button, ConfirmDialog, Select } from '@/components/ui';
 import { ProtectedPage } from '@/components/permissions';
 import {
   domainService,
@@ -18,6 +18,7 @@ import {
   type PipelineRun,
   type GithubIntegrationLite,
 } from '@/services/domain.service';
+import { renderTemplatesService, type RenderTemplate } from '@/services/render-templates.service';
 import { formatDate } from '@/lib/utils';
 import type { TableColumn } from '@/types';
 import toast from 'react-hot-toast';
@@ -761,12 +762,13 @@ function s_error(run: PipelineRun): string | null {
 // ============================================================
 // Sync-to-repo modal (render wslproxy vhost files → commit to GitHub)
 // ============================================================
-const EMPTY_REPO = { environment: 'prod', repo_url: '', branch: 'main', github_integration_id: '' };
+const EMPTY_REPO = { environment: 'prod', repo_url: '', branch: 'main', github_integration_id: '', template_uuid: '' };
 
 function RepoSyncModal({ onClose }: { onClose: () => void }) {
   const [form, setForm] = useState({ ...EMPTY_REPO });
   const [preview, setPreview] = useState<SyncToRepoResult | null>(null);
   const [busy, setBusy] = useState(false);
+  const [templates, setTemplates] = useState<RenderTemplate[]>([]);
 
   // Prefill from saved Sync Settings so no re-entry is needed.
   useEffect(() => {
@@ -780,6 +782,9 @@ function RepoSyncModal({ onClose }: { onClose: () => void }) {
         github_integration_id: s.settings?.github_integration_id || '',
       }));
     }).catch(() => {});
+    // Domain JSON-format templates for the picker (falls back to the built-in
+    // default when none is chosen).
+    renderTemplatesService.list('domain_wslproxy').then(setTemplates).catch(() => setTemplates([]));
   }, []);
 
   const dryRun = async () => {
@@ -823,6 +828,21 @@ function RepoSyncModal({ onClose }: { onClose: () => void }) {
           <Input placeholder="target branch (PR base, default main)" value={form.branch} onChange={(e) => setForm({ ...form, branch: e.target.value })} />
           <RepoUrlField className="col-span-2" value={form.repo_url} onChange={(v) => setForm({ ...form, repo_url: v })} />
           <Input className="col-span-2" placeholder="GitHub integration id (uuid)" value={form.github_integration_id} onChange={(e) => setForm({ ...form, github_integration_id: e.target.value })} />
+          <div className="col-span-2">
+            <Select
+              label="JSON format template"
+              value={form.template_uuid}
+              onChange={(e) => setForm({ ...form, template_uuid: e.target.value })}
+              helperText="Pick a saved domain template, or leave as the built-in default format."
+            >
+              <option value="">Default (built-in WSL Proxy format)</option>
+              {templates.map((t) => (
+                <option key={t.uuid} value={t.uuid}>
+                  {t.name}{t.is_default ? ' (default)' : ''}
+                </option>
+              ))}
+            </Select>
+          </div>
         </div>
 
         {preview && (

--- a/opsapi-dashboard/components/cms/PageEditor.tsx
+++ b/opsapi-dashboard/components/cms/PageEditor.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { ArrowLeft, Save, Loader2 } from 'lucide-react';
 import { Button, Input, Textarea, Select, Card } from '@/components/ui';
 import { RichTextEditor } from '@/components/academy';
 import { cmsService, type CmsPage, type PageInput, type PageStatus } from '@/services/cms.service';
+import { renderTemplatesService, type RenderTemplate } from '@/services/render-templates.service';
 import toast from 'react-hot-toast';
 
 function slugify(text: string): string {
@@ -52,6 +53,15 @@ export default function PageEditor({ page }: PageEditorProps) {
   const [contentJson, setContentJson] = useState(page?.content_json ?? '');
   const [status, setStatus] = useState<PageStatus>(page?.status ?? 'draft');
   const [template, setTemplate] = useState(page?.template ?? 'default');
+  const [pageTemplates, setPageTemplates] = useState<RenderTemplate[]>([]);
+
+  // Load the namespace's page-layout templates for the picker.
+  useEffect(() => {
+    renderTemplatesService
+      .list('cms_page')
+      .then(setPageTemplates)
+      .catch(() => setPageTemplates([]));
+  }, []);
   const [menuOrder, setMenuOrder] = useState<number>(page?.menu_order ?? 0);
   const [showInNav, setShowInNav] = useState<boolean>(page?.show_in_nav ?? false);
   const [featuredImage, setFeaturedImage] = useState(page?.featured_image_url ?? '');
@@ -230,12 +240,21 @@ export default function PageEditor({ page }: PageEditorProps) {
 
           <Card>
             <h3 className="mb-3 font-semibold text-secondary-900">Template</h3>
-            <Input
-              value={template}
-              onChange={(e) => setTemplate(e.target.value)}
-              placeholder="default"
-              helperText="Theme template hint for the public site."
-            />
+            <Select value={template} onChange={(e) => setTemplate(e.target.value)}>
+              <option value="default">Default (raw content)</option>
+              {pageTemplates.map((t) => (
+                <option key={t.uuid} value={t.slug}>
+                  {t.name}
+                  {t.is_default ? ' (default)' : ''}
+                </option>
+              ))}
+            </Select>
+            <p className="mt-1.5 text-sm text-secondary-500">
+              The layout the public site renders this page into.{' '}
+              <a href="/dashboard/cms?tab=templates" className="text-primary-600 hover:underline">
+                Manage templates
+              </a>
+            </p>
           </Card>
 
           <Card>

--- a/opsapi-dashboard/components/cms/TemplatesTab.tsx
+++ b/opsapi-dashboard/components/cms/TemplatesTab.tsx
@@ -1,0 +1,379 @@
+'use client';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { Plus, Edit, Trash2, Loader2, Star, Eye, Code2, LayoutTemplate, Globe } from 'lucide-react';
+import { usePermissions } from '@/contexts/PermissionsContext';
+import { Button, Input, Select, Card, Badge, Modal, ConfirmDialog } from '@/components/ui';
+import {
+  renderTemplatesService,
+  renderTemplateTypeLabel,
+  type RenderTemplate,
+  type RenderTemplateType,
+} from '@/services/render-templates.service';
+import toast from 'react-hot-toast';
+
+const TYPE_FILTERS: { value: '' | RenderTemplateType; label: string }[] = [
+  { value: '', label: 'All types' },
+  { value: 'cms_page', label: 'Page layouts' },
+  { value: 'domain_wslproxy', label: 'Domain (WSL Proxy JSON)' },
+];
+
+const SAMPLE_CONTENT: Record<RenderTemplateType, string> = {
+  cms_page:
+    '<article class="page">\n  <h1>{{title}}</h1>\n  <div class="excerpt">{{excerpt}}</div>\n  <main>{{content}}</main>\n</article>',
+  domain_wslproxy:
+    '{\n  "id": "host:{{server_name}}",\n  "root": "{{root}}",\n  "ssl_enabled": {{ssl_enabled}}\n}',
+};
+const SAMPLE_DATA: Record<RenderTemplateType, string> = {
+  cms_page: '{\n  "title": "About Us",\n  "excerpt": "Who we are",\n  "content": "<p>Body…</p>"\n}',
+  domain_wslproxy: '{\n  "server_name": "acme.com",\n  "root": "/var/www",\n  "ssl_enabled": true\n}',
+};
+
+interface EditorState {
+  uuid?: string;
+  name: string;
+  template_type: RenderTemplateType;
+  content: string;
+  sample_data: string;
+  description: string;
+  is_default: boolean;
+}
+
+const emptyEditor = (type: RenderTemplateType = 'cms_page'): EditorState => ({
+  name: '',
+  template_type: type,
+  content: SAMPLE_CONTENT[type],
+  sample_data: SAMPLE_DATA[type],
+  description: '',
+  is_default: false,
+});
+
+export default function TemplatesTab() {
+  const { hasPermission } = usePermissions();
+  const canWrite = hasPermission('templates', 'update');
+  const canDelete = hasPermission('templates', 'delete');
+
+  const [templates, setTemplates] = useState<RenderTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [typeFilter, setTypeFilter] = useState<'' | RenderTemplateType>('');
+
+  const [editor, setEditor] = useState<EditorState | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [preview, setPreview] = useState<string | null>(null);
+  const [previewing, setPreviewing] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState<RenderTemplate | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      setTemplates(await renderTemplatesService.list(typeFilter || undefined));
+    } catch {
+      toast.error('Failed to load templates');
+    } finally {
+      setLoading(false);
+    }
+  }, [typeFilter]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const openNew = () => {
+    setPreview(null);
+    setEditor(emptyEditor((typeFilter as RenderTemplateType) || 'cms_page'));
+  };
+  const openEdit = (t: RenderTemplate) => {
+    setPreview(null);
+    setEditor({
+      uuid: t.uuid,
+      name: t.name,
+      template_type: t.template_type,
+      content: t.content ?? '',
+      sample_data: t.sample_data ?? '',
+      description: t.description ?? '',
+      is_default: t.is_default,
+    });
+  };
+
+  const runPreview = async () => {
+    if (!editor) return;
+    setPreviewing(true);
+    try {
+      let data: Record<string, unknown> | undefined;
+      if (editor.sample_data.trim()) {
+        try {
+          data = JSON.parse(editor.sample_data);
+        } catch {
+          toast.error('Sample data is not valid JSON');
+          setPreviewing(false);
+          return;
+        }
+      }
+      const res = await renderTemplatesService.previewRaw(editor.content, data);
+      setPreview(res.rendered);
+    } catch {
+      toast.error('Preview failed');
+    } finally {
+      setPreviewing(false);
+    }
+  };
+
+  const save = async () => {
+    if (!editor) return;
+    if (!editor.name.trim()) {
+      toast.error('Name is required');
+      return;
+    }
+    if (editor.sample_data.trim()) {
+      try {
+        JSON.parse(editor.sample_data);
+      } catch {
+        toast.error('Sample data is not valid JSON');
+        return;
+      }
+    }
+    setSaving(true);
+    try {
+      const payload = {
+        name: editor.name,
+        template_type: editor.template_type,
+        content: editor.content,
+        sample_data: editor.sample_data,
+        description: editor.description,
+        is_default: editor.is_default,
+      };
+      if (editor.uuid) {
+        await renderTemplatesService.update(editor.uuid, payload);
+        toast.success('Template updated');
+      } else {
+        await renderTemplatesService.create(payload);
+        toast.success('Template created');
+      }
+      setEditor(null);
+      load();
+    } catch {
+      toast.error('Failed to save template');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const doDelete = async () => {
+    if (!confirmDelete) return;
+    setDeleting(true);
+    try {
+      await renderTemplatesService.remove(confirmDelete.uuid);
+      toast.success('Template deleted');
+      setConfirmDelete(null);
+      load();
+    } catch {
+      toast.error('Failed to delete template');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-sm text-secondary-500">
+            Define a reusable layout/format with <code className="rounded bg-secondary-100 px-1">{'{{slots}}'}</code>{' '}
+            once — then pick it in the Page editor or the Domains sync.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="w-48">
+            <Select value={typeFilter} onChange={(e) => setTypeFilter(e.target.value as '' | RenderTemplateType)}>
+              {TYPE_FILTERS.map((o) => (
+                <option key={o.value || 'all'} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </Select>
+          </div>
+          {canWrite && (
+            <Button onClick={openNew}>
+              <Plus className="mr-1 h-4 w-4" /> New Template
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-secondary-400" />
+        </div>
+      ) : templates.length === 0 ? (
+        <Card>
+          <div className="flex flex-col items-center gap-2 py-10 text-center">
+            <LayoutTemplate className="h-8 w-8 text-secondary-300" />
+            <p className="text-secondary-600">No templates yet.</p>
+            <p className="text-sm text-secondary-400">
+              Create a page layout or a domain JSON format to reuse across your content.
+            </p>
+          </div>
+        </Card>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          {templates.map((t) => (
+            <Card key={t.uuid} className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  {t.template_type === 'cms_page' ? (
+                    <LayoutTemplate className="h-4 w-4 shrink-0 text-primary-500" />
+                  ) : (
+                    <Globe className="h-4 w-4 shrink-0 text-primary-500" />
+                  )}
+                  <span className="truncate font-medium text-secondary-900">{t.name}</span>
+                  {t.is_default && (
+                    <Badge variant="success" size="sm">
+                      <Star className="mr-0.5 h-3 w-3" /> default
+                    </Badge>
+                  )}
+                </div>
+                <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                  <Badge variant="secondary" size="sm">
+                    {renderTemplateTypeLabel(t.template_type)}
+                  </Badge>
+                  <span className="truncate text-xs text-secondary-400">/{t.slug}</span>
+                </div>
+                {t.placeholders && t.placeholders.length > 0 && (
+                  <div className="mt-2 flex flex-wrap gap-1">
+                    {t.placeholders.slice(0, 8).map((p) => (
+                      <code key={p} className="rounded bg-secondary-100 px-1.5 py-0.5 text-[11px] text-secondary-600">
+                        {`{{${p}}}`}
+                      </code>
+                    ))}
+                  </div>
+                )}
+              </div>
+              <div className="flex shrink-0 items-center gap-1">
+                {canWrite && (
+                  <button onClick={() => openEdit(t)} className="rounded p-1.5 text-secondary-500 hover:bg-secondary-100 hover:text-primary-600" aria-label="Edit">
+                    <Edit className="h-4 w-4" />
+                  </button>
+                )}
+                {canDelete && (
+                  <button onClick={() => setConfirmDelete(t)} className="rounded p-1.5 text-secondary-500 hover:bg-error-50 hover:text-error-600" aria-label="Delete">
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                )}
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {/* Editor modal */}
+      <Modal
+        isOpen={Boolean(editor)}
+        onClose={() => setEditor(null)}
+        title={editor?.uuid ? 'Edit template' : 'New template'}
+        size="2xl"
+      >
+        {editor && (
+          <div className="space-y-4">
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <Input label="Name" value={editor.name} onChange={(e) => setEditor({ ...editor, name: e.target.value })} placeholder="Landing Layout" />
+              <Select
+                label="Type"
+                value={editor.template_type}
+                onChange={(e) => {
+                  const nt = e.target.value as RenderTemplateType;
+                  // Swap the starter samples only when the fields are still the defaults/empty.
+                  setEditor({
+                    ...editor,
+                    template_type: nt,
+                    content: editor.content && editor.content !== SAMPLE_CONTENT[editor.template_type] ? editor.content : SAMPLE_CONTENT[nt],
+                    sample_data: editor.sample_data && editor.sample_data !== SAMPLE_DATA[editor.template_type] ? editor.sample_data : SAMPLE_DATA[nt],
+                  });
+                }}
+                disabled={Boolean(editor.uuid)}
+              >
+                <option value="cms_page">Page layout</option>
+                <option value="domain_wslproxy">Domain (WSL Proxy JSON)</option>
+              </Select>
+            </div>
+
+            <div>
+              <label className="mb-1.5 flex items-center gap-1.5 text-sm font-medium text-secondary-700">
+                <Code2 className="h-4 w-4" /> Template content — use{' '}
+                <code className="rounded bg-secondary-100 px-1">{'{{slot}}'}</code> placeholders
+              </label>
+              <textarea
+                value={editor.content}
+                onChange={(e) => setEditor({ ...editor, content: e.target.value })}
+                spellCheck={false}
+                rows={9}
+                className="block w-full resize-y rounded-lg border border-secondary-300 bg-surface p-3 font-mono text-[13px] leading-relaxed text-secondary-900 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/20"
+              />
+            </div>
+
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-secondary-700">
+                Sample data (JSON) — used for preview &amp; as a placeholder guide
+              </label>
+              <textarea
+                value={editor.sample_data}
+                onChange={(e) => setEditor({ ...editor, sample_data: e.target.value })}
+                spellCheck={false}
+                rows={5}
+                className="block w-full resize-y rounded-lg border border-secondary-300 bg-surface p-3 font-mono text-[13px] leading-relaxed text-secondary-900 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/20"
+              />
+            </div>
+
+            <Input label="Description (optional)" value={editor.description} onChange={(e) => setEditor({ ...editor, description: e.target.value })} />
+
+            <label className="flex cursor-pointer items-center gap-2 text-sm text-secondary-700">
+              <input
+                type="checkbox"
+                checked={editor.is_default}
+                onChange={(e) => setEditor({ ...editor, is_default: e.target.checked })}
+                className="h-4 w-4 rounded border-secondary-300 text-primary-600"
+              />
+              Default template for this type
+            </label>
+
+            {preview !== null && (
+              <div>
+                <div className="mb-1 text-sm font-medium text-secondary-700">Preview (rendered with sample data)</div>
+                <pre className="max-h-48 overflow-auto rounded-lg border border-secondary-200 bg-secondary-50 p-3 text-[12px] leading-relaxed text-secondary-800 whitespace-pre-wrap wrap-break-word">
+                  {preview}
+                </pre>
+              </div>
+            )}
+
+            <div className="flex items-center justify-between pt-1">
+              <Button variant="outline" onClick={runPreview} disabled={previewing}>
+                {previewing ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Eye className="mr-1 h-4 w-4" />}
+                Preview
+              </Button>
+              <div className="flex gap-2">
+                <Button variant="outline" onClick={() => setEditor(null)}>
+                  Cancel
+                </Button>
+                <Button onClick={save} disabled={saving}>
+                  {saving && <Loader2 className="mr-1 h-4 w-4 animate-spin" />}
+                  {editor.uuid ? 'Save' : 'Create'}
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
+      </Modal>
+
+      <ConfirmDialog
+        isOpen={Boolean(confirmDelete)}
+        onClose={() => setConfirmDelete(null)}
+        onConfirm={doDelete}
+        title="Delete template"
+        message={`Delete "${confirmDelete?.name}"? Pages/domains using it fall back to the default or raw layout.`}
+        confirmText="Delete"
+        variant="danger"
+        isLoading={deleting}
+      />
+    </div>
+  );
+}

--- a/opsapi-dashboard/services/index.ts
+++ b/opsapi-dashboard/services/index.ts
@@ -97,6 +97,16 @@ export {
   type PostListResult,
 } from './cms.service';
 
+// Render Templates (namespace {{slot}} template library — CMS pages + domains)
+export {
+  renderTemplatesService,
+  renderTemplateTypeLabel,
+  type RenderTemplate,
+  type RenderTemplateType,
+  type RenderTemplateInput,
+  type RenderPreview,
+} from './render-templates.service';
+
 // Hospital & Care Home Management
 export { hospitalsService } from './hospitals.service';
 export { patientsService } from './patients.service';

--- a/opsapi-dashboard/services/render-templates.service.ts
+++ b/opsapi-dashboard/services/render-templates.service.ts
@@ -1,0 +1,105 @@
+import apiClient, { toFormData, buildQueryString } from '@/lib/api-client';
+
+// ============================================================
+// Types
+// ============================================================
+
+export type RenderTemplateType = 'cms_page' | 'domain_wslproxy';
+
+export interface RenderTemplate {
+  uuid: string;
+  name: string;
+  slug: string;
+  template_type: RenderTemplateType;
+  content?: string;
+  sample_data?: string;
+  description?: string;
+  is_default: boolean;
+  /** Placeholder names ({{...}}) parsed from content, returned by the API. */
+  placeholders?: string[];
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface RenderTemplateInput {
+  name: string;
+  slug?: string;
+  template_type: RenderTemplateType;
+  content?: string;
+  sample_data?: string;
+  description?: string;
+  is_default?: boolean;
+}
+
+export interface RenderPreview {
+  rendered: string;
+  placeholders: string[];
+}
+
+const TYPE_LABELS: Record<RenderTemplateType, string> = {
+  cms_page: 'Page layout',
+  domain_wslproxy: 'Domain (WSL Proxy JSON)',
+};
+export function renderTemplateTypeLabel(t: RenderTemplateType): string {
+  return TYPE_LABELS[t] ?? t;
+}
+
+function unwrap<T>(response: { data?: unknown }): T {
+  const body = response.data as { data?: T } | undefined;
+  return (body?.data as T) ?? ([] as unknown as T);
+}
+
+// ============================================================
+// Service
+// ============================================================
+
+export const renderTemplatesService = {
+  async list(type?: RenderTemplateType, search?: string): Promise<RenderTemplate[]> {
+    const qs = buildQueryString({ type, search });
+    const response = await apiClient.get(`/api/v2/render-templates${qs}`);
+    return unwrap<RenderTemplate[]>(response);
+  },
+
+  async get(uuid: string): Promise<RenderTemplate> {
+    const response = await apiClient.get(`/api/v2/render-templates/${uuid}`);
+    return unwrap<RenderTemplate>(response);
+  },
+
+  async create(data: RenderTemplateInput): Promise<RenderTemplate> {
+    const payload: Record<string, unknown> = { ...data };
+    if (data.is_default !== undefined) payload.is_default = data.is_default ? 'true' : 'false';
+    const response = await apiClient.post('/api/v2/render-templates', toFormData(payload));
+    return unwrap<RenderTemplate>(response);
+  },
+
+  async update(uuid: string, data: Partial<RenderTemplateInput>): Promise<RenderTemplate> {
+    const payload: Record<string, unknown> = { ...data };
+    if (data.is_default !== undefined) payload.is_default = data.is_default ? 'true' : 'false';
+    const response = await apiClient.put(`/api/v2/render-templates/${uuid}`, toFormData(payload));
+    return unwrap<RenderTemplate>(response);
+  },
+
+  async remove(uuid: string): Promise<void> {
+    await apiClient.delete(`/api/v2/render-templates/${uuid}`);
+  },
+
+  // Render a saved template with data (or its stored sample_data when omitted).
+  async preview(uuid: string, data?: Record<string, unknown>): Promise<RenderPreview> {
+    const response = await apiClient.post(
+      `/api/v2/render-templates/${uuid}/preview`,
+      toFormData({ data: data ? JSON.stringify(data) : undefined }),
+    );
+    return unwrap<RenderPreview>(response);
+  },
+
+  // Render ad-hoc content + data (live editor preview, nothing saved).
+  async previewRaw(content: string, data?: Record<string, unknown>): Promise<RenderPreview> {
+    const response = await apiClient.post(
+      '/api/v2/render-templates/preview',
+      toFormData({ content, data: data ? JSON.stringify(data) : undefined }),
+    );
+    return unwrap<RenderPreview>(response);
+  },
+};
+
+export default renderTemplatesService;


### PR DESCRIPTION
## What & why

You wanted to **define a template once** — a page layout ("this section on top, this here…"), or the JSON format pushed for domains — then **pick it** and have your data rendered into that format. This adds a namespace-scoped **Templates library** built on the `{{slot}}` engine the domains sync already used, and wires it into both **CMS Pages** and **Domains**.

## Backend (core, namespace-scoped, RBAC module `templates`)

- **`helper/template-render.lua`** — shared `{{slot}}` renderer + placeholder extractor (missing slots → empty; dotted keys supported).
- **`migrations/render-templates.lua`** — `render_templates` table (`name, slug, template_type` [`cms_page` | `domain_wslproxy`]`, content, sample_data, is_default`; unique slug per namespace+type; soft-deleted) + registers the `templates` RBAC module and grants owner/admin.
- **Model + `RenderTemplateQueries`** (scoped CRUD, list-by-type, one default per type, `preview`, `renderBySlug`) + **`routes/render-templates.lua`** (CRUD + saved/ad-hoc preview). Wired in `app.lua`, `migrations.lua`, and the core module list.

## Integrations

- **CMS Pages** — the Page editor's free-text "template" field becomes a **picker** of `cms_page` templates. The public page endpoint now returns **`rendered_html`**: the page composed into its chosen layout (`{{title}}`/`{{content}}`/`{{excerpt}}`/`{{seo_*}}`), falling back to raw `content_html` for "default".
- **Domains** — the sync modal gains a **`domain_wslproxy` template picker**; `sync-to-repo` resolves the chosen template's content into `server_template`, so the pushed JSON comes from a **named, reusable template** instead of a raw pasted string.

## Frontend

- `render-templates.service.ts` + a **"Templates" tab in the CMS hub** (`/dashboard/cms?tab=templates`) — define/edit, **live preview** against sample JSON, set default, filter by type. (Placed here to avoid the existing invoicing `/dashboard/templates`.)

## Verified locally

- Template CRUD + list-by-type + preview (placeholders auto-extracted).
- A published page fetched publicly rendered **into** its template:
  `<article class="page"><h1>Our Story</h1><div class="hero">How it began</div><main><p>…</p></main>…</article>`
- A domain sync **dry-run** with a chosen template produced `{"id":"host:…","root":"/var/www/html","ssl_enabled":true}` — the template's format, not the built-in default.
- Lua syntax OK; frontend `tsc` 0 errors, ESLint clean.

## Notes

- The library is **core/always-on** (namespace-scoped, empty by default) so both CMS and domains can rely on it regardless of `PROJECT_CODE`.
- Untouched: the separate invoicing **Document Templates** (`/dashboard/templates`, `/api/v2/templates`) — different feature, different table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)