### PR TITLE
fix(workstation-opsapi): dedicated LAN Postgres for int (partition-independent)

### DIFF
--- a/devops/helm-charts/diytaxreturn-lapis/templates/cronjob.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/templates/cronjob.yaml
@@ -94,10 +94,18 @@ spec:
                       name: {{ .Release.Name }}-secrets
                       key: MINIO_BUCKET
                 - name: POSTGRES_HOST
+                  {{- if and .Values.database .Values.database.host }}
+                  # Isolation: back up from THIS release's own Postgres host
+                  # (database.host — the dedicated workstation-db), not the
+                  # shared Vault POSTGRES_HOST, so the dump targets the same
+                  # server the app writes to.
+                  value: {{ .Values.database.host | quote }}
+                  {{- else }}
                   valueFrom:
                     secretKeyRef:
                       name: {{ .Release.Name }}-secrets
                       key: POSTGRES_HOST
+                  {{- end }}
                 - name: POSTGRES_USER
                   valueFrom:
                     secretKeyRef:
@@ -229,10 +237,18 @@ spec:
                       name: {{ .Release.Name }}-secrets
                       key: MINIO_BUCKET
                 - name: POSTGRES_HOST
+                  {{- if and .Values.database .Values.database.host }}
+                  # Isolation: back up from THIS release's own Postgres host
+                  # (database.host — the dedicated workstation-db), not the
+                  # shared Vault POSTGRES_HOST, so the dump targets the same
+                  # server the app writes to.
+                  value: {{ .Values.database.host | quote }}
+                  {{- else }}
                   valueFrom:
                     secretKeyRef:
                       name: {{ .Release.Name }}-secrets
                       key: POSTGRES_HOST
+                  {{- end }}
                 - name: POSTGRES_USER
                   valueFrom:
                     secretKeyRef:

--- a/devops/helm-charts/diytaxreturn-lapis/values-workstation-int.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/values-workstation-int.yaml
@@ -68,22 +68,29 @@ ingress:
 nodeSelector:
   kubernetes.io/hostname: debworker00
 
-# DATABASE ISOLATION.
-#   `host` is intentionally left UNSET so the chart's ExternalSecret falls back
-#   to the Vault POSTGRES_HOST (diy-tax-db.int.svc — the correct in-cluster
-#   Postgres). `name` points this release at its OWN database on that same
-#   server, isolating its data from the diytaxreturn-lapis release which shares
-#   the Vault secret. Without `name`, both releases would read/write the single
-#   `opsapi` database (verified 2026-08-10: identical 810-user DB). The chart
-#   turns `name` into a POSTGRES_DB env override (see deployment.yaml).
-#   PREREQUISITE: the database must exist before deploy (pguser has no CREATEDB):
-#     kubectl exec -n int diy-tax-db-0 -- psql -U postgres \
-#       -c 'CREATE DATABASE workstation_opsapi OWNER pguser'
-#   The postStart bootstrap then migrates it fresh (projectCode=all) and seeds
-#   the admin below. Other envs (acc/test/prod) need their own DB + this same
-#   block before they are stood up, or they will share that env's diytax DB.
+# DATABASE — dedicated Postgres on the LAN (moved here 2026-08-19).
+#   `host` points this release at its OWN `workstation-db` Postgres
+#   (devops/k8s/workstation-db.yaml — pgvector/pgvector:pg15 pinned to
+#   debworker00), NOT the shared Zalando `diy-tax-db`. Why the move: diy-tax-db
+#   runs on a cloud edge node (cloud002) whose `local-path` volume was wiped on
+#   reschedule — dropping workstation_opsapi — and the cloud<->LAN WireGuard mesh
+#   is down, so a LAN-pinned app (nodeSelector debworker00) cannot reach a
+#   cloud-pinned DB. A dedicated LAN DB co-located with the app + wslproxy
+#   ingress removes that cross-segment dependency entirely (data isolation AND
+#   partition-independence). The chart bakes `host` into config.lua (see
+#   externalsecret.yaml) and `name` into a POSTGRES_DB env override (see
+#   deployment.yaml). pguser reuses the Vault password; the database, the
+#   `vector` pgvector extension (needed by the tax-classifier migration), and an
+#   initdb self-heal for that extension are all provisioned by the manifest.
 database:
   name: workstation_opsapi
