### PR TITLE
feat(auth): namespace-scoped API keys for server-to-server access

### DIFF
--- a/lapis/app.lua
+++ b/lapis/app.lua
@@ -289,10 +289,15 @@ app:before_filter(function(self)
         -- Populate self.current_user from ngx.ctx.user for Lapis routes
         if ngx.ctx.user then
             self.current_user = ngx.ctx.user
-            -- Ensure user has a default namespace (lazy assignment on first request)
-            local ns_ok, ns_resolver = pcall(require, "helper.namespace-resolver")
-            if ns_ok then
-                pcall(ns_resolver.resolve, self.current_user)
+            self.api_key_auth = ngx.ctx.api_key_auth or nil
+            -- Ensure user has a default namespace (lazy assignment on first
+            -- request). API-key principals are not users — resolving one would
+            -- create membership rows for them, so skip it.
+            if not ngx.ctx.api_key_auth then
+                local ns_ok, ns_resolver = pcall(require, "helper.namespace-resolver")
+                if ns_ok then
+                    pcall(ns_resolver.resolve, self.current_user)
+                end
             end
         end
     end
@@ -371,6 +376,7 @@ safe_load_routes("routes.projects")
 safe_load_routes("routes.enquiries")
 safe_load_routes("routes.register")
 safe_load_routes("routes.namespaces")
+safe_load_routes("routes.api-keys")
 safe_load_routes("routes.email")
 safe_load_routes("routes.project-dashboard")
 

--- a/lapis/helper/api-key.lua
+++ b/lapis/helper/api-key.lua
@@ -35,6 +35,25 @@ function ApiKey.is_api_key(token)
     return type(token) == "string" and token:sub(1, #ApiKey.PREFIX) == ApiKey.PREFIX
 end
 
+--- May a key principal touch this URI?
+--
+-- Scope enforcement proper lives in the namespace middleware, but plenty of
+-- routes authenticate with requireAuth alone and never establish a namespace —
+-- on those, nothing would check a key's scopes at all. So keys are confined
+-- here, centrally and fail-closed: a key may only reach /api/v2/<module>/...
+-- for a module it is actually scoped for. Anything else is refused before the
+-- handler runs, including any route added later.
+-- @param principal table from ApiKey.authenticate
+-- @param uri string ngx.var.uri
+-- @return boolean
+function ApiKey.permits_uri(principal, uri)
+    if type(uri) ~= "string" then return false end
+    local module_name = uri:match("^/api/v2/([^/]+)/")
+    if not module_name then return false end
+    local scopes = principal and principal.scopes or {}
+    return scopes[module_name] ~= nil
+end
+
 --- Hash a raw key with SHA-256 for storage/lookup.
 -- @param raw string
 -- @return string Hex-encoded SHA-256 hash

--- a/lapis/helper/api-key.lua
+++ b/lapis/helper/api-key.lua
@@ -1,0 +1,156 @@
+--[[
+    API Key Helper (helper/api-key.lua)
+
+    Generates and authenticates namespace-scoped machine credentials.
+
+    A raw key is "opsk_" + 48 hex chars (24 random bytes), shown once at
+    creation and stored only as a SHA-256 hash (same scheme as
+    helper/refresh-token.lua). At request time the key arrives as
+    "Authorization: Bearer opsk_..." — the "opsk_" prefix is what routes a
+    bearer token here instead of to JWT verification.
+
+    authenticate() returns a *principal* table shaped so the rest of the
+    stack works unchanged: it carries api_key = true (the discriminator
+    every layer checks), the owning namespace row, and the key's scopes in
+    the same {module -> [actions]} shape as namespace role permissions.
+]]
+
+local db = require("lapis.db")
+local cjson = require("cjson")
+
+local ApiKey = {}
+
+ApiKey.PREFIX = "opsk_"
+
+-- How much of the raw key is kept in clear for display ("opsk_a1b2c3d").
+local PREFIX_DISPLAY_LEN = 12
+
+-- last_used_at is on the hot path; only touch it when it is older than this.
+local LAST_USED_THROTTLE_SECONDS = 60
+
+--- Does this bearer token look like an API key (vs a JWT)?
+-- @param token string|nil
+-- @return boolean
+function ApiKey.is_api_key(token)
+    return type(token) == "string" and token:sub(1, #ApiKey.PREFIX) == ApiKey.PREFIX
+end
+
+--- Hash a raw key with SHA-256 for storage/lookup.
+-- @param raw string
+-- @return string Hex-encoded SHA-256 hash
+function ApiKey.hash(raw)
+    local resty_sha256 = require("resty.sha256")
+    local str = require("resty.string")
+    local sha = resty_sha256:new()
+    sha:update(raw)
+    return str.to_hex(sha:final())
+end
+
+--- Generate a new key.
+-- @return string raw key ("opsk_" + 48 hex) — send to the caller, never stored
+-- @return string key_prefix (first 12 chars, display only)
+-- @return string key_hash (SHA-256 hex, what gets persisted)
+function ApiKey.generate()
+    local resty_random = require("resty.random")
+    local bytes = resty_random.bytes(24)
+    local hex
+    if bytes then
+        local parts = {}
+        for i = 1, #bytes do
+            parts[#parts + 1] = string.format("%02x", string.byte(bytes, i))
+        end
+        hex = table.concat(parts)
+    else
+        -- Fallback (less secure, but functional)
+        math.randomseed(ngx.now() * 1000 + ngx.worker.pid())
+        local parts = {}
+        for _ = 1, 24 do
+            parts[#parts + 1] = string.format("%02x", math.random(0, 255))
+        end
+        hex = table.concat(parts)
+    end
+
+    local raw = ApiKey.PREFIX .. hex
+    return raw, raw:sub(1, PREFIX_DISPLAY_LEN), ApiKey.hash(raw)
+end
+
+--- Opportunistically record use, at most once per throttle window.
+local function touch_last_used(key_id)
+    pcall(function()
+        db.query([[
+            UPDATE api_keys SET last_used_at = NOW()
+            WHERE id = ?
+              AND (last_used_at IS NULL OR last_used_at < NOW() - INTERVAL ']] ..
+            LAST_USED_THROTTLE_SECONDS .. [[ seconds')
+        ]], key_id)
+    end)
+end
+
+--- Authenticate a raw API key.
+-- @param raw string The bearer token (already known to carry the opsk_ prefix)
+-- @return table|nil principal (see module docstring) if the key is valid
+-- @return string|nil error message
+-- @return number|nil HTTP status for the error (401 or 403)
+function ApiKey.authenticate(raw)
+    if not raw or raw == "" then
+        return nil, "API key is required", 401
+    end
+
+    local rows = db.query([[
+        SELECT ak.id, ak.uuid, ak.name, ak.namespace_id, ak.scopes,
+               ak.expires_at, ak.revoked_at,
+               (ak.expires_at IS NOT NULL AND ak.expires_at < NOW()) AS is_expired,
+               ns.id AS ns_id, ns.uuid AS ns_uuid, ns.slug AS ns_slug,
+               ns.name AS ns_name, ns.status AS ns_status
+        FROM api_keys ak
+        JOIN namespaces ns ON ns.id = ak.namespace_id
+        WHERE ak.key_hash = ?
+        LIMIT 1
+    ]], ApiKey.hash(raw))
+
+    if not rows or #rows == 0 then
+        return nil, "Invalid API key", 401
+    end
+    local row = rows[1]
+
+    if row.revoked_at and row.revoked_at ~= ngx.null then
+        return nil, "API key has been revoked", 401
+    end
+    if row.is_expired then
+        return nil, "API key has expired", 401
+    end
+    if row.ns_status and row.ns_status ~= ngx.null and row.ns_status ~= "active" then
+        return nil, "Namespace is not accessible", 403
+    end
+
+    local scopes = {}
+    if row.scopes and row.scopes ~= ngx.null and row.scopes ~= "" then
+        local ok, decoded = pcall(cjson.decode, row.scopes)
+        if ok and type(decoded) == "table" then scopes = decoded end
+    end
+
+    touch_last_used(row.id)
+
+    return {
+        api_key = true,
+        key_id = row.id,
+        key_uuid = row.uuid,
+        key_name = row.name,
+        namespace_id = row.namespace_id,
+        namespace = {
+            id = row.ns_id,
+            uuid = row.ns_uuid,
+            slug = row.ns_slug,
+            name = row.ns_name,
+            status = row.ns_status,
+        },
+        scopes = scopes,
+        -- User-ish fields so downstream code that reads a user degrades
+        -- gracefully: the uuid matches no users row, so admin lookups and
+        -- author resolution simply come back empty.
+        uuid = row.uuid,
+        username = "api-key:" .. (row.name or row.uuid),
+    }, nil, nil
+end
+
+return ApiKey

--- a/lapis/helper/auth.lua
+++ b/lapis/helper/auth.lua
@@ -76,6 +76,25 @@ function _M.authenticate()
         ngx.exit(401)
     end
 
+    -- API keys ("opsk_...") are opaque credentials, not JWTs — authenticate
+    -- against the api_keys table instead of verifying a signature.
+    local ApiKeyHelper = require("helper.api-key")
+    if ApiKeyHelper.is_api_key(token) then
+        local principal, err_msg, err_status = ApiKeyHelper.authenticate(token)
+        if not principal then
+            ngx.log(ngx.WARN, "API key authentication failed: ", err_msg or "unknown")
+            ngx.status = err_status or 401
+            ngx.header.content_type = "application/json"
+            ngx.say('{"error":"' .. (err_msg or "Invalid API key") .. '"}')
+            ngx.exit(err_status or 401)
+        end
+        ngx.ctx.user = principal
+        ngx.ctx.api_key_auth = true
+        ngx.log(ngx.NOTICE, "API key authentication successful: ", principal.key_uuid,
+            " (namespace ", tostring(principal.namespace.slug), ")")
+        return
+    end
+
     -- Verify JWT
     local JWT_SECRET_KEY = Global.getEnvVar("JWT_SECRET_KEY")
     if not JWT_SECRET_KEY then

--- a/lapis/helper/auth.lua
+++ b/lapis/helper/auth.lua
@@ -88,6 +88,17 @@ function _M.authenticate()
             ngx.say('{"error":"' .. (err_msg or "Invalid API key") .. '"}')
             ngx.exit(err_status or 401)
         end
+        -- Confine the key to the modules it is scoped for. Routes that use
+        -- requireAuth without namespace middleware never check scopes, so
+        -- without this a cms-only key would reach them.
+        if not ApiKeyHelper.permits_uri(principal, uri) then
+            ngx.log(ngx.WARN, "API key ", principal.key_uuid, " denied for out-of-scope URI: ", uri)
+            ngx.status = 403
+            ngx.header.content_type = "application/json"
+            ngx.say('{"error":"API key is not scoped for this endpoint"}')
+            ngx.exit(403)
+        end
+
         ngx.ctx.user = principal
         ngx.ctx.api_key_auth = true
         ngx.log(ngx.NOTICE, "API key authentication successful: ", principal.key_uuid,

--- a/lapis/middleware/auth.lua
+++ b/lapis/middleware/auth.lua
@@ -15,6 +15,24 @@ function AuthMiddleware.authenticate(self)
         return nil, { error = "Invalid authorization format", status = 401 }
     end
 
+    -- API keys ("opsk_...") are opaque credentials, not JWTs. The global
+    -- before_filter usually verified this request already — reuse its result
+    -- instead of hitting the database again.
+    local ApiKeyHelper = require("helper.api-key")
+    if ApiKeyHelper.is_api_key(token) then
+        if ngx.ctx.api_key_auth and ngx.ctx.user then
+            return ngx.ctx.user, nil
+        end
+        local principal, err_msg, err_status = ApiKeyHelper.authenticate(token)
+        if not principal then
+            ngx.log(ngx.WARN, "API key authentication failed: ", err_msg or "unknown")
+            return nil, { error = err_msg or "Invalid API key", status = err_status or 401 }
+        end
+        ngx.ctx.user = principal
+        ngx.ctx.api_key_auth = true
+        return principal, nil
+    end
+
     local JWT_SECRET_KEY = Global.getEnvVar("JWT_SECRET_KEY")
     if not JWT_SECRET_KEY then
         return nil, { error = "JWT secret not configured", status = 500 }
@@ -56,6 +74,7 @@ function AuthMiddleware.requireAuth(handler)
 
         ngx.log(ngx.INFO, "Authentication successful for user: " .. (user.uuid or user.sub or "unknown"))
         self.current_user = user
+        self.api_key_auth = user.api_key == true or nil
         return handler(self)
     end
 end
@@ -82,6 +101,7 @@ function AuthMiddleware.requireAuthBefore(self)
 
     ngx.log(ngx.INFO, "Authentication successful for user: " .. (user and (user.uuid or user.sub) or "unknown"))
     self.current_user = user
+    self.api_key_auth = (user and user.api_key == true) or nil
 end
 
 function AuthMiddleware.requireRole(role, handler)

--- a/lapis/middleware/namespace.lua
+++ b/lapis/middleware/namespace.lua
@@ -73,6 +73,47 @@ end
 -- @return function Wrapped handler
 function NamespaceMiddleware.requireNamespace(handler)
     return function(self)
+        -- API-key principals are bound to exactly one namespace and have no
+        -- namespace_members row: their namespace comes from the key itself and
+        -- their permissions are the key's scopes. Namespace headers are allowed
+        -- only when they match the key's namespace — a key can never reach
+        -- another tenant. Keys are never owners or platform admins.
+        if self.current_user and self.current_user.api_key then
+            local ns = self.current_user.namespace or {}
+
+            local header_id = self.req.headers["x-namespace-id"]
+            local header_slug = self.req.headers["x-namespace-slug"]
+            if (header_id and header_id ~= "" and
+                    header_id ~= tostring(ns.id) and header_id ~= ns.uuid)
+                or (header_slug and header_slug ~= "" and header_slug ~= ns.slug) then
+                ngx.log(ngx.WARN, "API key ", self.current_user.key_uuid,
+                    " used with a namespace it does not belong to")
+                return {
+                    json = { error = "API key is not valid for the requested namespace" },
+                    status = 403
+                }
+            end
+
+            if ns.status ~= "active" then
+                return {
+                    json = { error = "Namespace is not accessible", status = ns.status },
+                    status = 403
+                }
+            end
+
+            self.namespace = ns
+            self.namespace_membership = nil
+            self.namespace_member = nil
+            self.namespace_permissions = self.current_user.scopes or {}
+            self.is_namespace_owner = false
+            self.is_platform_admin = false
+            self.api_key_auth = true
+
+            ngx.log(ngx.INFO, "Namespace context set: ", ns.slug,
+                " for API key: ", self.current_user.key_uuid)
+            return handler(self)
+        end
+
         -- Extract namespace identifier
         local namespace_identifier = extractNamespaceIdentifier(self)
 

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -150,6 +150,10 @@ local cms_menu_migrations = load_if_enabled(ProjectConfig.FEATURES.CMS, "migrati
 -- namespace-scoped, used by CMS pages + domains, so it isn't feature-gated.
 local render_template_migrations = require("migrations.render-templates")
 
+-- API keys (namespace-scoped machine credentials). Core/always-on: any
+-- project may grant server-to-server access, so it isn't feature-gated.
+local api_key_migrations = require("migrations.api-keys")
+
 -- Core enhancements (always load for namespace/rbac)
 local rbac_enhancements_migrations = require("migrations.rbac-enhancements")
 local namespace_system_migrations = require("migrations.namespace-system")
@@ -2323,6 +2327,9 @@ local _migrations = {
     ['843_create_render_templates'] = render_template_migrations[1],
     ['844_register_templates_module'] = render_template_migrations[2],
     ['845_render_templates_allow_domain_rule'] = render_template_migrations[3],
+
+    -- API keys (core): namespace-scoped machine credentials.
+    ['845_create_api_keys'] = api_key_migrations[1],
 
     -- Theme system foundation (Phase 0): drop obsolete scaffold.
     -- Replaced by new tables in Phase 1 migration 621_create_theme_system.

--- a/lapis/migrations/api-keys.lua
+++ b/lapis/migrations/api-keys.lua
@@ -1,0 +1,78 @@
+--[[
+    API Keys Migrations
+    ===================
+
+    Namespace-scoped machine credentials for server-to-server API access
+    (e.g. jobshout filing CMS drafts). A key is an opaque secret shaped
+    "opsk_" + 48 hex chars, shown once at creation and stored only as a
+    SHA-256 hash so a database leak does not expose usable credentials.
+
+    Each key carries its own permissions JSON ({"cms":["create"]}), which
+    at request time is dropped into self.namespace_permissions in place of
+    a member's role permissions — a key is never an owner or admin.
+
+    Tables:
+      1. api_keys
+
+    Management is gated on the existing namespace.manage permission
+    (NamespaceMiddleware.requireAdmin); no new RBAC module is registered.
+]]
+
+local schema = require("lapis.db.schema")
+local types = schema.types
+local db = require("lapis.db")
+
+local function table_exists(name)
+    local r = db.query([[SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = ?) as exists]], name)
+    return r[1] and r[1].exists
+end
+local function index_exists(name)
+    local r = db.query([[SELECT EXISTS (SELECT FROM pg_indexes WHERE indexname = ?) as exists]], name)
+    return r[1] and r[1].exists
+end
+
+return {
+    -- ========================================================================
+    -- [1] Create api_keys
+    -- ========================================================================
+    [1] = function()
+        if table_exists("api_keys") then return end
+
+        schema.create_table("api_keys", {
+            { "id", types.serial },
+            { "uuid", types.varchar({ unique = true }) },
+            { "namespace_id", types.integer },
+            { "name", types.varchar },
+            { "key_prefix", types.varchar },                  -- first 12 chars, for display only
+            { "key_hash", types.varchar({ unique = true }) }, -- SHA-256 hex of the full raw key
+            { "scopes", types.text },                         -- JSON: {"<module>":["<action>", ...]}
+            { "created_by", types.integer({ null = true }) }, -- users.id; soft reference
+            { "last_used_at", types.time({ null = true }) },
+            { "expires_at", types.time({ null = true }) },    -- NULL = never expires
+            { "revoked_at", types.time({ null = true }) },
+            { "created_at", types.time({ default = db.raw("NOW()") }) },
+            { "updated_at", types.time({ default = db.raw("NOW()") }) },
+            "PRIMARY KEY (id)"
+        })
+
+        pcall(function()
+            db.query([[
+                ALTER TABLE api_keys
+                ADD CONSTRAINT api_keys_namespace_fk
+                FOREIGN KEY (namespace_id) REFERENCES namespaces(id) ON DELETE CASCADE
+            ]])
+        end)
+
+        if not index_exists("idx_api_keys_uuid") then
+            db.query("CREATE UNIQUE INDEX idx_api_keys_uuid ON api_keys (uuid)")
+        end
+        -- Listing keys for a namespace; live keys are the common case.
+        if not index_exists("idx_api_keys_ns_live") then
+            db.query([[
+                CREATE INDEX idx_api_keys_ns_live
+                ON api_keys (namespace_id)
+                WHERE revoked_at IS NULL
+            ]])
+        end
+    end,
+}

--- a/lapis/models/ApiKeyModel.lua
+++ b/lapis/models/ApiKeyModel.lua
@@ -1,0 +1,7 @@
+local Model = require("lapis.db.model").Model
+
+local ApiKeys = Model:extend("api_keys", {
+    timestamp = true,
+})
+
+return ApiKeys

--- a/lapis/queries/ApiKeyQueries.lua
+++ b/lapis/queries/ApiKeyQueries.lua
@@ -1,0 +1,74 @@
+--[[
+    API Key Queries
+
+    Persistence for namespace-scoped machine credentials (api_keys table).
+    The raw key never reaches this layer — helper/api-key.lua generates it
+    and hands over only key_prefix + key_hash. key_hash is never selected
+    back out except by the authenticator's hash lookup.
+]]
+
+local db = require("lapis.db")
+local Global = require("helper.global")
+local ApiKeys = require("models.ApiKeyModel")
+
+local ApiKeyQueries = {}
+
+--- Persist a new key.
+-- @param params table {namespace_id, name, key_prefix, key_hash, scopes(json string), created_by?, expires_at?}
+-- @return table The created row (without key_hash)
+function ApiKeyQueries.create(params)
+    local row = ApiKeys:create({
+        uuid = Global.generateUUID(),
+        namespace_id = params.namespace_id,
+        name = params.name,
+        key_prefix = params.key_prefix,
+        key_hash = params.key_hash,
+        scopes = params.scopes,
+        created_by = params.created_by,
+        expires_at = params.expires_at,
+    }, { returning = "*" })
+    row.key_hash = nil
+    return row
+end
+
+--- List a namespace's keys, newest first. Never exposes key_hash.
+-- @param namespace_id number
+-- @return table[] rows
+function ApiKeyQueries.listByNamespace(namespace_id)
+    return db.query([[
+        SELECT uuid, name, key_prefix, scopes, last_used_at,
+               expires_at, revoked_at, created_at
+        FROM api_keys
+        WHERE namespace_id = ?
+        ORDER BY created_at DESC
+    ]], namespace_id)
+end
+
+--- Fetch one key by uuid, scoped to a namespace (ownership check).
+-- @param uuid string
+-- @param namespace_id number
+-- @return table|nil
+function ApiKeyQueries.findByUuidAndNamespace(uuid, namespace_id)
+    local rows = db.query([[
+        SELECT uuid, name, key_prefix, scopes, last_used_at,
+               expires_at, revoked_at, created_at
+        FROM api_keys
+        WHERE uuid = ? AND namespace_id = ?
+        LIMIT 1
+    ]], uuid, namespace_id)
+    return rows and rows[1] or nil
+end
+
+--- Revoke a key. Idempotent: revoking an already-revoked key is a no-op.
+-- @param uuid string
+-- @param namespace_id number
+-- @return boolean whether a live key was revoked by this call
+function ApiKeyQueries.revoke(uuid, namespace_id)
+    local result = db.query([[
+        UPDATE api_keys SET revoked_at = NOW(), updated_at = NOW()
+        WHERE uuid = ? AND namespace_id = ? AND revoked_at IS NULL
+    ]], uuid, namespace_id)
+    return result and result.affected_rows and result.affected_rows > 0 or false
+end
+
+return ApiKeyQueries

--- a/lapis/routes/api-keys.lua
+++ b/lapis/routes/api-keys.lua
@@ -1,0 +1,181 @@
+--[[
+    API Key Management Routes
+    =========================
+
+    Create, list and revoke namespace-scoped machine credentials (API keys).
+    A key authenticates as "Authorization: Bearer opsk_..." and can only do
+    what its scopes grant, inside its own namespace.
+
+    All endpoints require a real user session (JWT) with namespace admin
+    rights (owner or namespace.manage) — an API key can never manage keys.
+
+      POST   /api/v2/api-keys        {name, scopes, expires_at?} → raw key, once
+      GET    /api/v2/api-keys        list (never returns the key or its hash)
+      DELETE /api/v2/api-keys/:uuid  revoke (idempotent)
+]]
+
+local cjson = require("cjson")
+local db = require("lapis.db")
+local ApiKeyHelper = require("helper.api-key")
+local ApiKeyQueries = require("queries.ApiKeyQueries")
+local AuthMiddleware = require("middleware.auth")
+local NamespaceMiddleware = require("middleware.namespace")
+
+local function parse_body()
+    ngx.req.read_body()
+    local body = ngx.req.get_body_data()
+    if not body or body == "" then return nil end
+    local ok, decoded = pcall(cjson.decode, body)
+    if not ok or type(decoded) ~= "table" then return nil end
+    return decoded
+end
+
+--- Validate the scopes object: non-empty {module -> [action strings]}.
+-- Refuses the "namespace" module so a key can never mint or manage keys,
+-- members or roles (no self-escalation).
+-- @return table|nil normalized scopes
+-- @return string|nil error message
+local function validate_scopes(scopes)
+    if type(scopes) ~= "table" or next(scopes) == nil then
+        return nil, "scopes must be a non-empty object of module -> actions, e.g. {\"cms\":[\"create\"]}"
+    end
+    local out = {}
+    for module_name, actions in pairs(scopes) do
+        if type(module_name) ~= "string" or module_name == "" then
+            return nil, "scope module names must be strings"
+        end
+        if module_name == "namespace" then
+            return nil, "API keys cannot be granted the namespace module"
+        end
+        if type(actions) ~= "table" or #actions == 0 then
+            return nil, "scope actions for '" .. module_name .. "' must be a non-empty array"
+        end
+        local list = {}
+        for _, action in ipairs(actions) do
+            if type(action) ~= "string" or action == "" then
+                return nil, "scope actions for '" .. module_name .. "' must be strings"
+            end
+            list[#list + 1] = action
+        end
+        out[module_name] = list
+    end
+    return out
+end
+
+--- Shared guard: keys cannot manage keys.
+local function refuse_api_key_auth(self)
+    if self.api_key_auth then
+        return { json = { error = "API keys cannot manage API keys" }, status = 403 }
+    end
+    return nil
+end
+
+--- A list row with a computed revoked flag.
+local function present(row)
+    local revoked_at = row.revoked_at ~= ngx.null and row.revoked_at or nil
+    local scopes = {}
+    if row.scopes and row.scopes ~= ngx.null and row.scopes ~= "" then
+        local ok, decoded = pcall(cjson.decode, row.scopes)
+        if ok then scopes = decoded end
+    end
+    return {
+        uuid = row.uuid,
+        name = row.name,
+        key_prefix = row.key_prefix,
+        scopes = scopes,
+        last_used_at = row.last_used_at ~= ngx.null and row.last_used_at or nil,
+        expires_at = row.expires_at ~= ngx.null and row.expires_at or nil,
+        revoked_at = revoked_at,
+        revoked = revoked_at ~= nil,
+        created_at = row.created_at,
+    }
+end
+
+return function(app)
+    app:post("/api/v2/api-keys", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requireAdmin(function(self)
+            local refused = refuse_api_key_auth(self)
+            if refused then return refused end
+
+            local body = parse_body()
+            if not body then
+                return { json = { error = "Invalid JSON body" }, status = 400 }
+            end
+            if type(body.name) ~= "string" or body.name == "" then
+                return { json = { error = "name is required" }, status = 400 }
+            end
+            local scopes, scopes_err = validate_scopes(body.scopes)
+            if not scopes then
+                return { json = { error = scopes_err }, status = 400 }
+            end
+            if body.expires_at ~= nil and type(body.expires_at) ~= "string" then
+                return { json = { error = "expires_at must be a timestamp string" }, status = 400 }
+            end
+
+            -- The acting user's DB id, for the audit trail. The JWT carries
+            -- the uuid; resolve it, tolerating a missing row (created_by is a
+            -- soft reference).
+            local created_by
+            if self.current_user and self.current_user.uuid then
+                local users = db.select("id from users where uuid = ?", self.current_user.uuid)
+                created_by = users and users[1] and users[1].id or nil
+            end
+
+            local raw, key_prefix, key_hash = ApiKeyHelper.generate()
+            local row = ApiKeyQueries.create({
+                namespace_id = self.namespace.id,
+                name = body.name,
+                key_prefix = key_prefix,
+                key_hash = key_hash,
+                scopes = cjson.encode(scopes),
+                created_by = created_by,
+                expires_at = body.expires_at,
+            })
+
+            return {
+                json = {
+                    success = true,
+                    data = {
+                        key = raw,
+                        uuid = row.uuid,
+                        name = row.name,
+                        key_prefix = row.key_prefix,
+                        scopes = scopes,
+                        expires_at = body.expires_at,
+                    },
+                    meta = {
+                        note = "Store this key now — it cannot be retrieved again."
+                    }
+                },
+                status = 201
+            }
+        end)))
+
+    app:get("/api/v2/api-keys", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requireAdmin(function(self)
+            local refused = refuse_api_key_auth(self)
+            if refused then return refused end
+
+            local rows = ApiKeyQueries.listByNamespace(self.namespace.id)
+            local data = {}
+            for _, row in ipairs(rows or {}) do
+                data[#data + 1] = present(row)
+            end
+            return { json = { success = true, data = data } }
+        end)))
+
+    app:delete("/api/v2/api-keys/:uuid", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requireAdmin(function(self)
+            local refused = refuse_api_key_auth(self)
+            if refused then return refused end
+
+            local existing = ApiKeyQueries.findByUuidAndNamespace(
+                self.params.uuid, self.namespace.id)
+            if not existing then
+                return { json = { error = "API key not found" }, status = 404 }
+            end
+
+            ApiKeyQueries.revoke(self.params.uuid, self.namespace.id)
+            return { json = { success = true } }
+        end)))
+end

--- a/lapis/routes/api-keys.lua
+++ b/lapis/routes/api-keys.lua
@@ -108,8 +108,16 @@ return function(app)
             if not scopes then
                 return { json = { error = scopes_err }, status = 400 }
             end
-            if body.expires_at ~= nil and type(body.expires_at) ~= "string" then
-                return { json = { error = "expires_at must be a timestamp string" }, status = 400 }
+            -- Passed straight into the INSERT, so anything Postgres cannot read
+            -- as a timestamp would surface as a 500. Check the shape here.
+            if body.expires_at ~= nil then
+                if type(body.expires_at) ~= "string"
+                    or not body.expires_at:match("^%d%d%d%d%-%d%d%-%d%d") then
+                    return {
+                        json = { error = "expires_at must be a timestamp string, e.g. 2027-01-31 or 2027-01-31T09:00:00Z" },
+                        status = 400
+                    }
+                end
             end
 
             -- The acting user's DB id, for the audit trail. The JWT carries
@@ -161,7 +169,8 @@ return function(app)
             for _, row in ipairs(rows or {}) do
                 data[#data + 1] = present(row)
             end
-            return { json = { success = true, data = data } }
+            -- cjson encodes an empty Lua table as {}; a list must stay a list.
+            return { json = { success = true, data = #data > 0 and data or cjson.empty_array } }
         end)))
 
     app:delete("/api/v2/api-keys/:uuid", AuthMiddleware.requireAuth(


### PR DESCRIPTION
## Why

jobshout's Article Writer files blog drafts into the opsapi CMS. Its only auth option today is a hand-minted seed JWT (password + emailed OTP) kept alive via `/auth/refresh` — it dies if the caller is down past the 7-day grace window, and it impersonates a full user. This PR adds first-class machine credentials so external systems get a long-lived, revocable, least-privilege key instead.

## What

**Key format & storage**: `opsk_` + 48 hex chars, returned once at creation, stored only as a SHA-256 hash (same scheme as `helper/refresh-token.lua`).

**Authorization model**: a key is bound to exactly one namespace and carries its own scopes JSON (e.g. `{"cms":["create"]}`). At request time the scopes populate `self.namespace_permissions` in place of role permissions, so existing `requirePermission(module, action, ...)` checks work unchanged. A key is never a namespace owner, admin, or platform admin; `X-Namespace-Id/Slug` headers that don't match the key's namespace are refused with 403.

**Changes**:
- Migration `845_create_api_keys` (core): `api_keys` table — unique `key_hash`, `scopes`, `expires_at`, `revoked_at`, `last_used_at`, FK to namespaces with cascade
- `helper/api-key.lua` (new): generate / hash / authenticate, with a throttled `last_used_at` touch (≤1 write per key per 60s)
- `helper/auth.lua` + `middleware/auth.lua`: bearer tokens with the `opsk_` prefix branch to API-key authentication before JWT verification; JWT flow untouched
- `app.lua`: skip the lazy namespace-resolver for key principals (must not create membership rows); register `routes.api-keys`
- `middleware/namespace.lua`: early branch in `requireNamespace` for key principals (namespace from the key, membership lookup skipped)
- `routes/api-keys.lua` (new): `POST/GET/DELETE /api/v2/api-keys`, gated on `namespace.manage`; keys cannot manage keys; the `namespace` module is refused in scopes (no self-escalation); listing never returns hashes

## Security notes

- Raw key never persisted; hash lookup is O(1) on a unique index
- Revocation is immediate (checked on every request)
- A leaked jobshout key can only create CMS posts in its own namespace

## Testing

- All touched/new Lua files pass `luajit -bl` syntax check
- Consumer-side (jobshout) adapter changes are in the companion PR, with unit tests for header shape / no-retry-on-401/403 behaviour
- Verification on int after deploy: mint key → create draft → negative cases (wrong scope 403, revoked 401, cross-namespace 403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)