### PR TITLE
feat(dashboard): API Keys management UI

### DIFF
--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -1275,6 +1275,7 @@ local _migrations = {
         menu_system_migrations, 7),
     ['270_init_namespace_menu_configs'] = conditional_array(ProjectConfig.FEATURES.MENU, menu_system_migrations, 8),
     ['288_add_vault_menu_item'] = conditional_array(ProjectConfig.FEATURES.VAULT, menu_system_migrations, 9),
+    ['1000_add_api_keys_menu_item'] = conditional_array(ProjectConfig.FEATURES.MENU, menu_system_migrations, 10),
 
     -- Secret Vault (conditional)
     ['272_create_namespace_secret_vaults_table'] = conditional_array(ProjectConfig.FEATURES.VAULT,

--- a/lapis/migrations/menu-system.lua
+++ b/lapis/migrations/menu-system.lua
@@ -498,4 +498,58 @@ return {
             end
         end
     end,
+
+    -- ========================================
+    -- [10] Add API Keys menu item (namespace machine credentials)
+    -- Gated on "settings":read like the Settings item, so it shows to namespace
+    -- admins; the backend (routes/api-keys.lua) enforces owner/namespace.manage.
+    -- ========================================
+    [10] = function()
+        local MigrationUtils = require("helper.migration-utils")
+        local timestamp = MigrationUtils.getCurrentTimestamp()
+
+        -- Idempotent: skip if already seeded.
+        local existing = db.select("* FROM menu_items WHERE key = ?", "api-keys")
+        if #existing == 0 then
+            db.insert("menu_items", {
+                uuid = MigrationUtils.generateUUID(),
+                key = "api-keys",
+                name = "API Keys",
+                icon = "Key",
+                path = "/dashboard/namespace/api-keys",
+                module = "settings",
+                required_action = "read",
+                priority = 101,  -- Secondary nav, next to Settings
+                is_active = true,
+                is_admin_only = false,
+                always_show = false,
+                settings = "{}",
+                created_at = timestamp,
+                updated_at = timestamp
+            })
+        end
+
+        -- Enable for all existing namespaces.
+        local api_menu = db.select("* FROM menu_items WHERE key = ?", "api-keys")
+        if #api_menu > 0 then
+            local namespaces = db.select("* FROM namespaces")
+            for _, namespace in ipairs(namespaces) do
+                local config_exists = db.select([[
+                    * FROM namespace_menu_config
+                    WHERE namespace_id = ? AND menu_item_id = ?
+                ]], namespace.id, api_menu[1].id)
+
+                if #config_exists == 0 then
+                    db.insert("namespace_menu_config", {
+                        uuid = MigrationUtils.generateUUID(),
+                        namespace_id = namespace.id,
+                        menu_item_id = api_menu[1].id,
+                        is_enabled = true,
+                        created_at = timestamp,
+                        updated_at = timestamp
+                    })
+                end
+            end
+        end
+    end,
 }

--- a/opsapi-dashboard/app/dashboard/namespace/api-keys/new/page.tsx
+++ b/opsapi-dashboard/app/dashboard/namespace/api-keys/new/page.tsx
@@ -14,9 +14,9 @@ import {
   Check,
   Loader2,
   RotateCw,
+  Sparkles,
 } from 'lucide-react';
 import { Button, Card, Badge } from '@/components/ui';
-import { PageHeader } from '@/components/layout/PageHeader';
 import { useNamespace } from '@/contexts/NamespaceContext';
 import { apiKeysService, rolesService } from '@/services';
 import type {
@@ -88,7 +88,11 @@ export default function NewApiKeyPage() {
       return next;
     });
 
-  const scopeCount = Object.keys(scopes).length;
+  const moduleLabel = (n: string) => modules.find((m) => m.name === n)?.display_name || n;
+  const scopeEntries = Object.entries(scopes);
+  const scopeCount = scopeEntries.length;
+  const grantCount = scopeEntries.reduce((sum, [, acts]) => sum + acts.length, 0);
+
   const q = scopeQuery.trim().toLowerCase();
   const filteredModules = q
     ? modules.filter((m) =>
@@ -123,17 +127,15 @@ export default function NewApiKeyPage() {
   // ---- Guards --------------------------------------------------------------
   if (!currentNamespace) {
     return (
-      <Card className="p-8 text-center text-secondary-500">
-        Select a namespace to create an API key.
-      </Card>
+      <Card className="p-8 text-center text-secondary-500">Select a namespace to create an API key.</Card>
     );
   }
   if (!canManage) {
     return (
-      <div className="max-w-2xl mx-auto">
+      <div className="max-w-xl mx-auto">
         <Card className="p-10 text-center">
           <ShieldAlert className="w-10 h-10 text-secondary-300 mx-auto mb-3" />
-          <h3 className="text-secondary-900 font-medium">Not authorised</h3>
+          <h3 className="text-secondary-900 font-semibold">Not authorised</h3>
           <p className="text-secondary-500 text-sm mt-1">
             You need owner or namespace-manage rights to create API keys.
           </p>
@@ -145,176 +147,225 @@ export default function NewApiKeyPage() {
     );
   }
 
-  // ---- Reveal-once (full page) --------------------------------------------
-  if (created) {
-    return <RevealCreated created={created} onDone={() => router.push(KEYS_PATH)} />;
-  }
+  if (created) return <RevealCreated created={created} onDone={() => router.push(KEYS_PATH)} />;
 
-  // ---- Create form (full page) --------------------------------------------
+  // ---- Create form (full-width two-panel) ---------------------------------
   return (
-    <div className="max-w-3xl mx-auto space-y-6">
-      <button
-        onClick={() => router.push(KEYS_PATH)}
-        className="inline-flex items-center gap-1.5 text-sm text-secondary-500 hover:text-secondary-800"
-      >
-        <ArrowLeft className="w-4 h-4" /> Back to API keys
-      </button>
-
-      <PageHeader
-        title="Create API key"
-        description="A machine credential for scripts and services — scoped to this namespace and the exact permissions you choose."
-        icon={<Key className="w-6 h-6" />}
-      />
-
-      <Card className="p-6 flex items-start gap-3 bg-primary-500/5 border-primary-500/20">
-        <ShieldCheck className="w-5 h-5 text-primary-600 shrink-0 mt-0.5" />
-        <p className="text-sm text-secondary-600">
-          This key is locked to the <strong className="text-secondary-900">{currentNamespace.name}</strong>{' '}
-          namespace — it can never access another tenant. It can do <strong>only</strong> what you grant
-          below, and can never manage keys, members, or roles.
-        </p>
-      </Card>
-
-      {/* Name */}
-      <Card className="p-6 space-y-2">
-        <label className="block text-sm font-medium text-secondary-700">Name</label>
-        <input
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="e.g. blog-importer, ci-deploy"
-          className="w-full rounded-lg border border-secondary-300 px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
-          autoFocus
-        />
-        <p className="text-xs text-secondary-500">A label to recognise this key later — not secret.</p>
-      </Card>
-
-      {/* Permissions */}
-      <Card className="p-6 space-y-4">
-        <div className="flex items-center justify-between">
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <button
+          onClick={() => router.push(KEYS_PATH)}
+          className="inline-flex items-center justify-center w-9 h-9 rounded-lg border border-secondary-200 text-secondary-500 hover:text-secondary-800 hover:border-secondary-300 transition-colors"
+          aria-label="Back to API keys"
+        >
+          <ArrowLeft className="w-4 h-4" />
+        </button>
+        <div className="flex items-center gap-3">
+          <div className="w-11 h-11 rounded-xl bg-primary-500/10 flex items-center justify-center">
+            <Key className="w-5 h-5 text-primary-600" />
+          </div>
           <div>
-            <h3 className="text-sm font-medium text-secondary-800">Permissions</h3>
-            <p className="text-xs text-secondary-500 mt-0.5">
-              Pick a module, then the actions this key may perform. Least privilege — grant only what it needs.
+            <h1 className="text-xl font-bold text-secondary-900">Create API key</h1>
+            <p className="text-sm text-secondary-500">
+              A machine credential — scoped to this namespace and the exact permissions you choose.
             </p>
           </div>
-          {scopeCount > 0 && <Badge variant="info">{scopeCount} module{scopeCount > 1 ? 's' : ''}</Badge>}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-6 items-start">
+        {/* Main column */}
+        <div className="lg:col-span-8 space-y-6">
+          {/* Name */}
+          <Card className="p-6 space-y-2">
+            <label htmlFor="key-name" className="block text-sm font-semibold text-secondary-800">
+              Name
+            </label>
+            <input
+              id="key-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. blog-importer, ci-deploy"
+              className="w-full rounded-lg border border-secondary-300 px-3.5 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 transition"
+              autoFocus
+            />
+            <p className="text-xs text-secondary-500">A label to recognise this key later — not secret.</p>
+          </Card>
+
+          {/* Permissions */}
+          <Card className="p-6 space-y-4">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h2 className="text-sm font-semibold text-secondary-800">Permissions</h2>
+                <p className="text-xs text-secondary-500 mt-0.5">
+                  Pick a module, then the actions this key may perform. Least privilege — grant only what it needs.
+                </p>
+              </div>
+              {grantCount > 0 && (
+                <Badge variant="info">
+                  {grantCount} action{grantCount > 1 ? 's' : ''}
+                </Badge>
+              )}
+            </div>
+
+            {metaLoading ? (
+              <div className="flex justify-center py-12">
+                <Loader2 className="w-6 h-6 animate-spin text-primary-500" />
+              </div>
+            ) : metaError ? (
+              <div className="text-center py-10">
+                <p className="text-sm text-secondary-500">Couldn’t load available permissions.</p>
+                <Button className="mt-3" variant="outline" size="sm" onClick={loadMeta} leftIcon={<RotateCw className="w-4 h-4" />}>
+                  Retry
+                </Button>
+              </div>
+            ) : modules.length === 0 ? (
+              <p className="text-sm text-secondary-500 py-4">No scopable modules are enabled in this namespace.</p>
+            ) : (
+              <>
+                <div className="relative">
+                  <Search className="w-4 h-4 text-secondary-400 absolute left-3.5 top-1/2 -translate-y-1/2 pointer-events-none" />
+                  <input
+                    value={scopeQuery}
+                    onChange={(e) => setScopeQuery(e.target.value)}
+                    placeholder={`Search ${modules.length} modules…`}
+                    className="w-full rounded-lg border border-secondary-300 pl-10 pr-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 transition"
+                    aria-label="Search permissions"
+                  />
+                </div>
+
+                {filteredModules.length === 0 ? (
+                  <p className="text-sm text-secondary-500 text-center py-10">No modules match “{scopeQuery}”.</p>
+                ) : (
+                  <div className="grid gap-3 sm:grid-cols-2 2xl:grid-cols-3">
+                    {filteredModules.map((mod) => {
+                      const selected = scopes[mod.name] || [];
+                      const allOn = selected.length === actions.length && actions.length > 0;
+                      return (
+                        <div
+                          key={mod.name}
+                          className={`rounded-xl border p-4 transition-colors ${
+                            selected.length
+                              ? 'border-primary-300 bg-primary-500/[0.04]'
+                              : 'border-secondary-200 hover:border-secondary-300'
+                          }`}
+                        >
+                          <div className="flex items-center justify-between gap-2 mb-3">
+                            <div className="min-w-0">
+                              <div className="text-sm font-semibold text-secondary-900 truncate">
+                                {mod.display_name || mod.name}
+                              </div>
+                              {mod.category && (
+                                <div className="text-[10px] font-medium uppercase tracking-wider text-secondary-400 mt-0.5">
+                                  {mod.category}
+                                </div>
+                              )}
+                            </div>
+                            <button
+                              type="button"
+                              onClick={() => toggleAll(mod.name)}
+                              className="text-xs font-semibold text-primary-600 hover:text-primary-700 shrink-0"
+                            >
+                              {allOn ? 'Clear' : 'All'}
+                            </button>
+                          </div>
+                          <div className="flex flex-wrap gap-1.5">
+                            {actions.map((a) => {
+                              const active = selected.includes(a.name as string);
+                              return (
+                                <button
+                                  key={a.name}
+                                  type="button"
+                                  aria-pressed={active}
+                                  onClick={() => toggle(mod.name, a.name as string)}
+                                  className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium border transition-colors cursor-pointer ${
+                                    active
+                                      ? 'bg-primary-600 border-primary-600 text-white'
+                                      : 'bg-white border-secondary-300 text-secondary-600 hover:border-primary-400 hover:text-primary-600'
+                                  }`}
+                                  title={a.description || a.display_name || a.name}
+                                >
+                                  {active && <Check className="w-3 h-3" />}
+                                  {a.display_name || a.name}
+                                </button>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </>
+            )}
+          </Card>
         </div>
 
-        {metaLoading ? (
-          <div className="flex justify-center py-10">
-            <Loader2 className="w-6 h-6 animate-spin text-primary-500" />
-          </div>
-        ) : metaError ? (
-          <div className="text-center py-8">
-            <p className="text-sm text-secondary-500">Couldn’t load available permissions.</p>
-            <Button className="mt-3" variant="outline" size="sm" onClick={loadMeta} leftIcon={<RotateCw className="w-4 h-4" />}>
-              Retry
-            </Button>
-          </div>
-        ) : modules.length === 0 ? (
-          <p className="text-sm text-secondary-500 py-4">No scopable modules are enabled in this namespace.</p>
-        ) : (
-          <>
-            <div className="relative">
-              <Search className="w-4 h-4 text-secondary-400 absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none" />
+        {/* Sticky summary rail */}
+        <aside className="lg:col-span-4 lg:sticky lg:top-6 space-y-4">
+          <Card className="p-5 flex items-start gap-2.5 bg-primary-500/[0.06] border-primary-500/20">
+            <ShieldCheck className="w-5 h-5 text-primary-600 shrink-0 mt-0.5" />
+            <p className="text-sm text-secondary-600">
+              Locked to <strong className="text-secondary-900">{currentNamespace.name}</strong> — this key can
+              never reach another tenant, and can never manage keys, members, or roles.
+            </p>
+          </Card>
+
+          <Card className="p-5 space-y-4">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-secondary-800">Summary</h3>
+              <span className="text-xs text-secondary-500">
+                {scopeCount === 0 ? 'No permissions yet' : `${scopeCount} module${scopeCount > 1 ? 's' : ''}`}
+              </span>
+            </div>
+
+            {scopeCount === 0 ? (
+              <div className="rounded-lg border border-dashed border-secondary-200 px-3 py-6 text-center">
+                <Sparkles className="w-5 h-5 text-secondary-300 mx-auto mb-1.5" />
+                <p className="text-xs text-secondary-500">Select actions on the left to build this key’s access.</p>
+              </div>
+            ) : (
+              <div className="space-y-2 max-h-64 overflow-y-auto pr-1">
+                {scopeEntries.map(([mod, acts]) => (
+                  <div key={mod} className="flex items-start justify-between gap-2">
+                    <span className="text-sm font-medium text-secondary-800 truncate">{moduleLabel(mod)}</span>
+                    <span className="text-xs text-secondary-500 text-right shrink-0">{acts.join(', ')}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div className="pt-1 border-t border-secondary-100 space-y-2">
+              <label htmlFor="key-expiry" className="block text-xs font-semibold text-secondary-700">
+                Expiry (optional)
+              </label>
               <input
-                value={scopeQuery}
-                onChange={(e) => setScopeQuery(e.target.value)}
-                placeholder={`Search ${modules.length} modules…`}
-                className="w-full rounded-lg border border-secondary-300 pl-9 pr-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
-                aria-label="Search permissions"
+                id="key-expiry"
+                type="date"
+                value={expiresAt}
+                min={today}
+                onChange={(e) => setExpiresAt(e.target.value)}
+                className="w-full rounded-lg border border-secondary-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 transition"
               />
             </div>
 
-            {filteredModules.length === 0 ? (
-              <p className="text-sm text-secondary-500 text-center py-8">No modules match “{scopeQuery}”.</p>
-            ) : (
-              <div className="grid gap-3 sm:grid-cols-2">
-                {filteredModules.map((mod) => {
-                  const selected = scopes[mod.name] || [];
-                  const allOn = selected.length === actions.length && actions.length > 0;
-                  return (
-                    <div
-                      key={mod.name}
-                      className={`rounded-xl border p-4 transition-colors ${
-                        selected.length ? 'border-primary-300 bg-primary-500/5' : 'border-secondary-200'
-                      }`}
-                    >
-                      <div className="flex items-center justify-between gap-2 mb-3">
-                        <div className="min-w-0">
-                          <div className="text-sm font-semibold text-secondary-900 truncate">
-                            {mod.display_name || mod.name}
-                          </div>
-                          {mod.category && (
-                            <div className="text-[11px] uppercase tracking-wide text-secondary-400">{mod.category}</div>
-                          )}
-                        </div>
-                        <button
-                          type="button"
-                          onClick={() => toggleAll(mod.name)}
-                          className="text-xs font-medium text-primary-600 hover:text-primary-700 shrink-0"
-                        >
-                          {allOn ? 'Clear' : 'All'}
-                        </button>
-                      </div>
-                      <div className="flex flex-wrap gap-2">
-                        {actions.map((a) => {
-                          const active = selected.includes(a.name as string);
-                          return (
-                            <button
-                              key={a.name}
-                              type="button"
-                              aria-pressed={active}
-                              onClick={() => toggle(mod.name, a.name as string)}
-                              className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium border transition-colors ${
-                                active
-                                  ? 'bg-primary-600 border-primary-600 text-white'
-                                  : 'bg-white border-secondary-300 text-secondary-600 hover:border-primary-400 hover:text-primary-600'
-                              }`}
-                              title={a.description || a.display_name || a.name}
-                            >
-                              {active && <Check className="w-3 h-3" />}
-                              {a.display_name || a.name}
-                            </button>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-          </>
-        )}
-      </Card>
-
-      {/* Expiry */}
-      <Card className="p-6 space-y-2">
-        <label className="block text-sm font-medium text-secondary-700">Expiry (optional)</label>
-        <input
-          type="date"
-          value={expiresAt}
-          min={today}
-          onChange={(e) => setExpiresAt(e.target.value)}
-          className="rounded-lg border border-secondary-300 px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
-        />
-        <p className="text-xs text-secondary-500">Leave blank for a key that never expires.</p>
-      </Card>
-
-      <div className="flex justify-end gap-3 pb-8">
-        <Button variant="outline" onClick={() => router.push(KEYS_PATH)} disabled={submitting}>
-          Cancel
-        </Button>
-        <Button onClick={submit} isLoading={submitting} leftIcon={<Key className="w-4 h-4" />}>
-          Create key
-        </Button>
+            <div className="flex flex-col gap-2 pt-1">
+              <Button onClick={submit} isLoading={submitting} leftIcon={<Key className="w-4 h-4" />} className="w-full justify-center">
+                Create key
+              </Button>
+              <Button variant="outline" onClick={() => router.push(KEYS_PATH)} disabled={submitting} className="w-full justify-center">
+                Cancel
+              </Button>
+            </div>
+          </Card>
+        </aside>
       </div>
     </div>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Reveal-once — full page, the raw secret is shown a single time
+// Reveal-once — the raw secret is shown a single time (full width)
 // ---------------------------------------------------------------------------
 
 function RevealCreated({ created, onDone }: { created: CreatedApiKey; onDone: () => void }) {
@@ -332,55 +383,64 @@ function RevealCreated({ created, onDone }: { created: CreatedApiKey; onDone: ()
   };
 
   return (
-    <div className="max-w-3xl mx-auto space-y-6">
-      <PageHeader
-        title="Your new API key"
-        description={`“${created.name}” is ready. Copy the secret now — it is shown only once.`}
-        icon={<Key className="w-6 h-6" />}
-      />
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <div className="w-11 h-11 rounded-xl bg-success-500/10 flex items-center justify-center">
+          <Check className="w-5 h-5 text-success-600" />
+        </div>
+        <div>
+          <h1 className="text-xl font-bold text-secondary-900">Your new API key</h1>
+          <p className="text-sm text-secondary-500">
+            “{created.name}” is ready. Copy the secret now — it is shown only once.
+          </p>
+        </div>
+      </div>
 
-      <Card className="p-4 flex items-start gap-2 bg-warning-500/10 border-warning-500/20">
+      <Card className="p-4 flex items-start gap-2.5 bg-warning-500/10 border-warning-500/20">
         <AlertTriangle className="w-5 h-5 text-warning-600 shrink-0 mt-0.5" />
         <p className="text-sm text-warning-600">
-          For security this secret is <strong>shown only once</strong> and cannot be retrieved again. Store it
-          in your secret manager now. Lost it? Revoke this key and create a new one.
+          For security this secret is <strong>shown only once</strong> and cannot be retrieved again. Store it in
+          your secret manager now. Lost it? Revoke this key and create a new one.
         </p>
       </Card>
 
-      <Card className="p-6 space-y-3">
-        <label className="block text-sm font-medium text-secondary-700">Secret key</label>
-        <div className="flex items-stretch gap-2">
-          <code className="flex-1 font-mono text-sm bg-secondary-50 text-secondary-900 rounded-lg px-4 py-3 break-all border border-secondary-200">
-            {created.key}
-          </code>
-          <Button variant="outline" onClick={copy} leftIcon={copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}>
-            {copied ? 'Copied' : 'Copy'}
-          </Button>
-        </div>
-        <div className="text-xs text-secondary-500 flex items-center gap-1.5">
-          <ShieldAlert className="w-3.5 h-3.5" />
-          Use as a bearer token: <code className="font-mono">Authorization: Bearer {created.key_prefix}…</code>
-        </div>
-      </Card>
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-6 items-start">
+        <Card className="lg:col-span-8 p-6 space-y-3">
+          <label className="block text-sm font-semibold text-secondary-800">Secret key</label>
+          <div className="flex items-stretch gap-2">
+            <code className="flex-1 font-mono text-sm bg-secondary-50 text-secondary-900 rounded-lg px-4 py-3.5 break-all border border-secondary-200">
+              {created.key}
+            </code>
+            <Button variant="outline" onClick={copy} leftIcon={copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}>
+              {copied ? 'Copied' : 'Copy'}
+            </Button>
+          </div>
+          <div className="text-xs text-secondary-500 flex items-center gap-1.5 pt-1">
+            <ShieldAlert className="w-3.5 h-3.5" />
+            Use as a bearer token: <code className="font-mono">Authorization: Bearer {created.key_prefix}…</code>
+          </div>
+        </Card>
 
-      <Card className="p-6 space-y-3">
-        <div className="flex items-center gap-2 text-sm font-medium text-secondary-800">
-          <Lock className="w-4 h-4 text-secondary-400" /> This key can do
-        </div>
-        <div className="flex flex-wrap gap-2">
-          {Object.entries(created.scopes || {}).map(([mod, acts]) => (
-            <Badge key={mod} variant="secondary">
-              {mod}: {(acts as string[]).join('/')}
-            </Badge>
-          ))}
-        </div>
-        {created.expires_at && (
-          <p className="text-xs text-secondary-500">Expires {new Date(created.expires_at).toLocaleDateString()}.</p>
-        )}
-      </Card>
-
-      <div className="flex justify-end pb-8">
-        <Button onClick={onDone}>Done</Button>
+        <Card className="lg:col-span-4 p-6 space-y-3">
+          <div className="flex items-center gap-2 text-sm font-semibold text-secondary-800">
+            <Lock className="w-4 h-4 text-secondary-400" /> This key can do
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {Object.entries(created.scopes || {}).map(([mod, acts]) => (
+              <Badge key={mod} variant="secondary">
+                {mod}: {(acts as string[]).join('/')}
+              </Badge>
+            ))}
+          </div>
+          {created.expires_at && (
+            <p className="text-xs text-secondary-500">Expires {new Date(created.expires_at).toLocaleDateString()}.</p>
+          )}
+          <div className="pt-2">
+            <Button onClick={onDone} className="w-full justify-center">
+              Done
+            </Button>
+          </div>
+        </Card>
       </div>
     </div>
   );

--- a/opsapi-dashboard/app/dashboard/namespace/api-keys/new/page.tsx
+++ b/opsapi-dashboard/app/dashboard/namespace/api-keys/new/page.tsx
@@ -1,0 +1,387 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  Key,
+  ArrowLeft,
+  Search,
+  ShieldCheck,
+  ShieldAlert,
+  AlertTriangle,
+  Lock,
+  Copy,
+  Check,
+  Loader2,
+  RotateCw,
+} from 'lucide-react';
+import { Button, Card, Badge } from '@/components/ui';
+import { PageHeader } from '@/components/layout/PageHeader';
+import { useNamespace } from '@/contexts/NamespaceContext';
+import { apiKeysService, rolesService } from '@/services';
+import type {
+  CreatedApiKey,
+  ApiKeyScopes,
+  NamespaceModuleMeta,
+  NamespaceActionMeta,
+} from '@/types';
+import toast from 'react-hot-toast';
+
+const KEYS_PATH = '/dashboard/namespace/api-keys';
+
+export default function NewApiKeyPage() {
+  const router = useRouter();
+  const { currentNamespace, isNamespaceOwner, hasPermission } = useNamespace();
+  const canManage = isNamespaceOwner || hasPermission('api_keys', 'manage');
+
+  const [name, setName] = useState('');
+  const [scopes, setScopes] = useState<ApiKeyScopes>({});
+  const [scopeQuery, setScopeQuery] = useState('');
+  const [expiresAt, setExpiresAt] = useState('');
+  const [modules, setModules] = useState<NamespaceModuleMeta[]>([]);
+  const [actions, setActions] = useState<NamespaceActionMeta[]>([]);
+  const [metaLoading, setMetaLoading] = useState(true);
+  const [metaError, setMetaError] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [created, setCreated] = useState<CreatedApiKey | null>(null);
+
+  const loadMeta = useCallback(async () => {
+    setMetaLoading(true);
+    setMetaError(false);
+    try {
+      const meta = (await rolesService.getPermissionsMeta()) as unknown as {
+        modules: NamespaceModuleMeta[];
+        actions: NamespaceActionMeta[];
+      };
+      // Backend forbids the "namespace" module on API keys (no self-escalation).
+      setModules((meta.modules || []).filter((m) => m && m.name && m.name !== 'namespace'));
+      setActions(meta.actions || []);
+    } catch {
+      setMetaError(true);
+    } finally {
+      setMetaLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (canManage) loadMeta();
+  }, [canManage, loadMeta]);
+
+  const toggle = (mod: string, action: string) =>
+    setScopes((prev) => {
+      const set = new Set(prev[mod] || []);
+      if (set.has(action)) set.delete(action);
+      else set.add(action);
+      const next = { ...prev };
+      if (set.size === 0) delete next[mod];
+      else next[mod] = Array.from(set);
+      return next;
+    });
+
+  const toggleAll = (mod: string) =>
+    setScopes((prev) => {
+      const all = actions.map((a) => a.name as string);
+      const has = (prev[mod] || []).length === all.length && all.length > 0;
+      const next = { ...prev };
+      if (has) delete next[mod];
+      else next[mod] = all;
+      return next;
+    });
+
+  const scopeCount = Object.keys(scopes).length;
+  const q = scopeQuery.trim().toLowerCase();
+  const filteredModules = q
+    ? modules.filter((m) =>
+        [m.display_name, m.name, m.category, m.description]
+          .filter(Boolean)
+          .some((v) => String(v).toLowerCase().includes(q)),
+      )
+    : modules;
+
+  const today = new Date().toISOString().slice(0, 10);
+
+  const submit = async () => {
+    if (!name.trim()) return toast.error('Give the key a name');
+    if (scopeCount === 0) return toast.error('Grant at least one permission');
+    if (expiresAt && expiresAt < today) return toast.error('Expiry cannot be in the past');
+    setSubmitting(true);
+    try {
+      const result = await apiKeysService.create({
+        name: name.trim(),
+        scopes,
+        expires_at: expiresAt || undefined,
+      });
+      setCreated(result);
+      toast.success('API key created');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to create API key');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // ---- Guards --------------------------------------------------------------
+  if (!currentNamespace) {
+    return (
+      <Card className="p-8 text-center text-secondary-500">
+        Select a namespace to create an API key.
+      </Card>
+    );
+  }
+  if (!canManage) {
+    return (
+      <div className="max-w-2xl mx-auto">
+        <Card className="p-10 text-center">
+          <ShieldAlert className="w-10 h-10 text-secondary-300 mx-auto mb-3" />
+          <h3 className="text-secondary-900 font-medium">Not authorised</h3>
+          <p className="text-secondary-500 text-sm mt-1">
+            You need owner or namespace-manage rights to create API keys.
+          </p>
+          <Button className="mt-4" variant="outline" onClick={() => router.push(KEYS_PATH)}>
+            Back to API keys
+          </Button>
+        </Card>
+      </div>
+    );
+  }
+
+  // ---- Reveal-once (full page) --------------------------------------------
+  if (created) {
+    return <RevealCreated created={created} onDone={() => router.push(KEYS_PATH)} />;
+  }
+
+  // ---- Create form (full page) --------------------------------------------
+  return (
+    <div className="max-w-3xl mx-auto space-y-6">
+      <button
+        onClick={() => router.push(KEYS_PATH)}
+        className="inline-flex items-center gap-1.5 text-sm text-secondary-500 hover:text-secondary-800"
+      >
+        <ArrowLeft className="w-4 h-4" /> Back to API keys
+      </button>
+
+      <PageHeader
+        title="Create API key"
+        description="A machine credential for scripts and services — scoped to this namespace and the exact permissions you choose."
+        icon={<Key className="w-6 h-6" />}
+      />
+
+      <Card className="p-6 flex items-start gap-3 bg-primary-500/5 border-primary-500/20">
+        <ShieldCheck className="w-5 h-5 text-primary-600 shrink-0 mt-0.5" />
+        <p className="text-sm text-secondary-600">
+          This key is locked to the <strong className="text-secondary-900">{currentNamespace.name}</strong>{' '}
+          namespace — it can never access another tenant. It can do <strong>only</strong> what you grant
+          below, and can never manage keys, members, or roles.
+        </p>
+      </Card>
+
+      {/* Name */}
+      <Card className="p-6 space-y-2">
+        <label className="block text-sm font-medium text-secondary-700">Name</label>
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. blog-importer, ci-deploy"
+          className="w-full rounded-lg border border-secondary-300 px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+          autoFocus
+        />
+        <p className="text-xs text-secondary-500">A label to recognise this key later — not secret.</p>
+      </Card>
+
+      {/* Permissions */}
+      <Card className="p-6 space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-sm font-medium text-secondary-800">Permissions</h3>
+            <p className="text-xs text-secondary-500 mt-0.5">
+              Pick a module, then the actions this key may perform. Least privilege — grant only what it needs.
+            </p>
+          </div>
+          {scopeCount > 0 && <Badge variant="info">{scopeCount} module{scopeCount > 1 ? 's' : ''}</Badge>}
+        </div>
+
+        {metaLoading ? (
+          <div className="flex justify-center py-10">
+            <Loader2 className="w-6 h-6 animate-spin text-primary-500" />
+          </div>
+        ) : metaError ? (
+          <div className="text-center py-8">
+            <p className="text-sm text-secondary-500">Couldn’t load available permissions.</p>
+            <Button className="mt-3" variant="outline" size="sm" onClick={loadMeta} leftIcon={<RotateCw className="w-4 h-4" />}>
+              Retry
+            </Button>
+          </div>
+        ) : modules.length === 0 ? (
+          <p className="text-sm text-secondary-500 py-4">No scopable modules are enabled in this namespace.</p>
+        ) : (
+          <>
+            <div className="relative">
+              <Search className="w-4 h-4 text-secondary-400 absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none" />
+              <input
+                value={scopeQuery}
+                onChange={(e) => setScopeQuery(e.target.value)}
+                placeholder={`Search ${modules.length} modules…`}
+                className="w-full rounded-lg border border-secondary-300 pl-9 pr-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+                aria-label="Search permissions"
+              />
+            </div>
+
+            {filteredModules.length === 0 ? (
+              <p className="text-sm text-secondary-500 text-center py-8">No modules match “{scopeQuery}”.</p>
+            ) : (
+              <div className="grid gap-3 sm:grid-cols-2">
+                {filteredModules.map((mod) => {
+                  const selected = scopes[mod.name] || [];
+                  const allOn = selected.length === actions.length && actions.length > 0;
+                  return (
+                    <div
+                      key={mod.name}
+                      className={`rounded-xl border p-4 transition-colors ${
+                        selected.length ? 'border-primary-300 bg-primary-500/5' : 'border-secondary-200'
+                      }`}
+                    >
+                      <div className="flex items-center justify-between gap-2 mb-3">
+                        <div className="min-w-0">
+                          <div className="text-sm font-semibold text-secondary-900 truncate">
+                            {mod.display_name || mod.name}
+                          </div>
+                          {mod.category && (
+                            <div className="text-[11px] uppercase tracking-wide text-secondary-400">{mod.category}</div>
+                          )}
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => toggleAll(mod.name)}
+                          className="text-xs font-medium text-primary-600 hover:text-primary-700 shrink-0"
+                        >
+                          {allOn ? 'Clear' : 'All'}
+                        </button>
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        {actions.map((a) => {
+                          const active = selected.includes(a.name as string);
+                          return (
+                            <button
+                              key={a.name}
+                              type="button"
+                              aria-pressed={active}
+                              onClick={() => toggle(mod.name, a.name as string)}
+                              className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium border transition-colors ${
+                                active
+                                  ? 'bg-primary-600 border-primary-600 text-white'
+                                  : 'bg-white border-secondary-300 text-secondary-600 hover:border-primary-400 hover:text-primary-600'
+                              }`}
+                              title={a.description || a.display_name || a.name}
+                            >
+                              {active && <Check className="w-3 h-3" />}
+                              {a.display_name || a.name}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </>
+        )}
+      </Card>
+
+      {/* Expiry */}
+      <Card className="p-6 space-y-2">
+        <label className="block text-sm font-medium text-secondary-700">Expiry (optional)</label>
+        <input
+          type="date"
+          value={expiresAt}
+          min={today}
+          onChange={(e) => setExpiresAt(e.target.value)}
+          className="rounded-lg border border-secondary-300 px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+        />
+        <p className="text-xs text-secondary-500">Leave blank for a key that never expires.</p>
+      </Card>
+
+      <div className="flex justify-end gap-3 pb-8">
+        <Button variant="outline" onClick={() => router.push(KEYS_PATH)} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button onClick={submit} isLoading={submitting} leftIcon={<Key className="w-4 h-4" />}>
+          Create key
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Reveal-once — full page, the raw secret is shown a single time
+// ---------------------------------------------------------------------------
+
+function RevealCreated({ created, onDone }: { created: CreatedApiKey; onDone: () => void }) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(created.key);
+      setCopied(true);
+      toast.success('API key copied to clipboard');
+      setTimeout(() => setCopied(false), 2500);
+    } catch {
+      toast.error('Could not copy — select the key and copy it manually');
+    }
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto space-y-6">
+      <PageHeader
+        title="Your new API key"
+        description={`“${created.name}” is ready. Copy the secret now — it is shown only once.`}
+        icon={<Key className="w-6 h-6" />}
+      />
+
+      <Card className="p-4 flex items-start gap-2 bg-warning-500/10 border-warning-500/20">
+        <AlertTriangle className="w-5 h-5 text-warning-600 shrink-0 mt-0.5" />
+        <p className="text-sm text-warning-600">
+          For security this secret is <strong>shown only once</strong> and cannot be retrieved again. Store it
+          in your secret manager now. Lost it? Revoke this key and create a new one.
+        </p>
+      </Card>
+
+      <Card className="p-6 space-y-3">
+        <label className="block text-sm font-medium text-secondary-700">Secret key</label>
+        <div className="flex items-stretch gap-2">
+          <code className="flex-1 font-mono text-sm bg-secondary-50 text-secondary-900 rounded-lg px-4 py-3 break-all border border-secondary-200">
+            {created.key}
+          </code>
+          <Button variant="outline" onClick={copy} leftIcon={copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}>
+            {copied ? 'Copied' : 'Copy'}
+          </Button>
+        </div>
+        <div className="text-xs text-secondary-500 flex items-center gap-1.5">
+          <ShieldAlert className="w-3.5 h-3.5" />
+          Use as a bearer token: <code className="font-mono">Authorization: Bearer {created.key_prefix}…</code>
+        </div>
+      </Card>
+
+      <Card className="p-6 space-y-3">
+        <div className="flex items-center gap-2 text-sm font-medium text-secondary-800">
+          <Lock className="w-4 h-4 text-secondary-400" /> This key can do
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {Object.entries(created.scopes || {}).map(([mod, acts]) => (
+            <Badge key={mod} variant="secondary">
+              {mod}: {(acts as string[]).join('/')}
+            </Badge>
+          ))}
+        </div>
+        {created.expires_at && (
+          <p className="text-xs text-secondary-500">Expires {new Date(created.expires_at).toLocaleDateString()}.</p>
+        )}
+      </Card>
+
+      <div className="flex justify-end pb-8">
+        <Button onClick={onDone}>Done</Button>
+      </div>
+    </div>
+  );
+}

--- a/opsapi-dashboard/app/dashboard/namespace/api-keys/page.tsx
+++ b/opsapi-dashboard/app/dashboard/namespace/api-keys/page.tsx
@@ -9,6 +9,7 @@ import {
   Check,
   Loader2,
   ShieldAlert,
+  ShieldCheck,
   AlertTriangle,
 } from 'lucide-react';
 import { Button, Card, Badge, Modal, ConfirmDialog, Table } from '@/components/ui';
@@ -180,6 +181,7 @@ export default function ApiKeysPage() {
 
       {createOpen && (
         <CreateApiKeyModal
+          namespaceName={currentNamespace.name}
           onClose={() => setCreateOpen(false)}
           onCreated={(created) => {
             setCreateOpen(false);
@@ -210,9 +212,11 @@ export default function ApiKeysPage() {
 // ---------------------------------------------------------------------------
 
 function CreateApiKeyModal({
+  namespaceName,
   onClose,
   onCreated,
 }: {
+  namespaceName: string;
   onClose: () => void;
   onCreated: (created: CreatedApiKey) => void;
 }) {
@@ -278,6 +282,14 @@ function CreateApiKeyModal({
   return (
     <Modal isOpen onClose={onClose} title="Create API key" size="lg">
       <div className="space-y-5">
+        <div className="flex items-start gap-2 rounded-lg bg-primary-500/5 border border-primary-500/20 p-3">
+          <ShieldCheck className="w-5 h-5 text-primary-600 shrink-0 mt-0.5" />
+          <p className="text-sm text-secondary-600">
+            This key is locked to the <strong className="text-secondary-900">{namespaceName}</strong> namespace —
+            it can never access another. It can do <strong>only</strong> what you grant below, nothing more.
+          </p>
+        </div>
+
         <div>
           <label className="block text-sm font-medium text-secondary-700 mb-1.5">Name</label>
           <input

--- a/opsapi-dashboard/app/dashboard/namespace/api-keys/page.tsx
+++ b/opsapi-dashboard/app/dashboard/namespace/api-keys/page.tsx
@@ -11,6 +11,7 @@ import {
   ShieldAlert,
   ShieldCheck,
   AlertTriangle,
+  Search,
 } from 'lucide-react';
 import { Button, Card, Badge, Modal, ConfirmDialog, Table } from '@/components/ui';
 import { PageHeader } from '@/components/layout/PageHeader';
@@ -222,6 +223,7 @@ function CreateApiKeyModal({
 }) {
   const [name, setName] = useState('');
   const [scopes, setScopes] = useState<ApiKeyScopes>({});
+  const [scopeQuery, setScopeQuery] = useState('');
   const [expiresAt, setExpiresAt] = useState('');
   const [modules, setModules] = useState<NamespaceModuleMeta[]>([]);
   const [actions, setActions] = useState<NamespaceActionMeta[]>([]);
@@ -259,6 +261,15 @@ function CreateApiKeyModal({
   };
 
   const scopeCount = Object.keys(scopes).length;
+
+  const q = scopeQuery.trim().toLowerCase();
+  const filteredModules = q
+    ? modules.filter((m) =>
+        [m.display_name, m.name, m.category, m.description]
+          .filter(Boolean)
+          .some((v) => String(v).toLowerCase().includes(q)),
+      )
+    : modules;
 
   const submit = async () => {
     if (!name.trim()) return toast.error('Give the key a name');
@@ -313,29 +324,57 @@ function CreateApiKeyModal({
           ) : modules.length === 0 ? (
             <p className="text-sm text-secondary-500">No scopable modules available in this namespace.</p>
           ) : (
-            <div className="border border-secondary-200 rounded-lg divide-y divide-secondary-100 max-h-64 overflow-y-auto">
-              {modules.map((mod) => (
-                <div key={mod.name} className="px-3 py-2.5">
-                  <div className="text-sm font-medium text-secondary-800">{mod.display_name || mod.name}</div>
-                  <div className="flex flex-wrap gap-x-4 gap-y-1.5 mt-1.5">
-                    {actions.map((a) => {
-                      const checked = (scopes[mod.name] || []).includes(a.name);
-                      return (
-                        <label key={a.name} className="flex items-center gap-1.5 cursor-pointer select-none">
-                          <input
-                            type="checkbox"
-                            checked={checked}
-                            onChange={() => toggle(mod.name, a.name)}
-                            className="w-4 h-4 text-primary-600 border-secondary-300 rounded focus:ring-primary-500"
-                          />
-                          <span className="text-sm text-secondary-600">{a.display_name || a.name}</span>
-                        </label>
-                      );
-                    })}
-                  </div>
-                </div>
-              ))}
-            </div>
+            <>
+              <div className="relative mb-2">
+                <Search className="w-4 h-4 text-secondary-400 absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none" />
+                <input
+                  value={scopeQuery}
+                  onChange={(e) => setScopeQuery(e.target.value)}
+                  placeholder={`Search ${modules.length} modules…`}
+                  className="w-full rounded-lg border border-secondary-300 pl-9 pr-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+                  aria-label="Search permissions"
+                />
+              </div>
+              <div className="border border-secondary-200 rounded-lg divide-y divide-secondary-100 max-h-64 overflow-y-auto">
+                {filteredModules.length === 0 ? (
+                  <p className="text-sm text-secondary-500 px-3 py-6 text-center">
+                    No modules match “{scopeQuery}”.
+                  </p>
+                ) : (
+                  filteredModules.map((mod) => {
+                    const modSelected = (scopes[mod.name] || []).length;
+                    return (
+                      <div key={mod.name} className="px-3 py-2.5">
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm font-medium text-secondary-800">
+                            {mod.display_name || mod.name}
+                          </span>
+                          {modSelected > 0 && (
+                            <Badge variant="info">{modSelected}</Badge>
+                          )}
+                        </div>
+                        <div className="flex flex-wrap gap-x-4 gap-y-1.5 mt-1.5">
+                          {actions.map((a) => {
+                            const checked = (scopes[mod.name] || []).includes(a.name);
+                            return (
+                              <label key={a.name} className="flex items-center gap-1.5 cursor-pointer select-none">
+                                <input
+                                  type="checkbox"
+                                  checked={checked}
+                                  onChange={() => toggle(mod.name, a.name)}
+                                  className="w-4 h-4 text-primary-600 border-secondary-300 rounded focus:ring-primary-500"
+                                />
+                                <span className="text-sm text-secondary-600">{a.display_name || a.name}</span>
+                              </label>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    );
+                  })
+                )}
+              </div>
+            </>
           )}
           {scopeCount > 0 && (
             <p className="text-xs text-secondary-500 mt-1">{scopeCount} module{scopeCount > 1 ? 's' : ''} scoped.</p>

--- a/opsapi-dashboard/app/dashboard/namespace/api-keys/page.tsx
+++ b/opsapi-dashboard/app/dashboard/namespace/api-keys/page.tsx
@@ -1,0 +1,413 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  Key,
+  Plus,
+  Trash2,
+  Copy,
+  Check,
+  Loader2,
+  ShieldAlert,
+  AlertTriangle,
+} from 'lucide-react';
+import { Button, Card, Badge, Modal, ConfirmDialog, Table } from '@/components/ui';
+import { PageHeader } from '@/components/layout/PageHeader';
+import { useNamespace } from '@/contexts/NamespaceContext';
+import { apiKeysService, rolesService } from '@/services';
+import type {
+  ApiKey,
+  CreatedApiKey,
+  ApiKeyScopes,
+  NamespaceModuleMeta,
+  NamespaceActionMeta,
+  TableColumn,
+} from '@/types';
+import toast from 'react-hot-toast';
+
+const fmtDate = (s?: string | null) =>
+  s ? new Date(s).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' }) : '—';
+
+export default function ApiKeysPage() {
+  const { currentNamespace, isNamespaceOwner, hasPermission } = useNamespace();
+  const canManage = isNamespaceOwner || hasPermission('api_keys', 'manage');
+
+  const [keys, setKeys] = useState<ApiKey[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createdKey, setCreatedKey] = useState<CreatedApiKey | null>(null);
+  const [keyToRevoke, setKeyToRevoke] = useState<ApiKey | null>(null);
+  const [isRevoking, setIsRevoking] = useState(false);
+
+  const fetchKeys = useCallback(async () => {
+    if (!currentNamespace) return;
+    setIsLoading(true);
+    try {
+      setKeys(await apiKeysService.list());
+    } catch {
+      toast.error('Failed to load API keys');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [currentNamespace]);
+
+  useEffect(() => {
+    fetchKeys();
+  }, [fetchKeys]);
+
+  const doRevoke = async () => {
+    if (!keyToRevoke) return;
+    setIsRevoking(true);
+    try {
+      await apiKeysService.revoke(keyToRevoke.uuid);
+      toast.success('API key revoked');
+      setKeyToRevoke(null);
+      fetchKeys();
+    } catch {
+      toast.error('Failed to revoke API key');
+    } finally {
+      setIsRevoking(false);
+    }
+  };
+
+  if (!currentNamespace) {
+    return (
+      <Card className="p-8 text-center text-secondary-500">
+        Select a namespace to manage its API keys.
+      </Card>
+    );
+  }
+
+  const columns: TableColumn<ApiKey>[] = [
+    {
+      key: 'name',
+      header: 'Name',
+      render: (k) => (
+        <div className="flex items-center gap-2">
+          <Key className="w-4 h-4 text-secondary-400 shrink-0" />
+          <span className="font-medium text-secondary-900">{k.name}</span>
+        </div>
+      ),
+    },
+    {
+      key: 'key_prefix',
+      header: 'Key',
+      render: (k) => (
+        <code className="font-mono text-xs bg-secondary-50 text-secondary-700 rounded px-2 py-1">
+          {k.key_prefix}…
+        </code>
+      ),
+    },
+    {
+      key: 'scopes',
+      header: 'Scopes',
+      render: (k) => {
+        const entries = Object.entries(k.scopes || {});
+        if (entries.length === 0) return <span className="text-secondary-400">—</span>;
+        return (
+          <div className="flex flex-wrap gap-1">
+            {entries.map(([mod, actions]) => (
+              <Badge key={mod} variant="secondary" title={actions.join(', ')}>
+                {mod}: {actions.join('/')}
+              </Badge>
+            ))}
+          </div>
+        );
+      },
+    },
+    { key: 'last_used_at', header: 'Last used', render: (k) => <span className="text-secondary-600">{fmtDate(k.last_used_at)}</span> },
+    { key: 'expires_at', header: 'Expires', render: (k) => <span className="text-secondary-600">{fmtDate(k.expires_at)}</span> },
+    {
+      key: 'status',
+      header: 'Status',
+      render: (k) =>
+        k.revoked ? <Badge variant="error">Revoked</Badge> : <Badge variant="success">Active</Badge>,
+    },
+    {
+      key: 'actions',
+      header: '',
+      render: (k) =>
+        canManage && !k.revoked ? (
+          <button
+            onClick={() => setKeyToRevoke(k)}
+            className="text-secondary-400 hover:text-error-600 transition-colors"
+            title="Revoke key"
+            aria-label={`Revoke ${k.name}`}
+          >
+            <Trash2 className="w-4 h-4" />
+          </button>
+        ) : null,
+    },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="API Keys"
+        description={`Machine credentials for ${currentNamespace.name}. Keys authenticate as "Authorization: Bearer opsk_…" and only do what their scopes allow.`}
+        icon={<Key className="w-6 h-6" />}
+        actions={
+          canManage ? (
+            <Button onClick={() => setCreateOpen(true)} leftIcon={<Plus className="w-4 h-4" />}>
+              Create API key
+            </Button>
+          ) : undefined
+        }
+      />
+
+      {isLoading ? (
+        <div className="flex justify-center py-16">
+          <Loader2 className="w-6 h-6 animate-spin text-primary-500" />
+        </div>
+      ) : keys.length === 0 ? (
+        <Card className="p-10 text-center">
+          <Key className="w-10 h-10 text-secondary-300 mx-auto mb-3" />
+          <h3 className="text-secondary-900 font-medium">No API keys yet</h3>
+          <p className="text-secondary-500 text-sm mt-1">
+            Create a key to let scripts and services call the API without a user login.
+          </p>
+          {canManage && (
+            <Button className="mt-4" onClick={() => setCreateOpen(true)} leftIcon={<Plus className="w-4 h-4" />}>
+              Create API key
+            </Button>
+          )}
+        </Card>
+      ) : (
+        <Card>
+          <Table columns={columns} data={keys} keyExtractor={(k) => k.uuid} />
+        </Card>
+      )}
+
+      {createOpen && (
+        <CreateApiKeyModal
+          onClose={() => setCreateOpen(false)}
+          onCreated={(created) => {
+            setCreateOpen(false);
+            setCreatedKey(created);
+            fetchKeys();
+          }}
+        />
+      )}
+
+      {createdKey && <RevealKeyModal created={createdKey} onClose={() => setCreatedKey(null)} />}
+
+      <ConfirmDialog
+        isOpen={!!keyToRevoke}
+        onClose={() => setKeyToRevoke(null)}
+        onConfirm={doRevoke}
+        title="Revoke API key"
+        message={`Revoke "${keyToRevoke?.name}"? Any script using it will immediately stop working. This cannot be undone.`}
+        confirmText="Revoke"
+        variant="danger"
+        isLoading={isRevoking}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Create modal — name + scope matrix (module × action) + optional expiry
+// ---------------------------------------------------------------------------
+
+function CreateApiKeyModal({
+  onClose,
+  onCreated,
+}: {
+  onClose: () => void;
+  onCreated: (created: CreatedApiKey) => void;
+}) {
+  const [name, setName] = useState('');
+  const [scopes, setScopes] = useState<ApiKeyScopes>({});
+  const [expiresAt, setExpiresAt] = useState('');
+  const [modules, setModules] = useState<NamespaceModuleMeta[]>([]);
+  const [actions, setActions] = useState<NamespaceActionMeta[]>([]);
+  const [metaLoading, setMetaLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const meta = (await rolesService.getPermissionsMeta()) as unknown as {
+          modules: NamespaceModuleMeta[];
+          actions: NamespaceActionMeta[];
+        };
+        // The backend forbids the "namespace" module on API keys (no self-escalation).
+        setModules((meta.modules || []).filter((m) => m.name !== 'namespace'));
+        setActions(meta.actions || []);
+      } catch {
+        toast.error('Could not load available scopes');
+      } finally {
+        setMetaLoading(false);
+      }
+    })();
+  }, []);
+
+  const toggle = (mod: string, action: string) => {
+    setScopes((prev) => {
+      const current = new Set(prev[mod] || []);
+      if (current.has(action)) current.delete(action);
+      else current.add(action);
+      const next = { ...prev };
+      if (current.size === 0) delete next[mod];
+      else next[mod] = Array.from(current);
+      return next;
+    });
+  };
+
+  const scopeCount = Object.keys(scopes).length;
+
+  const submit = async () => {
+    if (!name.trim()) return toast.error('Give the key a name');
+    if (scopeCount === 0) return toast.error('Select at least one scope');
+    setSubmitting(true);
+    try {
+      const created = await apiKeysService.create({
+        name: name.trim(),
+        scopes,
+        expires_at: expiresAt || undefined,
+      });
+      toast.success('API key created');
+      onCreated(created);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to create API key');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal isOpen onClose={onClose} title="Create API key" size="lg">
+      <div className="space-y-5">
+        <div>
+          <label className="block text-sm font-medium text-secondary-700 mb-1.5">Name</label>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. blog-importer, ci-deploy"
+            className="w-full rounded-lg border border-secondary-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+            autoFocus
+          />
+          <p className="text-xs text-secondary-500 mt-1">A label to recognise this key later — not secret.</p>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-secondary-700 mb-1.5">
+            Scopes <span className="text-secondary-400 font-normal">— what this key may do</span>
+          </label>
+          {metaLoading ? (
+            <div className="flex justify-center py-6">
+              <Loader2 className="w-5 h-5 animate-spin text-primary-500" />
+            </div>
+          ) : modules.length === 0 ? (
+            <p className="text-sm text-secondary-500">No scopable modules available in this namespace.</p>
+          ) : (
+            <div className="border border-secondary-200 rounded-lg divide-y divide-secondary-100 max-h-64 overflow-y-auto">
+              {modules.map((mod) => (
+                <div key={mod.name} className="px-3 py-2.5">
+                  <div className="text-sm font-medium text-secondary-800">{mod.display_name || mod.name}</div>
+                  <div className="flex flex-wrap gap-x-4 gap-y-1.5 mt-1.5">
+                    {actions.map((a) => {
+                      const checked = (scopes[mod.name] || []).includes(a.name);
+                      return (
+                        <label key={a.name} className="flex items-center gap-1.5 cursor-pointer select-none">
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            onChange={() => toggle(mod.name, a.name)}
+                            className="w-4 h-4 text-primary-600 border-secondary-300 rounded focus:ring-primary-500"
+                          />
+                          <span className="text-sm text-secondary-600">{a.display_name || a.name}</span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+          {scopeCount > 0 && (
+            <p className="text-xs text-secondary-500 mt-1">{scopeCount} module{scopeCount > 1 ? 's' : ''} scoped.</p>
+          )}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-secondary-700 mb-1.5">
+            Expiry <span className="text-secondary-400 font-normal">— optional</span>
+          </label>
+          <input
+            type="date"
+            value={expiresAt}
+            onChange={(e) => setExpiresAt(e.target.value)}
+            className="rounded-lg border border-secondary-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+          />
+          <p className="text-xs text-secondary-500 mt-1">Leave blank for a key that never expires.</p>
+        </div>
+
+        <div className="flex justify-end gap-3 pt-2">
+          <Button variant="outline" onClick={onClose} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button onClick={submit} isLoading={submitting}>
+            Create key
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Reveal-once modal — shows the raw secret a single time
+// ---------------------------------------------------------------------------
+
+function RevealKeyModal({ created, onClose }: { created: CreatedApiKey; onClose: () => void }) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(created.key);
+      setCopied(true);
+      toast.success('API key copied to clipboard');
+      setTimeout(() => setCopied(false), 2500);
+    } catch {
+      toast.error('Could not copy — select and copy manually');
+    }
+  };
+
+  return (
+    <Modal isOpen onClose={onClose} title="Your new API key" size="lg" showClose={false}>
+      <div className="space-y-4">
+        <div className="flex items-start gap-2 rounded-lg bg-warning-500/10 border border-warning-500/20 p-3">
+          <AlertTriangle className="w-5 h-5 text-warning-600 shrink-0 mt-0.5" />
+          <p className="text-sm text-warning-600">
+            Copy this key now — for security it is <strong>shown only once</strong> and cannot be retrieved
+            again. If you lose it, revoke it and create a new one.
+          </p>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-secondary-700 mb-1.5">
+            {created.name}
+          </label>
+          <div className="flex items-stretch gap-2">
+            <code className="flex-1 font-mono text-sm bg-secondary-50 text-secondary-900 rounded-lg px-3 py-2.5 break-all border border-secondary-200">
+              {created.key}
+            </code>
+            <Button variant="outline" onClick={copy} leftIcon={copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}>
+              {copied ? 'Copied' : 'Copy'}
+            </Button>
+          </div>
+        </div>
+
+        <div className="text-xs text-secondary-500 flex items-center gap-1.5">
+          <ShieldAlert className="w-3.5 h-3.5" />
+          Use it as a bearer token: <code className="font-mono">Authorization: Bearer {created.key_prefix}…</code>
+        </div>
+
+        <div className="flex justify-end pt-1">
+          <Button onClick={onClose}>Done</Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/opsapi-dashboard/app/dashboard/namespace/api-keys/page.tsx
+++ b/opsapi-dashboard/app/dashboard/namespace/api-keys/page.tsx
@@ -1,43 +1,27 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import {
-  Key,
-  Plus,
-  Trash2,
-  Copy,
-  Check,
-  Loader2,
-  ShieldAlert,
-  ShieldCheck,
-  AlertTriangle,
-  Search,
-} from 'lucide-react';
-import { Button, Card, Badge, Modal, ConfirmDialog, Table } from '@/components/ui';
+import { useRouter } from 'next/navigation';
+import { Key, Plus, Trash2, Loader2 } from 'lucide-react';
+import { Button, Card, Badge, ConfirmDialog, Table } from '@/components/ui';
 import { PageHeader } from '@/components/layout/PageHeader';
 import { useNamespace } from '@/contexts/NamespaceContext';
-import { apiKeysService, rolesService } from '@/services';
-import type {
-  ApiKey,
-  CreatedApiKey,
-  ApiKeyScopes,
-  NamespaceModuleMeta,
-  NamespaceActionMeta,
-  TableColumn,
-} from '@/types';
+import { apiKeysService } from '@/services';
+import type { ApiKey, TableColumn } from '@/types';
 import toast from 'react-hot-toast';
+
+const NEW_PATH = '/dashboard/namespace/api-keys/new';
 
 const fmtDate = (s?: string | null) =>
   s ? new Date(s).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' }) : '—';
 
 export default function ApiKeysPage() {
+  const router = useRouter();
   const { currentNamespace, isNamespaceOwner, hasPermission } = useNamespace();
   const canManage = isNamespaceOwner || hasPermission('api_keys', 'manage');
 
   const [keys, setKeys] = useState<ApiKey[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [createOpen, setCreateOpen] = useState(false);
-  const [createdKey, setCreatedKey] = useState<CreatedApiKey | null>(null);
   const [keyToRevoke, setKeyToRevoke] = useState<ApiKey | null>(null);
   const [isRevoking, setIsRevoking] = useState(false);
 
@@ -65,8 +49,8 @@ export default function ApiKeysPage() {
       toast.success('API key revoked');
       setKeyToRevoke(null);
       fetchKeys();
-    } catch {
-      toast.error('Failed to revoke API key');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to revoke API key');
     } finally {
       setIsRevoking(false);
     }
@@ -108,9 +92,9 @@ export default function ApiKeysPage() {
         if (entries.length === 0) return <span className="text-secondary-400">—</span>;
         return (
           <div className="flex flex-wrap gap-1">
-            {entries.map(([mod, actions]) => (
-              <Badge key={mod} variant="secondary" title={actions.join(', ')}>
-                {mod}: {actions.join('/')}
+            {entries.map(([mod, acts]) => (
+              <Badge key={mod} variant="secondary" title={(acts as string[]).join(', ')}>
+                {mod}: {(acts as string[]).join('/')}
               </Badge>
             ))}
           </div>
@@ -122,8 +106,7 @@ export default function ApiKeysPage() {
     {
       key: 'status',
       header: 'Status',
-      render: (k) =>
-        k.revoked ? <Badge variant="error">Revoked</Badge> : <Badge variant="success">Active</Badge>,
+      render: (k) => (k.revoked ? <Badge variant="error">Revoked</Badge> : <Badge variant="success">Active</Badge>),
     },
     {
       key: 'actions',
@@ -146,11 +129,11 @@ export default function ApiKeysPage() {
     <div className="space-y-6">
       <PageHeader
         title="API Keys"
-        description={`Machine credentials for ${currentNamespace.name}. Keys authenticate as "Authorization: Bearer opsk_…" and only do what their scopes allow.`}
+        description={`Machine credentials for ${currentNamespace.name}. Keys authenticate as "Authorization: Bearer opsk_…" and only do what their scopes allow — within this namespace.`}
         icon={<Key className="w-6 h-6" />}
         actions={
           canManage ? (
-            <Button onClick={() => setCreateOpen(true)} leftIcon={<Plus className="w-4 h-4" />}>
+            <Button onClick={() => router.push(NEW_PATH)} leftIcon={<Plus className="w-4 h-4" />}>
               Create API key
             </Button>
           ) : undefined
@@ -169,7 +152,7 @@ export default function ApiKeysPage() {
             Create a key to let scripts and services call the API without a user login.
           </p>
           {canManage && (
-            <Button className="mt-4" onClick={() => setCreateOpen(true)} leftIcon={<Plus className="w-4 h-4" />}>
+            <Button className="mt-4" onClick={() => router.push(NEW_PATH)} leftIcon={<Plus className="w-4 h-4" />}>
               Create API key
             </Button>
           )}
@@ -179,20 +162,6 @@ export default function ApiKeysPage() {
           <Table columns={columns} data={keys} keyExtractor={(k) => k.uuid} />
         </Card>
       )}
-
-      {createOpen && (
-        <CreateApiKeyModal
-          namespaceName={currentNamespace.name}
-          onClose={() => setCreateOpen(false)}
-          onCreated={(created) => {
-            setCreateOpen(false);
-            setCreatedKey(created);
-            fetchKeys();
-          }}
-        />
-      )}
-
-      {createdKey && <RevealKeyModal created={createdKey} onClose={() => setCreatedKey(null)} />}
 
       <ConfirmDialog
         isOpen={!!keyToRevoke}
@@ -205,260 +174,5 @@ export default function ApiKeysPage() {
         isLoading={isRevoking}
       />
     </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Create modal — name + scope matrix (module × action) + optional expiry
-// ---------------------------------------------------------------------------
-
-function CreateApiKeyModal({
-  namespaceName,
-  onClose,
-  onCreated,
-}: {
-  namespaceName: string;
-  onClose: () => void;
-  onCreated: (created: CreatedApiKey) => void;
-}) {
-  const [name, setName] = useState('');
-  const [scopes, setScopes] = useState<ApiKeyScopes>({});
-  const [scopeQuery, setScopeQuery] = useState('');
-  const [expiresAt, setExpiresAt] = useState('');
-  const [modules, setModules] = useState<NamespaceModuleMeta[]>([]);
-  const [actions, setActions] = useState<NamespaceActionMeta[]>([]);
-  const [metaLoading, setMetaLoading] = useState(true);
-  const [submitting, setSubmitting] = useState(false);
-
-  useEffect(() => {
-    (async () => {
-      try {
-        const meta = (await rolesService.getPermissionsMeta()) as unknown as {
-          modules: NamespaceModuleMeta[];
-          actions: NamespaceActionMeta[];
-        };
-        // The backend forbids the "namespace" module on API keys (no self-escalation).
-        setModules((meta.modules || []).filter((m) => m.name !== 'namespace'));
-        setActions(meta.actions || []);
-      } catch {
-        toast.error('Could not load available scopes');
-      } finally {
-        setMetaLoading(false);
-      }
-    })();
-  }, []);
-
-  const toggle = (mod: string, action: string) => {
-    setScopes((prev) => {
-      const current = new Set(prev[mod] || []);
-      if (current.has(action)) current.delete(action);
-      else current.add(action);
-      const next = { ...prev };
-      if (current.size === 0) delete next[mod];
-      else next[mod] = Array.from(current);
-      return next;
-    });
-  };
-
-  const scopeCount = Object.keys(scopes).length;
-
-  const q = scopeQuery.trim().toLowerCase();
-  const filteredModules = q
-    ? modules.filter((m) =>
-        [m.display_name, m.name, m.category, m.description]
-          .filter(Boolean)
-          .some((v) => String(v).toLowerCase().includes(q)),
-      )
-    : modules;
-
-  const submit = async () => {
-    if (!name.trim()) return toast.error('Give the key a name');
-    if (scopeCount === 0) return toast.error('Select at least one scope');
-    setSubmitting(true);
-    try {
-      const created = await apiKeysService.create({
-        name: name.trim(),
-        scopes,
-        expires_at: expiresAt || undefined,
-      });
-      toast.success('API key created');
-      onCreated(created);
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to create API key');
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  return (
-    <Modal isOpen onClose={onClose} title="Create API key" size="lg">
-      <div className="space-y-5">
-        <div className="flex items-start gap-2 rounded-lg bg-primary-500/5 border border-primary-500/20 p-3">
-          <ShieldCheck className="w-5 h-5 text-primary-600 shrink-0 mt-0.5" />
-          <p className="text-sm text-secondary-600">
-            This key is locked to the <strong className="text-secondary-900">{namespaceName}</strong> namespace —
-            it can never access another. It can do <strong>only</strong> what you grant below, nothing more.
-          </p>
-        </div>
-
-        <div>
-          <label className="block text-sm font-medium text-secondary-700 mb-1.5">Name</label>
-          <input
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="e.g. blog-importer, ci-deploy"
-            className="w-full rounded-lg border border-secondary-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
-            autoFocus
-          />
-          <p className="text-xs text-secondary-500 mt-1">A label to recognise this key later — not secret.</p>
-        </div>
-
-        <div>
-          <label className="block text-sm font-medium text-secondary-700 mb-1.5">
-            Scopes <span className="text-secondary-400 font-normal">— what this key may do</span>
-          </label>
-          {metaLoading ? (
-            <div className="flex justify-center py-6">
-              <Loader2 className="w-5 h-5 animate-spin text-primary-500" />
-            </div>
-          ) : modules.length === 0 ? (
-            <p className="text-sm text-secondary-500">No scopable modules available in this namespace.</p>
-          ) : (
-            <>
-              <div className="relative mb-2">
-                <Search className="w-4 h-4 text-secondary-400 absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none" />
-                <input
-                  value={scopeQuery}
-                  onChange={(e) => setScopeQuery(e.target.value)}
-                  placeholder={`Search ${modules.length} modules…`}
-                  className="w-full rounded-lg border border-secondary-300 pl-9 pr-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
-                  aria-label="Search permissions"
-                />
-              </div>
-              <div className="border border-secondary-200 rounded-lg divide-y divide-secondary-100 max-h-64 overflow-y-auto">
-                {filteredModules.length === 0 ? (
-                  <p className="text-sm text-secondary-500 px-3 py-6 text-center">
-                    No modules match “{scopeQuery}”.
-                  </p>
-                ) : (
-                  filteredModules.map((mod) => {
-                    const modSelected = (scopes[mod.name] || []).length;
-                    return (
-                      <div key={mod.name} className="px-3 py-2.5">
-                        <div className="flex items-center gap-2">
-                          <span className="text-sm font-medium text-secondary-800">
-                            {mod.display_name || mod.name}
-                          </span>
-                          {modSelected > 0 && (
-                            <Badge variant="info">{modSelected}</Badge>
-                          )}
-                        </div>
-                        <div className="flex flex-wrap gap-x-4 gap-y-1.5 mt-1.5">
-                          {actions.map((a) => {
-                            const checked = (scopes[mod.name] || []).includes(a.name);
-                            return (
-                              <label key={a.name} className="flex items-center gap-1.5 cursor-pointer select-none">
-                                <input
-                                  type="checkbox"
-                                  checked={checked}
-                                  onChange={() => toggle(mod.name, a.name)}
-                                  className="w-4 h-4 text-primary-600 border-secondary-300 rounded focus:ring-primary-500"
-                                />
-                                <span className="text-sm text-secondary-600">{a.display_name || a.name}</span>
-                              </label>
-                            );
-                          })}
-                        </div>
-                      </div>
-                    );
-                  })
-                )}
-              </div>
-            </>
-          )}
-          {scopeCount > 0 && (
-            <p className="text-xs text-secondary-500 mt-1">{scopeCount} module{scopeCount > 1 ? 's' : ''} scoped.</p>
-          )}
-        </div>
-
-        <div>
-          <label className="block text-sm font-medium text-secondary-700 mb-1.5">
-            Expiry <span className="text-secondary-400 font-normal">— optional</span>
-          </label>
-          <input
-            type="date"
-            value={expiresAt}
-            onChange={(e) => setExpiresAt(e.target.value)}
-            className="rounded-lg border border-secondary-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
-          />
-          <p className="text-xs text-secondary-500 mt-1">Leave blank for a key that never expires.</p>
-        </div>
-
-        <div className="flex justify-end gap-3 pt-2">
-          <Button variant="outline" onClick={onClose} disabled={submitting}>
-            Cancel
-          </Button>
-          <Button onClick={submit} isLoading={submitting}>
-            Create key
-          </Button>
-        </div>
-      </div>
-    </Modal>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Reveal-once modal — shows the raw secret a single time
-// ---------------------------------------------------------------------------
-
-function RevealKeyModal({ created, onClose }: { created: CreatedApiKey; onClose: () => void }) {
-  const [copied, setCopied] = useState(false);
-
-  const copy = async () => {
-    try {
-      await navigator.clipboard.writeText(created.key);
-      setCopied(true);
-      toast.success('API key copied to clipboard');
-      setTimeout(() => setCopied(false), 2500);
-    } catch {
-      toast.error('Could not copy — select and copy manually');
-    }
-  };
-
-  return (
-    <Modal isOpen onClose={onClose} title="Your new API key" size="lg" showClose={false}>
-      <div className="space-y-4">
-        <div className="flex items-start gap-2 rounded-lg bg-warning-500/10 border border-warning-500/20 p-3">
-          <AlertTriangle className="w-5 h-5 text-warning-600 shrink-0 mt-0.5" />
-          <p className="text-sm text-warning-600">
-            Copy this key now — for security it is <strong>shown only once</strong> and cannot be retrieved
-            again. If you lose it, revoke it and create a new one.
-          </p>
-        </div>
-
-        <div>
-          <label className="block text-sm font-medium text-secondary-700 mb-1.5">
-            {created.name}
-          </label>
-          <div className="flex items-stretch gap-2">
-            <code className="flex-1 font-mono text-sm bg-secondary-50 text-secondary-900 rounded-lg px-3 py-2.5 break-all border border-secondary-200">
-              {created.key}
-            </code>
-            <Button variant="outline" onClick={copy} leftIcon={copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}>
-              {copied ? 'Copied' : 'Copy'}
-            </Button>
-          </div>
-        </div>
-
-        <div className="text-xs text-secondary-500 flex items-center gap-1.5">
-          <ShieldAlert className="w-3.5 h-3.5" />
-          Use it as a bearer token: <code className="font-mono">Authorization: Bearer {created.key_prefix}…</code>
-        </div>
-
-        <div className="flex justify-end pt-1">
-          <Button onClick={onClose}>Done</Button>
-        </div>
-      </div>
-    </Modal>
   );
 }

--- a/opsapi-dashboard/hooks/useMenu.ts
+++ b/opsapi-dashboard/hooks/useMenu.ts
@@ -45,6 +45,8 @@ async function loadIconMap(): Promise<Record<string, LucideIcon>> {
     BarChart3: icons.BarChart3,
     UserCircle: icons.UserCircle,
     Shield: icons.Shield,
+    Key: icons.Key,
+    KeyRound: icons.KeyRound,
     Building2: icons.Building2,
     Rocket: icons.Rocket,
     Kanban: icons.Kanban,

--- a/opsapi-dashboard/services/apiKeys.service.ts
+++ b/opsapi-dashboard/services/apiKeys.service.ts
@@ -9,6 +9,23 @@ import type { ApiKey, CreateApiKeyDto, CreatedApiKey } from '@/types';
  */
 const JSON_HEADERS = { headers: { 'Content-Type': 'application/json' } };
 
+/**
+ * Surface the backend's own message. axios throws on a 4xx BEFORE we can read the
+ * body, and the API answers errors as { error: "..." } — so a raw axios error
+ * ("Request failed with status code 403") would otherwise reach the UI. Prefer
+ * the response body, then the axios message, then a caller fallback.
+ */
+function messageFrom(err: unknown, fallback: string): string {
+  if (typeof err === 'object' && err !== null) {
+    const e = err as {
+      response?: { data?: { error?: string; message?: string } };
+      message?: string;
+    };
+    return e.response?.data?.error || e.response?.data?.message || e.message || fallback;
+  }
+  return fallback;
+}
+
 export const apiKeysService = {
   /** List the current namespace's keys (never returns the secret or its hash). */
   async list(): Promise<ApiKey[]> {
@@ -18,20 +35,28 @@ export const apiKeysService = {
 
   /** Create a key; the raw secret is returned ONCE in `data.key`. */
   async create(payload: CreateApiKeyDto): Promise<CreatedApiKey> {
-    const res = await apiClient.post<{ success: boolean; data: CreatedApiKey; error?: string }>(
-      '/api/v2/api-keys',
-      payload,
-      JSON_HEADERS,
-    );
-    if (!res.data?.success || !res.data?.data) {
-      throw new Error(res.data?.error || 'Failed to create API key');
+    try {
+      const res = await apiClient.post<{ success: boolean; data: CreatedApiKey; error?: string }>(
+        '/api/v2/api-keys',
+        payload,
+        JSON_HEADERS,
+      );
+      if (!res.data?.success || !res.data?.data) {
+        throw new Error(res.data?.error || 'Failed to create API key');
+      }
+      return res.data.data;
+    } catch (err) {
+      throw new Error(messageFrom(err, 'Failed to create API key'));
     }
-    return res.data.data;
   },
 
   /** Revoke a key (idempotent). */
   async revoke(uuid: string): Promise<void> {
-    await apiClient.delete(`/api/v2/api-keys/${uuid}`);
+    try {
+      await apiClient.delete(`/api/v2/api-keys/${uuid}`);
+    } catch (err) {
+      throw new Error(messageFrom(err, 'Failed to revoke API key'));
+    }
   },
 };
 

--- a/opsapi-dashboard/services/apiKeys.service.ts
+++ b/opsapi-dashboard/services/apiKeys.service.ts
@@ -1,0 +1,38 @@
+import apiClient from '@/lib/api-client';
+import type { ApiKey, CreateApiKeyDto, CreatedApiKey } from '@/types';
+
+/**
+ * Namespace-scoped API keys (machine credentials).
+ * Backend: lapis/routes/api-keys.lua. The api-client interceptor attaches the
+ * auth token + X-Namespace-Id automatically; these endpoints require a JSON body
+ * (not the default form-encoding) and return a { success, data, error } envelope.
+ */
+const JSON_HEADERS = { headers: { 'Content-Type': 'application/json' } };
+
+export const apiKeysService = {
+  /** List the current namespace's keys (never returns the secret or its hash). */
+  async list(): Promise<ApiKey[]> {
+    const res = await apiClient.get<{ success: boolean; data: ApiKey[] }>('/api/v2/api-keys');
+    return res.data?.data || [];
+  },
+
+  /** Create a key; the raw secret is returned ONCE in `data.key`. */
+  async create(payload: CreateApiKeyDto): Promise<CreatedApiKey> {
+    const res = await apiClient.post<{ success: boolean; data: CreatedApiKey; error?: string }>(
+      '/api/v2/api-keys',
+      payload,
+      JSON_HEADERS,
+    );
+    if (!res.data?.success || !res.data?.data) {
+      throw new Error(res.data?.error || 'Failed to create API key');
+    }
+    return res.data.data;
+  },
+
+  /** Revoke a key (idempotent). */
+  async revoke(uuid: string): Promise<void> {
+    await apiClient.delete(`/api/v2/api-keys/${uuid}`);
+  },
+};
+
+export default apiKeysService;

--- a/opsapi-dashboard/services/index.ts
+++ b/opsapi-dashboard/services/index.ts
@@ -122,3 +122,4 @@ export {
   alertsService,
   dementiaService,
 } from './familyAccess.service';
+export { apiKeysService } from './apiKeys.service';

--- a/opsapi-dashboard/types/index.ts
+++ b/opsapi-dashboard/types/index.ts
@@ -697,6 +697,45 @@ export interface NamespaceActionMeta {
 }
 
 // ============================================
+// API Keys (namespace-scoped machine credentials)
+// Backend: lapis/routes/api-keys.lua
+// ============================================
+
+/** scopes shape: { module_machine_name: ["create", "read", ...] } */
+export type ApiKeyScopes = Record<string, string[]>;
+
+export interface ApiKey {
+  uuid: string;
+  name: string;
+  /** Short, non-secret prefix for display, e.g. "opsk_a1b2c3d". */
+  key_prefix: string;
+  scopes: ApiKeyScopes;
+  last_used_at?: string | null;
+  expires_at?: string | null;
+  revoked_at?: string | null;
+  revoked: boolean;
+  created_at: string;
+}
+
+export interface CreateApiKeyDto {
+  name: string;
+  scopes: ApiKeyScopes;
+  /** ISO date/datetime string, e.g. "2027-01-31". Optional = never expires. */
+  expires_at?: string;
+}
+
+/** Returned ONCE from create — carries the raw secret `key`, never retrievable again. */
+export interface CreatedApiKey {
+  uuid: string;
+  name: string;
+  key_prefix: string;
+  scopes: ApiKeyScopes;
+  expires_at?: string | null;
+  /** The full "opsk_…" secret. Shown once; store it now. */
+  key: string;
+}
+
+// ============================================
 // User Namespace Settings (User-First Architecture)
 // Users are GLOBAL, namespaces are assigned to users
 // ============================================


### PR DESCRIPTION
Adds a first-class **API Keys** page to the dashboard so users generate and manage machine credentials properly — no more copying JWTs from devtools.

### Why
The backend already has the full feature (`lapis/routes/api-keys.lua`: create/list/revoke, `requireAdmin`, `opsk_` keys SHA-256-hashed at rest, revealed once, scopes validated, no self-escalation) — but there was **no UI**, so there was no supported way for a customer to mint a key.

### What's in it
- **`app/dashboard/namespace/api-keys/page.tsx`** — lists keys (name, `key_prefix`, scopes, last-used, expiry, Active/Revoked), Create + Revoke. Mirrors the Roles page conventions (`useNamespace`, `PageHeader`, `Table`, `ConfirmDialog`, `react-hot-toast`).
  - **Create modal**: name + a **scope matrix** (module × action) sourced from the same RBAC meta the Roles UI uses (`/api/v2/namespace/roles/meta/permissions`), excluding the `namespace` module the backend forbids; optional expiry.
  - **Reveal-once modal**: shows the raw `opsk_…` secret **a single time** with copy-to-clipboard and a "shown once, store it now" warning (the create endpoint returns `key` only once).
- **`services/apiKeys.service.ts`** (+ barrel export) — JSON-body requests against the `{success,data,error}` envelope; the api-client injects auth + `X-Namespace-Id`.
- **Types**: `ApiKey` / `CreateApiKeyDto` / `CreatedApiKey`.
- **`hooks/useMenu.ts`** — maps the `Key` icon.
- **Menu migration** `1000_add_api_keys_menu_item` (`menu-system.lua` step 10) — seeds the sidebar entry (gated `settings:read`, like Settings) and enables it per namespace, idempotently.

### Security
No backend changes needed — it stays enforced server-side (`requireAuth` + `requireAdmin`; keys hashed; `namespace` scope refused; keys can't manage keys). The UI gate is defence-in-depth only.

### Verification
- `tsc --noEmit`: new files clean. `eslint`: new files clean (only pre-existing `useMenu` warnings remain).
- `luajit` loads `menu-system.lua` + `migrations.lua` clean; migration is idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)