### PR TITLE
feat(documents): revalidate the website static site on content changes

### DIFF
--- a/lapis/.env.example
+++ b/lapis/.env.example
@@ -204,3 +204,18 @@ CORS_CREDENTIALS=true
 # to the OpenResty worker's Lua scope (already added).
 # OPSAPI_DEPLOY_ENV=local
 # LAPIS_ENVIRONMENT=development
+
+# --- Website static-site revalidation (workstation-website) ------------------
+# When blog content (a "document") is created/updated/deleted, lib/website-
+# revalidate.lua fires a GitHub `repository_dispatch: content-updated` that
+# rebuilds + redeploys the static site. The call is async (ngx.timer) and
+# coalesced (one dispatch per debounce window), so it never blocks or fails a
+# content save. Set WEBSITE_DISPATCH_TOKEN ONLY in the env that owns publishing
+# (e.g. prod); leaving it empty disables the notifier (int/test stay silent).
+# All five must be whitelisted in nginx.conf's `env` list (already added).
+#
+# WEBSITE_DISPATCH_TOKEN=      # GitHub PAT with contents:write on the repo
+# WEBSITE_REPO_OWNER=bwalia
+# WEBSITE_REPO_NAME=workstation-website
+# WEBSITE_DISPATCH_EVENT=content-updated
+# WEBSITE_DISPATCH_DEBOUNCE=60 # seconds to coalesce a burst of edits

--- a/lapis/lib/github-repo.lua
+++ b/lapis/lib/github-repo.lua
@@ -251,6 +251,25 @@ function GithubRepo.dispatch_workflow(opts)
     return status == 204 or status == 200, nil
 end
 
+--- Fire a repository_dispatch event (POST /repos/{owner}/{repo}/dispatches).
+--- Triggers any workflow listening on `on: repository_dispatch: types: [...]`.
+--- Unlike workflow_dispatch this needs no workflow file/ref and carries a free
+--- `client_payload`, which suits "content changed, please rebuild" signals.
+-- @param opts { token, owner, repo, event_type, client_payload? }
+-- @return true, nil  OR  nil, err
+function GithubRepo.repository_dispatch(opts)
+    assert(opts and opts.token and opts.owner and opts.repo and opts.event_type,
+        "token/owner/repo/event_type required")
+    local path = string.format("/repos/%s/%s/dispatches", opts.owner, opts.repo)
+    local _, status, err = api(opts.token, "POST", path, {
+        event_type = opts.event_type,
+        client_payload = opts.client_payload or nil,
+    })
+    if err then return nil, err end
+    -- GitHub returns 204 No Content on success.
+    return status == 204, nil
+end
+
 --- Find the workflow run created by a dispatch. workflow_dispatch returns no run
 --- id, so we poll the workflow's runs and pick the newest created at/after
 --- `since_iso` (an ISO-8601 UTC string captured just before dispatch). Retries a

