### PR TITLE
feat(cms): website notifier can POST /api/revalidate (ISR mode)

### DIFF
--- a/lapis/.env.example
+++ b/lapis/.env.example
@@ -205,19 +205,25 @@ CORS_CREDENTIALS=true
 # OPSAPI_DEPLOY_ENV=local
 # LAPIS_ENVIRONMENT=development
 
-# --- Website static-site revalidation (workstation-website) ------------------
+# --- Website revalidation (workstation-website) ------------------------------
 # When a cms_post is created/updated/deleted in the workstation namespace,
-# lib/website-revalidate.lua fires a GitHub `repository_dispatch: content-updated`
-# that rebuilds + redeploys the static site. The call is async (ngx.timer) and
-# coalesced (one dispatch per debounce window), so it never blocks or fails a
-# content save. Set WEBSITE_DISPATCH_TOKEN ONLY in the env that owns publishing
-# (e.g. prod); leaving it empty disables the notifier (int/test stay silent).
-# WEBSITE_NAMESPACE_ID scopes it so only that namespace's posts fire a rebuild
-# (unset = any namespace). All must be whitelisted in nginx.conf (already added).
+# lib/website-revalidate.lua refreshes the site. Async (ngx.timer), coalesced
+# (one call per debounce window), namespace-scoped, and a no-op unless a mode is
+# configured — so int/test stay silent and only the publishing env fires.
+# WEBSITE_NAMESPACE_ID scopes it (unset = any namespace). Two modes:
 #
+# (A) ISR mode — POST /api/revalidate on the Next (K3S) server: content live in
+#     seconds, no rebuild. Takes precedence when both vars are set.
+# WEBSITE_REVALIDATE_URL=            # website base URL, e.g. https://www.workstation.co.uk
+# WEBSITE_REVALIDATE_SECRET=         # shared secret (sent as x-revalidate-secret)
+# WEBSITE_REVALIDATE_SSL_VERIFY=true # "false" for an internal/self-signed target
+#
+# (B) Static mode — GitHub repository_dispatch that rebuilds the S3 static site.
 # WEBSITE_DISPATCH_TOKEN=       # GitHub PAT with contents:write on the repo
-# WEBSITE_NAMESPACE_ID=         # numeric namespaces.id of the workstation site
 # WEBSITE_REPO_OWNER=bwalia
 # WEBSITE_REPO_NAME=workstation-website
 # WEBSITE_DISPATCH_EVENT=content-updated
+#
+# (both)
+# WEBSITE_NAMESPACE_ID=         # numeric namespaces.id of the workstation site
 # WEBSITE_DISPATCH_DEBOUNCE=60  # seconds to coalesce a burst of edits

--- a/lapis/lib/website-revalidate.lua
+++ b/lapis/lib/website-revalidate.lua
@@ -2,43 +2,56 @@
     Website revalidation notifier
     =============================
     When CMS blog content (a cms_post) is created / updated / soft-deleted in the
-    workstation namespace, tell the workstation-website repo to rebuild + redeploy
-    its static site by firing a GitHub `repository_dispatch: content-updated`
-    event. That workflow re-fetches published posts from this API and re-syncs the
-    live S3 root — the "revalidate" step for a statically-served site. See
-    workstation-website/docs/architecture.md.
+    workstation namespace, tell the workstation-website to refresh. Two delivery
+    modes, chosen by env — so the same code serves the static site today and the
+    ISR (K3S) site after the cutover:
+
+      * "revalidate" (ISR)  — POST WEBSITE_REVALIDATE_URL/api/revalidate with the
+        shared secret. The Next server busts the `cms-posts` cache tag and the
+        next request re-fetches: content live in SECONDS, no rebuild.
+        Selected when WEBSITE_REVALIDATE_URL + WEBSITE_REVALIDATE_SECRET are set.
+      * "dispatch" (static) — fire a GitHub `repository_dispatch: content-updated`
+        that rebuilds + re-syncs the S3 static site (minutes).
+        Selected when WEBSITE_DISPATCH_TOKEN is set.
+
+    revalidate mode wins when both are configured, so the cutover is just setting
+    the two revalidate env vars — no code change.
 
     Guarantees (why each matters for a content-save path):
