### PR TITLE
feat(cms): pg_trgm post-search index + webhook/public-endpoint hardening

### DIFF
--- a/lapis/lib/webhook-dispatcher.lua
+++ b/lapis/lib/webhook-dispatcher.lua
@@ -45,7 +45,7 @@ function WebhookDispatcher.trigger(webhook, event, data)
     local ok, http = pcall(require, "resty.http")
     if not ok then return false, nil, "resty.http not available" end
     local httpc = http.new()
-    httpc:set_timeout(10000)
+    httpc:set_timeouts(2000, 5000, 5000)
     local res, err = httpc:request_uri(webhook.url, {
         method = "POST",
         headers = {

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -2311,6 +2311,7 @@ local _migrations = {
     -- after cms_posts/cms_categories exist; keys 839-996 are already taken).
     ['997_create_cms_post_categories'] = conditional_array(ProjectConfig.FEATURES.CMS, cms_migrations, 7),
     ['998_create_cms_webhooks'] = conditional_array(ProjectConfig.FEATURES.CMS, cms_migrations, 8),
+    ['999_cms_posts_search_trgm'] = conditional_array(ProjectConfig.FEATURES.CMS, cms_migrations, 9),
     -- CMS sidebar menu item + RBAC module ("cms") + role grants + enable for namespaces
     ['839_seed_cms_menu_items'] = conditional_array(ProjectConfig.FEATURES.CMS, cms_menu_migrations, 1),
     ['840_register_cms_modules'] = conditional_array(ProjectConfig.FEATURES.CMS, cms_menu_migrations, 2),

--- a/lapis/migrations/cms-system.lua
+++ b/lapis/migrations/cms-system.lua
@@ -506,4 +506,24 @@ return {
             ]])
         end
     end,
+
+    -- ========================================================================
+    -- [9] Search indexing: pg_trgm GIN indexes so listPublished's
+    --     `title ILIKE '%q%' OR excerpt ILIKE '%q%'` is index-backed (a plain
+    --     btree can't serve a leading-wildcard LIKE). All guarded, so a lack of
+    --     the extension/privilege degrades to a seq scan rather than failing.
+    -- ========================================================================
+    [9] = function()
+        pcall(function() db.query("CREATE EXTENSION IF NOT EXISTS pg_trgm") end)
+        if not index_exists("idx_cms_posts_title_trgm") then
+            pcall(function()
+                db.query("CREATE INDEX idx_cms_posts_title_trgm ON cms_posts USING gin (title gin_trgm_ops)")
+            end)
+        end
+        if not index_exists("idx_cms_posts_excerpt_trgm") then
+            pcall(function()
+                db.query("CREATE INDEX idx_cms_posts_excerpt_trgm ON cms_posts USING gin (excerpt gin_trgm_ops)")
+            end)
+        end
+    end,
 }

--- a/lapis/queries/CmsPostQueries.lua
+++ b/lapis/queries/CmsPostQueries.lua
@@ -287,7 +287,7 @@ end
 function CmsPostQueries.list(namespace_id, params)
     params = params or {}
     local page = tonumber(params.page) or 1
-    local perPage = tonumber(params.perPage) or 20
+    local perPage = math.min(math.max(tonumber(params.perPage) or 20, 1), 100)
     local offset = (page - 1) * perPage
 
     local where = { "p.namespace_id = ?", "p.deleted_at IS NULL" }
@@ -410,7 +410,7 @@ end
 function CmsPostQueries.listPublished(namespace_id, params)
     params = params or {}
     local page = tonumber(params.page) or 1
-    local perPage = tonumber(params.perPage) or 12
+    local perPage = math.min(math.max(tonumber(params.perPage) or 12, 1), 50)
     local offset = (page - 1) * perPage
 
     local where = { "p.namespace_id = ?", "p.deleted_at IS NULL",

--- a/lapis/routes/cms-webhooks.lua
+++ b/lapis/routes/cms-webhooks.lua
@@ -57,11 +57,8 @@ return function(app)
     app:post("/api/v2/cms/webhooks", AuthMiddleware.requireAuth(
         NamespaceMiddleware.requirePermission("cms", "create", function(self)
             local body = parse_body()
-            if not body.url or body.url == "" then
-                return api_response(400, nil, "url is required")
-            end
-            if not body.url:match("^https?://") then
-                return api_response(400, nil, "url must be http(s)")
+            if type(body.url) ~= "string" or not body.url:match("^https?://") then
+                return api_response(400, nil, "url must be a valid http(s) URL")
             end
             local webhook = CmsWebhookQueries.create(self.namespace.id, {
                 name = body.name,
@@ -83,8 +80,8 @@ return function(app)
     app:put("/api/v2/cms/webhooks/:uuid", AuthMiddleware.requireAuth(
         NamespaceMiddleware.requirePermission("cms", "update", function(self)
             local body = parse_body()
-            if body.url ~= nil and body.url ~= "" and not body.url:match("^https?://") then
-                return api_response(400, nil, "url must be http(s)")
+            if body.url ~= nil and (type(body.url) ~= "string" or not body.url:match("^https?://")) then
+                return api_response(400, nil, "url must be a valid http(s) URL")
             end
             local fields = {}
             for _, k in ipairs({ "name", "url", "secret", "events" }) do


### PR DESCRIPTION
Follow-up to #565 (generic per-tenant outgoing webhooks). Adds the search index the website's server-side search relies on, plus a hardening pass on the CMS public + webhook endpoints.

## Changes
- **pg_trgm GIN index** (`999_cms_posts_search_trgm`) on `cms_posts` title/excerpt so the public `?search=` on `listPublished` is index-backed (`ILIKE '%q%'`), not a scan. Migration is `pcall`-guarded and idempotent.
- **`listPublished` perPage clamp** — public 1..50, admin 1..100, so a caller can't request an unbounded page and exhaust the DB.
- **Webhook `url` type-guard** — type-check before `:match` (a non-string JSON value no longer crashes the route); single clear error on create + update.
- **Dispatcher timeouts** — `set_timeouts(connect, send, read)` instead of one 10s blanket timeout, so a slow/black-hole receiver can't pin a request.

## Notes
- SaaS-safe: no website-specific coupling; all generic per-tenant behaviour.
- `luajit -bl` syntax-checked each touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)