### PR TITLE
feat(cms): power the workstation website — multi-category posts + rebuild-on-publish

### DIFF
--- a/lapis/.env.example
+++ b/lapis/.env.example
@@ -204,3 +204,20 @@ CORS_CREDENTIALS=true
 # to the OpenResty worker's Lua scope (already added).
 # OPSAPI_DEPLOY_ENV=local
 # LAPIS_ENVIRONMENT=development
+
+# --- Website static-site revalidation (workstation-website) ------------------
+# When a cms_post is created/updated/deleted in the workstation namespace,
+# lib/website-revalidate.lua fires a GitHub `repository_dispatch: content-updated`
+# that rebuilds + redeploys the static site. The call is async (ngx.timer) and
+# coalesced (one dispatch per debounce window), so it never blocks or fails a
+# content save. Set WEBSITE_DISPATCH_TOKEN ONLY in the env that owns publishing
+# (e.g. prod); leaving it empty disables the notifier (int/test stay silent).
+# WEBSITE_NAMESPACE_ID scopes it so only that namespace's posts fire a rebuild
+# (unset = any namespace). All must be whitelisted in nginx.conf (already added).
+#
+# WEBSITE_DISPATCH_TOKEN=       # GitHub PAT with contents:write on the repo
+# WEBSITE_NAMESPACE_ID=         # numeric namespaces.id of the workstation site
+# WEBSITE_REPO_OWNER=bwalia
+# WEBSITE_REPO_NAME=workstation-website
+# WEBSITE_DISPATCH_EVENT=content-updated
+# WEBSITE_DISPATCH_DEBOUNCE=60  # seconds to coalesce a burst of edits

--- a/lapis/lib/github-repo.lua
+++ b/lapis/lib/github-repo.lua
@@ -251,6 +251,25 @@ function GithubRepo.dispatch_workflow(opts)
     return status == 204 or status == 200, nil
 end
 
+--- Fire a repository_dispatch event (POST /repos/{owner}/{repo}/dispatches).
+--- Triggers any workflow listening on `on: repository_dispatch: types: [...]`.
+--- Unlike workflow_dispatch this needs no workflow file/ref and carries a free
+--- `client_payload`, which suits "content changed, please rebuild" signals.
+-- @param opts { token, owner, repo, event_type, client_payload? }
+-- @return true, nil  OR  nil, err
+function GithubRepo.repository_dispatch(opts)
+    assert(opts and opts.token and opts.owner and opts.repo and opts.event_type,
+        "token/owner/repo/event_type required")
+    local path = string.format("/repos/%s/%s/dispatches", opts.owner, opts.repo)
+    local _, status, err = api(opts.token, "POST", path, {
+        event_type = opts.event_type,
+        client_payload = opts.client_payload or nil,
+    })
+    if err then return nil, err end
+    -- GitHub returns 204 No Content on success.
+    return status == 204, nil
+end
+
 --- Find the workflow run created by a dispatch. workflow_dispatch returns no run
 --- id, so we poll the workflow's runs and pick the newest created at/after
 --- `since_iso` (an ISO-8601 UTC string captured just before dispatch). Retries a

