### PR TITLE
Domains: attach shared WSL Proxy rules, smart sync, multi-repo targets

### DIFF
--- a/lapis/helper/wslproxy-server.lua
+++ b/lapis/helper/wslproxy-server.lua
@@ -291,14 +291,18 @@ end
 -- @param env string      environment/profile
 -- @param data_base string|nil  data root (default .github/wslproxy/data)
 -- @param opts table|nil  { server_template, rule_template, default_rule_id,
---                          default_backend, sync_rules (default true) }
+--                          default_backend, sync_rules (default true),
+--                          resolve_template(uuid, type),
+--                          -- Attached shared rules (a domain with wslproxy_rule_id):
+--                          fetch_rule(rule_id) -> content, err       (canonical JSON from WSL Proxy)
+--                          rule_exists_in_repo(path) -> bool, err     (skip if already committed) }
 -- @return { files={{path,content}...}, rendered={{path,server_name,content}...},
---           count, rules_count, warnings={...} }
+--           count, rules_count, warnings={...}, skipped={{rule_id,path,reason}...} }
 function WslproxyServer.build_sync_files(domains, env, data_base, opts)
     opts = opts or {}
     local sync_rules = opts.sync_rules ~= false -- default ON
-    local files, rendered, manifest, warnings = {}, {}, {}, {}
-    -- rule_id -> { backend, servers = {server-id...} }
+    local files, rendered, manifest, warnings, skipped = {}, {}, {}, {}, {}
+    -- rule_id -> { backend, servers = {server-id...}, attached }
     local rules = {}
     local rule_order = {}
 
@@ -313,13 +317,19 @@ function WslproxyServer.build_sync_files(domains, env, data_base, opts)
                 table.insert(rendered, { path = path, server_name = d.domain_name, content = json })
                 table.insert(manifest, { server_name = d.domain_name, target = d.proxy_target or "" })
 
-                -- Accumulate the rule this server references.
+                -- Accumulate the rule this server references. A domain with an
+                -- explicit wslproxy_rule_id has ATTACHED a shared WSL Proxy rule
+                -- (chosen from the live API) — that rule is fetched + reused, not
+                -- generated. Any contributing domain marking it attached wins.
                 local rid = WslproxyServer.effective_rule_id(d, opts)
+                local attached = trim(d.wslproxy_rule_id) ~= ""
                 if not rules[rid] then
                     rules[rid] = { backend = effective_backend(d, opts), servers = {},
-                        path = trim(d.rule_path), rule_template_uuid = trim(d.rule_template_uuid or "") }
+                        path = trim(d.rule_path), rule_template_uuid = trim(d.rule_template_uuid or ""),
+                        attached = attached }
                     table.insert(rule_order, rid)
                 else
+                    if attached then rules[rid].attached = true end
                     if trim(rules[rid].backend) == "" then
                         rules[rid].backend = effective_backend(d, opts)
                     end
@@ -336,7 +346,41 @@ function WslproxyServer.build_sync_files(domains, env, data_base, opts)
     if sync_rules then
         for _, rid in ipairs(rule_order) do
             local r = rules[rid]
-            if trim(r.backend) == "" then
+            local rule_file_path = WslproxyServer.rule_repo_path(env, rid .. ".json", data_base)
+
+            if r.attached and opts.fetch_rule then
+                -- Attached shared rule: never generate it. Skip if it is already
+                -- committed (don't overwrite a rule that may be owned elsewhere);
+                -- otherwise fetch the canonical JSON from WSL Proxy and push it so
+                -- the server's dependency exists.
+                local present = false
+                if opts.rule_exists_in_repo then
+                    local exists, exerr = opts.rule_exists_in_repo(rule_file_path)
+                    if exists == true then
+                        present = true
+                    elseif exists == nil and exerr then
+                        -- Couldn't confirm: fall through and push the canonical
+                        -- rule (safe — it IS the source of truth), but flag it.
+                        table.insert(warnings, "rule '" .. rid .. "' existence check failed ("
+                            .. tostring(exerr) .. "); pushing the WSL Proxy copy")
+                    end
+                end
+                if present then
+                    table.insert(skipped, { rule_id = rid, path = rule_file_path, reason = "already in repo" })
+                else
+                    local content, ferr = opts.fetch_rule(rid)
+                    if content and content ~= "" then
+                        table.insert(files, { path = rule_file_path, content = content })
+                        table.insert(rendered, { path = rule_file_path,
+                            server_name = "(rule from wslproxy) " .. rid, content = content })
+                        rules_count = rules_count + 1
+                    else
+                        table.insert(warnings, "attached rule '" .. rid
+                            .. "' could not be fetched from WSL Proxy (" .. tostring(ferr)
+                            .. "); its server(s) will not route until it is present")
+                    end
+                end
+            elseif trim(r.backend) == "" then
                 table.insert(warnings, "rule '" .. rid .. "' skipped: no proxy_target/default_backend "
                     .. "— set one to generate its backend")
             else
@@ -371,6 +415,7 @@ function WslproxyServer.build_sync_files(domains, env, data_base, opts)
         count = #manifest,
         rules_count = rules_count,
         warnings = warnings,
+        skipped = skipped, -- attached rules already present in the repo (not re-pushed)
     }
 end
 

--- a/lapis/lib/github-repo.lua
+++ b/lapis/lib/github-repo.lua
@@ -67,6 +67,25 @@ local function api(token, method, path, body)
     return decoded, res.status, nil
 end
 
+--- Does a file path already exist on a branch? Used by the domain sync to skip
+--- pushing a shared rule that is already committed (never overwrite a rule that
+--- may be owned by another repo/domain).
+-- @param opts { token, owner, repo, branch? }
+-- @param path string  repo-relative path
+-- @return true|false, nil  OR  nil, err  (nil only on a genuine API error)
+function GithubRepo.file_exists(opts, path)
+    assert(opts and opts.token and opts.owner and opts.repo, "token/owner/repo required")
+    local branch = opts.branch or "main"
+    -- Escape each path SEGMENT but keep the slashes as real separators.
+    local encoded = tostring(path):gsub("[^/]+", function(seg) return ngx.escape_uri(seg) end)
+    local url = "/repos/" .. opts.owner .. "/" .. opts.repo .. "/contents/" .. encoded
+        .. "?ref=" .. ngx.escape_uri(branch)
+    local _, status, err = api(opts.token, "GET", url)
+    if status == 200 then return true, nil end
+    if status == 404 then return false, nil end
+    return nil, err or ("unexpected status " .. tostring(status))
+end
+
 --- Commit files atomically. add/update-only (base_tree preserves everything else).
 -- @param opts { token, owner, repo, branch, message, files={{path,content}...}, author_name?, author_email? }
 -- @return commit_sha, nil OR nil, err