-      * Non-blocking — the GitHub call runs in an ngx.timer AFTER the response is
-        sent, so a slow or down GitHub never delays or fails saving a post.
+      * Non-blocking — the outbound call runs in an ngx.timer AFTER the response
+        is sent, so a slow/down website never delays or fails saving a post.
       * Never throws — the whole scheduling path is pcall-wrapped; a bug here can
         never break a create/update/delete.
-      * Coalesced — a burst of edits schedules a SINGLE dispatch after a short
-        debounce window (the rebuild re-fetches ALL content, so only the last
-        change in a window matters). Uses the shared `cache` dict; degrades to
-        one-timer-per-change if the dict is unavailable.
-      * Opt-in per env — a no-op unless WEBSITE_DISPATCH_TOKEN is set, so int /
-        test opsapi stay silent and only the env that owns publishing fires.
+      * Coalesced — a burst of edits schedules a SINGLE call after a short
+        debounce window. Uses the shared `cache` dict; degrades to one-timer-
+        per-change if the dict is unavailable.
+      * Opt-in per env — a no-op unless a mode is configured, so int / test
+        opsapi stay silent and only the env that owns publishing fires.
       * Namespace-scoped — when WEBSITE_NAMESPACE_ID is set, only that namespace's
-        posts trigger a rebuild, so other tenants' CMS activity is ignored. Unset
-        = fire for any namespace (single-tenant default).
+        posts fire, so other tenants' CMS activity is ignored. Unset = any.
 
     Env (must also be whitelisted in nginx.conf `env` directives):
-      WEBSITE_DISPATCH_TOKEN     GitHub PAT with contents:write on the repo.
-                                 Unset = notifier disabled.
-      WEBSITE_NAMESPACE_ID       Only this namespace's posts fire a rebuild.
-                                 Unset = any namespace.
-      WEBSITE_REPO_OWNER         default "bwalia"
-      WEBSITE_REPO_NAME          default "workstation-website"
-      WEBSITE_DISPATCH_EVENT     default "content-updated"
-      WEBSITE_DISPATCH_DEBOUNCE  seconds to coalesce a burst, default 60
+      -- ISR mode --
+      WEBSITE_REVALIDATE_URL         website base URL; /api/revalidate is appended.
+      WEBSITE_REVALIDATE_SECRET      shared secret (sent as x-revalidate-secret).
+      WEBSITE_REVALIDATE_SSL_VERIFY  "false" to skip TLS verify (internal/self-
+                                     signed). Default verify on.
+      -- static mode --
+      WEBSITE_DISPATCH_TOKEN         GitHub PAT with contents:write on the repo.
+      WEBSITE_REPO_OWNER             default "bwalia"
+      WEBSITE_REPO_NAME              default "workstation-website"
+      WEBSITE_DISPATCH_EVENT         default "content-updated"
+      -- both --
+      WEBSITE_NAMESPACE_ID           only this namespace's posts fire. Unset = any.
+      WEBSITE_DISPATCH_DEBOUNCE      seconds to coalesce a burst, default 60.
 ]]
 
 local GithubRepo = require("lib.github-repo")
+local cjson = require("cjson")
 
 local WebsiteRevalidate = {}
 
--- Only one dispatch may be scheduled per debounce window; this key in the shared
+-- Only one call may be scheduled per debounce window; this key in the shared
 -- `cache` dict is the guard (add() succeeds only when it is absent).
 local SCHED_KEY = "website_revalidate:scheduled"
 
@@ -48,50 +61,102 @@ local function env(name, default)
     return v
 end
 
--- Returns the resolved config, or nil when the notifier is disabled (no token).
+-- Returns the resolved config, or nil when the notifier is disabled.
+-- revalidate (ISR) mode takes precedence over dispatch (static) mode.
 local function resolve_config()
+    local debounce = tonumber(env("WEBSITE_DISPATCH_DEBOUNCE", "60")) or 60
+    local namespace_id = tonumber(env("WEBSITE_NAMESPACE_ID"))  -- nil = any namespace
+
+    local revalidate_url = env("WEBSITE_REVALIDATE_URL")
+    local revalidate_secret = env("WEBSITE_REVALIDATE_SECRET")
+    if revalidate_url and revalidate_secret then
+        return {
+            mode = "revalidate",
+            url = revalidate_url:gsub("/+$", "") .. "/api/revalidate",
+            secret = revalidate_secret,
+            ssl_verify = env("WEBSITE_REVALIDATE_SSL_VERIFY", "true") ~= "false",
+            debounce = debounce,
+            namespace_id = namespace_id,
+        }
+    end
+
     local token = env("WEBSITE_DISPATCH_TOKEN")
