### PR TITLE
fix(int): pin opsapi API + dashboard to debian010 (debworker00 at pod cap)

### DIFF
--- a/devops/helm-charts/diytaxreturn-lapis/values-workstation-int.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/values-workstation-int.yaml
@@ -68,12 +68,13 @@ ingress:
           pathType: Prefix
   tls: []
 
-# Pin the pod to debworker00 (a debian node with disk headroom). Combines with
-# the chart's NotIn-lubuntu001 affinity. Routing is independent of pod
-# placement — traefik-edge on the edge nodes reaches this ClusterIP Service
-# wherever the pod runs.
+# Pin the pod to debian010 (a debian LAN node with pod headroom). Moved off
+# debworker00, which hit its 110/110 pod cap and left the pod Pending. debian010
+# still reaches workstation-db (a ClusterIP on the LAN mesh) fine. Combines with
+# the chart's NotIn-lubuntu001 affinity. Routing is independent of pod placement —
+# traefik-edge on the edge nodes reaches this ClusterIP Service wherever it runs.
 nodeSelector:
-  kubernetes.io/hostname: debworker00
+  kubernetes.io/hostname: debian010
 
 # DATABASE — dedicated Postgres on the LAN (moved here 2026-08-19).
 #   `host` points this release at its OWN `workstation-db` Postgres

--- a/devops/helm-charts/opsapi-dashboard/values-workstation-int.yaml
+++ b/devops/helm-charts/opsapi-dashboard/values-workstation-int.yaml
@@ -22,5 +22,7 @@ ingress:
   annotations: {}
   tls: []
 
+# Pinned to debian010 alongside the API pod — debworker00 hit its 110/110 pod
+# cap. The UI talks to the API over HTTPS, so placement is routing-independent.
 nodeSelector:
-  kubernetes.io/hostname: debworker00
+  kubernetes.io/hostname: debian010


### PR DESCRIPTION
## What
Repoint both **int** opsapi releases' `nodeSelector` from `debworker00` → `debian010`:
- `devops/helm-charts/diytaxreturn-lapis/values-workstation-int.yaml` (API)
- `devops/helm-charts/opsapi-dashboard/values-workstation-int.yaml` (dashboard UI)

## Why
`debworker00` hit its **110/110 pod cap**, so the new `workstation-opsapi` pod
sat **Pending / FailedScheduling** and int-opsapi went down after the last
deploy. `debian010` is another debian **LAN** node with pod headroom that still
reaches the LAN `workstation-db` ClusterIP, so DB connectivity is unaffected.

The incident was already recovered live with `kubectl patch` (pod booted on
debian010, migrations ran, `/: 200`). This PR **persists** that placement so the
next helm deploy doesn't revert it back to the full node.

## Verification (post-live-patch, before this PR)
- `int-opsapi.workstation.co.uk/api/v2/system/info` → **200**
- `int-opsapi.workstation.co.uk/api/v2/public/cms/workstation/posts` → **200**
- `int-opsapi-ui.workstation.co.uk/login` → **200**
- `295_add_api_keys_menu_item` migration applied (pod Ready ⇒ postStart migrate succeeded)

## Follow-up (not in this PR)
Single-node pins are brittle; a LAN-only `nodeAffinity` set (any debian/debworker node, excluding cloud + lubuntu001) would be more resilient. Deferred to keep this change minimal and match the recovered state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)