--- a/lapis/lib/wslproxy-client.lua
+++ b/lapis/lib/wslproxy-client.lua
@@ -1,0 +1,198 @@
+--[[
+    WSL Proxy control-plane API client (per-namespace)
+    ==================================================
+
+    Thin client over the WSL Proxy admin API so opsapi can list/fetch the SHARED
+    rules a domain attaches to (instead of minting one rule per domain).
+
+    Auth is per-namespace: each namespace stores its own connection (api_url +
+    email + AES-encrypted password) via WslproxyConnectionQueries. This module
+    decrypts server-side, logs in (POST /api/user/login -> body.data.accessToken),
+    caches the bearer token per namespace, and re-logs-in once on 401.
+
+    Endpoints used:
+      POST /api/user/login   { email, password }        -> { data: { accessToken } }
+      GET  /api/rules                                    -> list (or { data: [...] })
+      GET  /api/rules/{id}                               -> one  (or { data: {...} })
+
+    Every function returns (result, err) — it never throws across the route
+    boundary. The WSL Proxy admin token expires ~1h with no refresh, so a cached
+    token is used until it 401s, then we re-login exactly once.
+]]
+
+local cjson = require("cjson")
+local WslproxyConnectionQueries = require("queries.WslproxyConnectionQueries")
+
+local WslproxyClient = {}
+
+-- Per-namespace token cache. ngx.shared would share across workers, but a plain
+-- module table is enough here (a re-login per worker is cheap and self-healing).
+-- ponytail: per-worker cache; move to ngx.shared.wslproxy_tokens if login QPS matters.
+local token_cache = {}
+local TOKEN_TTL = 45 * 60 -- seconds, comfortably under HMRC-style ~1h expiry
+
+local function now()
+    return (ngx and ngx.now and ngx.now()) or os.time()
+end
+
+local function trim_url(u)
+    return (tostring(u or ""):gsub("%s+$", ""):gsub("/+$", ""))
+end
+
+-- Verify TLS for https endpoints (production); http (internal) has no TLS to
+-- verify. Requires lua_ssl_trusted_certificate in nginx.conf for https verify.
+local function ssl_verify_for(url)
+    return url:match("^https://") ~= nil
+end
+
+local function http_request(url, opts)
+    local ok, http = pcall(require, "resty.http")
+    if not ok then return nil, "resty.http not available" end
+    local httpc = http.new()
+    httpc:set_timeout(opts.timeout or 15000)
+    local res, rerr = httpc:request_uri(url, {
+        method = opts.method or "GET",
+        headers = opts.headers,
+        body = opts.body,
+        ssl_verify = ssl_verify_for(url),
+    })
+    if not res then return nil, "WSL Proxy not reachable: " .. tostring(rerr) end
+    local decoded
+    if res.body and res.body ~= "" then
+        local dok, d = pcall(cjson.decode, res.body)
+        if dok then decoded = d end
+    end
+    return { status = res.status, body = decoded, raw = res.body }, nil
+end
+
+-- Log in and return a fresh token (bypasses the cache).
+local function login(conn)
+    local url = trim_url(conn.api_url) .. "/api/user/login"
+    local res, err = http_request(url, {
+        method = "POST",
+        headers = { ["Content-Type"] = "application/json", ["Accept"] = "application/json" },
+        body = cjson.encode({ email = conn.email, password = conn.password }),
+    })
+    if not res then return nil, err end
+    if res.status == 401 or res.status == 403 then
+        return nil, "WSL Proxy login rejected — check the email and password"
+    end
+    if res.status >= 400 then
+        return nil, "WSL Proxy login failed (HTTP " .. tostring(res.status) .. ")"
+    end
+    local b = res.body or {}
+    local token = (b.data and b.data.accessToken) or b.accessToken or b.token
+    if not token or token == "" then
+        return nil, "WSL Proxy login returned no token"
+    end
+    return token, nil
+end
+
+-- Validate ad-hoc credentials by attempting a login (used by /connect before
+-- anything is persisted). @param conn { api_url, email, password }.
+-- @return true, nil  OR  false, err
+function WslproxyClient.verify(conn)
+    if not conn or trim_url(conn.api_url) == "" then return false, "api_url is required" end
+    local token, err = login(conn)
+    if not token then return false, err end
+    return true, nil
+end
+
+-- A namespace-bound client: { get(path), list_rules(search), get_rule(id) }.
+-- Returns nil, err if the namespace has no stored connection.
+function WslproxyClient.for_namespace(namespace_id)
+    local conn, cerr = WslproxyConnectionQueries.getDecrypted(namespace_id)
+    if not conn then return nil, cerr end
+    local base = trim_url(conn.api_url)
+
+    local function ensure_token(force)
+        local cached = token_cache[namespace_id]
+        if not force and cached and cached.token and cached.exp > now() then
+            return cached.token, nil
+        end
+        local token, err = login(conn)
+        if not token then
+            token_cache[namespace_id] = nil
+            return nil, err
+        end
+        token_cache[namespace_id] = { token = token, exp = now() + TOKEN_TTL }
+        return token, nil
+    end
+
+    -- GET {path}, re-logging in once on 401. Returns (decoded_body, raw, err).
+    local function get(path)
+        local token, terr = ensure_token(false)
+        if not token then return nil, nil, terr end
+        local function call(tok)
+            return http_request(base .. path, {
+                method = "GET",
+                headers = { ["Authorization"] = "Bearer " .. tok, ["Accept"] = "application/json" },
+            })
+        end
+        local res, err = call(token)
+        if not res then return nil, nil, err end
+        if res.status == 401 then -- token likely expired: re-login once and retry
+            token, terr = ensure_token(true)
+            if not token then return nil, nil, terr end
+            res, err = call(token)
+            if not res then return nil, nil, err end
+        end
+        if res.status == 404 then return nil, nil, "not_found" end
+        if res.status >= 400 then
+            return nil, nil, "WSL Proxy API error (HTTP " .. tostring(res.status) .. ")"
+        end
+        return res.body, res.raw, nil
+    end
+
+    -- Normalise the list response to a plain array of rule objects, optionally
+    -- filtered by a name/id search and by environment (rule.profile_id).
+    local function list_rules(search, environment)
+        local body, _, err = get("/api/rules")
+        if err then return nil, err end
+        local items = body
+        if type(body) == "table" and body.data ~= nil then items = body.data end
+        if type(items) ~= "table" then items = {} end
+        local q = (search and search ~= "") and tostring(search):lower() or nil
+        local env = (environment and environment ~= "") and tostring(environment) or nil
+        if not q and not env then return items, nil end
+        local out = {}
+        for _, r in ipairs(items) do
+            local ok_env = (not env) or (tostring(r.profile_id or "") == env)
+            local ok_q = true
+            if q then
+                local hay = ((r.name or "") .. " " .. (r.id or "")):lower()
+                ok_q = hay:find(q, 1, true) ~= nil
+            end
+            if ok_env and ok_q then table.insert(out, r) end
+        end
+        return out, nil
+    end
+
+    -- Fetch one rule. Returns (rule_table, raw_json_string, err). raw preserves
+    -- the exact JSON shape for committing verbatim to the repo.
+    local function get_rule(id)
+        if not id or id == "" then return nil, nil, "rule id required" end
+        local body, raw, err = get("/api/rules/" .. tostring(id))
+        if err == "not_found" then return nil, nil, "rule not found in WSL Proxy: " .. tostring(id) end
+        if err then return nil, nil, err end
+        local rule = body
+        if type(body) == "table" and body.data ~= nil then rule = body.data end
+        -- Re-encode from the unwrapped object so the committed file is the rule
+        -- itself, not the { data: ... } envelope.
+        local out_raw = raw
+        if type(body) == "table" and body.data ~= nil then
+            out_raw = cjson.encode(rule)
+        end
+        return rule, out_raw, nil
+    end
+
+    return {
+        namespace_id = namespace_id,
+        api_url = base,
+        get = get,
+        list_rules = list_rules,
+        get_rule = get_rule,
+    }, nil
+end
+
+return WslproxyClient

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -332,6 +332,8 @@ local domain_menu_items_migrations = load_if_enabled(ProjectConfig.FEATURES.SERV
 local domain_wslproxy_fields_migrations = load_if_enabled(ProjectConfig.FEATURES.SERVICES, "migrations.domain-wslproxy-fields") or {}
 local domain_pipeline_runs_migrations = load_if_enabled(ProjectConfig.FEATURES.SERVICES, "migrations.domain-pipeline-runs") or {}
 local domain_sync_settings_migrations = load_if_enabled(ProjectConfig.FEATURES.SERVICES, "migrations.domain-sync-settings") or {}
+local wslproxy_connection_migrations = load_if_enabled(ProjectConfig.FEATURES.SERVICES, "migrations.wslproxy-connection") or {}
+local domain_sync_repos_migrations = load_if_enabled(ProjectConfig.FEATURES.SERVICES, "migrations.domain-sync-repos") or {}
 
 -- Timesheets
 local timesheet_system_migrations = load_if_enabled(ProjectConfig.FEATURES.TIMESHEETS, "migrations.timesheet-system") or {}
@@ -1741,6 +1743,9 @@ local _migrations = {
     ['607_domain_wslproxy_fields'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_wslproxy_fields_migrations, 1),
     ['613_domain_rule_path'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_wslproxy_fields_migrations, 2),
     ['614_domain_template_uuids'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_wslproxy_fields_migrations, 3),
+    ['615_domain_sync_repo_uuid'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_wslproxy_fields_migrations, 4),
+    ['616_wslproxy_connection'] = conditional_array(ProjectConfig.FEATURES.SERVICES, wslproxy_connection_migrations, 1),
+    ['617_domain_sync_repos'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_sync_repos_migrations, 1),
     ['608_domain_pipeline_runs'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_pipeline_runs_migrations, 1),
     ['609_domain_sync_settings'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_sync_settings_migrations, 1),
     ['612_domain_sync_templates'] = conditional_array(ProjectConfig.FEATURES.SERVICES, domain_sync_settings_migrations, 2),

--- a/lapis/migrations/domain-sync-repos.lua
+++ b/lapis/migrations/domain-sync-repos.lua
@@ -1,0 +1,41 @@
+--[[
+    Domain sync repositories (multi-repo)
+    =====================================
+
+    Named GitHub repos a namespace can sync domains to. The single
+    domain_sync_settings row is the DEFAULT repo; this table holds the ADDITIONAL
+    ones. Each domain is assigned to a repo (domains.sync_repo_uuid); at sync the
+    domains are grouped by their assigned repo and one PR is opened per repo,
+    each authenticated with that repo's own GitHub integration.
+
+    See queries/DomainSyncRepoQueries.lua and routes/domains.lua. Gated on
+    FEATURES.SERVICES. Idempotent.
+]]
+
+local db = require("lapis.db")
+
+return {
+    [1] = function()
+        pcall(function()
+            db.query([[
+                CREATE TABLE IF NOT EXISTS domain_sync_repos (
+                    id                     SERIAL PRIMARY KEY,
+                    uuid                   TEXT UNIQUE,
+                    namespace_id           INTEGER NOT NULL,
+                    name                   TEXT,
+                    owner                  TEXT NOT NULL,
+                    repo                   TEXT NOT NULL,
+                    branch                 TEXT DEFAULT 'main',
+                    github_integration_id  TEXT,
+                    created_at             TIMESTAMPTZ DEFAULT NOW(),
+                    updated_at             TIMESTAMPTZ DEFAULT NOW(),
+                    UNIQUE (namespace_id, owner, repo, branch)
+                )
+            ]])
+        end)
+        pcall(function()
+            db.query([[CREATE INDEX IF NOT EXISTS domain_sync_repos_ns_idx
+                       ON domain_sync_repos (namespace_id)]])
+        end)
+    end,
+}

--- a/lapis/migrations/domain-wslproxy-fields.lua
+++ b/lapis/migrations/domain-wslproxy-fields.lua
@@ -57,4 +57,14 @@ return {
         add_column([[ALTER TABLE domains ADD COLUMN IF NOT EXISTS server_template_uuid TEXT]])
         add_column([[ALTER TABLE domains ADD COLUMN IF NOT EXISTS rule_template_uuid TEXT]])
     end,
+
+    -- [4] Which managed repo a domain syncs to (domain_sync_repos.uuid). Blank ->
+    -- the namespace's default repo (Sync Settings). Domains are assigned to repos
+    -- in the sync modal; the sync groups by repo and opens one PR per repo. See
+    -- migrations/domain-sync-repos.lua and routes/domains.lua (sync-to-repo).
+    [4] = function()
+        local exists = db.query("SELECT to_regclass('public.domains') IS NOT NULL AS ok")
+        if not (exists and exists[1] and exists[1].ok) then return end
+        add_column([[ALTER TABLE domains ADD COLUMN IF NOT EXISTS sync_repo_uuid TEXT]])
+    end,
 }

--- a/lapis/migrations/wslproxy-connection.lua
+++ b/lapis/migrations/wslproxy-connection.lua
@@ -1,0 +1,37 @@
+--[[
+    Namespace → WSL Proxy connection
+    ================================
+
+    Per-namespace, encrypted-at-rest credentials for the WSL Proxy control-plane
+    API (URL + email + password). The password is stored AES-encrypted via
+    Global.encryptSecret (keyed by OPENSSL_SECRET_KEY) — never plaintext, never
+    returned over the API; decrypted server-side only to log in and list/fetch
+    rules. Mirrors queries/DomainCredentialQueries.lua.
+
+    See lib/wslproxy-client.lua (the API client) and routes/domains.lua
+    (connect/status/disconnect + /wslproxy/rules). Gated on FEATURES.SERVICES.
+
+    One row per namespace (UNIQUE) → upsert via ON CONFLICT. Idempotent.
+]]
+
+local db = require("lapis.db")
+
+return {
+    [1] = function()
+        pcall(function()
+            db.query([[
+                CREATE TABLE IF NOT EXISTS namespace_wslproxy_connections (
+                    id                  SERIAL PRIMARY KEY,
+                    uuid                TEXT UNIQUE,
+                    namespace_id        INTEGER NOT NULL UNIQUE,
+                    api_url             TEXT NOT NULL,
+                    email               TEXT,
+                    encrypted_password  TEXT NOT NULL,
+                    connected_at        TIMESTAMPTZ,
+                    created_at          TIMESTAMPTZ DEFAULT NOW(),
+                    updated_at          TIMESTAMPTZ DEFAULT NOW()
+                )
+            ]])
+        end)
+    end,
+}

--- a/lapis/queries/DomainQueries.lua
+++ b/lapis/queries/DomainQueries.lua
@@ -26,6 +26,8 @@ local WRITABLE_FIELDS = {
     "listen_ports", "proxy_target", "rule_path",
     -- Per-domain template choice (render_templates uuids)
     "server_template_uuid", "rule_template_uuid",
+    -- Which managed repo this domain syncs to (blank -> namespace default repo)
+    "sync_repo_uuid",
 }
 
 --------------------------------------------------------------------------------

--- a/lapis/queries/DomainSyncRepoQueries.lua
+++ b/lapis/queries/DomainSyncRepoQueries.lua
@@ -1,0 +1,106 @@
+--[[
+    Domain Sync Repo Queries
+    ========================
+
+    Namespace-scoped list of GitHub repos a namespace syncs domains to (the
+    "additional" repos beyond the single default in domain_sync_settings). Each
+    domain is assigned to one via domains.sync_repo_uuid; the sync groups domains
+    by repo and opens one PR per repo, using that repo's github_integration_id.
+]]
+
+local Global = require("helper.global")
+local SyncSettings = require("queries.DomainSyncSettingsQueries")
+local db = require("lapis.db")
+
+local DomainSyncRepoQueries = {}
+
+local function row_to_public(r)
+    if not r then return nil end
+    return {
+        uuid = r.uuid,
+        name = r.name,
+        owner = r.owner,
+        repo = r.repo,
+        branch = r.branch or "main",
+        github_integration_id = r.github_integration_id,
+        created_at = r.created_at,
+        updated_at = r.updated_at,
+    }
+end
+
+--- All managed repos for a namespace (does NOT include the settings default).
+function DomainSyncRepoQueries.list(namespace_id)
+    local rows = db.query(
+        "SELECT * FROM domain_sync_repos WHERE namespace_id = ? ORDER BY name ASC, owner ASC, repo ASC",
+        namespace_id)
+    local out = {}
+    for _, r in ipairs(rows or {}) do table.insert(out, row_to_public(r)) end
+    return out
+end
+
+function DomainSyncRepoQueries.getByUuid(namespace_id, uuid)
+    local rows = db.query(
+        "SELECT * FROM domain_sync_repos WHERE namespace_id = ? AND uuid = ? LIMIT 1", namespace_id, uuid)
+    return rows and rows[1] or nil
+end
+
+-- Derive owner/repo/branch from params: a pasted repo_url wins, else explicit
+-- owner/repo. Returns owner, repo, branch or nil, err.
+local function resolve_repo_fields(params)
+    local owner, repo, branch = params.owner, params.repo, params.branch
+    if params.repo_url and params.repo_url ~= "" then
+        local parsed = SyncSettings.parse_repo_url(params.repo_url)
+        if not parsed then return nil, "Could not parse the repository URL" end
+        owner, repo = parsed.owner, parsed.repo
+        if (not branch or branch == "") and parsed.branch then branch = parsed.branch end
+    end
+    if not owner or owner == "" or not repo or repo == "" then
+        return nil, "owner and repo (or a repo_url) are required"
+    end
+    return owner, repo, (branch and branch ~= "") and branch or "main"
+end
+
+function DomainSyncRepoQueries.create(namespace_id, params)
+    local owner, repo, branch = resolve_repo_fields(params)
+    if not owner then return nil, repo end -- repo holds the error message here
+    local rows = db.query([[
+        INSERT INTO domain_sync_repos
+            (uuid, namespace_id, name, owner, repo, branch, github_integration_id, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+        ON CONFLICT (namespace_id, owner, repo, branch) DO UPDATE SET
+            name = EXCLUDED.name,
+            github_integration_id = EXCLUDED.github_integration_id,
+            updated_at = NOW()
+        RETURNING *
+    ]], Global.generateUUID(), namespace_id, params.name or (owner .. "/" .. repo),
+        owner, repo, branch, params.github_integration_id or db.NULL)
+    return row_to_public(rows and rows[1] or nil)
+end
+
+function DomainSyncRepoQueries.update(namespace_id, uuid, params)
+    local existing = DomainSyncRepoQueries.getByUuid(namespace_id, uuid)
+    if not existing then return nil, "Repo not found" end
+    local owner, repo, branch = resolve_repo_fields({
+        repo_url = params.repo_url,
+        owner = params.owner or existing.owner,
+        repo = params.repo or existing.repo,
+        branch = params.branch or existing.branch,
+    })
+    if not owner then return nil, repo end
+    local rows = db.query([[
+        UPDATE domain_sync_repos
+        SET name = ?, owner = ?, repo = ?, branch = ?, github_integration_id = ?, updated_at = NOW()
+        WHERE namespace_id = ? AND uuid = ?
+        RETURNING *
+    ]], params.name or existing.name, owner, repo, branch,
+        params.github_integration_id ~= nil and params.github_integration_id or existing.github_integration_id,
+        namespace_id, uuid)
+    return row_to_public(rows and rows[1] or nil)
+end
+
+function DomainSyncRepoQueries.delete(namespace_id, uuid)
+    db.query("DELETE FROM domain_sync_repos WHERE namespace_id = ? AND uuid = ?", namespace_id, uuid)
+    return true
+end
+
+return DomainSyncRepoQueries

--- a/lapis/queries/WslproxyConnectionQueries.lua
+++ b/lapis/queries/WslproxyConnectionQueries.lua
@@ -1,0 +1,101 @@
+--[[
+    WSL Proxy Connection Queries
+    ============================
+
+    One encrypted WSL Proxy control-plane connection per namespace (api_url,
+    email, password). The password is AES-encrypted at rest via
+    Global.encryptSecret (keyed by OPENSSL_SECRET_KEY) and decrypted server-side
+    only — never returned over any API. Mirrors DomainCredentialQueries.
+
+    Consumed by lib/wslproxy-client.lua (login + list/get rules) and
+    routes/domains.lua (connect / status / disconnect / rules proxy).
+]]
+
+local Global = require("helper.global")
+local db = require("lapis.db")
+
+local WslproxyConnectionQueries = {}
+
+-- Public-safe projection: NEVER includes encrypted_password.
+local function sanitize(row)
+    if not row then return { connected = false } end
+    return {
+        connected = row.encrypted_password ~= nil and row.encrypted_password ~= "",
+        uuid = row.uuid,
+        api_url = row.api_url,
+        email = row.email,
+        has_secret = row.encrypted_password ~= nil and row.encrypted_password ~= "",
+        connected_at = row.connected_at,
+        updated_at = row.updated_at,
+    }
+end
+WslproxyConnectionQueries.sanitize = sanitize
+
+--- Raw row for a namespace (internal — contains the encrypted password).
+function WslproxyConnectionQueries.get(namespace_id)
+    local rows = db.query(
+        "SELECT * FROM namespace_wslproxy_connections WHERE namespace_id = ? LIMIT 1", namespace_id)
+    return rows and rows[1] or nil
+end
+
+--- Public status (no secrets) for a namespace.
+function WslproxyConnectionQueries.status(namespace_id)
+    return sanitize(WslproxyConnectionQueries.get(namespace_id))
+end
+
+--- Create or replace the namespace's connection. Encrypts the password.
+-- @param params { namespace_id, api_url, email?, password (plaintext) }
+-- @return public projection, nil  OR  nil, err
+function WslproxyConnectionQueries.save(params)
+    assert(params.namespace_id, "namespace_id required")
+    local api_url = params.api_url and tostring(params.api_url):gsub("^%s+", ""):gsub("%s+$", "") or ""
+    if api_url == "" then return nil, "api_url is required" end
+
+    local existing = WslproxyConnectionQueries.get(params.namespace_id)
+    -- A blank password on update means "keep the stored one".
+    local encrypted = existing and existing.encrypted_password or nil
+    if params.password and params.password ~= "" then
+        local ok, enc = pcall(Global.encryptSecret, params.password)
+        if not ok or not enc then return nil, "Failed to encrypt password" end
+        encrypted = enc
+    end
+    if not encrypted then return nil, "password is required" end
+
+    -- Upsert on the UNIQUE(namespace_id). Idempotent; one row per namespace.
+    local rows = db.query([[
+        INSERT INTO namespace_wslproxy_connections
+            (uuid, namespace_id, api_url, email, encrypted_password, connected_at, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, NOW(), NOW(), NOW())
+        ON CONFLICT (namespace_id) DO UPDATE SET
+            api_url = EXCLUDED.api_url,
+            email = EXCLUDED.email,
+            encrypted_password = EXCLUDED.encrypted_password,
+            connected_at = NOW(),
+            updated_at = NOW()
+        RETURNING *
+    ]], existing and existing.uuid or Global.generateUUID(),
+        params.namespace_id, api_url, params.email or db.NULL, encrypted)
+
+    return sanitize(rows and rows[1] or nil)
+end
+
+--- Internal: decrypted credentials for server-side API calls.
+-- @return { api_url, email, password }, nil  OR  nil, err. Never expose this.
+function WslproxyConnectionQueries.getDecrypted(namespace_id)
+    local row = WslproxyConnectionQueries.get(namespace_id)
+    if not row or not row.encrypted_password or row.encrypted_password == "" then
+        return nil, "WSL Proxy is not connected for this namespace"
+    end
+    local ok, password = pcall(Global.decryptSecret, row.encrypted_password)
+    if not ok or not password then
+        return nil, "Failed to decrypt stored WSL Proxy password"
+    end
+    return { api_url = row.api_url, email = row.email, password = password }, nil
+end
+
+function WslproxyConnectionQueries.delete(namespace_id)
+    db.query("DELETE FROM namespace_wslproxy_connections WHERE namespace_id = ?", namespace_id)
+    return true
+end
+
+return WslproxyConnectionQueries

--- a/lapis/routes/domains.lua
+++ b/lapis/routes/domains.lua
@@ -77,6 +77,10 @@ return function(app)
         return { status = status, json = { success = false, error = msg } }
     end
 
+    local function trim(s)
+        return (tostring(s == nil and "" or s):gsub("^%s+", ""):gsub("%s+$", ""))
+    end
+
     -- Load a domain and enforce namespace ownership (platform admins bypass).
     local function load_owned_domain(self, uuid)
         local domain = DomainQueries.getDomain(uuid)
@@ -128,6 +132,22 @@ return function(app)
         end)
     ))
 