-    if not token then return nil end
-    return {
-        token = token,
-        owner = env("WEBSITE_REPO_OWNER", "bwalia"),
-        repo = env("WEBSITE_REPO_NAME", "workstation-website"),
-        event_type = env("WEBSITE_DISPATCH_EVENT", "content-updated"),
-        debounce = tonumber(env("WEBSITE_DISPATCH_DEBOUNCE", "60")) or 60,
-        namespace_id = tonumber(env("WEBSITE_NAMESPACE_ID")),  -- nil = any namespace
-    }
+    if token then
+        return {
+            mode = "dispatch",
+            token = token,
+            owner = env("WEBSITE_REPO_OWNER", "bwalia"),
+            repo = env("WEBSITE_REPO_NAME", "workstation-website"),
+            event_type = env("WEBSITE_DISPATCH_EVENT", "content-updated"),
+            debounce = debounce,
+            namespace_id = namespace_id,
+        }
+    end
+
+    return nil  -- neither mode configured -> disabled
 end
 
--- ngx.timer callback: runs outside the request. Fires exactly one dispatch and
+-- POST the ISR revalidate webhook. Returns ok, err.
+local function post_revalidate(cfg, reason)
+    local ok_req, http = pcall(require, "resty.http")
+    if not ok_req then return nil, "resty.http not available" end
+    local httpc = http.new()
+    httpc:set_timeout(10000)
+    local res, err = httpc:request_uri(cfg.url, {
+        method = "POST",
+        headers = {
+            ["x-revalidate-secret"] = cfg.secret,
+            ["Content-Type"] = "application/json",
+            ["User-Agent"] = "opsapi-website-revalidate",
+        },
+        body = cjson.encode({ reason = reason, at = os.date("!%Y-%m-%dT%H:%M:%SZ") }),
+        ssl_verify = cfg.ssl_verify,
+    })
+    if not res then return nil, "request failed: " .. tostring(err) end
+    if res.status >= 200 and res.status < 300 then return true, nil end
+    return nil, "HTTP " .. tostring(res.status)
+end
+
+-- ngx.timer callback: runs outside the request. Fires exactly one call and
 -- clears the guard so the next window can schedule again.
 local function fire(premature, cfg, reason)
     if premature then return end
     local dict = ngx.shared.cache
     if dict then dict:delete(SCHED_KEY) end
-    local ok, err = GithubRepo.repository_dispatch({
-        token = cfg.token,
-        owner = cfg.owner,
-        repo = cfg.repo,
-        event_type = cfg.event_type,
-        client_payload = { reason = reason, at = os.date("!%Y-%m-%dT%H:%M:%SZ") },
-    })
-    if ok then
-        ngx.log(ngx.NOTICE, "website-revalidate: dispatched '", cfg.event_type,
-            "' to ", cfg.owner, "/", cfg.repo, " (", tostring(reason), ")")
+
+    if cfg.mode == "revalidate" then
+        local ok, err = post_revalidate(cfg, reason)
+        if ok then
+            ngx.log(ngx.NOTICE, "website-revalidate: revalidated ", cfg.url, " (", tostring(reason), ")")
+        else
+            ngx.log(ngx.ERR, "website-revalidate: revalidate POST failed: ", tostring(err))
+        end
     else
-        ngx.log(ngx.ERR, "website-revalidate: dispatch failed: ", tostring(err))
+        local ok, err = GithubRepo.repository_dispatch({
+            token = cfg.token,
+            owner = cfg.owner,
+            repo = cfg.repo,
+            event_type = cfg.event_type,
+            client_payload = { reason = reason, at = os.date("!%Y-%m-%dT%H:%M:%SZ") },
+        })
+        if ok then
+            ngx.log(ngx.NOTICE, "website-revalidate: dispatched '", cfg.event_type,
+                "' to ", cfg.owner, "/", cfg.repo, " (", tostring(reason), ")")
+        else
+            ngx.log(ngx.ERR, "website-revalidate: dispatch failed: ", tostring(err))
+        end
     end
 end
 