--- a/lapis/lib/website-revalidate.lua
+++ b/lapis/lib/website-revalidate.lua
@@ -1,0 +1,108 @@
+--[[
+    Website revalidation notifier
+    =============================
+    When blog content (a "document") is created / updated / deleted, tell the
+    workstation-website repo to rebuild + redeploy its static site by firing a
+    GitHub `repository_dispatch: content-updated` event. That workflow re-fetches
+    content from this API and re-syncs the live S3 root — the "revalidate" step
+    for a statically-served site. See workstation-website/docs/architecture.md.
+
+    Guarantees (why each matters for a content-save path):
+      * Non-blocking — the GitHub call runs in an ngx.timer AFTER the response is
+        sent, so a slow or down GitHub never delays or fails saving a document.
+      * Never throws — the whole scheduling path is pcall-wrapped; a bug here can
+        never break a create/update/delete.
+      * Coalesced — a burst of edits schedules a SINGLE dispatch after a short
+        debounce window (the rebuild re-fetches ALL content, so only the last
+        change in a window matters). Uses the shared `cache` dict; degrades to
+        one-timer-per-change if the dict is unavailable.
+      * Opt-in per env — a no-op unless WEBSITE_DISPATCH_TOKEN is set, so int /
+        test opsapi stay silent and only the env that owns publishing fires.
+
+    Env (must also be whitelisted in nginx.conf `env` directives):
+      WEBSITE_DISPATCH_TOKEN     GitHub PAT with contents:write on the repo.
+                                 Unset = notifier disabled.
+      WEBSITE_REPO_OWNER         default "bwalia"
+      WEBSITE_REPO_NAME          default "workstation-website"
+      WEBSITE_DISPATCH_EVENT     default "content-updated"
+      WEBSITE_DISPATCH_DEBOUNCE  seconds to coalesce a burst, default 60
+]]
+
+local GithubRepo = require("lib.github-repo")
+
+local WebsiteRevalidate = {}
+
+-- Only one dispatch may be scheduled per debounce window; this key in the shared
+-- `cache` dict is the guard (add() succeeds only when it is absent).
+local SCHED_KEY = "website_revalidate:scheduled"
+
+local function env(name, default)
+    local v = os.getenv(name)
+    if v == nil or v == "" then return default end
+    return v
+end
+
+-- Returns the resolved config, or nil when the notifier is disabled (no token).
+local function resolve_config()
+    local token = env("WEBSITE_DISPATCH_TOKEN")
+    if not token then return nil end
+    return {
+        token = token,
+        owner = env("WEBSITE_REPO_OWNER", "bwalia"),
+        repo = env("WEBSITE_REPO_NAME", "workstation-website"),
+        event_type = env("WEBSITE_DISPATCH_EVENT", "content-updated"),
+        debounce = tonumber(env("WEBSITE_DISPATCH_DEBOUNCE", "60")) or 60,
+    }
+end
+
+-- ngx.timer callback: runs outside the request. Fires exactly one dispatch and
+-- clears the guard so the next window can schedule again.
+local function fire(premature, cfg, reason)
+    if premature then return end
+    local dict = ngx.shared.cache
+    if dict then dict:delete(SCHED_KEY) end
+    local ok, err = GithubRepo.repository_dispatch({
+        token = cfg.token,
+        owner = cfg.owner,
+        repo = cfg.repo,
+        event_type = cfg.event_type,
+        client_payload = { reason = reason, at = os.date("!%Y-%m-%dT%H:%M:%SZ") },
+    })
+    if ok then
+        ngx.log(ngx.NOTICE, "website-revalidate: dispatched '", cfg.event_type,
+            "' to ", cfg.owner, "/", cfg.repo, " (", tostring(reason), ")")
+    else
+        ngx.log(ngx.ERR, "website-revalidate: dispatch failed: ", tostring(err))
+    end
+end
+
+--- Schedule a coalesced site rebuild. Safe to call on every content mutation:
+--- never blocks, never throws, no-op when disabled or off-request.
+-- @param reason string  e.g. "document.created" — for logs / client_payload only
+function WebsiteRevalidate.notify(reason)
+    local ok, err = pcall(function()
+        local cfg = resolve_config()
+        if not cfg then return end                          -- disabled (no token)
+        if not (ngx and ngx.timer and ngx.timer.at) then return end  -- off-request
+
+        local dict = ngx.shared.cache
+        if dict then
+            -- First change in the window schedules the timer; the rest fold into
+            -- it. add() succeeds only while the key is absent; the TTL is a
+            -- safety net in case the timer never runs.
+            local added = dict:add(SCHED_KEY, 1, cfg.debounce + 30)
+            if not added then return end
+        end
+
+        local scheduled, terr = ngx.timer.at(cfg.debounce, fire, cfg, reason)
+        if not scheduled then
+            if dict then dict:delete(SCHED_KEY) end          -- let a later change retry
+            ngx.log(ngx.ERR, "website-revalidate: could not schedule timer: ", tostring(terr))
+        end
+    end)
+    if not ok then
+        ngx.log(ngx.ERR, "website-revalidate: notify error: ", tostring(err))
+    end
+end
+
+return WebsiteRevalidate

--- a/lapis/nginx.conf
+++ b/lapis/nginx.conf
@@ -194,6 +194,18 @@ env AUTH_COOKIE_TRUSTED_DOMAINS;
 env AUTH_COOKIE_DOMAIN;
 env AUTH_COOKIE_INSECURE;
 
+# lib/website-revalidate.lua reads these to fire a GitHub repository_dispatch
+# that rebuilds the workstation-website static site when blog content changes.
+# openresty strips process env by default, so these must be whitelisted for
+# os.getenv() to return anything in the worker. Leaving WEBSITE_DISPATCH_TOKEN
+# unset disables the notifier (int/test stay silent; set it only where
+# publishing happens). See .env.example for the full matrix.
+env WEBSITE_DISPATCH_TOKEN;
+env WEBSITE_REPO_OWNER;
+env WEBSITE_REPO_NAME;
+env WEBSITE_DISPATCH_EVENT;
+env WEBSITE_DISPATCH_DEBOUNCE;
+
 worker_processes ${{NUM_WORKERS}};
 error_log stderr notice;
 daemon off;