+    -- Minimal list of EVERY domain (no pagination cap) for the sync modal's
+    -- domain -> repo assignment matrix.
+    app:get("/api/v2/domains/all", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "read", function(self)
+            local rows = DomainQueries.getAllForNamespace(self.namespace.id)
+            local out = {}
+            for _, d in ipairs(rows or {}) do
+                table.insert(out, {
+                    uuid = d.uuid, domain_name = d.domain_name,
+                    environment = d.environment or "prod", sync_repo_uuid = d.sync_repo_uuid or "",
+                })
+            end
+            return ok_resp(out)
+        end)
+    ))
+
     -- Export: a bare JSON array consumed by the k3s sync job.
     app:get("/api/v2/domains/export", AuthMiddleware.requireAuth(
         NamespaceMiddleware.requirePermission("domains", "read", function(self)
@@ -157,27 +177,70 @@ return function(app)
     app:post("/api/v2/domains/sync-to-repo", AuthMiddleware.requireAuth(
         NamespaceMiddleware.requirePermission("domains", "update", function(self)
             local data = parse_body(self)
-            -- Resolve target from saved Sync Settings; request params override.
+            -- The single Sync Settings row is the DEFAULT repo + namespace defaults
+            -- (backend, rule id, sync_rules, data_base, environment, templates).
             local SyncSettings = require("queries.DomainSyncSettingsQueries")
-            local eff, missing = SyncSettings.resolve(self.namespace.id, data)
-            if #missing > 0 then
-                return err_resp(400, "Missing " .. table.concat(missing, ", ")
-                    .. " — set them here or configure Sync Settings once")
-            end
+            local eff = SyncSettings.resolve(self.namespace.id, data)
             local env = eff.environment
-            local owner = eff.owner
-            local repo = eff.repo
+            local default_repo = {
+                name = "Default", owner = eff.owner, repo = eff.repo, branch = eff.branch or "main",
+                github_integration_id = eff.github_integration_id,
+            }
+            local is_dry = data.dry_run == true or data.dry_run == "true"
 
-            -- Render every domain in this namespace+env to a WSL Proxy server file
-            -- (+ the opsapi-managed manifest used by the DNS reconcile).
+            -- domain_uuids (array) and assignments (map) may arrive as real JSON
+            -- (JSON body) OR as a JSON string inside a form field (the dashboard's
+            -- api-client defaults to form-urlencoded). Accept both.
+            local function as_table(v)
+                if type(v) == "table" then return v end
+                if type(v) == "string" and v ~= "" then
+                    local ok, decoded = pcall(cjson.decode, v)
+                    if ok and type(decoded) == "table" then return decoded end
+                end
+                return nil
+            end
+            local req_assignments = as_table(data.assignments) or {}
+            local req_domain_uuids = as_table(data.domain_uuids)
+
+            -- Persist the domain -> repo assignments the user made in the sync
+            -- modal, so the mapping is remembered next time. A dry-run is a pure
+            -- PREVIEW and must not mutate anything.
+            if not is_dry then
+                for dom_uuid, repo_uuid in pairs(req_assignments) do
+                    local dom = DomainQueries.getDomain(dom_uuid)
+                    if dom and tonumber(dom.namespace_id) == tonumber(self.namespace.id) then
+                        DomainQueries.updateDomain(dom_uuid,
+                            { sync_repo_uuid = (type(repo_uuid) == "string" and repo_uuid) or "" })
+                    end
+                end
+            end
+
+            -- Managed repos (uuid -> repo). A domain resolves to its assigned
+            -- managed repo, else the default repo above.
+            local RepoQ = require("queries.DomainSyncRepoQueries")
+            local repo_by_uuid = {}
+            for _, r in ipairs(RepoQ.list(self.namespace.id)) do repo_by_uuid[r.uuid] = r end
+            local function resolve_repo(d)
+                -- Prefer the in-flight assignment from the request (the user's
+                -- current, possibly-unsaved choice); fall back to the stored one.
+                local uuid = req_assignments[d.uuid] ~= nil and trim(req_assignments[d.uuid]) or trim(d.sync_repo_uuid)
+                if uuid ~= "" and repo_by_uuid[uuid] then return repo_by_uuid[uuid] end
+                return default_repo
+            end
+
             local WslproxyServer = require("helper.wslproxy-server")
             local rows = DomainQueries.getAllForNamespace(self.namespace.id)
 
-            -- Chosen library Templates override the raw strings, so both the
-            -- server JSON (domain_wslproxy) and the rule JSON (domain_rule) formats
-            -- are picked from named, reusable templates instead of pasted inline.
-            -- The domain's own fields (server_name, root, rule_path, backend, …)
-            -- fill the {{placeholders}} at sync time.
+            -- Only sync the selected domains (the sync modal sends the checked
+            -- set). Omitted -> every domain in the environment (backward compat).
+            local selected = nil
+            if req_domain_uuids and #req_domain_uuids > 0 then
+                selected = {}
+                for _, u in ipairs(req_domain_uuids) do selected[tostring(u)] = true end
+            end
+
+            -- Named, reusable JSON-format templates (per-domain choice wins; else
+            -- the Sync Settings default; else the built-in format).
             local RTQ = require("queries.RenderTemplateQueries")
             local function template_content(uuid, want_type)
                 if not uuid or uuid == "" then return nil end
@@ -187,105 +250,167 @@ return function(app)
                 end
                 return nil
             end
-            local server_template = template_content(data.template_uuid, "domain_wslproxy") or eff.server_template
-            local rule_template = template_content(data.rule_template_uuid, "domain_rule") or eff.rule_template
 
-            -- Pass the namespace's template + rule defaults so rendering is
-            -- data-driven (dashboard-configurable), not hardcoded. Also emits a
-            -- rule file per referenced rule id so a synced domain actually routes.
-            local built = WslproxyServer.build_sync_files(rows, env, eff.data_base, {
-                server_template = server_template,
-                rule_template   = rule_template,
+            -- Attached shared rules are fetched LIVE from WSL Proxy (if connected)
+            -- and pushed only when missing; otherwise domains fall back to
+            -- template-generated rules (backward compatible).
+            local fetch_rule = nil
+            do
+                local WslproxyClient = require("lib.wslproxy-client")
+                local wc = WslproxyClient.for_namespace(self.namespace.id)
+                if wc then
+                    fetch_rule = function(rid)
+                        local _, raw, ferr = wc.get_rule(rid)
+                        if raw and raw ~= "" then return raw, nil end
+                        return nil, ferr or "fetch failed"
+                    end
+                end
+            end
+
+            -- Group the (selected) domains by their resolved repo.
+            local groups, order = {}, {}
+            for _, d in ipairs(rows or {}) do
+                if (d.environment or "prod") == env and (not selected or selected[tostring(d.uuid)]) then
+                    local rp = resolve_repo(d)
+                    local key = tostring(rp.owner) .. "/" .. tostring(rp.repo) .. "@" .. tostring(rp.branch)
+                    if not groups[key] then
+                        groups[key] = { repo = rp, rows = {} }
+                        table.insert(order, key)
+                    end
+                    table.insert(groups[key].rows, d)
+                end
+            end
+            if #order == 0 then
+                return err_resp(400, "No domains selected for environment '" .. env .. "'")
+            end
+
+            local base_opts = {
                 default_rule_id = eff.default_rule_id,
                 default_backend = eff.default_backend,
                 sync_rules      = eff.sync_rules,
-                -- Per-domain templates: each domain's server_template_uuid /
-                -- rule_template_uuid (chosen on the domain form) wins over the
-                -- sync-level pick above. This resolver turns a uuid into content.
-                resolve_template = function(uuid, want_type)
-                    return template_content(uuid, want_type)
-                end,
-            })
-            local files = built.files
-            local rendered = built.rendered
+                resolve_template = function(uuid, want_type) return template_content(uuid, want_type) end,
+                fetch_rule = fetch_rule,
+            }
+            -- Per-group server/rule template = the repo has none, so use the
+            -- namespace default (per-domain choice still wins inside the renderer).
+            base_opts.server_template = eff.server_template
+            base_opts.rule_template = eff.rule_template
 
-            if built.count == 0 then
-                return err_resp(400, "No domains for environment '" .. env .. "' to sync")
+            -- DRY RUN: render each group; no token, no commit, no existence check.
+            if is_dry then
+                local out = {}
+                for _, key in ipairs(order) do
+                    local g = groups[key]
+                    local built = WslproxyServer.build_sync_files(g.rows, env, eff.data_base, base_opts)
+                    table.insert(out, { repo = g.repo.owner .. "/" .. g.repo.repo, branch = g.repo.branch,
+                        repo_name = g.repo.name, count = #built.files, rules = built.rules_count,
+                        warnings = built.warnings, skipped = built.skipped, files = built.rendered })
+                end
+                return ok_resp({ dry_run = true, environment = env, repos = out })
             end
 
-            -- Dry-run: return the rendered files without committing.
-            if data.dry_run == true or data.dry_run == "true" then
-                return ok_resp({ dry_run = true, environment = env, count = #files,
-                    rules = built.rules_count, warnings = built.warnings, files = rendered })
-            end
-
-            -- Resolve the GitHub token from the linked services integration.
-            if not eff.github_integration_id then
-                return err_resp(400, "No GitHub integration linked — configure Sync Settings (repo + GitHub auth)")
-            end
+            -- Resolve + decrypt a GitHub token PER repo (each repo carries its own
+            -- integration). Memoised so repos sharing an integration decrypt once.
             local ok_sq, ServiceQueries = pcall(require, "queries.ServiceQueries")
-            if not ok_sq then return err_resp(500, "services module unavailable") end
-            local integration = ServiceQueries.getGithubIntegration(eff.github_integration_id, true)
-            if not integration then return err_resp(404, "GitHub integration not found") end
-            if tonumber(integration.namespace_id) ~= tonumber(self.namespace.id) then
-                return err_resp(403, "Integration belongs to another namespace")
-            end
-            local token = integration.github_token_decrypted
-            if not token or token == "" then
-                return err_resp(400, "Could not decrypt the GitHub integration token")
+            local token_cache = {}
+            local function resolve_token(integration_id)
+                if not integration_id or integration_id == "" then
+                    return nil, "no GitHub integration set for this repo — configure it in Sync Settings"
+                end
+                if token_cache[integration_id] then
+                    return token_cache[integration_id].token, token_cache[integration_id].err
+                end
+                local tok, err
+                if not ok_sq then
+                    err = "services module unavailable"
+                else
+                    local integ = ServiceQueries.getGithubIntegration(integration_id, true)
+                    if not integ then err = "GitHub integration not found"
+                    elseif tonumber(integ.namespace_id) ~= tonumber(self.namespace.id) then
+                        err = "Integration belongs to another namespace"
+                    else
+                        tok = integ.github_token_decrypted
+                        if not tok or tok == "" then err = "Could not decrypt the GitHub integration token" end
+                    end
+                end
+                token_cache[integration_id] = { token = tok, err = err }
+                return tok, err
             end
 
-            -- Never fast-forward the base branch (e.g. main) directly. Branch off
-            -- it, commit the rendered files there, and open a PR back to it so a
-            -- human reviews + merges. base_branch is the configured target
-            -- (eff.branch, usually main); the head branch is unique per sync.
             local GithubRepo = require("lib.github-repo")
             local Global = require("helper.global")
-            local base_branch = eff.branch or "main"
-            local short = tostring(Global.generateUUID()):gsub("%-", ""):sub(1, 6)
-            local new_branch = "opsapi-domains/sync-" .. env .. "-"
-                .. os.date("!%Y%m%d-%H%M%S") .. "-" .. short
-            local commit_msg = data.message
-                or ("chore(domains): sync " .. #files .. " " .. env .. " domains from opsapi")
-            local pr_body = table.concat({
-                "Automated domain sync from opsapi — please review and merge.",
-                "",
-                "- Environment: `" .. env .. "`",
-                "- Files: " .. #files .. " (rules: " .. tostring(built.rules_count) .. ")",
-                "- Target branch: `" .. base_branch .. "`",
-                "",
-                "Generated by the domains module. Merging applies these WSL Proxy"
-                    .. " vhost changes to `" .. base_branch .. "`.",
-            }, "\n")
 
-            local result, gerr = GithubRepo.sync_via_pull_request({
-                token = token,
-                owner = owner,
-                repo = repo,
-                base_branch = base_branch,
-                new_branch = new_branch,
-                message = commit_msg,
-                files = files,
-                author_name = "opsapi-domain-sync",
-                author_email = "domain-sync@opsapi",
-                pr_title = data.pr_title or commit_msg,
-                pr_body = pr_body,
-            })
-            if not result then return err_resp(502, "GitHub sync failed: " .. tostring(gerr)) end
+            -- One PR per repo group. Never fast-forwards a base branch directly.
+            local results, any_ok, any_fail = {}, false, false
+            for _, key in ipairs(order) do
+                local g = groups[key]
+                local repo_label = tostring(g.repo.owner) .. "/" .. tostring(g.repo.repo)
 
-            return ok_resp({
-                environment = env,
-                repo = owner .. "/" .. repo,
-                base_branch = result.base,
-                branch = result.branch,
-                commit = result.commit,
-                pr_url = result.pr_url,
-                pr_number = result.pr_number,
-                count = #files,
-                rules = built.rules_count,
-                warnings = built.warnings,
-                files = rendered,
-            })
+                -- Guard: a repo must have owner/repo and a usable token.
+                if not g.repo.owner or g.repo.owner == "" or not g.repo.repo or g.repo.repo == "" then
+                    table.insert(results, { repo = repo_label, branch = g.repo.branch, repo_name = g.repo.name,
+                        ok = false, error = "repo not configured — assign these domains to a repo or set a default in Sync Settings" })
+                    any_fail = true
+                else
+                    local token, terr = resolve_token(g.repo.github_integration_id)
+                    if not token then
+                        table.insert(results, { repo = repo_label, branch = g.repo.branch, repo_name = g.repo.name,
+                            ok = false, error = terr })
+                        any_fail = true
+                    else
+                        local opts = {}
+                        for k, v in pairs(base_opts) do opts[k] = v end
+                        opts.rule_exists_in_repo = function(path)
+                            return GithubRepo.file_exists({ token = token, owner = g.repo.owner, repo = g.repo.repo, branch = g.repo.branch }, path)
+                        end
+
+                        local built = WslproxyServer.build_sync_files(g.rows, env, eff.data_base, opts)
+                        if #built.files == 0 then
+                            table.insert(results, { repo = repo_label, branch = g.repo.branch, repo_name = g.repo.name,
+                                ok = false, error = "nothing to sync (rules skipped or unrenderable)", warnings = built.warnings })
+                            any_fail = true
+                        else
+                            local short = tostring(Global.generateUUID()):gsub("%-", ""):sub(1, 6)
+                            local new_branch = "opsapi-domains/sync-" .. env .. "-"
+                                .. os.date("!%Y%m%d-%H%M%S") .. "-" .. short
+                            local commit_msg = data.message
+                                or ("chore(domains): sync " .. #built.files .. " " .. env .. " domains from opsapi")
+                            local pr_body = table.concat({
+                                "Automated domain sync from opsapi — please review and merge.",
+                                "",
+                                "- Environment: `" .. env .. "`",
+                                "- Repo: `" .. repo_label .. "` → `" .. g.repo.branch .. "`",
+                                "- Files: " .. #built.files .. " (rules: " .. tostring(built.rules_count) .. ")",
+                                "",
+                                "Generated by the domains module.",
+                            }, "\n")
+
+                            local result, gerr = GithubRepo.sync_via_pull_request({
+                                token = token, owner = g.repo.owner, repo = g.repo.repo,
+                                base_branch = g.repo.branch, new_branch = new_branch,
+                                message = commit_msg, files = built.files,
+                                author_name = "opsapi-domain-sync", author_email = "domain-sync@opsapi",
+                                pr_title = data.pr_title or commit_msg, pr_body = pr_body,
+                            })
+                            if not result then
+                                table.insert(results, { repo = repo_label, branch = g.repo.branch, repo_name = g.repo.name,
+                                    ok = false, error = tostring(gerr), warnings = built.warnings })
+                                any_fail = true
+                            else
+                                table.insert(results, { repo = repo_label, branch = g.repo.branch, repo_name = g.repo.name,
+                                    ok = true, base_branch = result.base, head_branch = result.branch, commit = result.commit,
+                                    pr_url = result.pr_url, pr_number = result.pr_number,
+                                    count = #built.files, rules = built.rules_count,
+                                    warnings = built.warnings, skipped = built.skipped, files = built.rendered })
+                                any_ok = true
+                            end
+                        end
+                    end
+                end
+            end
+
+            return { status = any_ok and 200 or 502,
+                json = { success = any_ok, data = { environment = env, any_failed = any_fail, repos = results } } }
         end)
     ))
 
@@ -424,6 +549,112 @@ return function(app)
             if not ok_sq then return ok_resp({}) end
             local list = ServiceQueries.getGithubIntegrations(self.namespace.id) or {}
             return ok_resp(list)
+        end)
+    ))
+
+    -- ========================================================================
+    -- SYNC REPOS (managed multi-repo targets; the settings row is the default)
+    -- ========================================================================
+
+    app:get("/api/v2/domains/sync-repos", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "read", function(self)
+            local Q = require("queries.DomainSyncRepoQueries")
+            return ok_resp(Q.list(self.namespace.id))
+        end)
+    ))
+
+    app:post("/api/v2/domains/sync-repos", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "update", function(self)
+            local data = parse_body(self)
+            local Q = require("queries.DomainSyncRepoQueries")
+            local repo, err = Q.create(self.namespace.id, {
+                name = data.name, repo_url = data.repo_url,
+                owner = data.owner, repo = data.repo, branch = data.branch,
+                github_integration_id = data.github_integration_id,
+            })
+            if not repo then return err_resp(400, err or "Failed to add repo") end
+            return { status = 201, json = { success = true, data = repo } }
+        end)
+    ))
+
+    app:put("/api/v2/domains/sync-repos/:uuid", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "update", function(self)
+            local data = parse_body(self)
+            local Q = require("queries.DomainSyncRepoQueries")
+            local repo, err = Q.update(self.namespace.id, self.params.uuid, {
+                name = data.name, repo_url = data.repo_url,
+                owner = data.owner, repo = data.repo, branch = data.branch,
+                github_integration_id = data.github_integration_id,
+            })
+            if not repo then return err_resp(err == "Repo not found" and 404 or 400, err or "Update failed") end
+            return ok_resp(repo)
+        end)
+    ))
+
+    app:delete("/api/v2/domains/sync-repos/:uuid", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "delete", function(self)
+            require("queries.DomainSyncRepoQueries").delete(self.namespace.id, self.params.uuid)
+            return ok_resp({ deleted = true })
+        end)
+    ))
+
+    -- ========================================================================
+    -- WSL PROXY CONNECTION + shared rules (before /:uuid)
+    --
+    -- A namespace connects its WSL Proxy control plane once (URL + email +
+    -- password, stored AES-encrypted). Domains then ATTACH a shared rule chosen
+    -- from that live API (see the /wslproxy/rules dropdown) instead of minting
+    -- one rule per domain. The password is never returned; it is decrypted
+    -- server-side only to log in and list/fetch rules.
+    -- ========================================================================
+
+    app:get("/api/v2/domains/wslproxy/status", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "read", function(self)
+            local WC = require("queries.WslproxyConnectionQueries")
+            return ok_resp(WC.status(self.namespace.id))
+        end)
+    ))
+
+    -- Connect (or replace) — validates by a LIVE login before persisting, so a
+    -- bad URL/credential fails fast and nothing invalid is stored.
+    app:post("/api/v2/domains/wslproxy/connect", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "update", function(self)
+            local data = parse_body(self)
+            local api_url = trim(data.api_url)
+            local email = trim(data.email)
+            local password = data.password
+            if api_url == "" then return err_resp(400, "api_url is required") end
+            if not password or password == "" then return err_resp(400, "password is required") end
+
+            local WslproxyClient = require("lib.wslproxy-client")
+            local ok, verr = WslproxyClient.verify({ api_url = api_url, email = email, password = password })
+            if not ok then return err_resp(400, verr or "Could not connect to WSL Proxy") end
+
+            local WC = require("queries.WslproxyConnectionQueries")
+            local saved, serr = WC.save({
+                namespace_id = self.namespace.id, api_url = api_url, email = email, password = password,
+            })
+            if not saved then return err_resp(500, serr or "Failed to save connection") end
+            return ok_resp(saved)
+        end)
+    ))
+
+    app:delete("/api/v2/domains/wslproxy/disconnect", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "delete", function(self)
+            require("queries.WslproxyConnectionQueries").delete(self.namespace.id)
+            return ok_resp({ disconnected = true })
+        end)
+    ))
+
+    -- Searchable list of shared rules for the domain form's rule dropdown.
+    app:get("/api/v2/domains/wslproxy/rules", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requirePermission("domains", "read", function(self)
+            local WslproxyClient = require("lib.wslproxy-client")
+            local client, cerr = WslproxyClient.for_namespace(self.namespace.id)
+            if not client then return err_resp(409, cerr or "Connect WSL Proxy first") end
+            local rules, rerr = client.list_rules(self.params.search, self.params.environment)
+            if not rules then return err_resp(502, rerr or "Failed to list WSL Proxy rules") end
+            return ok_resp(rules)
         end)
     ))
 
