### PR TITLE
fix(migrations): api-keys menu key sorts before menu_items exists (blocks deploys)

### DIFF
--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -1275,7 +1275,11 @@ local _migrations = {
         menu_system_migrations, 7),
     ['270_init_namespace_menu_configs'] = conditional_array(ProjectConfig.FEATURES.MENU, menu_system_migrations, 8),
     ['288_add_vault_menu_item'] = conditional_array(ProjectConfig.FEATURES.VAULT, menu_system_migrations, 9),
-    ['1000_add_api_keys_menu_item'] = conditional_array(ProjectConfig.FEATURES.MENU, menu_system_migrations, 10),
+    -- Key MUST sort after 263_create_menu_items_table etc. Lapis orders migrations
+    -- lexicographically, so '1000' sorted BEFORE '263' and ran before menu_items
+    -- existed. '295' sorts after the menu-table migrations. (Never applied under
+    -- the old key — the fresh-DB gate rejected it before any deploy recorded it.)
+    ['295_add_api_keys_menu_item'] = conditional_array(ProjectConfig.FEATURES.MENU, menu_system_migrations, 10),
 
     -- Secret Vault (conditional)
     ['272_create_namespace_secret_vaults_table'] = conditional_array(ProjectConfig.FEATURES.VAULT,


### PR DESCRIPTION
**Hotfix — unblocks all backend deploys.**

The merged `1000_add_api_keys_menu_item` migration key sorts **lexicographically before** `263_create_menu_items_table` (Lapis orders migrations by string key). So on the fresh-DB migration gate it ran while `menu_items` didn't exist yet:

```
Migrating: 1000_add_api_keys_menu_item
Error: relation "menu_items" does not exist
::error::lapis migrate failed against a fresh database — deploys blocked
```

That failed the gate → the int deploy was **skipped** (so the menu migration + latest backend never reached int).

Fix: rename the key to `295_add_api_keys_menu_item` (295 sorts after 263/265/288 — the menu-table migrations). The step body is unchanged. Never applied under the old key (the gate discarded the fresh DB; the real deploy was skipped), so no rename/rollback hazard. `luajit` loads clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)