--- a/lapis/queries/DocumentQueries.lua
+++ b/lapis/queries/DocumentQueries.lua
@@ -7,6 +7,7 @@ local TagsModel = require "models.TagsModel"
 local ImageModel = require "models.ImageModel"
 local cJson = require "cjson"
 local db = require("lapis.db")
+local WebsiteRevalidate = require "lib.website-revalidate"
 
 local DocumentQueries = {}
 
@@ -142,6 +143,7 @@ function DocumentQueries.create(data)
     end
     savedDocument.internal_id = savedDocument.id
     savedDocument.id = savedDocument.uuid
+    WebsiteRevalidate.notify("document.created")
     return {
         data = savedDocument
     }
@@ -305,6 +307,7 @@ function DocumentQueries.update(id, params)
         returning = "*"
     })
     if updateDoc then
+        WebsiteRevalidate.notify("document.updated")
         return { data = params }
     end
     return { data = nil }
@@ -314,7 +317,9 @@ function DocumentQueries.destroy(id)
     local record = DocumentModel:find({
         uuid = id
     })
-    return record:delete()
+    local deleted = record:delete()
+    if deleted then WebsiteRevalidate.notify("document.deleted") end
+    return deleted
 end
 
 function DocumentQueries.deleteMultiple(params)
@@ -324,6 +329,7 @@ function DocumentQueries.deleteMultiple(params)
         for _, record in ipairs(deleteAble) do
             record:delete()
         end
+        if #deleteAble > 0 then WebsiteRevalidate.notify("document.deleted") end
     end
     return {
         data = deleteAble


### PR DESCRIPTION
## What

The OPSAPI side of the workstation-website static-site content flow. When a blog **document** is created/updated/deleted, OPSAPI fires a GitHub `repository_dispatch: content-updated` at `bwalia/workstation-website`, which rebuilds + re-syncs the live S3 site. This is the **"revalidate"** for a statically-served front door.

Pairs with workstation-website PR #152 (which added the `repository_dispatch: content-updated` trigger + `docs/architecture.md`).

## How

- **`lib/website-revalidate.lua`** — the notifier:
  - **Async** — the GitHub call runs in an `ngx.timer` *after* the response, so a slow/down GitHub never delays or fails a content save.
  - **Never throws** — the whole path is `pcall`-wrapped; a bug here can't break a create/update/delete.
  - **Coalesced** — a burst of edits schedules a **single** dispatch per debounce window (default 60s) using the shared `cache` dict; the rebuild re-fetches *all* content, so only the last change in a window matters.
  - **Opt-in per env** — a no-op unless `WEBSITE_DISPATCH_TOKEN` is set, so int/test stay silent and only the publishing env fires.
- **`lib/github-repo.lua`** — added `repository_dispatch()` beside the existing `dispatch_workflow()`, reusing the module's `resty.http` + auth path (no new HTTP code).
- **`queries/DocumentQueries.lua`** — `notify()` on the success path of `create` / `update` / `destroy` / `deleteMultiple` — the single choke point every document route flows through.
- **`nginx.conf`** — whitelisted the five `WEBSITE_*` env vars (OpenResty strips process env otherwise). **`.env.example`** documents them.

## Config (set only where publishing happens, e.g. prod opsapi)

| Var | Default | Notes |
|-----|---------|-------|
| `WEBSITE_DISPATCH_TOKEN` | — (unset = disabled) | GitHub PAT with **contents: write** on the repo |
| `WEBSITE_REPO_OWNER` | `bwalia` | |
| `WEBSITE_REPO_NAME` | `workstation-website` | |
| `WEBSITE_DISPATCH_EVENT` | `content-updated` | must match the workflow's `types:` |
| `WEBSITE_DISPATCH_DEBOUNCE` | `60` | seconds to coalesce a burst |

Add the token to the prod opsapi sealed-secret; leave it unset on int/test.

## Verification

- All touched Lua parses (LuaJIT `loadfile`).
- Behaviour proven with an isolated harness stubbing `ngx` + the GitHub client — **10 assertions**: disabled without token; first change schedules one timer at the right delay; a burst folds into it; firing produces exactly one dispatch with the right event/owner/repo; guard cleared after firing; env overrides applied.

## Safety notes
- Built in an isolated worktree off `main`, so the in-progress `feat/sso-oidc-provider` work in the tree was untouched and its OIDC changes are **not** in this PR.
- Fires on any successful mutation (not gated on published-status) — simplest correct behaviour; an unpublish/delete must also rebuild. Over-triggering on a draft save is harmless (idempotent rebuild) and the debounce absorbs bursts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)