@@ -654,6 +885,10 @@ return function(app)
                 -- WSL Proxy rule match path (default "/"). The rule id itself is
                 -- auto-generated (opsapi-<domain>) by the renderer.
                 rule_path = data.rule_path or "/",
+                -- Per-domain template choice + assigned sync repo (blank -> default).
+                server_template_uuid = data.server_template_uuid,
+                rule_template_uuid = data.rule_template_uuid,
+                sync_repo_uuid = data.sync_repo_uuid,
                 metadata = metadata or "{}",
             })
             if not created then

--- a/opsapi-dashboard/app/dashboard/domains/page.tsx
+++ b/opsapi-dashboard/app/dashboard/domains/page.tsx
@@ -5,7 +5,7 @@ import {
   Search, Plus, Trash2, Edit, RefreshCw, Globe, ShieldCheck, AlertTriangle,
   Clock, X, Cloud, GitBranch, Download, Play, KeyRound, Settings,
 } from 'lucide-react';
-import { Input, Table, Badge, Pagination, Card, Modal, Button, ConfirmDialog, Select } from '@/components/ui';
+import { Input, Table, Badge, Pagination, Card, Modal, Button, ConfirmDialog } from '@/components/ui';
 import { ProtectedPage } from '@/components/permissions';
 import {
   domainService,
@@ -17,11 +17,68 @@ import {
   type SyncToRepoResult,
   type PipelineRun,
   type GithubIntegrationLite,
+  type WslproxyStatus,
+  type WslproxyRule,
+  type DomainSyncRepo,
 } from '@/services/domain.service';
 import { renderTemplatesService, type RenderTemplate } from '@/services/render-templates.service';
-import { formatDate } from '@/lib/utils';
+import { formatDate, cn } from '@/lib/utils';
 import type { TableColumn } from '@/types';
+import type { LucideIcon } from 'lucide-react';
 import toast from 'react-hot-toast';
+
+// ── Shared modal building blocks (consistent card + field styling) ──────────
+const SELECT_CLS = 'w-full rounded-lg border border-secondary-300 bg-white px-3 py-2.5 text-sm text-secondary-900 hover:border-secondary-400 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/20';
+
+// A titled card section — icon chip + title + optional subtitle, then body.
+function Section({ title, subtitle, icon: Icon, children, className }: {
+  title?: string; subtitle?: string; icon?: LucideIcon; children: React.ReactNode; className?: string;
+}) {
+  return (
+    <section className={cn('overflow-hidden rounded-xl border border-secondary-200', className)}>
+      {title && (
+        <div className="flex items-start gap-3 border-b border-secondary-100 bg-secondary-50/70 px-4 py-3">
+          {Icon && (
+            <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white text-secondary-600 ring-1 ring-secondary-200">
+              <Icon className="h-4 w-4" />
+            </span>
+          )}
+          <div className="min-w-0">
+            <h3 className="text-sm font-semibold text-secondary-900">{title}</h3>
+            {subtitle && <p className="mt-0.5 text-xs leading-relaxed text-secondary-500">{subtitle}</p>}
+          </div>
+        </div>
+      )}
+      <div className="space-y-4 p-4">{children}</div>
+    </section>
+  );
+}
+
+// Label + control + helper text, evenly spaced.
+function Field({ label, hint, required, children }: {
+  label?: string; hint?: string; required?: boolean; children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      {label && (
+        <label className="block text-sm font-medium text-secondary-700">
+          {label}{required && <span className="text-error-500"> *</span>}
+        </label>
+      )}
+      {children}
+      {hint && <p className="text-xs leading-relaxed text-secondary-500">{hint}</p>}
+    </div>
+  );
+}
+
+// A right-aligned modal footer that sticks to the bottom of the scroll area.
+function ModalFooter({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="sticky bottom-0 -mx-6 -mb-6 mt-2 flex items-center justify-end gap-2 border-t border-secondary-200 bg-surface-elevated px-6 py-4">
+      {children}
+    </div>
+  );
+}
 
 // Days until a date (UTC-ish, day granularity). null if no date.
 function daysUntil(dateStr?: string): number | null {
@@ -93,10 +150,138 @@ const EMPTY_FORM = {
   ssl_email: '',
   proxy_target: '',
   rule_path: '/',
+  // Attach an existing SHARED WSL Proxy rule (chosen from the live API). Blank =
+  // generate a per-domain rule from the template.
+  wslproxy_rule_id: '',
   // Per-domain template choice (blank = sync-level pick / built-in default)
   server_template_uuid: '',
   rule_template_uuid: '',
+  // Which managed repo this domain syncs to (blank = namespace default repo)
+  sync_repo_uuid: '',
 };
+
+// Attach an existing SHARED WSL Proxy rule to a domain (instead of minting one
+// per domain). Self-contained: checks the namespace's WSL Proxy connection,
+// offers an inline connect flow when absent, and a debounced searchable list of
+// rules from the live API when present. Blank value = auto-generate a rule.
+function WslproxyRulePicker({ value, onChange, environment }: { value: string; onChange: (v: string) => void; environment: string }) {
+  const [status, setStatus] = useState<WslproxyStatus | null>(null);
+  const [checking, setChecking] = useState(true);
+  const [search, setSearch] = useState('');
+  const [rules, setRules] = useState<WslproxyRule[]>([]);
+  const [loadingRules, setLoadingRules] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [connectOpen, setConnectOpen] = useState(false);
+  const [conn, setConn] = useState({ api_url: '', email: '', password: '' });
+  const [connecting, setConnecting] = useState(false);
+
+  const refreshStatus = useCallback(async () => {
+    setChecking(true);
+    try { setStatus(await domainService.getWslproxyStatus()); }
+    catch { setStatus({ connected: false }); }
+    finally { setChecking(false); }
+  }, []);
+  useEffect(() => { refreshStatus(); }, [refreshStatus]);
+
+  // Debounced rule search — scoped to the selected environment (fetches the
+  // prod rules for prod, int rules for int, …). Re-runs when env changes.
+  useEffect(() => {
+    if (!status?.connected || !open) return;
+    let active = true;
+    setLoadingRules(true);
+    const t = setTimeout(async () => {
+      try { const r = await domainService.listWslproxyRules(search || undefined, environment || undefined); if (active) setRules(r); }
+      catch { if (active) setRules([]); }
+      finally { if (active) setLoadingRules(false); }
+    }, 300);
+    return () => { active = false; clearTimeout(t); };
+  }, [search, status?.connected, open, environment]);
+
+  const doConnect = async () => {
+    if (!conn.api_url.trim() || !conn.password) { toast.error('API URL and password are required'); return; }
+    setConnecting(true);
+    try {
+      await domainService.connectWslproxy(conn);
+      toast.success('WSL Proxy connected');
+      setConnectOpen(false);
+      setConn({ api_url: '', email: '', password: '' });
+      await refreshStatus();
+    } catch (err) {
+      const m = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
+      toast.error(m || 'Could not connect to WSL Proxy');
+    } finally { setConnecting(false); }
+  };
+
+  return (
+    <div>
+      {checking ? (
+        <p className="text-xs text-secondary-500">Checking WSL Proxy…</p>
+      ) : !status?.connected ? (
+        <div className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-dashed border-secondary-300 bg-secondary-50 px-3 py-2.5">
+          <p className="text-xs text-secondary-500">WSL Proxy isn&apos;t connected — connect it to reuse shared rules.</p>
+          <Button type="button" variant="secondary" size="sm" onClick={() => setConnectOpen(true)}>Connect WSL Proxy</Button>
+        </div>
+      ) : value ? (
+        <div className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2.5">
+          <div className="min-w-0">
+            <div className="text-xs font-medium text-emerald-800">Attached shared rule</div>
+            <div className="truncate font-mono text-sm text-emerald-900">{value}</div>
+          </div>
+          <Button type="button" variant="secondary" size="sm" onClick={() => onChange('')}>Change</Button>
+        </div>
+      ) : (
+        <div className="relative">
+          <Input
+            placeholder={`Search ${environment} rules…`}
+            value={search}
+            onFocus={() => setOpen(true)}
+            onChange={(e) => { setSearch(e.target.value); setOpen(true); }}
+          />
+          {open && (
+            <div className="absolute z-20 mt-1 max-h-56 w-full overflow-auto rounded-lg border border-secondary-200 bg-white shadow-lg">
+              {loadingRules ? (
+                <div className="px-3 py-2 text-xs text-secondary-500">Loading…</div>
+              ) : rules.length === 0 ? (
+                <div className="px-3 py-2 text-xs text-secondary-500">No <span className="font-medium">{environment}</span> rules found</div>
+              ) : rules.map((r) => (
+                <button
+                  type="button"
+                  key={String(r.id)}
+                  className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-secondary-50"
+                  onClick={() => { onChange(String(r.id)); setOpen(false); }}
+                >
+                  <span className="truncate font-medium">{r.name || String(r.id)}</span>
+                  <span className="shrink-0 font-mono text-xs text-secondary-400">{String(r.id).slice(0, 12)}…</span>
+                </button>
+              ))}
+            </div>
+          )}
+          <p className="mt-1.5 text-xs text-secondary-500">Reuse one shared rule across servers (a single k3s ingress rule). Leave blank to auto-generate.</p>
+        </div>
+      )}
+
+      <Modal isOpen={connectOpen} onClose={() => setConnectOpen(false)} title="Connect WSL Proxy" size="lg">
+        <div className="space-y-5">
+          <Section title="Connection" subtitle="Stored encrypted for this namespace, used only to list/fetch shared rules. The password is never shown again." icon={KeyRound}>
+            <Field label="API URL" required>
+              <Input placeholder="https://gateway.example.com" value={conn.api_url} onChange={(e) => setConn({ ...conn, api_url: e.target.value })} />
+            </Field>
+            <Field label="Email">
+              <Input placeholder="admin@example.com" value={conn.email} onChange={(e) => setConn({ ...conn, email: e.target.value })} />
+            </Field>
+            <Field label="Password" required>
+              <Input type="password" value={conn.password} onChange={(e) => setConn({ ...conn, password: e.target.value })} />
+            </Field>
+          </Section>
+          <ModalFooter>
+            <Button type="button" variant="secondary" onClick={() => setConnectOpen(false)}>Cancel</Button>
+            <Button type="button" onClick={doConnect} disabled={connecting} isLoading={connecting}>Connect</Button>
+          </ModalFooter>
+        </div>
+      </Modal>
+    </div>
+  );
+}
 
 function DomainsPageContent() {
   const [domains, setDomains] = useState<Domain[]>([]);
@@ -113,6 +298,9 @@ function DomainsPageContent() {
   const [formOpen, setFormOpen] = useState(false);
   const [editing, setEditing] = useState<Domain | null>(null);
   const [form, setForm] = useState({ ...EMPTY_FORM });
+  // Routing rule mode: attach an existing shared WSL Proxy rule, or create a new
+  // one (generated from the template). Attach is the default for new domains.
+  const [ruleMode, setRuleMode] = useState<'attach' | 'create'>('attach');
   const [deleteTarget, setDeleteTarget] = useState<Domain | null>(null);
   const [credOpen, setCredOpen] = useState(false);
   const [dnsTarget, setDnsTarget] = useState<Domain | null>(null);
@@ -123,6 +311,9 @@ function DomainsPageContent() {
   // Domain server/rule format templates for the per-domain pickers in the form.
   const [serverTemplates, setServerTemplates] = useState<RenderTemplate[]>([]);
   const [ruleTemplates, setRuleTemplates] = useState<RenderTemplate[]>([]);
+  // Managed sync repos (for the per-domain repo picker; the default repo lives
+  // in Sync Settings). Refreshed when the form opens.
+  const [syncRepos, setSyncRepos] = useState<DomainSyncRepo[]>([]);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -158,9 +349,12 @@ function DomainsPageContent() {
     renderTemplatesService.list('domain_rule').then(setRuleTemplates).catch(() => setRuleTemplates([]));
   }, []);
 
-  const openCreate = () => { setEditing(null); setForm({ ...EMPTY_FORM }); setFormOpen(true); };
+  const loadSyncRepos = () => { domainService.listSyncRepos().then(setSyncRepos).catch(() => setSyncRepos([])); };
+  const openCreate = () => { setEditing(null); setForm({ ...EMPTY_FORM }); setRuleMode('attach'); loadSyncRepos(); setFormOpen(true); };
   const openEdit = (d: Domain) => {
     setEditing(d);
+    setRuleMode(d.wslproxy_rule_id ? 'attach' : 'create');
+    loadSyncRepos();
     setForm({
       domain_name: d.domain_name,
       registrar: d.registrar || '',
@@ -172,8 +366,10 @@ function DomainsPageContent() {
       ssl_email: d.ssl_email || '',
       proxy_target: d.proxy_target || '',
       rule_path: d.rule_path || '/',
+      wslproxy_rule_id: d.wslproxy_rule_id || '',
       server_template_uuid: d.server_template_uuid || '',
       rule_template_uuid: d.rule_template_uuid || '',
+      sync_repo_uuid: d.sync_repo_uuid || '',
     });
     setFormOpen(true);
   };
@@ -370,8 +566,8 @@ function DomainsPageContent() {
       )}
 
       {/* Add / Edit modal */}
-      <Modal isOpen={formOpen} onClose={() => setFormOpen(false)} title={editing ? 'Edit domain' : 'Add domain'}>
-        <div className="space-y-3">
+      <Modal isOpen={formOpen} onClose={() => setFormOpen(false)} title={editing ? 'Edit domain' : 'Add domain'} size="2xl">
+        <div className="space-y-4">
           <div>
             <label className="text-sm font-medium">Domain name *</label>
             <Input
@@ -405,70 +601,117 @@ function DomainsPageContent() {
               />
             </div>
           </div>
-          <div className="rounded border border-secondary-200 p-3 space-y-3">
-            <div className="text-xs font-semibold uppercase text-secondary-500">WSL Proxy routing (repo sync)</div>
+          <div className="rounded-xl border border-secondary-200 bg-secondary-50/40 p-4 space-y-4">
+            <div className="flex items-center gap-2">
+              <GitBranch className="h-4 w-4 text-secondary-400" />
+              <div className="text-xs font-semibold uppercase tracking-wide text-secondary-500">WSL Proxy routing (repo sync)</div>
+            </div>
+
             <div className="grid grid-cols-2 gap-3">
               <div>
                 <label className="text-sm font-medium">Environment</label>
                 <select className="w-full rounded-md border border-secondary-200 px-3 py-2 text-sm" value={form.environment} onChange={(e) => setForm({ ...form, environment: e.target.value })}>
                   {['prod', 'acc', 'test', 'int', 'dev'].map((x) => <option key={x} value={x}>{x}</option>)}
                 </select>
-              </div>
-              <div>
-                <label className="text-sm font-medium">Backend</label>
-                <Input placeholder="193.237.176.232:8888" value={form.proxy_target} onChange={(e) => setForm({ ...form, proxy_target: e.target.value })} />
-                <p className="mt-1 text-xs text-secondary-500">Where this domain routes — the rule&apos;s backend. Blank = the Sync Settings default backend.</p>
-              </div>
-            </div>
-            <div className="grid grid-cols-2 gap-3">
-              <div>
-                <label className="text-sm font-medium">Path</label>
-                <Input placeholder="/" value={form.rule_path} onChange={(e) => setForm({ ...form, rule_path: e.target.value })} />
+                <p className="mt-1 text-xs text-secondary-500">Rules are fetched and files synced for this environment.</p>
               </div>
               <div>
                 <label className="text-sm font-medium">SSL email</label>
                 <Input placeholder="admin@example.com" value={form.ssl_email} onChange={(e) => setForm({ ...form, ssl_email: e.target.value })} />
               </div>
             </div>
-            {/* Per-domain template choice — which saved JSON format this domain's
-                server + rule files use at sync. Manage them in Templates → Layouts
-                & Formats. Blank uses the built-in default. */}
-            <div className="grid grid-cols-2 gap-3">
-              <div>
-                <label className="text-sm font-medium">Server template</label>
-                <select className="w-full rounded-md border border-secondary-200 px-3 py-2 text-sm" value={form.server_template_uuid} onChange={(e) => setForm({ ...form, server_template_uuid: e.target.value })}>
-                  <option value="">Default (built-in format)</option>
-                  {serverTemplates.map((t) => (
-                    <option key={t.uuid} value={t.uuid}>{t.name}{t.is_default ? ' (default)' : ''}</option>
-                  ))}
-                </select>
+
+            {/* Routing rule: attach an existing shared rule OR create a new one. */}
+            <div className="rounded-lg border border-secondary-200 bg-white p-3 space-y-3">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <label className="text-sm font-medium">Routing rule</label>
+                <div className="inline-flex rounded-lg border border-secondary-200 bg-secondary-50 p-0.5 text-xs font-medium">
+                  <button
+                    type="button"
+                    onClick={() => setRuleMode('attach')}
+                    className={`rounded-md px-3 py-1 transition ${ruleMode === 'attach' ? 'bg-white text-secondary-900 shadow-sm' : 'text-secondary-500 hover:text-secondary-700'}`}
+                  >Attach shared rule</button>
+                  <button
+                    type="button"
+                    onClick={() => { setRuleMode('create'); setForm((f) => ({ ...f, wslproxy_rule_id: '' })); }}
+                    className={`rounded-md px-3 py-1 transition ${ruleMode === 'create' ? 'bg-white text-secondary-900 shadow-sm' : 'text-secondary-500 hover:text-secondary-700'}`}
+                  >Create new rule</button>
+                </div>
               </div>
-              <div>
-                <label className="text-sm font-medium">Rule template</label>
-                <select className="w-full rounded-md border border-secondary-200 px-3 py-2 text-sm" value={form.rule_template_uuid} onChange={(e) => setForm({ ...form, rule_template_uuid: e.target.value })}>
-                  <option value="">Default (built-in format)</option>
-                  {ruleTemplates.map((t) => (
-                    <option key={t.uuid} value={t.uuid}>{t.name}{t.is_default ? ' (default)' : ''}</option>
-                  ))}
-                </select>
-              </div>
+
+              {ruleMode === 'attach' ? (
+                <WslproxyRulePicker
+                  value={form.wslproxy_rule_id}
+                  environment={form.environment}
+                  onChange={(v) => setForm({ ...form, wslproxy_rule_id: v })}
+                />
+              ) : (
+                <div className="space-y-3">
+                  <p className="text-xs text-secondary-500">
+                    Not on WSL Proxy yet? Define it here — it&apos;s generated from the template and pushed on sync.
+                  </p>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div>
+                      <label className="text-sm font-medium">Backend</label>
+                      <Input placeholder="193.237.176.232:8888" value={form.proxy_target} onChange={(e) => setForm({ ...form, proxy_target: e.target.value })} />
+                      <p className="mt-1 text-xs text-secondary-500">Where this domain routes — the rule&apos;s backend. Blank skips the rule (the server still syncs).</p>
+                    </div>
+                    <div>
+                      <label className="text-sm font-medium">Path</label>
+                      <Input placeholder="/" value={form.rule_path} onChange={(e) => setForm({ ...form, rule_path: e.target.value })} />
+                    </div>
+                  </div>
+                  <div>
+                    <label className="text-sm font-medium">Rule format template</label>
+                    <select className="w-full rounded-md border border-secondary-200 px-3 py-2 text-sm" value={form.rule_template_uuid} onChange={(e) => setForm({ ...form, rule_template_uuid: e.target.value })}>
+                      <option value="">Default (built-in format)</option>
+                      {ruleTemplates.map((t) => (
+                        <option key={t.uuid} value={t.uuid}>{t.name}{t.is_default ? ' (default)' : ''}</option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="rounded bg-secondary-50 border border-secondary-200 p-2 text-xs text-secondary-600">
+                    New rule: <span className="font-mono text-secondary-800">{ruleSlug(form.domain_name)}</span>
+                    {' '}— path <span className="font-mono text-secondary-800">{form.rule_path || '/'}</span>
+                    {' '}→ <span className="font-mono text-secondary-800">{form.proxy_target || '(default backend)'}</span>
+                  </div>
+                </div>
+              )}
             </div>
-            {/* Live preview of the rule that will be auto-created on sync — the
-                user never types a "rule id". */}
-            <div className="rounded bg-secondary-50 border border-secondary-200 p-2 text-xs text-secondary-600">
-              Auto-created rule: <span className="font-mono text-secondary-800">{ruleSlug(form.domain_name)}</span>
-              {' '}— path <span className="font-mono text-secondary-800">{form.rule_path || '/'}</span>
-              {' '}→ <span className="font-mono text-secondary-800">{form.proxy_target || '(Sync Settings default backend)'}</span>
+
+            {/* Server (vhost) file format — always applies. */}
+            <div>
+              <label className="text-sm font-medium">Server template</label>
+              <select className="w-full rounded-md border border-secondary-200 px-3 py-2 text-sm" value={form.server_template_uuid} onChange={(e) => setForm({ ...form, server_template_uuid: e.target.value })}>
+                <option value="">Default (built-in format)</option>
+                {serverTemplates.map((t) => (
+                  <option key={t.uuid} value={t.uuid}>{t.name}{t.is_default ? ' (default)' : ''}</option>
+                ))}
+              </select>
+              <p className="mt-1 text-xs text-secondary-500">JSON format for this domain&apos;s server (vhost) file. Blank = built-in default.</p>
+            </div>
+
+            {/* Which repo this domain syncs to — the default repo, or one of the
+                managed repos (add them in Sync Settings). You can also reassign at
+                sync time in the Sync modal. */}
+            <div>
+              <label className="text-sm font-medium">Sync to repo</label>
+              <select className="w-full rounded-md border border-secondary-200 px-3 py-2 text-sm" value={form.sync_repo_uuid} onChange={(e) => setForm({ ...form, sync_repo_uuid: e.target.value })}>
+                <option value="">Default repo (Sync Settings)</option>
+                {syncRepos.map((r) => (
+                  <option key={r.uuid} value={r.uuid}>{r.name || `${r.owner}/${r.repo}`} ({r.owner}/{r.repo})</option>
+                ))}
+              </select>
             </div>
           </div>
           <div>
             <label className="text-sm font-medium">Notes</label>
             <Input value={form.notes} onChange={(e) => setForm({ ...form, notes: e.target.value })} />
           </div>
-          <div className="flex justify-end gap-2 pt-2">
+          <ModalFooter>
             <Button variant="secondary" onClick={() => setFormOpen(false)}>Cancel</Button>
-            <Button onClick={submitForm}>{editing ? 'Save' : 'Add domain'}</Button>
-          </div>
+            <Button onClick={submitForm}>{editing ? 'Save changes' : 'Add domain'}</Button>
+          </ModalFooter>
         </div>
       </Modal>
 
@@ -537,6 +780,82 @@ function RepoUrlField({ value, onChange, className }: { value: string; onChange:
 // ============================================================
 // Sync Settings modal — configure the repo target + GitHub auth ONCE.
 // ============================================================
+// Manage the ADDITIONAL repos a namespace syncs to (the settings row above is
+// the default repo). Each repo can carry its own GitHub token.
+function ReposManager({ integrations }: { integrations: GithubIntegrationLite[] }) {
+  const [repos, setRepos] = useState<DomainSyncRepo[]>([]);
+  const [form, setForm] = useState({ name: '', repo_url: '', branch: 'main', github_integration_id: '' });
+  const [adding, setAdding] = useState(false);
+
+  const load = () => domainService.listSyncRepos().then(setRepos).catch(() => setRepos([]));
+  useEffect(() => { load(); }, []);
+
+  const integrationName = (id?: string) => {
+    const i = integrations.find((x) => x.uuid === id);
+    return i ? (i.name || i.github_username || i.uuid.slice(0, 8)) : undefined;
+  };
+
+  const add = async () => {
+    if (!form.repo_url.trim()) { toast.error('Paste a repository URL'); return; }
+    setAdding(true);
+    try {
+      await domainService.createSyncRepo({
+        name: form.name.trim() || undefined,
+        repo_url: form.repo_url.trim(),
+        branch: form.branch.trim() || 'main',
+        github_integration_id: form.github_integration_id || undefined,
+      });
+      toast.success('Repository added');
+      setForm({ name: '', repo_url: '', branch: 'main', github_integration_id: '' });
+      load();
+    } catch (e) {
+      const m = (e as { response?: { data?: { error?: string } } })?.response?.data?.error;
+      toast.error(m || 'Could not add repository');
+    } finally { setAdding(false); }
+  };
+
+  const remove = async (uuid: string) => {
+    try { await domainService.deleteSyncRepo(uuid); load(); } catch { toast.error('Delete failed'); }
+  };
+
+  return (
+    <Section title="Additional repositories" subtitle="Sync domains to more than one repo. Each domain picks its repo; each repo uses its own GitHub token." icon={GitBranch}>
+      {repos.length > 0 && (
+        <ul className="divide-y divide-secondary-100 overflow-hidden rounded-lg border border-secondary-200">
+          {repos.map((r) => (
+            <li key={r.uuid} className="flex items-center justify-between gap-2 px-3 py-2.5 text-sm">
+              <div className="min-w-0">
+                <div className="truncate font-medium text-secondary-900">{r.name || `${r.owner}/${r.repo}`}</div>
+                <div className="truncate text-xs text-secondary-500">
+                  {r.owner}/{r.repo} · {r.branch}
+                  {r.github_integration_id ? ` · ${integrationName(r.github_integration_id) || 'token set'}` : ' · no token'}
+                </div>
+              </div>
+              <Button variant="ghost" size="sm" onClick={() => remove(r.uuid)} aria-label="Remove repository"><Trash2 className="h-4 w-4 text-error-500" /></Button>
+            </li>
+          ))}
+        </ul>
+      )}
+      <div className="space-y-3 rounded-lg border border-dashed border-secondary-300 bg-secondary-50/50 p-3">
+        <Field label="Add a repository">
+          <Input placeholder="Paste repo URL — https://github.com/owner/repo" value={form.repo_url} onChange={(e) => setForm({ ...form, repo_url: e.target.value })} />
+        </Field>
+        <div className="grid grid-cols-2 gap-3">
+          <Input placeholder="name (optional)" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} />
+          <Input placeholder="branch (default main)" value={form.branch} onChange={(e) => setForm({ ...form, branch: e.target.value })} />
+        </div>
+        <select className={SELECT_CLS} value={form.github_integration_id} onChange={(e) => setForm({ ...form, github_integration_id: e.target.value })}>
+          <option value="">GitHub token for this repo (optional)</option>
+          {integrations.map((i) => <option key={i.uuid} value={i.uuid}>{i.name || i.github_username || i.uuid.slice(0, 8)}</option>)}
+        </select>
+        <div className="flex justify-end">
+          <Button variant="secondary" size="sm" onClick={add} disabled={adding} isLoading={adding}><Plus className="mr-1 h-4 w-4" /> Add repository</Button>
+        </div>
+      </div>
+    </Section>
+  );
+}
+
 function SyncSettingsModal({ onClose }: { onClose: () => void }) {
   const [form, setForm] = useState({ repo_url: '', branch: 'main', default_environment: 'prod', github_integration_id: '', default_backend: '', sync_rules: true });
   const [integrations, setIntegrations] = useState<GithubIntegrationLite[]>([]);
@@ -605,69 +924,63 @@ function SyncSettingsModal({ onClose }: { onClose: () => void }) {
   };
 
   return (
-    <Modal isOpen onClose={onClose} title="Domain sync settings">
-      <div className="space-y-4">
-        <p className="text-sm text-secondary-500">
-          Configure the target repo and GitHub authentication <span className="font-medium">once</span>.
-          After this, “Sync to Repo” and “Run Pipeline” just work — no re-entering.
+    <Modal isOpen onClose={onClose} title="Domain sync settings" size="xl">
+      <div className="space-y-5">
+        <p className="text-sm leading-relaxed text-secondary-500">
+          This is your <span className="font-medium text-secondary-700">default repo</span> and GitHub auth. Add more repos below,
+          then assign each domain to a repo (on its form or in the Sync modal). Rules are set per-domain — nothing to re-enter here.
         </p>
 
-        {/* Repo target — paste the repo URL, we work out owner/repo/branch */}
-        <div className="space-y-2">
-          <RepoUrlField value={form.repo_url} onChange={(v) => setForm({ ...form, repo_url: v })} />
-          <div className="grid grid-cols-2 gap-2">
-            <Input placeholder="branch (default main)" value={form.branch} onChange={(e) => setForm({ ...form, branch: e.target.value })} />
-            <select className="rounded-md border border-secondary-200 px-3 py-2 text-sm" value={form.default_environment} onChange={(e) => setForm({ ...form, default_environment: e.target.value })}>
-              {['prod', 'acc', 'test', 'int', 'dev'].map((x) => <option key={x} value={x}>{x}</option>)}
-            </select>
+        <Section title="Default repository" subtitle="Where domains sync unless assigned to another repo." icon={GitBranch}>
+          <Field label="Repository">
+            <RepoUrlField value={form.repo_url} onChange={(v) => setForm({ ...form, repo_url: v })} />
+          </Field>
+          <div className="grid grid-cols-2 gap-4">
+            <Field label="Branch">
+              <Input placeholder="main" value={form.branch} onChange={(e) => setForm({ ...form, branch: e.target.value })} />
+            </Field>
+            <Field label="Default environment">
+              <select className={SELECT_CLS} value={form.default_environment} onChange={(e) => setForm({ ...form, default_environment: e.target.value })}>
+                {['prod', 'acc', 'test', 'int', 'dev'].map((x) => <option key={x} value={x}>{x}</option>)}
+              </select>
+            </Field>
           </div>
-        </div>
+        </Section>
 
-        {/* Rules — a synced domain needs a backend to route to. Without a
-            per-domain Proxy target, this default backend is used to generate
-            the rule; leave blank + no Proxy target = server synced, no rule. */}
-        <div className="rounded border border-secondary-200 p-3 space-y-2">
-          <label className="flex items-center gap-2 text-sm font-medium">
-            <input type="checkbox" checked={form.sync_rules} onChange={(e) => setForm({ ...form, sync_rules: e.target.checked })} />
-            Generate WSL Proxy rule files
-          </label>
-          {form.sync_rules && (
-            <>
-              <Input placeholder="Default backend — e.g. 193.237.176.232:8888" value={form.default_backend} onChange={(e) => setForm({ ...form, default_backend: e.target.value })} />
-              <p className="text-xs text-secondary-500">
-                Used for any domain that has no <span className="font-medium">Proxy target</span> of its own. A rule needs a backend to point at — without one the rule is skipped (the server still syncs).
-              </p>
-            </>
-          )}
-        </div>
-
-        {/* GitHub auth */}
-        <div className="rounded border border-secondary-200 p-3 space-y-2">
-          <div className="flex items-center gap-3 text-sm">
-            <span className="font-medium">GitHub authentication</span>
-            <label className="flex items-center gap-1"><input type="radio" checked={authMode === 'existing'} onChange={() => setAuthMode('existing')} /> Use existing</label>
-            <label className="flex items-center gap-1"><input type="radio" checked={authMode === 'new'} onChange={() => setAuthMode('new')} /> Add token</label>
+        <Section title="GitHub authentication" subtitle="Used to open the sync pull request. Stored encrypted." icon={KeyRound}>
+          <div className="inline-flex rounded-lg border border-secondary-200 bg-secondary-50 p-0.5 text-xs font-medium">
+            <button type="button" onClick={() => setAuthMode('existing')} className={`rounded-md px-3 py-1.5 transition ${authMode === 'existing' ? 'bg-white text-secondary-900 shadow-sm' : 'text-secondary-500 hover:text-secondary-700'}`}>Use existing</button>
+            <button type="button" onClick={() => setAuthMode('new')} className={`rounded-md px-3 py-1.5 transition ${authMode === 'new' ? 'bg-white text-secondary-900 shadow-sm' : 'text-secondary-500 hover:text-secondary-700'}`}>Add token</button>
           </div>
           {authMode === 'existing' ? (
-            <select className="w-full rounded-md border border-secondary-200 px-3 py-2 text-sm" value={form.github_integration_id} onChange={(e) => setForm({ ...form, github_integration_id: e.target.value })}>
-              <option value="">
-                {integrations.length ? (integrationName ? `Current: ${integrationName}` : 'Select an integration…') : 'No integrations — add a token'}
-              </option>
-              {integrations.map((i) => <option key={i.uuid} value={i.uuid}>{i.name || i.github_username || i.uuid.slice(0, 8)}</option>)}
-            </select>
+            <Field label="Integration">
+              <select className={SELECT_CLS} value={form.github_integration_id} onChange={(e) => setForm({ ...form, github_integration_id: e.target.value })}>
+                <option value="">
+                  {integrations.length ? (integrationName ? `Current: ${integrationName}` : 'Select an integration…') : 'No integrations — add a token'}
+                </option>
+                {integrations.map((i) => <option key={i.uuid} value={i.uuid}>{i.name || i.github_username || i.uuid.slice(0, 8)}</option>)}
+              </select>
+            </Field>
           ) : (
-            <div className="grid grid-cols-2 gap-2">
-              <Input className="col-span-2" type="password" placeholder="GitHub PAT (Contents + Actions: write)" value={newToken} onChange={(e) => setNewToken(e.target.value)} />
-              <Input className="col-span-2" placeholder="label (e.g. Domain Sync)" value={newTokenName} onChange={(e) => setNewTokenName(e.target.value)} />
-              <p className="col-span-2 text-xs text-secondary-500">Stored encrypted; validated against GitHub before saving.</p>
-            </div>
+            <>
+              <Field label="Personal access token" hint="Needs repo Contents + Actions: write. Validated against GitHub before saving.">
+                <Input type="password" placeholder="ghp_…" value={newToken} onChange={(e) => setNewToken(e.target.value)} />
+              </Field>
+              <Field label="Label">
+                <Input placeholder="e.g. Domain Sync" value={newTokenName} onChange={(e) => setNewTokenName(e.target.value)} />
+              </Field>
+            </>
           )}
-        </div>
+        </Section>
 
-        <div className="flex justify-end gap-2 pt-2">
+        {/* Additional repos — the multi-repo list. The default above + these are
+            what a domain can be assigned to. */}
+        <ReposManager integrations={integrations} />
+
+        <ModalFooter>
           <Button variant="secondary" onClick={onClose}>Cancel</Button>
-          <Button onClick={save} disabled={saving}>Save settings</Button>
-        </div>
+          <Button onClick={save} disabled={saving} isLoading={saving}>Save settings</Button>
+        </ModalFooter>
       </div>
     </Modal>
   );
@@ -731,58 +1044,67 @@ function PipelineModal({ onClose }: { onClose: () => void }) {
   };
 
   return (
-    <Modal isOpen onClose={onClose} title="Run domain pipeline">
-      <div className="space-y-4">
-        <p className="text-sm text-secondary-500">
+    <Modal isOpen onClose={onClose} title="Run domain pipeline" size="xl">
+      <div className="space-y-5">
+        <p className="text-sm leading-relaxed text-secondary-500">
           opsapi commits the WSL Proxy vhosts, then runs — in order, waiting for each —
-          <span className="font-medium"> Cloudflare DNS reconcile → WSL Proxy register → Auto-tag (build &amp; push)</span>.
+          <span className="font-medium text-secondary-700"> Cloudflare DNS reconcile → WSL Proxy register → Auto-tag (build &amp; push)</span>.
         </p>
 
         {!run && (
-          <div className="grid grid-cols-2 gap-2">
-            <select className="rounded-md border border-secondary-200 px-3 py-2 text-sm" value={form.environment} onChange={(e) => setForm({ ...form, environment: e.target.value })}>
-              {['prod', 'acc', 'test', 'int', 'dev'].map((x) => <option key={x} value={x}>{x}</option>)}
-            </select>
-            <Input placeholder="branch (default main)" value={form.branch} onChange={(e) => setForm({ ...form, branch: e.target.value })} />
-            <RepoUrlField className="col-span-2" value={form.repo_url} onChange={(v) => setForm({ ...form, repo_url: v })} />
-            <Input className="col-span-2" placeholder="GitHub integration id (uuid)" value={form.github_integration_id} onChange={(e) => setForm({ ...form, github_integration_id: e.target.value })} />
-          </div>
+          <Section title="Target" subtitle="Defaults come from Sync Settings — override here if needed." icon={GitBranch}>
+            <div className="grid grid-cols-2 gap-4">
+              <Field label="Environment">
+                <select className={SELECT_CLS} value={form.environment} onChange={(e) => setForm({ ...form, environment: e.target.value })}>
+                  {['prod', 'acc', 'test', 'int', 'dev'].map((x) => <option key={x} value={x}>{x}</option>)}
+                </select>
+              </Field>
+              <Field label="Branch">
+                <Input placeholder="main" value={form.branch} onChange={(e) => setForm({ ...form, branch: e.target.value })} />
+              </Field>
+            </div>
+            <Field label="Repository">
+              <RepoUrlField value={form.repo_url} onChange={(v) => setForm({ ...form, repo_url: v })} />
+            </Field>
+            <Field label="GitHub integration id" hint="Leave blank to use the Sync Settings integration.">
+              <Input placeholder="uuid" value={form.github_integration_id} onChange={(e) => setForm({ ...form, github_integration_id: e.target.value })} />
+            </Field>
+          </Section>
         )}
 
         {run && (
-          <div className="space-y-2">
-            <div className="flex items-center gap-2 text-sm">
-              <span className="font-medium">Run</span>
-              <span className="text-secondary-500">{run.uuid.slice(0, 8)}</span>
+          <Section title="Pipeline run" icon={Play}>
+            <div className="flex flex-wrap items-center gap-2 text-sm">
+              <span className="font-medium text-secondary-900">{run.uuid.slice(0, 8)}</span>
               {stepBadge(run.status)}
               {run.commit_sha && <span className="text-xs text-secondary-500">commit {run.commit_sha.slice(0, 7)}</span>}
             </div>
-            {run.error && <div className="rounded bg-error-50 p-2 text-xs text-error-700">{run.error}</div>}
-            <ol className="space-y-1">
+            {run.error && <div className="rounded-lg bg-error-50 p-2.5 text-xs text-error-700">{run.error}</div>}
+            <ol className="space-y-2">
               {run.steps.map((s) => (
-                <li key={s.name} className="flex items-center justify-between rounded border border-secondary-200 px-2 py-1 text-sm">
+                <li key={s.name} className="flex items-center justify-between rounded-lg border border-secondary-200 px-3 py-2 text-sm">
                   <span className="flex items-center gap-2">
                     {stepBadge(s.status)}
-                    <span>{s.name}</span>
+                    <span className="font-medium text-secondary-800">{s.name}</span>
                     {s.conclusion && s.conclusion !== 'success' && <span className="text-xs text-error-600">({s.conclusion})</span>}
                   </span>
                   {s.run_url && (
-                    <a href={s.run_url} target="_blank" rel="noopener noreferrer" className="text-xs text-primary-600 hover:underline">view run ↗</a>
+                    <a href={s.run_url} target="_blank" rel="noopener noreferrer" className="text-xs font-medium text-primary-600 hover:underline">view run ↗</a>
                   )}
                 </li>
               ))}
             </ol>
             {s_error(run) && <div className="text-xs text-error-600">{s_error(run)}</div>}
-          </div>
+          </Section>
         )}
 
-        <div className="flex justify-end gap-2 pt-2">
+        <ModalFooter>
           <Button variant="secondary" onClick={onClose}>Close</Button>
-          {!run && <Button onClick={start} disabled={starting}><Play className="h-4 w-4 mr-1" /> Start</Button>}
+          {!run && <Button onClick={start} disabled={starting} isLoading={starting}><Play className="mr-1 h-4 w-4" /> Start pipeline</Button>}
           {run && (run.status === 'success' || run.status === 'failed') && (
             <Button onClick={() => setRun(null)}>New run</Button>
           )}
-        </div>
+        </ModalFooter>
       </div>
     </Modal>
   );
@@ -797,146 +1119,214 @@ function s_error(run: PipelineRun): string | null {
 // ============================================================
 // Sync-to-repo modal (render wslproxy vhost files → commit to GitHub)
 // ============================================================
-const EMPTY_REPO = { environment: 'prod', repo_url: '', branch: 'main', github_integration_id: '', template_uuid: '', rule_template_uuid: '' };
+type SyncDomain = Pick<Domain, 'uuid' | 'domain_name' | 'environment' | 'sync_repo_uuid'>;
 
 function RepoSyncModal({ onClose }: { onClose: () => void }) {
-  const [form, setForm] = useState({ ...EMPTY_REPO });
+  const [environment, setEnvironment] = useState('prod');
+  const [domains, setDomains] = useState<SyncDomain[]>([]);
+  const [repos, setRepos] = useState<DomainSyncRepo[]>([]);
+  const [defaultRepo, setDefaultRepo] = useState<{ owner?: string; repo?: string } | null>(null);
+  const [assignments, setAssignments] = useState<Record<string, string>>({});
+  const [selected, setSelected] = useState<Record<string, boolean>>({});
   const [preview, setPreview] = useState<SyncToRepoResult | null>(null);
+  const [previewing, setPreviewing] = useState(false);
   const [busy, setBusy] = useState(false);
-  const [templates, setTemplates] = useState<RenderTemplate[]>([]);
-  const [ruleTemplates, setRuleTemplates] = useState<RenderTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
 
-  // Prefill from saved Sync Settings so no re-entry is needed.
+  // Load the default repo (Sync Settings), the managed repos, and every domain
+  // (assignment + selection seeded from each domain's stored repo).
   useEffect(() => {
-    domainService.getSyncSettings().then((s) => {
-      if (!s.settings) return;
-      setForm((f) => ({
-        ...f,
-        environment: s.settings?.default_environment || f.environment,
-        repo_url: (s.settings?.owner && s.settings?.repo) ? `https://github.com/${s.settings.owner}/${s.settings.repo}` : '',
-        branch: s.settings?.branch || 'main',
-        github_integration_id: s.settings?.github_integration_id || '',
-      }));
-    }).catch(() => {});
-    // Domain server + rule JSON-format templates for the pickers (each falls
-    // back to the built-in default when none is chosen).
-    renderTemplatesService.list('domain_wslproxy').then(setTemplates).catch(() => setTemplates([]));
-    renderTemplatesService.list('domain_rule').then(setRuleTemplates).catch(() => setRuleTemplates([]));
+    (async () => {
+      setLoading(true);
+      try {
+        const [s, r, list] = await Promise.all([
+          domainService.getSyncSettings(),
+          domainService.listSyncRepos().catch(() => []),
+          domainService.listAllDomains(),
+        ]);
+        setRepos(r);
+        if (s.settings) {
+          setEnvironment(s.settings.default_environment || 'prod');
+          setDefaultRepo({ owner: s.settings.owner, repo: s.settings.repo });
+        }
+        setDomains(list);
+        const a: Record<string, string> = {};
+        const sel: Record<string, boolean> = {};
+        list.forEach((d) => { a[d.uuid] = d.sync_repo_uuid || ''; sel[d.uuid] = true; });
+        setAssignments(a);
+        setSelected(sel);
+      } catch { toast.error('Failed to load domains'); } finally { setLoading(false); }
+    })();
   }, []);
 
-  const dryRun = async () => {
-    const parsed = parseRepoUrl(form.repo_url);
-    if (!parsed) { toast.error('Enter a valid GitHub repository URL'); return; }
-    setBusy(true);
-    try {
-      setPreview(await domainService.syncToRepo({ ...form, owner: parsed.owner, repo: parsed.repo, branch: parsed.branch || form.branch, dry_run: true }));
-    } catch { toast.error('Preview failed'); } finally { setBusy(false); }
+  const envDomains = domains.filter((d) => (d.environment || 'prod') === environment);
+  const selectedUuids = envDomains.filter((d) => selected[d.uuid]).map((d) => d.uuid);
+  const allChecked = envDomains.length > 0 && envDomains.every((d) => selected[d.uuid]);
+  const defaultLabel = defaultRepo?.owner && defaultRepo?.repo
+    ? `Default (${defaultRepo.owner}/${defaultRepo.repo})`
+    : 'Default (set in Sync Settings)';
+
+  const toggleAll = (v: boolean) =>
+    setSelected((prev) => { const n = { ...prev }; envDomains.forEach((d) => { n[d.uuid] = v; }); return n; });
+
+  const assignmentsFor = (uuids: string[]) => {
+    const asg: Record<string, string> = {};
+    uuids.forEach((u) => { asg[u] = assignments[u] || ''; });
+    return asg;
   };
 
-  const commit = async () => {
-    const parsed = parseRepoUrl(form.repo_url);
-    if (!parsed) { toast.error('Enter a valid GitHub repository URL'); return; }
-    if (!form.github_integration_id) { toast.error('Select a GitHub integration id'); return; }
+  // Live preview: a READ-ONLY dry-run that re-runs (debounced) whenever the
+  // selection, per-domain repo, or environment changes — so the preview ALWAYS
+  // matches exactly what "Sync" would push. Keyed on a stable signature so that
+  // setPreview() (which changes `preview`) does not retrigger this effect.
+  const previewSig = `${environment}|${selectedUuids.map((u) => `${u}:${assignments[u] || ''}`).sort().join(',')}`;
+  useEffect(() => {
+    if (loading) return;
+    if (selectedUuids.length === 0) { setPreview(null); setPreviewing(false); return; }
+    let active = true;
+    setPreviewing(true);
+    const uuids = selectedUuids;
+    const t = setTimeout(async () => {
+      try {
+        const r = await domainService.syncToRepo({ environment, dry_run: true, domain_uuids: uuids, assignments: assignmentsFor(uuids) });
+        if (active) setPreview(r);
+      } catch { if (active) setPreview(null); }
+      finally { if (active) setPreviewing(false); }
+    }, 400);
+    return () => { active = false; clearTimeout(t); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [previewSig, loading]);
+
+  const runSync = async () => {
+    if (selectedUuids.length === 0) { toast.error('Select at least one domain to sync'); return; }
     setBusy(true);
-    const tid = toast.loading('Opening pull request…');
+    const tid = toast.loading('Opening pull requests…');
     try {
-      const r = await domainService.syncToRepo({ ...form, owner: parsed.owner, repo: parsed.repo, branch: parsed.branch || form.branch });
-      toast.success(
-        r.pr_number ? `PR #${r.pr_number} opened — ${r.count} file(s)` : `Synced ${r.count} file(s)`,
+      const r = await domainService.syncToRepo({ environment, dry_run: false, domain_uuids: selectedUuids, assignments: assignmentsFor(selectedUuids) });
+      setPreview(r);
+      const okCount = r.repos.filter((g) => g.ok).length;
+      const prs = r.repos.filter((g) => g.ok && g.pr_number).map((g) => `#${g.pr_number}`);
+      toast[r.any_failed ? 'error' : 'success'](
+        r.any_failed
+          ? `Synced ${okCount}/${r.repos.length} repo(s) — some failed`
+          : (prs.length ? `Opened PR ${prs.join(', ')} across ${okCount} repo(s)` : `Synced ${okCount} repo(s)`),
         { id: tid },
       );
-      setPreview(r);
-    } catch { toast.error('Sync failed — check integration & permissions', { id: tid }); } finally { setBusy(false); }
+    } catch {
+      toast.error('Sync failed — check repo & token', { id: tid });
+    } finally { setBusy(false); }
   };
 
   return (
-    <Modal isOpen onClose={onClose} title="Sync domains → repo (WSL Proxy vhosts)">
-      <div className="space-y-3">
+    <Modal isOpen onClose={onClose} title="Sync domains → repos" size="2xl">
+      <div className="space-y-4">
         <p className="text-sm text-secondary-500">
-          Renders each domain in the selected environment as a WSL Proxy server file, commits them to a
-          new branch off the target branch, and opens a pull request (add/update only — existing files
-          are never touched, and nothing lands on the target branch without review). The GitHub token
-          comes from a services GitHub integration.
+          Pick which domains to sync and the repo each goes to. Domains are grouped by repo and one pull
+          request is opened per repo (add/update only — nothing lands without review). Add or edit repos in{' '}
+          <span className="font-medium">Sync Settings</span>.
         </p>
-        <div className="grid grid-cols-2 gap-2">
-          <select className="rounded-md border border-secondary-200 px-3 py-2 text-sm" value={form.environment} onChange={(e) => setForm({ ...form, environment: e.target.value })}>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <label className="text-sm font-medium">Environment</label>
+          <select className="rounded-md border border-secondary-200 px-3 py-2 text-sm" value={environment} onChange={(e) => setEnvironment(e.target.value)}>
             {['prod', 'acc', 'test', 'int', 'dev'].map((x) => <option key={x} value={x}>{x}</option>)}
           </select>
-          <Input placeholder="target branch (PR base, default main)" value={form.branch} onChange={(e) => setForm({ ...form, branch: e.target.value })} />
-          <RepoUrlField className="col-span-2" value={form.repo_url} onChange={(v) => setForm({ ...form, repo_url: v })} />
-          <Input className="col-span-2" placeholder="GitHub integration id (uuid)" value={form.github_integration_id} onChange={(e) => setForm({ ...form, github_integration_id: e.target.value })} />
-          <div>
-            <Select
-              label="Server JSON template"
-              value={form.template_uuid}
-              onChange={(e) => setForm({ ...form, template_uuid: e.target.value })}
-              helperText="Server file format."
-            >
-              <option value="">Default (built-in)</option>
-              {templates.map((t) => (
-                <option key={t.uuid} value={t.uuid}>
-                  {t.name}{t.is_default ? ' (default)' : ''}
-                </option>
-              ))}
-            </Select>
+          <span className="text-xs text-secondary-500">{envDomains.length} domain{envDomains.length === 1 ? '' : 's'} · {selectedUuids.length} selected</span>
+        </div>
+
+        <div className="overflow-hidden rounded-lg border border-secondary-200">
+          <div className="grid grid-cols-[auto_1fr_minmax(170px,240px)] items-center gap-2 border-b border-secondary-200 bg-secondary-50 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-secondary-500">
+            <input type="checkbox" checked={allChecked} onChange={(e) => toggleAll(e.target.checked)} />
+            <span>Domain</span>
+            <span>Sync to repo</span>
           </div>
-          <div>
-            <Select
-              label="Rule JSON template"
-              value={form.rule_template_uuid}
-              onChange={(e) => setForm({ ...form, rule_template_uuid: e.target.value })}
-              helperText="Rule file format (path/backend)."
-            >
-              <option value="">Default (built-in)</option>
-              {ruleTemplates.map((t) => (
-                <option key={t.uuid} value={t.uuid}>
-                  {t.name}{t.is_default ? ' (default)' : ''}
-                </option>
-              ))}
-            </Select>
+          <div className="max-h-72 divide-y divide-secondary-100 overflow-auto">
+            {loading ? (
+              <div className="px-3 py-6 text-center text-sm text-secondary-500">Loading…</div>
+            ) : envDomains.length === 0 ? (
+              <div className="px-3 py-6 text-center text-sm text-secondary-500">No domains in <span className="font-medium">{environment}</span>.</div>
+            ) : envDomains.map((d) => (
+              <div key={d.uuid} className="grid grid-cols-[auto_1fr_minmax(170px,240px)] items-center gap-2 px-3 py-2 text-sm">
+                <input type="checkbox" checked={!!selected[d.uuid]} onChange={(e) => setSelected({ ...selected, [d.uuid]: e.target.checked })} />
+                <span className="truncate font-medium">{d.domain_name}</span>
+                <select className="rounded-md border border-secondary-200 px-2 py-1.5 text-sm" value={assignments[d.uuid] || ''} onChange={(e) => setAssignments({ ...assignments, [d.uuid]: e.target.value })}>
+                  <option value="">{defaultLabel}</option>
+                  {repos.map((r) => <option key={r.uuid} value={r.uuid}>{r.name || `${r.owner}/${r.repo}`}</option>)}
+                </select>
+              </div>
+            ))}
           </div>
         </div>
 
-        {preview && (
-          <div className="rounded border border-secondary-200 p-2 text-sm">
-            <div className="mb-1 font-medium">
-              {preview.dry_run
-                ? 'Preview'
-                : (preview.pr_number ? `PR #${preview.pr_number} opened` : 'Synced')} — {preview.count} file(s)
-              {typeof preview.rules === 'number' && <span className="ml-1 font-normal text-secondary-500">({preview.rules} rule{preview.rules === 1 ? '' : 's'})</span>}
-            </div>
-            {!preview.dry_run && preview.pr_url && (
-              <div className="mb-2 rounded bg-emerald-50 border border-emerald-200 p-2 text-xs">
-                <a href={preview.pr_url} target="_blank" rel="noopener noreferrer" className="font-medium text-emerald-700 underline">
-                  Review &amp; merge pull request #{preview.pr_number} →
-                </a>
-                <div className="mt-0.5 text-emerald-700/80">
-                  branch <code>{preview.branch}</code> → <code>{preview.base_branch}</code>
-                  {preview.commit && <> · commit {preview.commit.slice(0, 7)}</>}
-                </div>
-              </div>
-            )}
-            <ul className="max-h-40 overflow-auto text-xs text-secondary-600">
-              {preview.files.map((f) => <li key={f.path}>{f.path}</li>)}
-            </ul>
-            {preview.warnings && preview.warnings.length > 0 && (
-              <div className="mt-2 rounded bg-amber-50 border border-amber-200 p-2 text-xs text-amber-800">
-                <div className="font-medium">⚠ {preview.warnings.length} warning{preview.warnings.length === 1 ? '' : 's'}</div>
-                <ul className="mt-1 list-disc pl-4">
-                  {preview.warnings.map((w, i) => <li key={i}>{w}</li>)}
-                </ul>
-              </div>
-            )}
+        {!preview && (
+          <div className="rounded-lg border border-dashed border-secondary-200 bg-secondary-50/50 px-3 py-4 text-center text-xs text-secondary-500">
+            {selectedUuids.length === 0 ? 'Select at least one domain to preview the sync.' : (previewing ? 'Building preview…' : 'Preview will appear here.')}
           </div>
         )}
 
-        <div className="flex justify-between pt-2">
-          <Button variant="secondary" onClick={dryRun} disabled={busy}><Download className="h-4 w-4 mr-1" /> Preview</Button>
-          <div className="flex gap-2">
-            <Button variant="secondary" onClick={onClose}>Close</Button>
-            <Button onClick={commit} disabled={busy}><GitBranch className="h-4 w-4 mr-1" /> Sync &amp; open PR</Button>
+        {preview && (
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 text-sm font-medium">
+              {preview.dry_run ? 'Preview' : 'Sync result'} — {preview.repos.length} repo{preview.repos.length === 1 ? '' : 's'}
+              {preview.any_failed && <span className="font-normal text-red-600">(some failed)</span>}
+              {previewing && <span className="font-normal text-secondary-400">· updating…</span>}
+            </div>
+            {preview.repos.map((g, gi) => (
+              <div key={`${g.repo}@${g.branch}-${gi}`} className="rounded border border-secondary-200 p-2 text-sm">
+                <div className="mb-1 font-medium">
+                  {g.repo_name && <span className="mr-1 text-secondary-700">{g.repo_name}:</span>}
+                  <code>{g.repo}</code> → <code>{g.branch}</code>
+                  {' '}— {g.count ?? 0} file(s)
+                  {typeof g.rules === 'number' && <span className="ml-1 font-normal text-secondary-500">({g.rules} rule{g.rules === 1 ? '' : 's'})</span>}
+                  {!preview.dry_run && (g.ok
+                    ? <span className="ml-2 text-emerald-700">✓ {g.pr_number ? `PR #${g.pr_number}` : 'synced'}</span>
+                    : <span className="ml-2 text-red-600">✗ failed</span>)}
+                </div>
+                {!preview.dry_run && g.ok && g.pr_url && (
+                  <div className="mb-2 rounded bg-emerald-50 border border-emerald-200 p-2 text-xs">
+                    <a href={g.pr_url} target="_blank" rel="noopener noreferrer" className="font-medium text-emerald-700 underline">
+                      Review &amp; merge pull request #{g.pr_number} →
+                    </a>
+                    <div className="mt-0.5 text-emerald-700/80">
+                      branch <code>{g.head_branch}</code> → <code>{g.base_branch}</code>
+                      {g.commit && <> · commit {g.commit.slice(0, 7)}</>}
+                    </div>
+                  </div>
+                )}
+                {!g.ok && g.error && (
+                  <div className="mb-2 rounded bg-red-50 border border-red-200 p-2 text-xs text-red-700">{g.error}</div>
+                )}
+                {g.files && g.files.length > 0 && (
+                  <ul className="max-h-40 overflow-auto text-xs text-secondary-600">
+                    {g.files.map((f) => <li key={f.path}>{f.path}</li>)}
+                  </ul>
+                )}
+                {g.skipped && g.skipped.length > 0 && (
+                  <div className="mt-2 rounded bg-secondary-50 border border-secondary-200 p-2 text-xs text-secondary-600">
+                    <div className="font-medium">↩ {g.skipped.length} shared rule{g.skipped.length === 1 ? '' : 's'} already in repo (reused, not re-pushed)</div>
+                    <ul className="mt-1 list-disc pl-4">
+                      {g.skipped.map((s) => <li key={s.path}>{s.rule_id}</li>)}
+                    </ul>
+                  </div>
+                )}
+                {g.warnings && g.warnings.length > 0 && (
+                  <div className="mt-2 rounded bg-amber-50 border border-amber-200 p-2 text-xs text-amber-800">
+                    <div className="font-medium">⚠ {g.warnings.length} warning{g.warnings.length === 1 ? '' : 's'}</div>
+                    <ul className="mt-1 list-disc pl-4">
+                      {g.warnings.map((w, i) => <li key={i}>{w}</li>)}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            ))}
           </div>
-        </div>
+        )}
+
+        <ModalFooter>
+          <span className="mr-auto text-xs text-secondary-500">{selectedUuids.length} domain{selectedUuids.length === 1 ? '' : 's'} selected · preview updates live</span>
+          <Button variant="secondary" onClick={onClose}>Close</Button>
+          <Button onClick={runSync} disabled={busy || loading || selectedUuids.length === 0} isLoading={busy}><GitBranch className="mr-1 h-4 w-4" /> Sync selected &amp; open PRs</Button>
+        </ModalFooter>
       </div>
     </Modal>
   );
@@ -974,25 +1364,29 @@ function CredentialModal({ onClose }: { onClose: () => void }) {
   };
 
   return (
-    <Modal isOpen onClose={onClose} title="Cloudflare API token">
-      <div className="space-y-3">
-        <p className="text-sm text-secondary-500">
-          Stored encrypted at rest (AES). Used server-side for zone &amp; DNS management.
-          {hasSecret && <span className="ml-1 text-success-600">A token is already configured.</span>}
-        </p>
-        <Input
-          type="password"
-          placeholder={hasSecret ? '•••••••• (replace)' : 'CF API token'}
-          value={token}
-          onChange={(e) => setToken(e.target.value)}
-        />
-        <div className="flex justify-between pt-2">
-          <Button variant="secondary" onClick={verify} disabled={!hasSecret}>Verify</Button>
-          <div className="flex gap-2">
-            <Button variant="secondary" onClick={onClose}>Close</Button>
-            <Button onClick={save} disabled={saving}>Save token</Button>
-          </div>
-        </div>
+    <Modal isOpen onClose={onClose} title="Cloudflare API token" size="lg">
+      <div className="space-y-5">
+        <Section title="API token" subtitle="Stored encrypted at rest (AES). Used server-side for zone & DNS management." icon={Cloud}>
+          {hasSecret && (
+            <div className="flex items-center gap-2 rounded-lg border border-success-200 bg-success-50 px-3 py-2 text-xs text-success-700">
+              <ShieldCheck className="h-4 w-4" /> A token is already configured.
+            </div>
+          )}
+          <Field label="Token" hint="Zone: read · DNS: edit for the domains you manage.">
+            <Input
+              type="password"
+              placeholder={hasSecret ? '•••••••• (replace)' : 'CF API token'}
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+            />
+          </Field>
+        </Section>
+
+        <ModalFooter>
+          <Button variant="secondary" onClick={verify} disabled={!hasSecret} className="mr-auto">Verify</Button>
+          <Button variant="secondary" onClick={onClose}>Close</Button>
+          <Button onClick={save} disabled={saving} isLoading={saving}>Save token</Button>
+        </ModalFooter>
       </div>
     </Modal>
   );
@@ -1036,46 +1430,55 @@ function DnsModal({ domain, onClose }: { domain: Domain; onClose: () => void }) 
   };
 
   return (
-    <Modal isOpen onClose={onClose} title={`Cloudflare DNS — ${domain.domain_name}`}>
-      <div className="space-y-4">
-        {err && <div className="rounded bg-error-50 p-3 text-sm text-error-700">{err}</div>}
-        {zoneId && <div className="text-xs text-secondary-500">Zone: {zoneId}</div>}
+    <Modal isOpen onClose={onClose} title={`Cloudflare DNS — ${domain.domain_name}`} size="2xl">
+      <div className="space-y-5">
+        {err && <div className="rounded-lg border border-error-200 bg-error-50 p-3 text-sm text-error-700">{err}</div>}
 
-        {/* Add record */}
-        <div className="grid grid-cols-12 gap-2 rounded border border-secondary-200 p-2">
-          <select className="col-span-2 rounded border px-2 py-1 text-sm" value={newRec.type} onChange={(e) => setNewRec({ ...newRec, type: e.target.value })}>
-            {['A', 'AAAA', 'CNAME', 'TXT', 'MX', 'NS'].map((t) => <option key={t}>{t}</option>)}
-          </select>
-          <input className="col-span-3 rounded border px-2 py-1 text-sm" placeholder="name" value={newRec.name} onChange={(e) => setNewRec({ ...newRec, name: e.target.value })} />
-          <input className="col-span-5 rounded border px-2 py-1 text-sm" placeholder="content" value={newRec.content} onChange={(e) => setNewRec({ ...newRec, content: e.target.value })} />
-          <Button className="col-span-2" onClick={addRecord}><Plus className="h-4 w-4" /></Button>
-        </div>
+        <Section title="Add record" subtitle={zoneId ? `Zone ${zoneId}` : undefined} icon={Cloud}>
+          <div className="grid grid-cols-12 gap-3">
+            <select className={cn(SELECT_CLS, 'col-span-3')} value={newRec.type} onChange={(e) => setNewRec({ ...newRec, type: e.target.value })}>
+              {['A', 'AAAA', 'CNAME', 'TXT', 'MX', 'NS'].map((t) => <option key={t}>{t}</option>)}
+            </select>
+            <Input className="col-span-4" placeholder="name" value={newRec.name} onChange={(e) => setNewRec({ ...newRec, name: e.target.value })} />
+            <Input className="col-span-5" placeholder="content" value={newRec.content} onChange={(e) => setNewRec({ ...newRec, content: e.target.value })} />
+            <div className="col-span-12 flex justify-end">
+              <Button size="sm" onClick={addRecord}><Plus className="mr-1 h-4 w-4" /> Add record</Button>
+            </div>
+          </div>
+        </Section>
 
         {/* Records list */}
-        <div className="max-h-72 overflow-auto">
-          {loading ? (
-            <div className="p-4 text-center text-sm text-secondary-500">Loading…</div>
-          ) : records.length === 0 ? (
-            <div className="p-4 text-center text-sm text-secondary-500">No records.</div>
-          ) : (
-            <table className="w-full text-sm">
-              <thead><tr className="text-left text-secondary-500"><th className="p-1">Type</th><th className="p-1">Name</th><th className="p-1">Content</th><th /></tr></thead>
-              <tbody>
-                {records.map((r) => (
-                  <tr key={r.id} className="border-t border-secondary-100">
-                    <td className="p-1"><Badge variant="secondary">{r.type}</Badge></td>
-                    <td className="p-1">{r.name}{r.proxied && <span className="ml-1 text-warning-600" title="Proxied">☁</span>}</td>
-                    <td className="p-1 truncate max-w-[200px]" title={r.content}>{r.content}</td>
-                    <td className="p-1 text-right">
-                      <button className="rounded p-1 text-error-600 hover:bg-error-50" onClick={() => del(r.id)}><Trash2 className="h-4 w-4" /></button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
+        <div className="overflow-hidden rounded-xl border border-secondary-200">
+          <div className="max-h-72 overflow-auto">
+            {loading ? (
+              <div className="p-6 text-center text-sm text-secondary-500">Loading…</div>
+            ) : records.length === 0 ? (
+              <div className="p-6 text-center text-sm text-secondary-500">No DNS records yet.</div>
+            ) : (
+              <table className="w-full text-sm">
+                <thead className="bg-secondary-50/70 text-left text-xs font-semibold uppercase tracking-wide text-secondary-500">
+                  <tr><th className="px-3 py-2">Type</th><th className="px-3 py-2">Name</th><th className="px-3 py-2">Content</th><th className="px-3 py-2" /></tr>
+                </thead>
+                <tbody>
+                  {records.map((r) => (
+                    <tr key={r.id} className="border-t border-secondary-100">
+                      <td className="px-3 py-2"><Badge variant="secondary">{r.type}</Badge></td>
+                      <td className="px-3 py-2">{r.name}{r.proxied && <span className="ml-1 text-warning-600" title="Proxied">☁</span>}</td>
+                      <td className="max-w-60 truncate px-3 py-2" title={r.content}>{r.content}</td>
+                      <td className="px-3 py-2 text-right">
+                        <button className="rounded-lg p-1.5 text-error-600 hover:bg-error-50" onClick={() => del(r.id)} aria-label="Delete record"><Trash2 className="h-4 w-4" /></button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
         </div>
-        <div className="flex justify-end"><Button variant="secondary" onClick={onClose}>Close</Button></div>
+
+        <ModalFooter>
+          <Button variant="secondary" onClick={onClose}>Close</Button>
+        </ModalFooter>
       </div>
     </Modal>
   );
@@ -1137,60 +1540,60 @@ function SyncModal({ onClose }: { onClose: () => void }) {
   };
 
   return (
-    <Modal isOpen onClose={onClose} title="Domain sync jobs (k3s)">
-      <div className="space-y-4">
-        <p className="text-sm text-secondary-500">
+    <Modal isOpen onClose={onClose} title="Domain sync jobs (k3s)" size="2xl">
+      <div className="space-y-5">
+        <p className="text-sm leading-relaxed text-secondary-500">
           Generate a Kubernetes CronJob that pushes your domain list as JSON to a GitHub repo on a
           schedule. Secrets (GitHub PAT + opsapi token) come from a k8s Secret populated by the vault/ESO —
           never stored here.
         </p>
 
-        {/* Existing configs */}
         {configs.length > 0 && (
-          <div className="space-y-2">
-            {configs.map((c) => (
-              <div key={c.uuid} className="flex items-center justify-between rounded border border-secondary-200 p-2 text-sm">
-                <div>
-                  <div className="font-medium">{c.name}</div>
-                  <div className="text-xs text-secondary-500">{c.github_repo} · {c.schedule} · last: {c.last_status || 'never'}</div>
-                </div>
-                <div className="flex gap-1">
-                  <button title="View CronJob manifest" className="rounded p-1.5 hover:bg-secondary-100" onClick={() => showManifest(c)}><Download className="h-4 w-4" /></button>
-                  <button title="Run once now" className="rounded p-1.5 hover:bg-secondary-100" onClick={() => runNow(c)}><Play className="h-4 w-4" /></button>
-                  <button title="Delete" className="rounded p-1.5 text-error-600 hover:bg-error-50" onClick={() => del(c)}><Trash2 className="h-4 w-4" /></button>
-                </div>
-              </div>
-            ))}
-          </div>
+          <Section title="Scheduled jobs" icon={Clock}>
+            <ul className="divide-y divide-secondary-100 overflow-hidden rounded-lg border border-secondary-200">
+              {configs.map((c) => (
+                <li key={c.uuid} className="flex items-center justify-between gap-2 px-3 py-2.5 text-sm">
+                  <div className="min-w-0">
+                    <div className="truncate font-medium text-secondary-900">{c.name}</div>
+                    <div className="truncate text-xs text-secondary-500">{c.github_repo} · {c.schedule} · last: {c.last_status || 'never'}</div>
+                  </div>
+                  <div className="flex gap-1">
+                    <button title="View CronJob manifest" className="rounded-lg p-1.5 hover:bg-secondary-100" onClick={() => showManifest(c)}><Download className="h-4 w-4" /></button>
+                    <button title="Run once now" className="rounded-lg p-1.5 hover:bg-secondary-100" onClick={() => runNow(c)}><Play className="h-4 w-4" /></button>
+                    <button title="Delete" className="rounded-lg p-1.5 text-error-600 hover:bg-error-50" onClick={() => del(c)}><Trash2 className="h-4 w-4" /></button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </Section>
         )}
 
-        {/* New config */}
-        <div className="grid grid-cols-2 gap-2 rounded border border-secondary-200 p-3">
-          <Input placeholder="Name *" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} />
-          <Input placeholder="owner/repo *" value={form.github_repo} onChange={(e) => setForm({ ...form, github_repo: e.target.value })} />
-          <Input placeholder="branch" value={form.github_branch} onChange={(e) => setForm({ ...form, github_branch: e.target.value })} />
-          <Input placeholder="file path (domains.json)" value={form.file_path} onChange={(e) => setForm({ ...form, file_path: e.target.value })} />
-          <Input placeholder="cron (0 3 * * *)" value={form.schedule} onChange={(e) => setForm({ ...form, schedule: e.target.value })} />
-          <Input placeholder="k8s Secret name (ESO)" value={form.github_token_secret_ref} onChange={(e) => setForm({ ...form, github_token_secret_ref: e.target.value })} />
-          <Input className="col-span-2" placeholder="opsapi base URL (in-cluster export endpoint)" value={form.opsapi_base_url} onChange={(e) => setForm({ ...form, opsapi_base_url: e.target.value })} />
-          <div className="col-span-2 flex justify-end"><Button onClick={create}><Plus className="h-4 w-4 mr-1" /> Create sync job</Button></div>
-        </div>
+        <Section title="New sync job" icon={Plus}>
+          <div className="grid grid-cols-2 gap-3">
+            <Input placeholder="Name *" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} />
+            <Input placeholder="owner/repo *" value={form.github_repo} onChange={(e) => setForm({ ...form, github_repo: e.target.value })} />
+            <Input placeholder="branch" value={form.github_branch} onChange={(e) => setForm({ ...form, github_branch: e.target.value })} />
+            <Input placeholder="file path (domains.json)" value={form.file_path} onChange={(e) => setForm({ ...form, file_path: e.target.value })} />
+            <Input placeholder="cron (0 3 * * *)" value={form.schedule} onChange={(e) => setForm({ ...form, schedule: e.target.value })} />
+            <Input placeholder="k8s Secret name (ESO)" value={form.github_token_secret_ref} onChange={(e) => setForm({ ...form, github_token_secret_ref: e.target.value })} />
+            <Input className="col-span-2" placeholder="opsapi base URL (in-cluster export endpoint)" value={form.opsapi_base_url} onChange={(e) => setForm({ ...form, opsapi_base_url: e.target.value })} />
+            <div className="col-span-2 flex justify-end"><Button size="sm" onClick={create}><Plus className="mr-1 h-4 w-4" /> Create sync job</Button></div>
+          </div>
+        </Section>
 
-        {/* Manifest preview */}
         {manifest && (
-          <div className="space-y-2">
-            <div className="flex items-center justify-between">
-              <span className="text-sm font-medium">Manifest</span>
-              <div className="flex gap-2">
-                <Button variant="secondary" onClick={download}><Download className="h-4 w-4 mr-1" /> Download</Button>
-                <button className="rounded p-1 hover:bg-secondary-100" onClick={() => setManifest(null)}><X className="h-4 w-4" /></button>
-              </div>
+          <Section title="Manifest" icon={Download}>
+            <div className="flex items-center justify-end gap-2">
+              <Button variant="secondary" size="sm" onClick={download}><Download className="mr-1 h-4 w-4" /> Download</Button>
+              <button className="rounded-lg p-1.5 hover:bg-secondary-100" onClick={() => setManifest(null)} aria-label="Dismiss"><X className="h-4 w-4" /></button>
             </div>
-            <pre className="max-h-64 overflow-auto rounded bg-secondary-900 p-3 text-xs text-secondary-100">{manifest}</pre>
-          </div>
+            <pre className="max-h-64 overflow-auto rounded-lg bg-secondary-900 p-3 text-xs text-secondary-100">{manifest}</pre>
+          </Section>
         )}
 
-        <div className="flex justify-end"><Button variant="secondary" onClick={onClose}>Close</Button></div>
+        <ModalFooter>
+          <Button variant="secondary" onClick={onClose}>Close</Button>
+        </ModalFooter>
       </div>
     </Modal>
   );

--- a/opsapi-dashboard/services/domain.service.ts
+++ b/opsapi-dashboard/services/domain.service.ts
@@ -38,26 +38,66 @@ export interface Domain {
   rule_path?: string;
   server_template_uuid?: string;
   rule_template_uuid?: string;
+  // Which managed repo this domain syncs to (blank -> namespace default repo).
+  sync_repo_uuid?: string;
   created_at: string;
   updated_at: string;
 }
 
-export interface SyncToRepoResult {
-  environment: string;
-  repo?: string;
-  /** The head branch the sync committed to (created off base_branch). */
+/** A managed GitHub repo a namespace can sync domains to (beyond the default). */
+export interface DomainSyncRepo {
+  uuid: string;
+  name?: string;
+  owner: string;
+  repo: string;
   branch?: string;
-  /** The PR target branch (e.g. main) — changes are never pushed here directly. */
+  github_integration_id?: string;
+}
+
+/** One repo group's result — the sync groups domains by resolved repo and opens
+ *  one PR per repo, so each entry is an independent success/failure. */
+export interface RepoSyncResult {
+  repo: string;
+  repo_name?: string;
+  branch: string;
+  ok: boolean;
+  error?: string;
+  /** The PR target (base) branch — changes are never pushed here directly. */
   base_branch?: string;
+  /** The head branch the sync committed to (created off base). */
+  head_branch?: string;
   commit?: string;
-  /** URL of the pull request opened back to base_branch. */
   pr_url?: string;
   pr_number?: number;
-  count: number;
+  count?: number;
   rules?: number;
   warnings?: string[];
+  /** Attached rules already present in the repo (reused, not re-pushed). */
+  skipped?: { rule_id: string; path: string; reason: string }[];
+  files?: { path: string; server_name: string; content?: string }[];
+}
+
+export interface SyncToRepoResult {
+  environment: string;
   dry_run?: boolean;
-  files: { path: string; server_name: string; content?: string }[];
+  any_failed?: boolean;
+  repos: RepoSyncResult[];
+}
+
+export interface WslproxyStatus {
+  connected: boolean;
+  api_url?: string;
+  email?: string;
+  has_secret?: boolean;
+  connected_at?: string;
+}
+
+/** A shared WSL Proxy rule, as returned by the control-plane API. */
+export interface WslproxyRule {
+  id: string;
+  name?: string;
+  profile_id?: string;
+  [key: string]: unknown;
 }
 
 export interface DomainStats {
@@ -246,6 +286,13 @@ export const domainService = {
     return unwrap<Domain>(response);
   },
 
+  // Every domain (uuid, name, environment, assigned repo) with no page cap —
+  // for the sync modal's assignment matrix.
+  async listAllDomains(): Promise<Pick<Domain, 'uuid' | 'domain_name' | 'environment' | 'sync_repo_uuid'>[]> {
+    const response = await apiClient.get('/api/v2/domains/all');
+    return unwrap<Pick<Domain, 'uuid' | 'domain_name' | 'environment' | 'sync_repo_uuid'>[]>(response);
+  },
+
   async createDomain(data: Record<string, unknown>): Promise<Domain> {
     const response = await apiClient.post('/api/v2/domains', toFormData(data));
     return unwrap<Domain>(response);
@@ -275,8 +322,24 @@ export const domainService = {
     return unwrap<DomainStats>(response);
   },
 
-  async syncToRepo(data: Record<string, unknown>): Promise<SyncToRepoResult> {
-    const response = await apiClient.post('/api/v2/domains/sync-to-repo', toFormData(data));
+  // Sync selected domains, each to its assigned repo (one PR per repo). The
+  // api-client posts form-urlencoded, so the structured fields (domain_uuids
+  // array, assignments map) are sent as JSON STRINGS — the backend decodes them.
+  async syncToRepo(data: {
+    environment?: string;
+    dry_run?: boolean;
+    domain_uuids?: string[];
+    assignments?: Record<string, string>;
+    message?: string;
+  }): Promise<SyncToRepoResult> {
+    const payload: Record<string, unknown> = {
+      environment: data.environment,
+      dry_run: data.dry_run ? 'true' : 'false',
+      domain_uuids: JSON.stringify(data.domain_uuids ?? []),
+      assignments: JSON.stringify(data.assignments ?? {}),
+    };
+    if (data.message) payload.message = data.message;
+    const response = await apiClient.post('/api/v2/domains/sync-to-repo', toFormData(payload));
     return unwrap<SyncToRepoResult>(response);
   },
 
@@ -386,6 +449,49 @@ export const domainService = {
   async listGithubIntegrations(): Promise<GithubIntegrationLite[]> {
     const response = await apiClient.get('/api/v2/domains/github-integrations');
     return unwrap<GithubIntegrationLite[]>(response);
+  },
+
+  // ---- Managed sync repos (multi-repo targets) ----
+  async listSyncRepos(): Promise<DomainSyncRepo[]> {
+    const response = await apiClient.get('/api/v2/domains/sync-repos');
+    return unwrap<DomainSyncRepo[]>(response);
+  },
+
+  async createSyncRepo(data: { name?: string; repo_url?: string; owner?: string; repo?: string; branch?: string; github_integration_id?: string }): Promise<DomainSyncRepo> {
+    const response = await apiClient.post('/api/v2/domains/sync-repos', toFormData(data));
+    return unwrap<DomainSyncRepo>(response);
+  },
+
+  async updateSyncRepo(uuid: string, data: Record<string, unknown>): Promise<DomainSyncRepo> {
+    const response = await apiClient.put(`/api/v2/domains/sync-repos/${uuid}`, toFormData(data));
+    return unwrap<DomainSyncRepo>(response);
+  },
+
+  async deleteSyncRepo(uuid: string): Promise<void> {
+    await apiClient.delete(`/api/v2/domains/sync-repos/${uuid}`);
+  },
+
+  // ---- WSL Proxy connection + shared rules ----
+  async getWslproxyStatus(): Promise<WslproxyStatus> {
+    const response = await apiClient.get('/api/v2/domains/wslproxy/status');
+    return unwrap<WslproxyStatus>(response);
+  },
+
+  async connectWslproxy(data: { api_url: string; email?: string; password: string }): Promise<WslproxyStatus> {
+    const response = await apiClient.post('/api/v2/domains/wslproxy/connect', toFormData(data));
+    return unwrap<WslproxyStatus>(response);
+  },
+
+  async disconnectWslproxy(): Promise<void> {
+    await apiClient.delete('/api/v2/domains/wslproxy/disconnect');
+  },
+
+  /** Searchable list of shared rules for the domain form's rule dropdown,
+   *  optionally scoped to an environment (rule profile_id). */
+  async listWslproxyRules(search?: string, environment?: string): Promise<WslproxyRule[]> {
+    const qs = buildQueryString({ search: search || undefined, environment: environment || undefined });
+    const response = await apiClient.get(`/api/v2/domains/wslproxy/rules${qs}`);
+    return unwrap<WslproxyRule[]>(response);
   },
 };
 


### PR DESCRIPTION
## Summary

Reworks the domains → repo sync so operators **attach shared WSL Proxy rules** instead of minting one rule per domain, **fetch rules live** from the WSL Proxy control plane, and **sync to multiple repos** — assigning each domain to a repo and opening one PR per repo.

## Backend
- **Per-namespace WSL Proxy connection** (`namespace_wslproxy_connections`): connect / status / disconnect. Password AES-encrypted at rest (reuses `Global.encryptSecret`, mirrors `DomainCredentialQueries`); never returned over the API, decrypted server-side only. Connect is validated by a live login before anything is stored.
- **`lib/wslproxy-client.lua`**: per-namespace login with a cached bearer token (re-login once on 401), `list_rules(search, environment)` (env-filtered by `profile_id`), `get_rule(id)`. Env-aware `ssl_verify`; every call returns `(result, err)`.
- **Attach shared rules**: a domain's `wslproxy_rule_id` holds a rule chosen from the live API (`GET /api/v2/domains/wslproxy/rules`). At sync, a shared rule already present in the repo is **skipped** (`github-repo.file_exists`), a missing one is **fetched from WSL Proxy and pushed**, and an unattached domain **falls back to template generation** (backward compatible).
- **Multi-repo**: `domain_sync_repos` (managed repos) + `domains.sync_repo_uuid`. The sync groups the **selected** domains (`domain_uuids`) by their assigned repo and opens **one PR per repo**, each authenticated with that repo's own GitHub integration. Assignments persist only on a real sync — **dry-run is read-only**. Accepts `domain_uuids`/`assignments` as a JSON body or JSON-string form fields.
- `GET /api/v2/domains/all` (no page cap) for the assignment matrix; sync-repos CRUD.

## Frontend
- **Domain form**: *Attach shared rule* (env-filtered searchable dropdown + inline **Connect WSL Proxy**) vs *Create new rule*; a per-domain **Sync to repo** picker.
- **Sync modal**: a **domain → repo assignment matrix** with select-to-sync and a **live, debounced, read-only preview** grouped per repo.
- **Sync Settings**: default repo + a managed **Additional repositories** list (each with its own token); removed the redundant per-sync template + rule-generation controls (now per-domain).
- Every modal **widened and restyled** with shared `Section` / `Field` / `ModalFooter` blocks (ui-ux-pro-max): consistent cards, labels, 8pt spacing, sticky footers.

## Failure handling
WSL Proxy unreachable / auth / 404, GitHub API errors, not-connected (clear 4xx), attached-rule-missing, **per-repo isolation** (one repo failing never rolls back another), idempotent re-sync (skip-if-present), no secret ever leaked.

## Verified
Encryption round-trip; smart-rule skip/fetch/generate/fallback (Lua self-check); multi-repo grouping + selective sync + assignment persistence; dry-run read-only; **form-urlencoded** request path (matches the browser) correctly excludes unchecked domains; per-repo token failure is graceful. `luajit` syntax OK, `tsc` 0 errors, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)