---- Schedule a coalesced site rebuild. Safe to call on every content mutation:
+--- Schedule a coalesced website refresh. Safe to call on every content mutation:
 --- never blocks, never throws, no-op when disabled, off-request, or the post is
 --- in a namespace other than the configured website namespace.
--- @param reason string        e.g. "cms_post.created" — for logs / client_payload
+-- @param reason string        e.g. "cms_post.created" — for logs / payload
 -- @param namespace_id number  the mutated post's namespace (for scoping)
 function WebsiteRevalidate.notify(reason, namespace_id)
     local ok, err = pcall(function()
         local cfg = resolve_config()
-        if not cfg then return end                          -- disabled (no token)
+        if not cfg then return end                          -- disabled (no mode set)
         -- Namespace gate: when configured, ignore other tenants' posts.
         if cfg.namespace_id and tonumber(namespace_id) ~= cfg.namespace_id then return end
         if not (ngx and ngx.timer and ngx.timer.at) then return end  -- off-request

--- a/lapis/nginx.conf
+++ b/lapis/nginx.conf
@@ -207,6 +207,10 @@ env WEBSITE_REPO_OWNER;
 env WEBSITE_REPO_NAME;
 env WEBSITE_DISPATCH_EVENT;
 env WEBSITE_DISPATCH_DEBOUNCE;
+# ISR mode: POST /api/revalidate on the Next server instead of a rebuild.
+env WEBSITE_REVALIDATE_URL;
+env WEBSITE_REVALIDATE_SECRET;
+env WEBSITE_REVALIDATE_SSL_VERIFY;
 
 worker_processes ${{NUM_WORKERS}};
 error_log stderr notice;


### PR DESCRIPTION
The last app-code piece before the K3S/ISR cutover: the OPSAPI notifier can now refresh the website **either** by `POST /api/revalidate` (ISR — content live in seconds) **or** by `repository_dispatch` (static — S3 rebuild), chosen by env. Pairs with workstation-website #154.

## Two modes, no code change to switch
- **ISR mode** — `POST WEBSITE_REVALIDATE_URL/api/revalidate` with `x-revalidate-secret`. Next busts the `cms-posts` cache tag → the next request re-fetches. **Selected when `WEBSITE_REVALIDATE_URL` + `WEBSITE_REVALIDATE_SECRET` are set, and takes precedence.**
- **Static mode** — GitHub `repository_dispatch: content-updated` → S3 rebuild (unchanged, current behavior).

So the cutover on the OPSAPI side is just setting two env vars.

## Preserved guarantees
Async (`ngx.timer`, after the response), never throws (`pcall`), coalesced per debounce window, and **namespace-scoped** (`WEBSITE_NAMESPACE_ID`). The `CmsPostQueries` hook is untouched — it calls `notify(reason, namespace_id)` regardless of mode.

## Changes
- **`lib/website-revalidate.lua`** — `resolve_config` selects the mode; `fire()` branches; new `post_revalidate()` uses `resty.http` with `WEBSITE_REVALIDATE_SSL_VERIFY` (default verify on; set `false` for an internal/self-signed target).
- **`nginx.conf`** — whitelist `WEBSITE_REVALIDATE_URL` / `_SECRET` / `_SSL_VERIFY`.
- **`.env.example`** — document both modes.

## New env (ISR mode)
| Var | Notes |
|-----|-------|
| `WEBSITE_REVALIDATE_URL` | website base URL, e.g. `https://www.workstation.co.uk` (or the internal K3S service) |
| `WEBSITE_REVALIDATE_SECRET` | must match the website's `REVALIDATE_SECRET` |
| `WEBSITE_REVALIDATE_SSL_VERIFY` | `false` to skip TLS verify for an internal/self-signed target (default on) |

## Verification
Stubbed LuaJIT harness — **9 assertions**: mode selection, POST to `<url>/api/revalidate` with the secret header, trailing-slash trim, ISR-wins-when-both-set, dispatch fallback, and the namespace gate (fires only for the matching namespace).

Built in an isolated worktree off `main`; the `feat/sso-oidc-provider` WIP was untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)