+  host: workstation-db.int.svc.cluster.local
+
+# The dedicated workstation-db is a PLAIN Postgres with NO TLS, unlike the
+# Zalando diy-tax-db which enforced it (hostnossl reject). config.lua reads
+# POSTGRES_SSL (default "true" in the chart) to switch on pgmoon SSL — force it
+# OFF here or every DB call is rejected with "no encryption" and the API 500s.
+postgresSsl: "false"
 
 externalSecret:
   enabled: true

--- a/devops/k8s/workstation-db.yaml
+++ b/devops/k8s/workstation-db.yaml
@@ -1,0 +1,171 @@
+# workstation-db — dedicated Postgres owned by the WORKSTATION opsapi product.
+#
+# Why this exists (and why it is NOT diy-tax-db)
+# ----------------------------------------------
+# `int-opsapi.workstation.co.uk` (Helm release `workstation-opsapi`) used to run
+# on its own `workstation_opsapi` database INSIDE the shared Zalando `diy-tax-db`
+# cluster. That cluster runs on a cloud EDGE node (cloud002) with `local-path`
+# (node-local) storage, and the cluster is split into two network segments that
+# cannot do cross-segment pod networking:
+#   * cloud edge nodes (cloud001/002/003, public IPs, edge NoSchedule taint)
+#   * LAN worker nodes  (debianNNN / debworker00, 192.168.1.x) — run the
+#     wslproxy ingress that fronts *.workstation.co.uk
+# The bridge is a WireGuard mesh (wg0, 10.8.0.0/24) that is currently DOWN
+# (Ansible-managed, "rolled back"). On 2026-08-19 diy-tax-db was rescheduled
+# onto a fresh/empty local-path volume — wiping workstation_opsapi — and, being
+# cloud-pinned, it also sat on the far side of the partition from this
+# LAN-pinned app. Result: int-opsapi 503/timeout.
+#
+# Fix: give workstation its own Postgres ON THE LAN (debworker00), co-located
+# with the app and the wslproxy ingress, so nothing it needs crosses the broken
+# mesh. This is partition-independent AND fully data-isolated. The app is
+# repointed at it by `database.host` in values-workstation-int.yaml.
+#
+# Image: pgvector/pgvector:pg15 — the tax-classifier migration
+# (classification_reference_data) uses the `vector(384)` type, so the pgvector
+# extension MUST be available. The initdb ConfigMap below self-heals the
+# `CREATE EXTENSION vector` on a FRESH volume so a future wipe recovers on its
+# own (the app's postStart bootstrap then migrates + seeds it).
+#
+# Credentials: pguser REUSES the app's Vault password so the app connects with
+# no change. The `workstation-db-auth` Secret is provisioned by the
+# ExternalSecret below from the same Vault path the app reads
+# (secret/diytaxreturnuk/opsapi/int/config, property POSTGRES_PASSWORD) — no
+# plaintext in git (this repo is public).
+#
+# Apply (one-time; the StatefulSet's PVC persists across app redeploys):
+#   kubectl apply -f devops/k8s/workstation-db.yaml
+#
+# Other envs (acc/test/prod) that follow this pattern need their own copy of
+# this manifest (distinct names/host + the matching Vault path) before the
+# release is repointed off diy-tax-db.
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: workstation-db-auth
+  namespace: int
+  labels:
+    app: workstation-db
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: workstation-db-auth
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: POSTGRES_PASSWORD
+      remoteRef:
+        key: secret/diytaxreturnuk/opsapi/int/config
+        property: POSTGRES_PASSWORD
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: workstation-db-initdb
+  namespace: int
+  labels:
+    app: workstation-db
+data:
+  # Runs ONLY on a fresh (empty) data volume, against POSTGRES_DB
+  # (workstation_opsapi). Makes the pgvector type available before the app's
+  # first `lapis migrate`, so a wiped/rebuilt volume self-heals.
+  01-extensions.sql: |
+    CREATE EXTENSION IF NOT EXISTS vector;
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: workstation-db
+  namespace: int
+  labels:
+    app: workstation-db
+spec:
+  type: ClusterIP
+  selector:
+    app: workstation-db
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: workstation-db
+  namespace: int
+  labels:
+    app: workstation-db
+spec:
+  serviceName: workstation-db
+  replicas: 1
+  selector:
+    matchLabels:
+      app: workstation-db
+  template:
+    metadata:
+      labels:
+        app: workstation-db
+    spec:
+      # Pin to the same LAN node as the app + ingress so the DB is never on the
+      # far side of the cloud<->LAN partition.
+      nodeSelector:
+        kubernetes.io/hostname: debworker00
+      containers:
+        - name: postgres
+          image: pgvector/pgvector:pg15
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              value: pguser
+            - name: POSTGRES_DB
+              value: workstation_opsapi
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: workstation-db-auth
+                  key: POSTGRES_PASSWORD
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "pg_isready -U pguser -d workstation_opsapi -h 127.0.0.1"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "pg_isready -U pguser -h 127.0.0.1"]
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            - name: initdb
+              mountPath: /docker-entrypoint-initdb.d
+      volumes:
+        - name: initdb
+          configMap:
+            name: workstation-db-initdb
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: local-path
+        resources:
+          requests:
+            storage: 5Gi