--- a/lapis/lib/website-revalidate.lua
+++ b/lapis/lib/website-revalidate.lua
@@ -1,0 +1,119 @@
+--[[
+    Website revalidation notifier
+    =============================
+    When CMS blog content (a cms_post) is created / updated / soft-deleted in the
+    workstation namespace, tell the workstation-website repo to rebuild + redeploy
+    its static site by firing a GitHub `repository_dispatch: content-updated`
+    event. That workflow re-fetches published posts from this API and re-syncs the
+    live S3 root — the "revalidate" step for a statically-served site. See
+    workstation-website/docs/architecture.md.
+
+    Guarantees (why each matters for a content-save path):
+      * Non-blocking — the GitHub call runs in an ngx.timer AFTER the response is
+        sent, so a slow or down GitHub never delays or fails saving a post.
+      * Never throws — the whole scheduling path is pcall-wrapped; a bug here can
+        never break a create/update/delete.
+      * Coalesced — a burst of edits schedules a SINGLE dispatch after a short
+        debounce window (the rebuild re-fetches ALL content, so only the last
+        change in a window matters). Uses the shared `cache` dict; degrades to
+        one-timer-per-change if the dict is unavailable.
+      * Opt-in per env — a no-op unless WEBSITE_DISPATCH_TOKEN is set, so int /
+        test opsapi stay silent and only the env that owns publishing fires.
+      * Namespace-scoped — when WEBSITE_NAMESPACE_ID is set, only that namespace's
+        posts trigger a rebuild, so other tenants' CMS activity is ignored. Unset
+        = fire for any namespace (single-tenant default).
+
+    Env (must also be whitelisted in nginx.conf `env` directives):
+      WEBSITE_DISPATCH_TOKEN     GitHub PAT with contents:write on the repo.
+                                 Unset = notifier disabled.
+      WEBSITE_NAMESPACE_ID       Only this namespace's posts fire a rebuild.
+                                 Unset = any namespace.
+      WEBSITE_REPO_OWNER         default "bwalia"
+      WEBSITE_REPO_NAME          default "workstation-website"
+      WEBSITE_DISPATCH_EVENT     default "content-updated"
+      WEBSITE_DISPATCH_DEBOUNCE  seconds to coalesce a burst, default 60
+]]
+
+local GithubRepo = require("lib.github-repo")
+
+local WebsiteRevalidate = {}
+
+-- Only one dispatch may be scheduled per debounce window; this key in the shared
+-- `cache` dict is the guard (add() succeeds only when it is absent).
+local SCHED_KEY = "website_revalidate:scheduled"
+
+local function env(name, default)
+    local v = os.getenv(name)
+    if v == nil or v == "" then return default end
+    return v
+end
+
+-- Returns the resolved config, or nil when the notifier is disabled (no token).
+local function resolve_config()
+    local token = env("WEBSITE_DISPATCH_TOKEN")
+    if not token then return nil end
+    return {
+        token = token,
+        owner = env("WEBSITE_REPO_OWNER", "bwalia"),
+        repo = env("WEBSITE_REPO_NAME", "workstation-website"),
+        event_type = env("WEBSITE_DISPATCH_EVENT", "content-updated"),
+        debounce = tonumber(env("WEBSITE_DISPATCH_DEBOUNCE", "60")) or 60,
+        namespace_id = tonumber(env("WEBSITE_NAMESPACE_ID")),  -- nil = any namespace
+    }
+end
+
+-- ngx.timer callback: runs outside the request. Fires exactly one dispatch and
+-- clears the guard so the next window can schedule again.
+local function fire(premature, cfg, reason)
+    if premature then return end
+    local dict = ngx.shared.cache
+    if dict then dict:delete(SCHED_KEY) end
+    local ok, err = GithubRepo.repository_dispatch({
+        token = cfg.token,
+        owner = cfg.owner,
+        repo = cfg.repo,
+        event_type = cfg.event_type,
+        client_payload = { reason = reason, at = os.date("!%Y-%m-%dT%H:%M:%SZ") },
+    })
+    if ok then
+        ngx.log(ngx.NOTICE, "website-revalidate: dispatched '", cfg.event_type,
+            "' to ", cfg.owner, "/", cfg.repo, " (", tostring(reason), ")")
+    else
+        ngx.log(ngx.ERR, "website-revalidate: dispatch failed: ", tostring(err))
+    end
+end
+
+--- Schedule a coalesced site rebuild. Safe to call on every content mutation:
+--- never blocks, never throws, no-op when disabled, off-request, or the post is
+--- in a namespace other than the configured website namespace.
+-- @param reason string        e.g. "cms_post.created" — for logs / client_payload
+-- @param namespace_id number  the mutated post's namespace (for scoping)
+function WebsiteRevalidate.notify(reason, namespace_id)
+    local ok, err = pcall(function()
+        local cfg = resolve_config()
+        if not cfg then return end                          -- disabled (no token)
+        -- Namespace gate: when configured, ignore other tenants' posts.
+        if cfg.namespace_id and tonumber(namespace_id) ~= cfg.namespace_id then return end
+        if not (ngx and ngx.timer and ngx.timer.at) then return end  -- off-request
+
+        local dict = ngx.shared.cache
+        if dict then
+            -- First change in the window schedules the timer; the rest fold into
+            -- it. add() succeeds only while the key is absent; the TTL is a
+            -- safety net in case the timer never runs.
+            local added = dict:add(SCHED_KEY, 1, cfg.debounce + 30)
+            if not added then return end
+        end
+
+        local scheduled, terr = ngx.timer.at(cfg.debounce, fire, cfg, reason)
+        if not scheduled then
+            if dict then dict:delete(SCHED_KEY) end          -- let a later change retry
+            ngx.log(ngx.ERR, "website-revalidate: could not schedule timer: ", tostring(terr))
+        end
+    end)
+    if not ok then
+        ngx.log(ngx.ERR, "website-revalidate: notify error: ", tostring(err))
+    end
+end
+
+return WebsiteRevalidate

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -2307,6 +2307,9 @@ local _migrations = {
     ['836_cms_posts_indexes'] = conditional_array(ProjectConfig.FEATURES.CMS, cms_migrations, 4),
     ['837_create_cms_pages'] = conditional_array(ProjectConfig.FEATURES.CMS, cms_migrations, 5),
     ['838_create_cms_post_tags'] = conditional_array(ProjectConfig.FEATURES.CMS, cms_migrations, 6),
+    -- Multi-category support: post <-> category join (numbered 997 so it runs
+    -- after cms_posts/cms_categories exist; keys 839-996 are already taken).
+    ['997_create_cms_post_categories'] = conditional_array(ProjectConfig.FEATURES.CMS, cms_migrations, 7),
     -- CMS sidebar menu item + RBAC module ("cms") + role grants + enable for namespaces
     ['839_seed_cms_menu_items'] = conditional_array(ProjectConfig.FEATURES.CMS, cms_menu_migrations, 1),
     ['840_register_cms_modules'] = conditional_array(ProjectConfig.FEATURES.CMS, cms_menu_migrations, 2),

--- a/lapis/migrations/cms-system.lua
+++ b/lapis/migrations/cms-system.lua
@@ -402,4 +402,61 @@ return {
             db.query("CREATE INDEX idx_cms_post_tags_tag ON cms_post_tags (tag_id)")
         end
     end,
+
+    -- ========================================================================
+    -- [7] Create cms_post_categories (post <-> category many-to-many)
+    --     Adds multi-category support without dropping cms_posts.category_id,
+    --     which stays as the optional "primary" category (back-compat). The
+    --     join is the source of truth for the full set; existing category_id
+    --     values are backfilled so category filtering can rely on the join.
+    -- ========================================================================
+    [7] = function()
+        if table_exists("cms_post_categories") then return end
+
+        schema.create_table("cms_post_categories", {
+            { "id", types.serial },
+            { "post_id", types.integer },
+            { "category_id", types.integer },
+            { "created_at", types.time({ default = db.raw("NOW()") }) },
+            "PRIMARY KEY (id)"
+        })
+
+        pcall(function()
+            db.query([[
+                ALTER TABLE cms_post_categories
+                ADD CONSTRAINT cms_post_categories_post_fk
+                FOREIGN KEY (post_id) REFERENCES cms_posts(id) ON DELETE CASCADE
+            ]])
+        end)
+
+        pcall(function()
+            db.query([[
+                ALTER TABLE cms_post_categories
+                ADD CONSTRAINT cms_post_categories_category_fk
+                FOREIGN KEY (category_id) REFERENCES cms_categories(id) ON DELETE CASCADE
+            ]])
+        end)
+
+        pcall(function()
+            db.query([[
+                CREATE UNIQUE INDEX cms_post_categories_unique
+                ON cms_post_categories (post_id, category_id)
+            ]])
+        end)
+
+        if not index_exists("idx_cms_post_categories_category") then
+            db.query("CREATE INDEX idx_cms_post_categories_category ON cms_post_categories (category_id)")
+        end
+
+        -- Backfill: mirror each existing post's primary category_id into the
+        -- join so a category filter over the join returns pre-existing posts too.
+        pcall(function()
+            db.query([[
+                INSERT INTO cms_post_categories (post_id, category_id, created_at)
+                SELECT id, category_id, NOW() FROM cms_posts
+                WHERE category_id IS NOT NULL
+                ON CONFLICT (post_id, category_id) DO NOTHING
+            ]])
+        end)
+    end,
 }

--- a/lapis/nginx.conf
+++ b/lapis/nginx.conf
@@ -194,6 +194,20 @@ env AUTH_COOKIE_TRUSTED_DOMAINS;
 env AUTH_COOKIE_DOMAIN;
 env AUTH_COOKIE_INSECURE;
 
+# lib/website-revalidate.lua reads these to fire a GitHub repository_dispatch
+# that rebuilds the workstation-website static site when a cms_post changes.
+# openresty strips process env by default, so these must be whitelisted for
+# os.getenv() to return anything in the worker. Leaving WEBSITE_DISPATCH_TOKEN
+# unset disables the notifier (int/test stay silent; set it only where
+# publishing happens); WEBSITE_NAMESPACE_ID scopes it to one namespace.
+# See .env.example for the full matrix.
+env WEBSITE_DISPATCH_TOKEN;
+env WEBSITE_NAMESPACE_ID;
+env WEBSITE_REPO_OWNER;
+env WEBSITE_REPO_NAME;
+env WEBSITE_DISPATCH_EVENT;
+env WEBSITE_DISPATCH_DEBOUNCE;
+
 worker_processes ${{NUM_WORKERS}};
 error_log stderr notice;
 daemon off;

--- a/lapis/queries/CmsPostQueries.lua
+++ b/lapis/queries/CmsPostQueries.lua
@@ -14,6 +14,7 @@ local CmsPostModel = require "models.CmsPostModel"
 local CmsTagQueries = require "queries.CmsTagQueries"
 local Global = require "helper.global"
 local db = require("lapis.db")
+local WebsiteRevalidate = require "lib.website-revalidate"
 
 local CmsPostQueries = {}
 
@@ -180,7 +181,7 @@ CmsPostQueries.syncTags = syncTags
 --- Re-sync a post's category join rows from an array of category uuids (scoped).
 --- Categories must already exist in the namespace — unlike tags, we never
 --- auto-create them here. Duplicates and unknown/foreign uuids are ignored.
---- @return the resolved primary category_id (first valid uuid), or nil.
+-- Returns the resolved primary category_id (first valid uuid), or nil.
 local function syncCategories(namespace_id, post_id, category_uuids)
     if type(category_uuids) ~= "table" then return nil end
     local wanted = {}       -- category_id -> true
@@ -279,6 +280,7 @@ function CmsPostQueries.create(namespace_id, params)
     local post = CmsPostModel:create(insert, { returning = "*" })
     if category_uuids then syncCategories(namespace_id, post.id, category_uuids) end
     if params.tags ~= nil then syncTags(namespace_id, post.id, params.tags) end
+    WebsiteRevalidate.notify("cms_post.created", namespace_id)
     return hydrate(namespace_id, { post })[1]
 end
 
@@ -392,6 +394,7 @@ function CmsPostQueries.update(namespace_id, uuid, params)
         row:update({ category_id = primary or db.NULL, updated_at = db.raw("NOW()") })
     end
     if params.tags ~= nil then syncTags(namespace_id, row.id, params.tags) end
+    WebsiteRevalidate.notify("cms_post.updated", namespace_id)
     return CmsPostQueries.getByUuid(namespace_id, uuid)
 end
 
@@ -399,6 +402,7 @@ function CmsPostQueries.softDelete(namespace_id, uuid)
     local row = findScoped(namespace_id, uuid)
     if not row then return nil end
     row:update({ deleted_at = db.raw("NOW()"), updated_at = db.raw("NOW()") })
+    WebsiteRevalidate.notify("cms_post.deleted", namespace_id)
     return row
 end
 

--- a/lapis/queries/CmsPostQueries.lua
+++ b/lapis/queries/CmsPostQueries.lua
@@ -91,12 +91,38 @@ local function tagsForPosts(post_ids)
 end
 CmsPostQueries.tagsForPosts = tagsForPosts
 
---- Attach hydrated tags[] (and category slug/name) to a list of post rows.
+--- Fetch category rows ({name, slug, uuid}) attached to a set of post ids via
+--- the cms_post_categories join. Returns a map post_id -> array of categories.
+local function categoriesForPosts(post_ids)
+    local map = {}
+    for _, id in ipairs(post_ids) do map[id] = {} end
+    if #post_ids == 0 then return map end
+    local ph = {}
+    for i = 1, #post_ids do ph[i] = "?" end
+    local rows = db.query([[
+        SELECT pc.post_id, c.uuid, c.name, c.slug
+        FROM cms_post_categories pc
+        JOIN cms_categories c ON c.id = pc.category_id AND c.deleted_at IS NULL
+        WHERE pc.post_id IN (]] .. table.concat(ph, ", ") .. [[)
+        ORDER BY c.name ASC
+    ]], table.unpack(post_ids)) or {}
+    for _, r in ipairs(rows) do
+        local bucket = map[r.post_id]
+        if bucket then
+            table.insert(bucket, { uuid = r.uuid, name = r.name, slug = r.slug })
+        end
+    end
+    return map
+end
+CmsPostQueries.categoriesForPosts = categoriesForPosts
+
+--- Attach hydrated tags[], categories[] (and the primary category) to post rows.
 local function hydrate(namespace_id, posts)
     if #posts == 0 then return posts end
     local ids = {}
     for _, p in ipairs(posts) do ids[#ids + 1] = p.id end
     local tagMap = tagsForPosts(ids)
+    local catMap = categoriesForPosts(ids)
 
     -- Category lookup (one query for the referenced categories).
     local catRows = db.query([[
@@ -108,6 +134,9 @@ local function hydrate(namespace_id, posts)
 
     for _, p in ipairs(posts) do
         p.tags = tagMap[p.id] or {}
+        -- Full set of categories (many-to-many).
+        p.categories = catMap[p.id] or {}
+        -- Primary category kept for backward compatibility (category_id FK).
         if p.category_id and catById[p.category_id] then
             local c = catById[p.category_id]
             p.category = { uuid = c.uuid, name = c.name, slug = c.slug }
@@ -148,15 +177,80 @@ local function syncTags(namespace_id, post_id, tag_names)
 end
 CmsPostQueries.syncTags = syncTags
 
+--- Re-sync a post's category join rows from an array of category uuids (scoped).
+--- Categories must already exist in the namespace — unlike tags, we never
+--- auto-create them here. Duplicates and unknown/foreign uuids are ignored.
+--- @return the resolved primary category_id (first valid uuid), or nil.
+local function syncCategories(namespace_id, post_id, category_uuids)
+    if type(category_uuids) ~= "table" then return nil end
+    local wanted = {}       -- category_id -> true
+    local ordered = {}      -- resolved ids in input order (to pick a primary)
+    for _, uuid in ipairs(category_uuids) do
+        local cid = resolveCategoryId(namespace_id, uuid)
+        if cid and not wanted[cid] then
+            wanted[cid] = true
+            ordered[#ordered + 1] = cid
+        end
+    end
+
+    -- Existing join rows.
+    local existing = db.query("SELECT category_id FROM cms_post_categories WHERE post_id = ?", post_id) or {}
+    local have = {}
+    for _, r in ipairs(existing) do have[r.category_id] = true end
+
+    -- Insert missing.
+    for cid in pairs(wanted) do
+        if not have[cid] then
+            db.query("INSERT INTO cms_post_categories (post_id, category_id, created_at) VALUES (?, ?, NOW()) " ..
+                "ON CONFLICT (post_id, category_id) DO NOTHING", post_id, cid)
+        end
+    end
+    -- Remove stale.
+    for cid in pairs(have) do
+        if not wanted[cid] then
+            db.query("DELETE FROM cms_post_categories WHERE post_id = ? AND category_id = ?", post_id, cid)
+        end
+    end
+
+    return ordered[1]
+end
+CmsPostQueries.syncCategories = syncCategories
+
+--- Normalise category inputs: `category_uuids` (array) is authoritative when
+--- present; otherwise fall back to the legacy single `category_uuid`. Returns
+--- an array (possibly empty) or nil when neither field was supplied (caller
+--- then leaves categories untouched).
+local function normaliseCategoryUuids(params)
+    if type(params.category_uuids) == "table" then return params.category_uuids end
+    if params.category_uuid ~= nil then
+        return (params.category_uuid ~= "") and { params.category_uuid } or {}
+    end
+    return nil
+end
+
 function CmsPostQueries.create(namespace_id, params)
     local base = slugify((params.slug and params.slug ~= "") and params.slug or params.title)
     local status = params.status or "draft"
+
+    -- Multi-category: category_uuids (array) is authoritative; category_uuid
+    -- (single, legacy) is treated as a one-element list. The primary category_id
+    -- FK is the first resolvable uuid (kept for backward compatibility); the full
+    -- set is written to the join by syncCategories after the post row exists.
+    local category_uuids = normaliseCategoryUuids(params)
+    local primary_category_id
+    if category_uuids then
+        for _, uuid in ipairs(category_uuids) do
+            local cid = resolveCategoryId(namespace_id, uuid)
+            if cid then primary_category_id = cid; break end
+        end
+    end
+
     local insert = {
         uuid = Global.generateUUID(),
         namespace_id = namespace_id,
         -- Nullable FK: explicit NULL when unset (column has a DEFAULT 0 from
         -- lapis types.integer, which would violate the category FK).
-        category_id = resolveCategoryId(namespace_id, params.category_uuid) or db.NULL,
+        category_id = primary_category_id or db.NULL,
         title = params.title,
         slug = uniqueSlug(namespace_id, base),
         excerpt = params.excerpt,
@@ -183,6 +277,7 @@ function CmsPostQueries.create(namespace_id, params)
     end
 
     local post = CmsPostModel:create(insert, { returning = "*" })
+    if category_uuids then syncCategories(namespace_id, post.id, category_uuids) end
     if params.tags ~= nil then syncTags(namespace_id, post.id, params.tags) end
     return hydrate(namespace_id, { post })[1]
 end
@@ -202,7 +297,13 @@ function CmsPostQueries.list(namespace_id, params)
         table.insert(where, "p.status = ?"); table.insert(values, params.status)
     end
     if params.category_uuid and params.category_uuid ~= "" then
-        table.insert(where, "p.category_id = (SELECT id FROM cms_categories WHERE namespace_id = ? AND uuid = ? LIMIT 1)")
+        -- Match via the many-to-many join so a post shows under any of its
+        -- categories (the backfilled join includes each post's primary category).
+        table.insert(where, [[p.id IN (
+            SELECT pc.post_id FROM cms_post_categories pc
+            JOIN cms_categories c ON c.id = pc.category_id
+            WHERE c.namespace_id = ? AND c.uuid = ?
+        )]])
         table.insert(values, namespace_id); table.insert(values, params.category_uuid)
     end
     if params.is_featured ~= nil then
@@ -268,9 +369,9 @@ function CmsPostQueries.update(namespace_id, uuid, params)
     end
     if params.visibility ~= nil then fields.visibility = params.visibility end
     if params.is_featured ~= nil then fields.is_featured = params.is_featured and true or false end
-    if params.category_uuid ~= nil then
-        fields.category_id = resolveCategoryId(namespace_id, params.category_uuid) or db.NULL
-    end
+    -- Categories are synced to the join after the main update (which also sets
+    -- the primary category_id); nil = neither field supplied, leave untouched.
+    local category_uuids = normaliseCategoryUuids(params)
     if params.content_html ~= nil then
         fields.reading_minutes = readingMinutes(params.content_html)
     end
@@ -286,6 +387,10 @@ function CmsPostQueries.update(namespace_id, uuid, params)
     end
 
     row:update(fields)
+    if category_uuids then
+        local primary = syncCategories(namespace_id, row.id, category_uuids)
+        row:update({ category_id = primary or db.NULL, updated_at = db.raw("NOW()") })
+    end
     if params.tags ~= nil then syncTags(namespace_id, row.id, params.tags) end
     return CmsPostQueries.getByUuid(namespace_id, uuid)
 end
@@ -313,7 +418,13 @@ function CmsPostQueries.listPublished(namespace_id, params)
     local values = { namespace_id }
 
     if params.category and params.category ~= "" then
-        table.insert(where, "p.category_id = (SELECT id FROM cms_categories WHERE namespace_id = ? AND slug = ? LIMIT 1)")
+        -- Match via the many-to-many join (by category slug) so a post is served
+        -- under any of its categories, not only its primary one.
+        table.insert(where, [[p.id IN (
+            SELECT pc.post_id FROM cms_post_categories pc
+            JOIN cms_categories c ON c.id = pc.category_id
+            WHERE c.namespace_id = ? AND c.slug = ?
+        )]])
         table.insert(values, namespace_id); table.insert(values, params.category)
     end
     if params.tag and params.tag ~= "" then

--- a/lapis/routes/cms-posts.lua
+++ b/lapis/routes/cms-posts.lua
@@ -47,6 +47,7 @@ local function public_post(p)
         view_count = p.view_count,
         is_featured = p.is_featured,
         category = p.category,
+        categories = p.categories or {},
         tags = p.tags or {},
         seo_title = p.seo_title,
         seo_description = p.seo_description,
@@ -67,6 +68,7 @@ local function public_post_summary(p)
         reading_minutes = p.reading_minutes,
         is_featured = p.is_featured,
         category = p.category,
+        categories = p.categories or {},
         tags = p.tags or {},
     }
 end
@@ -121,6 +123,7 @@ return function(app)
                 visibility = visibility,
                 is_featured = to_bool(body.is_featured, false),
                 category_uuid = body.category_uuid,
+                category_uuids = coerce_list(body.category_uuids),
                 tags = coerce_list(body.tags),
                 author_uuid = user.uuid,
                 author_name = author_name,
@@ -156,6 +159,7 @@ return function(app)
                 if body[k] ~= nil then fields[k] = body[k] end
             end
             if body.is_featured ~= nil then fields.is_featured = to_bool(body.is_featured, false) end
+            if body.category_uuids ~= nil then fields.category_uuids = coerce_list(body.category_uuids) end
             if body.tags ~= nil then fields.tags = coerce_list(body.tags) end
 
             local post = CmsPostQueries.update(self.namespace.id, self.params.uuid, fields)

--- a/opsapi-dashboard/components/cms/PostEditor.tsx
+++ b/opsapi-dashboard/components/cms/PostEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { ArrowLeft, Save, X, Eye, Star, Loader2 } from 'lucide-react';
 import { Button, Input, Textarea, Select, Card } from '@/components/ui';
@@ -65,7 +65,13 @@ export default function PostEditor({ post }: PostEditorProps) {
   const [status, setStatus] = useState<PostStatus>(post?.status ?? 'draft');
   const [visibility, setVisibility] = useState<PostVisibility>(post?.visibility ?? 'public');
   const [isFeatured, setIsFeatured] = useState<boolean>(post?.is_featured ?? false);
-  const [categoryUuid, setCategoryUuid] = useState<string>(post?.category?.uuid ?? '');
+  const [categoryUuids, setCategoryUuids] = useState<string[]>(
+    post?.categories?.length
+      ? post.categories.map((c) => c.uuid)
+      : post?.category
+        ? [post.category.uuid]
+        : [],
+  );
   const [featuredImage, setFeaturedImage] = useState(post?.featured_image_url ?? '');
   const [authorName, setAuthorName] = useState(post?.author_name ?? '');
   const [scheduledAt, setScheduledAt] = useState(post?.scheduled_at ?? '');
@@ -120,10 +126,8 @@ export default function PostEditor({ post }: PostEditorProps) {
     }
   };
 
-  const categoryOptions = useMemo(
-    () => [{ value: '', label: 'No category' }, ...categories.map((c) => ({ value: c.uuid, label: c.name }))],
-    [categories],
-  );
+  const toggleCategory = (uuid: string) =>
+    setCategoryUuids((prev) => (prev.includes(uuid) ? prev.filter((u) => u !== uuid) : [...prev, uuid]));
 
   const buildPayload = (): PostInput => ({
     title: title.trim(),
@@ -135,7 +139,7 @@ export default function PostEditor({ post }: PostEditorProps) {
     status,
     visibility,
     is_featured: isFeatured,
-    category_uuid: categoryUuid || '',
+    category_uuids: categoryUuids,
     tags,
     author_name: authorName.trim() || undefined,
     scheduled_at: status === 'scheduled' ? scheduledAt || undefined : undefined,
@@ -304,14 +308,29 @@ export default function PostEditor({ post }: PostEditorProps) {
           </Card>
 
           <Card>
-            <h3 className="mb-3 font-semibold text-secondary-900">Category</h3>
-            <Select value={categoryUuid} onChange={(e) => setCategoryUuid(e.target.value)}>
-              {categoryOptions.map((o) => (
-                <option key={o.value || 'none'} value={o.value}>
-                  {o.label}
-                </option>
-              ))}
-            </Select>
+            <h3 className="mb-3 font-semibold text-secondary-900">Categories</h3>
+            {categories.length === 0 ? (
+              <p className="text-sm text-secondary-500">
+                No categories yet — create one under Categories first.
+              </p>
+            ) : (
+              <div className="flex max-h-56 flex-col gap-2 overflow-y-auto">
+                {categories.map((c) => (
+                  <label key={c.uuid} className="flex items-center gap-2 text-sm text-secondary-800">
+                    <input
+                      type="checkbox"
+                      className="h-4 w-4"
+                      checked={categoryUuids.includes(c.uuid)}
+                      onChange={() => toggleCategory(c.uuid)}
+                    />
+                    {c.name}
+                  </label>
+                ))}
+              </div>
+            )}
+            <p className="mt-2 text-xs text-secondary-500">
+              A post can belong to multiple categories.
+            </p>
           </Card>
 
           <Card>

--- a/opsapi-dashboard/services/cms.service.ts
+++ b/opsapi-dashboard/services/cms.service.ts
@@ -56,7 +56,8 @@ export interface CmsPost {
   reading_minutes?: number;
   view_count?: number;
   category_id?: number | null;
-  category?: CmsTaxonomyRef | null;
+  category?: CmsTaxonomyRef | null; // primary category (back-compat)
+  categories?: CmsTaxonomyRef[]; // full set (many-to-many)
   tags?: CmsTaxonomyRef[];
   created_at?: string;
   updated_at?: string;
@@ -116,7 +117,8 @@ export interface PostInput {
   status?: PostStatus;
   visibility?: PostVisibility;
   is_featured?: boolean;
-  category_uuid?: string;
+  category_uuid?: string; // legacy single category (still accepted)
+  category_uuids?: string[]; // multi-category (authoritative when present)
   tags?: string[];
   author_name?: string;
   scheduled_at?: string;
@@ -156,6 +158,7 @@ function unwrapData<T>(response: { data?: unknown }): T {
 function serializePost(data: Partial<PostInput>): Record<string, unknown> {
   const out: Record<string, unknown> = { ...data };
   if (data.tags !== undefined) out.tags = JSON.stringify(data.tags ?? []);
+  if (data.category_uuids !== undefined) out.category_uuids = JSON.stringify(data.category_uuids ?? []);
   if (data.is_featured !== undefined) out.is_featured = data.is_featured ? 'true' : 'false';
   return out;
 }


### PR DESCRIPTION
Makes the CMS the content source for the workstation website: a post can live in **multiple categories**, and publishing/editing a post **rebuilds the static site**. Website sends `namespace` + `category` from its env; the backend serves accordingly. Fully backward compatible.

## Part 1 — Multiple categories per post

A post could only be in one category (`cms_posts.category_id`). Adds a `cms_post_categories` join so a post shows under **any** of its category slugs.

- **Migration `[7]` `cms_post_categories`** (registered `997`; mirrors `cms_post_tags`; unique + FK CASCADE). **Backfills** existing `category_id` into the join; `category_id` stays as the optional **primary** category.
- **`CmsPostQueries`**: `categoriesForPosts` + `syncCategories` (resolve scoped uuids, insert-missing/delete-stale, dedup, ignore unknown, primary = first); `hydrate` returns `categories[]` + primary `category`; `create`/`update` take `category_uuids` (legacy single `category_uuid` still works); `list` + `listPublished` filter via the join.
- **`routes/cms-posts`**: accept `category_uuids`; expose `categories[]`.
- **Dashboard**: `PostEditor` single-select → **multi-select checkbox list**; `cms.service` adds `category_uuids` / `categories` and JSON-encodes like `tags`.

## Part 2 — Rebuild the site on content change

Publishing/editing/deleting a post in the **workstation namespace** fires a GitHub `repository_dispatch: content-updated`, which rebuilds + re-syncs the live S3 site. **Supersedes PR #562** (which hooked the now-unused `DocumentQueries`).

- **`lib/website-revalidate.lua`**: async (`ngx.timer`, after the response), never throws (`pcall`), coalesced (one dispatch per debounce window via the shared `cache` dict), opt-in per env (`WEBSITE_DISPATCH_TOKEN` unset = disabled), and **namespace-scoped** (`WEBSITE_NAMESPACE_ID` = only that namespace's posts fire; unset = any).
- **`lib/github-repo.lua`**: `repository_dispatch()` beside `dispatch_workflow()`, reusing its `resty.http` + auth.
- **`CmsPostQueries`**: `notify()` on create / update / softDelete, passing `namespace_id`.
- **`nginx.conf`** whitelists the six `WEBSITE_*` env vars; **`.env.example`** documents them.

## How the website consumes it (unchanged public API)
```
GET /api/v2/public/cms/{namespace}/posts?category={category-slug}   # published + public
GET /api/v2/public/cms/{namespace}/posts/{slug}
```

## Config (set only in the publishing env, e.g. prod opsapi)
| Var | Notes |
|-----|-------|
| `WEBSITE_DISPATCH_TOKEN` | GitHub PAT, `contents: write` (unset = revalidation disabled) |
| `WEBSITE_NAMESPACE_ID` | numeric `namespaces.id` of the workstation site (unset = any namespace) |
| `WEBSITE_REPO_OWNER` / `WEBSITE_REPO_NAME` | default `bwalia` / `workstation-website` |
| `WEBSITE_DISPATCH_EVENT` | default `content-updated` |
| `WEBSITE_DISPATCH_DEBOUNCE` | default `60`s |

## Verification
- All touched Lua parses (LuaJIT).
- `syncCategories` — 8-assertion stubbed harness (primary/insert/delete/dedup/unknown/empty/nil).
- Revalidation notifier — 6-assertion harness incl. the **namespace gate** (fires only for the matching namespace).
- Dashboard `tsc --noEmit` clean (0 errors).
- Built in an isolated worktree off `main`; the `feat/sso-oidc-provider` WIP was untouched.

## Migration safety
Additive (new table only), idempotent (guards + `pcall`), backfills existing data. No existing column/field changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)