### PR DESCRIPTION
## Problem

`https://int-opsapi.workstation.co.uk/` was down (503 → timeout). Root cause was a chain:

1. **Network partition** — the WireGuard mesh (`wg0`, `10.8.0.0/24`) that bridges the **cloud edge nodes** (`cloud00x`, where the shared Zalando `diy-tax-db` lives) and the **LAN worker nodes** (`debworker00`, where this app + the wslproxy ingress run) is **down** (Ansible-managed, "rolled back"). Cross-segment pod traffic black-holes.
2. **Lost DB** — `diy-tax-db` (on cloud002, `local-path` storage) was rescheduled onto a **fresh empty volume**, wiping `workstation_opsapi`, and it sat on the far side of the partition from the LAN-pinned app.
3. **pgvector** — the tax-classifier migration (`classification_reference_data`) needs the `vector` type.

## Fix — give workstation its own LAN Postgres

Co-locate a dedicated Postgres with the app + ingress on `debworker00`, so nothing it needs crosses the broken mesh. Partition-independent **and** fully data-isolated (which is what this release was always meant to be).

- **`devops/k8s/workstation-db.yaml` (new)** — `pgvector/pgvector:pg15` StatefulSet + Service + initdb ConfigMap (self-heals `CREATE EXTENSION vector` on a fresh volume) + ExternalSecret (pguser password pulled from the same Vault path the app uses — no plaintext in git).
- **`values-workstation-int.yaml`** — `database.host: workstation-db.int.svc.cluster.local` and `postgresSsl: "false"` (plain Postgres has no TLS; diy-tax-db enforced it). The chart already bakes `database.host` into `config.lua` and reads `postgresSsl`, so **the next Helm deploy connects to the new DB with no further change**.
- **`cronjob.yaml`** — backups honour `database.host`, so dumps target the new DB.

## Live status

Applied to the cluster and verified: `int-opsapi` root/health/ready = **200**, UI = 200, DB seeded (namespace `workstation`, admin, 42 modules), pgvector 0.8.6. Live now matches this branch.

## Notes / follow-ups (not in this PR)

- The **cloud↔LAN WireGuard mesh** is still down — an Ansible/host fix for whoever owns it. int-opsapi no longer depends on it, but other cross-segment services (and `kubectl exec/logs` into cloud00x pods) remain affected.
- `/health` shows **MinIO "degraded"** — the internal endpoint (`diytaxreturn-minio` on cloud002) is cross-partition; file/S3 ops via the internal endpoint won't work from the LAN until the mesh heals or MinIO is repointed to the workstation-owned MinIO.
- `workstation-db.yaml` is a one-time `kubectl apply` (like `workstation-minio.yaml`); its PVC persists across app redeploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)