### PR TITLE
feat(dashboard): API key entry points, admin namespace edit, settings redesign

### DIFF
--- a/opsapi-dashboard/app/dashboard/namespace/api-keys/new/page.tsx
+++ b/opsapi-dashboard/app/dashboard/namespace/api-keys/new/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import {
   Key,
   ArrowLeft,
@@ -18,6 +18,7 @@ import {
 } from 'lucide-react';
 import { Button, Card, Badge } from '@/components/ui';
 import { useNamespace } from '@/contexts/NamespaceContext';
+import { usePermissions } from '@/contexts/PermissionsContext';
 import { apiKeysService, rolesService } from '@/services';
 import type {
   CreatedApiKey,
@@ -31,8 +32,23 @@ const KEYS_PATH = '/dashboard/namespace/api-keys';
 
 export default function NewApiKeyPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { currentNamespace, isNamespaceOwner, hasPermission } = useNamespace();
-  const canManage = isNamespaceOwner || hasPermission('api_keys', 'manage');
+  const { isAdmin } = usePermissions();
+
+  // Optional target namespace (?ns=<uuid>&nsName=<name>) — a platform admin
+  // creating a key for another tenant without switching their whole context.
+  const targetNsId = searchParams.get('ns') || undefined;
+  const targetNsName = searchParams.get('nsName') || undefined;
+  const isForeign = !!targetNsId && targetNsId !== currentNamespace?.uuid;
+  const nsId = targetNsId || currentNamespace?.uuid;
+  const nsName = isForeign ? (targetNsName || 'this namespace') : currentNamespace?.name;
+  const canManage = isForeign ? isAdmin : isNamespaceOwner || hasPermission('api_keys', 'manage');
+
+  // Preserve the target-namespace params on the back/cancel links.
+  const keysHref = isForeign
+    ? `${KEYS_PATH}?ns=${encodeURIComponent(targetNsId!)}&nsName=${encodeURIComponent(targetNsName || '')}`
+    : KEYS_PATH;
 
   const [name, setName] = useState('');
   const [scopes, setScopes] = useState<ApiKeyScopes>({});
@@ -114,7 +130,7 @@ export default function NewApiKeyPage() {
         name: name.trim(),
         scopes,
         expires_at: expiresAt || undefined,
-      });
+      }, isForeign ? targetNsId : undefined);
       setCreated(result);
       toast.success('API key created');
     } catch (err) {
@@ -125,7 +141,7 @@ export default function NewApiKeyPage() {
   };
 
   // ---- Guards --------------------------------------------------------------
-  if (!currentNamespace) {
+  if (!nsId) {
     return (
       <Card className="p-8 text-center text-secondary-500">Select a namespace to create an API key.</Card>
     );
@@ -139,7 +155,7 @@ export default function NewApiKeyPage() {
           <p className="text-secondary-500 text-sm mt-1">
             You need owner or namespace-manage rights to create API keys.
           </p>
-          <Button className="mt-4" variant="outline" onClick={() => router.push(KEYS_PATH)}>
+          <Button className="mt-4" variant="outline" onClick={() => router.push(keysHref)}>
             Back to API keys
           </Button>
         </Card>
@@ -147,14 +163,14 @@ export default function NewApiKeyPage() {
     );
   }
 
-  if (created) return <RevealCreated created={created} onDone={() => router.push(KEYS_PATH)} />;
+  if (created) return <RevealCreated created={created} onDone={() => router.push(keysHref)} />;
 
   // ---- Create form (full-width two-panel) ---------------------------------
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-4">
         <button
-          onClick={() => router.push(KEYS_PATH)}
+          onClick={() => router.push(keysHref)}
           className="inline-flex items-center justify-center w-9 h-9 rounded-lg border border-secondary-200 text-secondary-500 hover:text-secondary-800 hover:border-secondary-300 transition-colors"
           aria-label="Back to API keys"
         >
@@ -306,7 +322,7 @@ export default function NewApiKeyPage() {
           <Card className="p-5 flex items-start gap-2.5 bg-primary-500/[0.06] border-primary-500/20">
             <ShieldCheck className="w-5 h-5 text-primary-600 shrink-0 mt-0.5" />
             <p className="text-sm text-secondary-600">
-              Locked to <strong className="text-secondary-900">{currentNamespace.name}</strong> — this key can
+              Locked to <strong className="text-secondary-900">{nsName}</strong> — this key can
               never reach another tenant, and can never manage keys, members, or roles.
             </p>
           </Card>
@@ -353,7 +369,7 @@ export default function NewApiKeyPage() {
               <Button onClick={submit} isLoading={submitting} leftIcon={<Key className="w-4 h-4" />} className="w-full justify-center">
                 Create key
               </Button>
-              <Button variant="outline" onClick={() => router.push(KEYS_PATH)} disabled={submitting} className="w-full justify-center">
+              <Button variant="outline" onClick={() => router.push(keysHref)} disabled={submitting} className="w-full justify-center">
                 Cancel
               </Button>
             </div>

--- a/opsapi-dashboard/app/dashboard/namespace/api-keys/page.tsx
+++ b/opsapi-dashboard/app/dashboard/namespace/api-keys/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { useRouter } from 'next/navigation';
-import { Key, Plus, Trash2, Loader2 } from 'lucide-react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Key, Plus, Trash2, Loader2, ShieldCheck } from 'lucide-react';
 import { Button, Card, Badge, ConfirmDialog, Table } from '@/components/ui';
 import { PageHeader } from '@/components/layout/PageHeader';
 import { useNamespace } from '@/contexts/NamespaceContext';
+import { usePermissions } from '@/contexts/PermissionsContext';
 import { apiKeysService } from '@/services';
 import type { ApiKey, TableColumn } from '@/types';
 import toast from 'react-hot-toast';
@@ -17,8 +18,23 @@ const fmtDate = (s?: string | null) =>
 
 export default function ApiKeysPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { currentNamespace, isNamespaceOwner, hasPermission } = useNamespace();
-  const canManage = isNamespaceOwner || hasPermission('api_keys', 'manage');
+  const { isAdmin } = usePermissions();
+
+  // Optional target namespace (?ns=<uuid>&nsName=<name>) lets a platform admin
+  // manage another tenant's keys without switching their whole context.
+  const targetNsId = searchParams.get('ns') || undefined;
+  const targetNsName = searchParams.get('nsName') || undefined;
+  const isForeign = !!targetNsId && targetNsId !== currentNamespace?.uuid;
+  const nsId = targetNsId || currentNamespace?.uuid;
+  const nsName = isForeign ? (targetNsName || 'this namespace') : currentNamespace?.name;
+  const canManage = isForeign ? isAdmin : isNamespaceOwner || hasPermission('api_keys', 'manage');
+
+  // Carry the target-namespace params onto the create page.
+  const newHref = isForeign
+    ? `${NEW_PATH}?ns=${encodeURIComponent(targetNsId!)}&nsName=${encodeURIComponent(targetNsName || '')}`
+    : NEW_PATH;
 
   const [keys, setKeys] = useState<ApiKey[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -26,16 +42,16 @@ export default function ApiKeysPage() {
   const [isRevoking, setIsRevoking] = useState(false);
 
   const fetchKeys = useCallback(async () => {
-    if (!currentNamespace) return;
+    if (!nsId) return;
     setIsLoading(true);
     try {
-      setKeys(await apiKeysService.list());
+      setKeys(await apiKeysService.list(isForeign ? targetNsId : undefined));
     } catch {
       toast.error('Failed to load API keys');
     } finally {
       setIsLoading(false);
     }
-  }, [currentNamespace]);
+  }, [nsId, isForeign, targetNsId]);
 
   useEffect(() => {
     fetchKeys();
@@ -45,7 +61,7 @@ export default function ApiKeysPage() {
     if (!keyToRevoke) return;
     setIsRevoking(true);
     try {
-      await apiKeysService.revoke(keyToRevoke.uuid);
+      await apiKeysService.revoke(keyToRevoke.uuid, isForeign ? targetNsId : undefined);
       toast.success('API key revoked');
       setKeyToRevoke(null);
       fetchKeys();
@@ -56,7 +72,7 @@ export default function ApiKeysPage() {
     }
   };
 
-  if (!currentNamespace) {
+  if (!nsId) {
     return (
       <Card className="p-8 text-center text-secondary-500">
         Select a namespace to manage its API keys.
@@ -129,16 +145,26 @@ export default function ApiKeysPage() {
     <div className="space-y-6">
       <PageHeader
         title="API Keys"
-        description={`Machine credentials for ${currentNamespace.name}. Keys authenticate as "Authorization: Bearer opsk_…" and only do what their scopes allow — within this namespace.`}
+        description={`Machine credentials for ${nsName}. Keys authenticate as "Authorization: Bearer opsk_…" and only do what their scopes allow — within this namespace.`}
         icon={<Key className="w-6 h-6" />}
         actions={
           canManage ? (
-            <Button onClick={() => router.push(NEW_PATH)} leftIcon={<Plus className="w-4 h-4" />}>
+            <Button onClick={() => router.push(newHref)} leftIcon={<Plus className="w-4 h-4" />}>
               Create API key
             </Button>
           ) : undefined
         }
       />
+
+      {isForeign && (
+        <Card className="p-4 flex items-start gap-2.5 bg-primary-500/[0.06] border-primary-500/20">
+          <ShieldCheck className="w-5 h-5 text-primary-600 shrink-0 mt-0.5" />
+          <p className="text-sm text-secondary-600">
+            You are managing keys for <strong className="text-secondary-900">{targetNsName || 'another namespace'}</strong> as a
+            platform administrator. Keys you create here belong to that namespace, not your own.
+          </p>
+        </Card>
+      )}
 
       {isLoading ? (
         <div className="flex justify-center py-16">
@@ -152,7 +178,7 @@ export default function ApiKeysPage() {
             Create a key to let scripts and services call the API without a user login.
           </p>
           {canManage && (
-            <Button className="mt-4" onClick={() => router.push(NEW_PATH)} leftIcon={<Plus className="w-4 h-4" />}>
+            <Button className="mt-4" onClick={() => router.push(newHref)} leftIcon={<Plus className="w-4 h-4" />}>
               Create API key
             </Button>
           )}

--- a/opsapi-dashboard/app/dashboard/namespace/page.tsx
+++ b/opsapi-dashboard/app/dashboard/namespace/page.tsx
@@ -12,6 +12,7 @@ import {
   Star,
   StarOff,
   Loader2,
+  Key,
 } from "lucide-react";
 import { Card, Badge, Button } from "@/components/ui";
 import { useNamespace } from "@/contexts/NamespaceContext";
@@ -28,7 +29,9 @@ export default function NamespacePage() {
     namespaces,
     defaultNamespaceInfo,
     setDefaultNamespace,
+    hasPermission,
   } = useNamespace();
+  const canManageKeys = isNamespaceOwner || hasPermission("api_keys", "manage");
   const [stats, setStats] = useState<NamespaceStats | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [settingDefault, setSettingDefault] = useState<string | null>(null);
@@ -267,6 +270,27 @@ export default function NamespacePage() {
             </div>
           </Card>
         </Link>
+
+        {canManageKeys && (
+          <Link href="/dashboard/namespace/api-keys">
+            <Card className="p-5 hover:shadow-md transition-shadow cursor-pointer group">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <div className="w-10 h-10 rounded-lg bg-primary-100 flex items-center justify-center group-hover:bg-primary-200 transition-colors">
+                    <Key className="w-5 h-5 text-primary-600" />
+                  </div>
+                  <div>
+                    <h3 className="font-semibold text-secondary-900">API Keys</h3>
+                    <p className="text-sm text-secondary-500">
+                      Machine credentials for scripts &amp; services
+                    </p>
+                  </div>
+                </div>
+                <ExternalLink className="w-4 h-4 text-secondary-400 group-hover:text-primary-500 transition-colors" />
+              </div>
+            </Card>
+          </Link>
+        )}
 
         {isNamespaceOwner && (
           <Link href="/dashboard/namespace/settings">

--- a/opsapi-dashboard/app/dashboard/namespace/settings/page.tsx
+++ b/opsapi-dashboard/app/dashboard/namespace/settings/page.tsx
@@ -1,85 +1,77 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import {
   Settings,
   Building2,
   Save,
   Loader2,
   AlertTriangle,
-  Globe,
-  Image,
   FileText,
+  Key,
 } from 'lucide-react';
-import { Button, Input, Card, Badge } from '@/components/ui';
+import { Button, Card, Badge } from '@/components/ui';
 import { PageHeader } from '@/components/layout/PageHeader';
+import NamespaceFormFields, { type NamespaceFieldValues } from '@/components/namespace/NamespaceFormFields';
 import { useNamespace } from '@/contexts/NamespaceContext';
 import { namespaceService } from '@/services';
-import type { UpdateNamespaceDto } from '@/types';
 import toast from 'react-hot-toast';
-import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+
+const EMPTY: NamespaceFieldValues = { name: '', description: '', domain: '', logo_url: '', banner_url: '' };
 
 export default function NamespaceSettingsPage() {
-  const router = useRouter();
   const { currentNamespace, isNamespaceOwner, refreshNamespaces } = useNamespace();
-  const [formData, setFormData] = useState<UpdateNamespaceDto>({
-    name: '',
-    description: '',
-    domain: '',
-    logo_url: '',
-    banner_url: '',
-  });
-  const [isLoading, setIsLoading] = useState(false);
+  const [initial, setInitial] = useState<NamespaceFieldValues>(EMPTY);
+  const [values, setValues] = useState<NamespaceFieldValues>(EMPTY);
   const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
     if (currentNamespace) {
-      setFormData({
+      const next: NamespaceFieldValues = {
         name: currentNamespace.name || '',
         description: currentNamespace.description || '',
         domain: currentNamespace.domain || '',
         logo_url: currentNamespace.logo_url || '',
         banner_url: currentNamespace.banner_url || '',
-      });
+      };
+      setInitial(next);
+      setValues(next);
     }
   }, [currentNamespace]);
 
-  const handleInputChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => {
-    const { name, value } = e.target;
-    setFormData((prev) => ({ ...prev, [name]: value }));
-  };
+  const dirty = useMemo(() => JSON.stringify(initial) !== JSON.stringify(values), [initial, values]);
+
+  const set = (name: keyof NamespaceFieldValues, value: string) =>
+    setValues((prev) => ({ ...prev, [name]: value }));
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!currentNamespace) return;
-
+    if (!currentNamespace || !values.name.trim()) {
+      if (!values.name.trim()) toast.error('Namespace name is required');
+      return;
+    }
     setIsSaving(true);
     try {
-      await namespaceService.updateCurrentNamespace(formData);
-      toast.success('Namespace settings updated successfully');
+      await namespaceService.updateCurrentNamespace(values);
+      setInitial(values);
+      toast.success('Settings saved');
       refreshNamespaces();
-    } catch (error) {
+    } catch {
       toast.error('Failed to update settings');
     } finally {
       setIsSaving(false);
     }
   };
 
-  // Redirect if not owner
   if (!isNamespaceOwner && currentNamespace) {
     return (
       <div className="space-y-6">
         <h1 className="text-2xl font-bold text-secondary-900">Namespace Settings</h1>
         <Card className="p-8 text-center">
           <AlertTriangle className="w-12 h-12 text-warning-500 mx-auto mb-4" />
-          <h2 className="text-lg font-semibold text-secondary-900 mb-2">
-            Access Restricted
-          </h2>
-          <p className="text-secondary-500">
-            Only namespace owners can access settings.
-          </p>
+          <h2 className="text-lg font-semibold text-secondary-900 mb-2">Access Restricted</h2>
+          <p className="text-secondary-500">Only namespace owners can change these settings.</p>
         </Card>
       </div>
     );
@@ -91,185 +83,51 @@ export default function NamespaceSettingsPage() {
         <h1 className="text-2xl font-bold text-secondary-900">Namespace Settings</h1>
         <Card className="p-8 text-center">
           <Building2 className="w-12 h-12 text-secondary-300 mx-auto mb-4" />
-          <p className="text-secondary-500">No namespace selected</p>
+          <p className="text-secondary-500">No namespace selected.</p>
         </Card>
       </div>
     );
   }
 
   return (
-    <div className="space-y-6 max-w-3xl">
+    <div className="max-w-4xl">
       <PageHeader
         title="Namespace Settings"
-        description={`Configure settings for ${currentNamespace.name}`}
+        description={`Configure ${currentNamespace.name}`}
         icon={<Settings className="h-5 w-5" />}
+        actions={
+          <Link
+            href={`/dashboard/namespace/api-keys`}
+            className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-secondary-700 bg-surface border border-secondary-300 rounded-lg hover:bg-secondary-50 transition-colors"
+          >
+            <Key className="w-4 h-4" />
+            API Keys
+          </Link>
+        }
       />
 
-      {/* Settings Form */}
-      <form onSubmit={handleSubmit} className="space-y-6">
-        {/* General Settings */}
-        <Card className="p-6">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="w-10 h-10 rounded-lg bg-primary-100 flex items-center justify-center">
-              <Settings className="w-5 h-5 text-primary-600" />
-            </div>
-            <div>
-              <h2 className="text-lg font-semibold text-secondary-900">
-                General Settings
-              </h2>
-              <p className="text-sm text-secondary-500">
-                Basic namespace information
-              </p>
-            </div>
-          </div>
+      <form onSubmit={handleSubmit} className="mt-6 space-y-6">
+        <NamespaceFormFields values={values} onChange={set} slug={currentNamespace.slug} disabled={isSaving} />
 
-          <div className="space-y-4">
-            <div>
-              <label className="block text-sm font-medium text-secondary-700 mb-1.5">
-                Namespace Name <span className="text-error-500">*</span>
-              </label>
-              <Input
-                name="name"
-                value={formData.name}
-                onChange={handleInputChange}
-                placeholder="My Company"
-                required
-              />
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium text-secondary-700 mb-1.5">
-                Slug
-              </label>
-              <Input
-                value={currentNamespace.slug}
-                disabled
-                className="bg-secondary-50"
-              />
-              <p className="text-xs text-secondary-500 mt-1">
-                Slug cannot be changed after creation
-              </p>
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium text-secondary-700 mb-1.5">
-                Description
-              </label>
-              <textarea
-                name="description"
-                value={formData.description}
-                onChange={handleInputChange}
-                placeholder="A brief description of your namespace..."
-                rows={3}
-                className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 resize-none"
-              />
-            </div>
-          </div>
-        </Card>
-
-        {/* Branding */}
-        <Card className="p-6">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="w-10 h-10 rounded-lg bg-warning-100 flex items-center justify-center">
-              <Image className="w-5 h-5 text-warning-600" />
-            </div>
-            <div>
-              <h2 className="text-lg font-semibold text-secondary-900">Branding</h2>
-              <p className="text-sm text-secondary-500">
-                Customize namespace appearance
-              </p>
-            </div>
-          </div>
-
-          <div className="space-y-4">
-            <div>
-              <label className="block text-sm font-medium text-secondary-700 mb-1.5">
-                Logo URL
-              </label>
-              <Input
-                name="logo_url"
-                value={formData.logo_url}
-                onChange={handleInputChange}
-                placeholder="https://example.com/logo.png"
-                leftIcon={<Image className="w-4 h-4" />}
-              />
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium text-secondary-700 mb-1.5">
-                Banner URL
-              </label>
-              <Input
-                name="banner_url"
-                value={formData.banner_url}
-                onChange={handleInputChange}
-                placeholder="https://example.com/banner.png"
-                leftIcon={<Image className="w-4 h-4" />}
-              />
-            </div>
-          </div>
-        </Card>
-
-        {/* Domain Settings */}
-        <Card className="p-6">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="w-10 h-10 rounded-lg bg-success-100 flex items-center justify-center">
-              <Globe className="w-5 h-5 text-success-600" />
-            </div>
-            <div>
-              <h2 className="text-lg font-semibold text-secondary-900">
-                Custom Domain
-              </h2>
-              <p className="text-sm text-secondary-500">
-                Configure a custom domain for your namespace
-              </p>
-            </div>
-          </div>
-
-          <div className="space-y-4">
-            <div>
-              <label className="block text-sm font-medium text-secondary-700 mb-1.5">
-                Custom Domain
-              </label>
-              <Input
-                name="domain"
-                value={formData.domain}
-                onChange={handleInputChange}
-                placeholder="app.mycompany.com"
-                leftIcon={<Globe className="w-4 h-4" />}
-              />
-              <p className="text-xs text-secondary-500 mt-1">
-                Point your domain&apos;s DNS to our servers to enable this feature
-              </p>
-            </div>
-          </div>
-        </Card>
-
-        {/* Plan Info */}
+        {/* Plan & limits (read-only) */}
         <Card className="p-6">
           <div className="flex items-center gap-3 mb-6">
             <div className="w-10 h-10 rounded-lg bg-secondary-100 flex items-center justify-center">
               <FileText className="w-5 h-5 text-secondary-600" />
             </div>
             <div>
-              <h2 className="text-lg font-semibold text-secondary-900">
-                Plan & Limits
-              </h2>
-              <p className="text-sm text-secondary-500">
-                Your current plan details
-              </p>
+              <h2 className="text-base font-semibold text-secondary-900">Plan &amp; Limits</h2>
+              <p className="text-sm text-secondary-500">Managed by your platform administrator</p>
             </div>
           </div>
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
             <div className="p-4 bg-secondary-50 rounded-lg">
-              <p className="text-sm text-secondary-500">Current Plan</p>
-              <Badge variant="default" className="mt-1 capitalize">
-                {currentNamespace.plan}
-              </Badge>
+              <p className="text-xs text-secondary-500">Current Plan</p>
+              <Badge variant="default" className="mt-1 capitalize">{currentNamespace.plan}</Badge>
             </div>
             <div className="p-4 bg-secondary-50 rounded-lg">
-              <p className="text-sm text-secondary-500">Status</p>
+              <p className="text-xs text-secondary-500">Status</p>
               <Badge
                 variant={currentNamespace.status === 'active' ? 'success' : 'warning'}
                 className="mt-1 capitalize"
@@ -278,42 +136,39 @@ export default function NamespaceSettingsPage() {
               </Badge>
             </div>
             <div className="p-4 bg-secondary-50 rounded-lg">
-              <p className="text-sm text-secondary-500">Max Users</p>
-              <p className="text-lg font-semibold text-secondary-900 mt-1">
-                {currentNamespace.max_users}
-              </p>
+              <p className="text-xs text-secondary-500">Max Users</p>
+              <p className="text-lg font-semibold text-secondary-900 mt-1">{currentNamespace.max_users}</p>
             </div>
             <div className="p-4 bg-secondary-50 rounded-lg">
-              <p className="text-sm text-secondary-500">Max Stores</p>
-              <p className="text-lg font-semibold text-secondary-900 mt-1">
-                {currentNamespace.max_stores}
-              </p>
+              <p className="text-xs text-secondary-500">Max Stores</p>
+              <p className="text-lg font-semibold text-secondary-900 mt-1">{currentNamespace.max_stores}</p>
             </div>
           </div>
         </Card>
 
-        {/* Save Button */}
-        <div className="flex justify-end gap-3">
-          <Button
-            type="button"
-            variant="secondary"
-            onClick={() => router.push('/dashboard/namespace')}
-          >
-            Cancel
-          </Button>
-          <Button type="submit" disabled={isSaving}>
-            {isSaving ? (
-              <>
-                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                Saving...
-              </>
-            ) : (
-              <>
-                <Save className="w-4 h-4 mr-2" />
-                Save Changes
-              </>
-            )}
-          </Button>
+        {/* Sticky action bar — sticks to the viewport bottom, stays within the
+            content column (no sidebar-width math needed). */}
+        <div className="sticky bottom-0 -mx-4 sm:-mx-6 px-4 sm:px-6 py-3 bg-surface/90 backdrop-blur border-t border-secondary-200 z-20 flex items-center justify-between gap-3 rounded-b-lg">
+          <p className="text-sm text-secondary-500">
+            {dirty ? 'You have unsaved changes.' : 'All changes saved.'}
+          </p>
+          <div className="flex items-center gap-3">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => setValues(initial)}
+              disabled={!dirty || isSaving}
+            >
+              Reset
+            </Button>
+            <Button type="submit" disabled={!dirty || isSaving}>
+              {isSaving ? (
+                <><Loader2 className="w-4 h-4 mr-2 animate-spin" /> Saving…</>
+              ) : (
+                <><Save className="w-4 h-4 mr-2" /> Save Changes</>
+              )}
+            </Button>
+          </div>
         </div>
       </form>
     </div>

--- a/opsapi-dashboard/app/dashboard/namespaces/[id]/edit/page.tsx
+++ b/opsapi-dashboard/app/dashboard/namespaces/[id]/edit/page.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import {
+  Settings,
+  Save,
+  Loader2,
+  AlertTriangle,
+  ArrowLeft,
+  SlidersHorizontal,
+} from 'lucide-react';
+import { Button, Card } from '@/components/ui';
+import { PageHeader } from '@/components/layout/PageHeader';
+import NamespaceFormFields, { type NamespaceFieldValues } from '@/components/namespace/NamespaceFormFields';
+import { usePermissions } from '@/contexts/PermissionsContext';
+import { namespaceService } from '@/services';
+import type { Namespace, NamespaceStatus, NamespacePlan } from '@/types';
+import toast from 'react-hot-toast';
+import Link from 'next/link';
+
+const EMPTY: NamespaceFieldValues = { name: '', description: '', domain: '', logo_url: '', banner_url: '' };
+const STATUSES: NamespaceStatus[] = ['active', 'pending', 'suspended', 'archived'];
+const PLANS: NamespacePlan[] = ['free', 'starter', 'professional', 'enterprise'];
+
+interface AdminFields {
+  status: NamespaceStatus;
+  plan: NamespacePlan;
+  max_users: number;
+  max_stores: number;
+}
+
+export default function EditNamespacePage() {
+  const params = useParams();
+  const router = useRouter();
+  const { isAdmin } = usePermissions();
+  const namespaceId = params.id as string;
+  const detailHref = `/dashboard/namespaces/${namespaceId}`;
+
+  const [namespace, setNamespace] = useState<Namespace | null>(null);
+  const [values, setValues] = useState<NamespaceFieldValues>(EMPTY);
+  const [initial, setInitial] = useState<NamespaceFieldValues>(EMPTY);
+  const [admin, setAdmin] = useState<AdminFields>({ status: 'active', plan: 'free', max_users: 0, max_stores: 0 });
+  const [initialAdmin, setInitialAdmin] = useState<AdminFields>(admin);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!namespaceId) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const ns = await namespaceService.getNamespaceById(namespaceId);
+      setNamespace(ns);
+      const v: NamespaceFieldValues = {
+        name: ns.name || '',
+        description: ns.description || '',
+        domain: ns.domain || '',
+        logo_url: ns.logo_url || '',
+        banner_url: ns.banner_url || '',
+      };
+      const a: AdminFields = {
+        status: ns.status,
+        plan: ns.plan,
+        max_users: ns.max_users ?? 0,
+        max_stores: ns.max_stores ?? 0,
+      };
+      setValues(v); setInitial(v);
+      setAdmin(a); setInitialAdmin(a);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to load namespace';
+      setError(message);
+      toast.error(message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [namespaceId]);
+
+  useEffect(() => {
+    if (isAdmin) load();
+  }, [isAdmin, load]);
+
+  const dirty = useMemo(
+    () => JSON.stringify(initial) !== JSON.stringify(values) || JSON.stringify(initialAdmin) !== JSON.stringify(admin),
+    [initial, values, initialAdmin, admin],
+  );
+
+  const set = (name: keyof NamespaceFieldValues, value: string) =>
+    setValues((prev) => ({ ...prev, [name]: value }));
+
+  const reset = () => { setValues(initial); setAdmin(initialAdmin); };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!values.name.trim()) return toast.error('Namespace name is required');
+    setIsSaving(true);
+    try {
+      const updated = await namespaceService.updateNamespaceAdmin(namespaceId, {
+        ...values,
+        status: admin.status,
+        plan: admin.plan,
+        max_users: Number(admin.max_users) || 0,
+        max_stores: Number(admin.max_stores) || 0,
+      });
+      setNamespace(updated);
+      setInitial(values); setInitialAdmin(admin);
+      toast.success('Namespace updated');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to update namespace');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  // ---- Guards --------------------------------------------------------------
+  if (!isAdmin) {
+    return (
+      <Card className="p-8 text-center max-w-lg mx-auto">
+        <AlertTriangle className="w-12 h-12 text-warning-500 mx-auto mb-4" />
+        <h2 className="text-lg font-semibold text-secondary-900 mb-2">Access Restricted</h2>
+        <p className="text-secondary-500 mb-4">You need platform administrator access to edit a namespace.</p>
+        <Link href="/dashboard/namespaces"><Button variant="outline">Back to Namespaces</Button></Link>
+      </Card>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-24">
+        <Loader2 className="w-6 h-6 animate-spin text-primary-500" />
+      </div>
+    );
+  }
+
+  if (error || !namespace) {
+    return (
+      <Card className="p-8 text-center max-w-lg mx-auto">
+        <AlertTriangle className="w-12 h-12 text-error-500 mx-auto mb-4" />
+        <h2 className="text-lg font-semibold text-secondary-900 mb-2">{error || 'Namespace not found'}</h2>
+        <div className="flex items-center justify-center gap-3 mt-4">
+          <Link href="/dashboard/namespaces"><Button variant="outline">Back to Namespaces</Button></Link>
+          <Button onClick={load}>Try again</Button>
+        </div>
+      </Card>
+    );
+  }
+
+  const selectCls =
+    'w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm bg-surface focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 capitalize';
+  const numberCls =
+    'w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500';
+
+  return (
+    <div className="max-w-4xl">
+      <div className="flex items-center gap-2 mb-2">
+        <button
+          onClick={() => router.push(detailHref)}
+          className="inline-flex items-center justify-center w-8 h-8 rounded-lg border border-secondary-200 text-secondary-500 hover:text-secondary-800 hover:border-secondary-300 transition-colors"
+          aria-label="Back to namespace"
+        >
+          <ArrowLeft className="w-4 h-4" />
+        </button>
+        <span className="text-sm text-secondary-500">Editing @{namespace.slug}</span>
+      </div>
+
+      <PageHeader
+        title={`Edit ${namespace.name}`}
+        description="Update this namespace's profile, branding, plan and limits."
+        icon={<Settings className="h-5 w-5" />}
+      />
+
+      <form onSubmit={handleSubmit} className="mt-6 space-y-6">
+        <NamespaceFormFields values={values} onChange={set} slug={namespace.slug} disabled={isSaving} />
+
+        {/* Admin-only: plan, status, limits */}
+        <Card className="p-6">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="w-10 h-10 rounded-lg bg-primary-100 flex items-center justify-center">
+              <SlidersHorizontal className="w-5 h-5 text-primary-600" />
+            </div>
+            <div>
+              <h2 className="text-base font-semibold text-secondary-900">Plan &amp; Limits</h2>
+              <p className="text-sm text-secondary-500">Administrator-only controls</p>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-secondary-700 mb-1.5">Status</label>
+              <select
+                value={admin.status}
+                onChange={(e) => setAdmin((p) => ({ ...p, status: e.target.value as NamespaceStatus }))}
+                className={selectCls}
+                disabled={isSaving}
+              >
+                {STATUSES.map((s) => <option key={s} value={s}>{s}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-secondary-700 mb-1.5">Plan</label>
+              <select
+                value={admin.plan}
+                onChange={(e) => setAdmin((p) => ({ ...p, plan: e.target.value as NamespacePlan }))}
+                className={selectCls}
+                disabled={isSaving}
+              >
+                {PLANS.map((p) => <option key={p} value={p}>{p}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-secondary-700 mb-1.5">Max Users</label>
+              <input
+                type="number" min={0}
+                value={admin.max_users}
+                onChange={(e) => setAdmin((p) => ({ ...p, max_users: Number(e.target.value) }))}
+                className={numberCls}
+                disabled={isSaving}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-secondary-700 mb-1.5">Max Stores</label>
+              <input
+                type="number" min={0}
+                value={admin.max_stores}
+                onChange={(e) => setAdmin((p) => ({ ...p, max_stores: Number(e.target.value) }))}
+                className={numberCls}
+                disabled={isSaving}
+              />
+            </div>
+          </div>
+        </Card>
+
+        {/* Sticky action bar */}
+        <div className="sticky bottom-0 -mx-4 sm:-mx-6 px-4 sm:px-6 py-3 bg-surface/90 backdrop-blur border-t border-secondary-200 z-20 flex items-center justify-between gap-3 rounded-b-lg">
+          <p className="text-sm text-secondary-500">
+            {dirty ? 'You have unsaved changes.' : 'All changes saved.'}
+          </p>
+          <div className="flex items-center gap-3">
+            <Button type="button" variant="secondary" onClick={reset} disabled={!dirty || isSaving}>
+              Reset
+            </Button>
+            <Button type="submit" disabled={!dirty || isSaving}>
+              {isSaving ? (
+                <><Loader2 className="w-4 h-4 mr-2 animate-spin" /> Saving…</>
+              ) : (
+                <><Save className="w-4 h-4 mr-2" /> Save Changes</>
+              )}
+            </Button>
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/opsapi-dashboard/app/dashboard/namespaces/[id]/page.tsx
+++ b/opsapi-dashboard/app/dashboard/namespaces/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import { AlertTriangle, Loader2 } from 'lucide-react';
+import { AlertTriangle } from 'lucide-react';
 import { Card, Button } from '@/components/ui';
 import {
   NamespaceHeader,
@@ -11,7 +11,6 @@ import {
   NamespaceSettingsCard,
   NamespaceActivityCard,
 } from '@/components/namespace';
-import { RequireAdmin } from '@/components/permissions/PermissionGate';
 import { usePermissions } from '@/contexts/PermissionsContext';
 import { namespaceService } from '@/services';
 import type { Namespace, NamespaceStats } from '@/types';
@@ -67,9 +66,12 @@ export default function NamespaceDetailsPage() {
     router.push(`/dashboard/namespaces/${namespaceId}/edit`);
   }, [router, namespaceId]);
 
-  const handleSettings = useCallback(() => {
-    router.push(`/dashboard/namespaces/${namespaceId}/settings`);
-  }, [router, namespaceId]);
+  const handleApiKeys = useCallback(() => {
+    if (!namespace) return;
+    // Target this namespace explicitly so an admin manages ITS keys, not their own.
+    const qs = new URLSearchParams({ ns: namespace.uuid, nsName: namespace.name });
+    router.push(`/dashboard/namespace/api-keys?${qs.toString()}`);
+  }, [router, namespace]);
 
   const handleInviteMember = useCallback(() => {
     // Could open a modal or navigate to members page with invite modal open
@@ -138,7 +140,7 @@ export default function NamespaceDetailsPage() {
             {error || 'Namespace Not Found'}
           </h2>
           <p className="text-secondary-500 mb-4">
-            The namespace you're looking for doesn't exist or you don't have permission to view it.
+            The namespace you&apos;re looking for doesn&apos;t exist or you don&apos;t have permission to view it.
           </p>
           <div className="flex items-center justify-center gap-3">
             <Link href="/dashboard/namespaces">
@@ -157,7 +159,7 @@ export default function NamespaceDetailsPage() {
       <NamespaceHeader
         namespace={namespace}
         onEdit={handleEdit}
-        onSettings={handleSettings}
+        onApiKeys={handleApiKeys}
       />
 
       {/* Main content grid */}

--- a/opsapi-dashboard/components/namespace/NamespaceFormFields.tsx
+++ b/opsapi-dashboard/components/namespace/NamespaceFormFields.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import React from 'react';
+import { Settings, Image as ImageIcon, Globe, Building2, Link2 } from 'lucide-react';
+import { Card, Input } from '@/components/ui';
+
+/** The editable fields common to namespace Settings and the admin Edit page. */
+export interface NamespaceFieldValues {
+  name: string;
+  description: string;
+  domain: string;
+  logo_url: string;
+  banner_url: string;
+}
+
+interface Props {
+  values: NamespaceFieldValues;
+  onChange: (name: keyof NamespaceFieldValues, value: string) => void;
+  /** Read-only slug — set at creation, never editable. */
+  slug: string;
+  disabled?: boolean;
+}
+
+/** A titled section card with an accent icon chip. */
+function Section({
+  icon,
+  tint,
+  title,
+  subtitle,
+  children,
+}: {
+  icon: React.ReactNode;
+  tint: string;
+  title: string;
+  subtitle: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Card className="p-6">
+      <div className="flex items-center gap-3 mb-6">
+        <div className={`w-10 h-10 rounded-lg flex items-center justify-center ${tint}`}>{icon}</div>
+        <div>
+          <h2 className="text-base font-semibold text-secondary-900">{title}</h2>
+          <p className="text-sm text-secondary-500">{subtitle}</p>
+        </div>
+      </div>
+      {children}
+    </Card>
+  );
+}
+
+function FieldLabel({ children, required }: { children: React.ReactNode; required?: boolean }) {
+  return (
+    <label className="block text-sm font-medium text-secondary-700 mb-1.5">
+      {children}
+      {required && <span className="text-error-500"> *</span>}
+    </label>
+  );
+}
+
+export default function NamespaceFormFields({ values, onChange, slug, disabled }: Props) {
+  return (
+    <div className="space-y-6">
+      <Section
+        icon={<Settings className="w-5 h-5 text-primary-600" />}
+        tint="bg-primary-100"
+        title="General"
+        subtitle="Basic namespace information"
+      >
+        <div className="space-y-4">
+          <div>
+            <FieldLabel required>Namespace Name</FieldLabel>
+            <Input
+              name="name"
+              value={values.name}
+              onChange={(e) => onChange('name', e.target.value)}
+              placeholder="My Company"
+              disabled={disabled}
+              required
+            />
+          </div>
+
+          <div>
+            <FieldLabel>Slug</FieldLabel>
+            <Input value={slug} disabled className="bg-secondary-50 font-mono text-secondary-500" />
+            <p className="text-xs text-secondary-500 mt-1">The slug is permanent — it can’t be changed after creation.</p>
+          </div>
+
+          <div>
+            <FieldLabel>Description</FieldLabel>
+            <textarea
+              name="description"
+              value={values.description}
+              onChange={(e) => onChange('description', e.target.value)}
+              placeholder="A brief description of this namespace…"
+              rows={3}
+              disabled={disabled}
+              className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 resize-none disabled:bg-secondary-50 disabled:text-secondary-400"
+            />
+          </div>
+        </div>
+      </Section>
+
+      <Section
+        icon={<ImageIcon className="w-5 h-5 text-warning-600" />}
+        tint="bg-warning-100"
+        title="Branding"
+        subtitle="Logo and banner shown across the namespace"
+      >
+        <div className="grid gap-5 sm:grid-cols-[auto,1fr] sm:items-start">
+          {/* Live preview */}
+          <div className="flex sm:flex-col items-center gap-3">
+            <div className="w-20 h-20 rounded-xl border border-secondary-200 bg-secondary-50 overflow-hidden flex items-center justify-center shrink-0">
+              {values.logo_url ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={values.logo_url}
+                  alt="Logo preview"
+                  className="w-full h-full object-cover"
+                  onError={(e) => ((e.currentTarget.style.display = 'none'))}
+                />
+              ) : (
+                <Building2 className="w-7 h-7 text-secondary-300" />
+              )}
+            </div>
+            <span className="text-xs text-secondary-400">Logo preview</span>
+          </div>
+
+          <div className="space-y-4">
+            <div>
+              <FieldLabel>Logo URL</FieldLabel>
+              <Input
+                name="logo_url"
+                value={values.logo_url}
+                onChange={(e) => onChange('logo_url', e.target.value)}
+                placeholder="https://example.com/logo.png"
+                leftIcon={<Link2 className="w-4 h-4" />}
+                disabled={disabled}
+              />
+            </div>
+            <div>
+              <FieldLabel>Banner URL</FieldLabel>
+              <Input
+                name="banner_url"
+                value={values.banner_url}
+                onChange={(e) => onChange('banner_url', e.target.value)}
+                placeholder="https://example.com/banner.png"
+                leftIcon={<Link2 className="w-4 h-4" />}
+                disabled={disabled}
+              />
+            </div>
+          </div>
+        </div>
+      </Section>
+
+      <Section
+        icon={<Globe className="w-5 h-5 text-success-600" />}
+        tint="bg-success-100"
+        title="Custom Domain"
+        subtitle="Serve this namespace on your own domain"
+      >
+        <div>
+          <FieldLabel>Domain</FieldLabel>
+          <Input
+            name="domain"
+            value={values.domain}
+            onChange={(e) => onChange('domain', e.target.value)}
+            placeholder="app.mycompany.com"
+            leftIcon={<Globe className="w-4 h-4" />}
+            disabled={disabled}
+          />
+          <p className="text-xs text-secondary-500 mt-1">Point your domain’s DNS (CNAME) to our servers to activate it.</p>
+        </div>
+      </Section>
+    </div>
+  );
+}

--- a/opsapi-dashboard/components/namespace/details/NamespaceHeader.tsx
+++ b/opsapi-dashboard/components/namespace/details/NamespaceHeader.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { memo } from 'react';
-import { Building2, Crown, ArrowLeft, Edit, Settings, MoreVertical } from 'lucide-react';
+import { Building2, Crown, ArrowLeft, Edit, Settings, Key } from 'lucide-react';
 import { Button, Badge } from '@/components/ui';
 import { cn } from '@/lib/utils';
 import Link from 'next/link';
@@ -11,6 +11,7 @@ export interface NamespaceHeaderProps {
   namespace: Namespace;
   onEdit?: () => void;
   onSettings?: () => void;
+  onApiKeys?: () => void;
   isLoading?: boolean;
 }
 
@@ -32,6 +33,7 @@ const NamespaceHeader: React.FC<NamespaceHeaderProps> = memo(function NamespaceH
   namespace,
   onEdit,
   onSettings,
+  onApiKeys,
   isLoading,
 }) {
   const statusConfig = STATUS_CONFIG[namespace.status] || STATUS_CONFIG.active;
@@ -99,6 +101,16 @@ const NamespaceHeader: React.FC<NamespaceHeaderProps> = memo(function NamespaceH
                 onClick={onEdit}
               >
                 Edit
+              </Button>
+            )}
+            {onApiKeys && (
+              <Button
+                variant="outline"
+                size="sm"
+                leftIcon={<Key className="w-4 h-4" />}
+                onClick={onApiKeys}
+              >
+                API Keys
               </Button>
             )}
             {onSettings && (

--- a/opsapi-dashboard/lib/api-client.ts
+++ b/opsapi-dashboard/lib/api-client.ts
@@ -105,9 +105,11 @@ apiClient.interceptors.request.use(
         config.headers.Authorization = `Bearer ${token}`;
       }
 
-      // Add namespace header from localStorage (user's current namespace context)
+      // Add namespace header from localStorage (user's current namespace context).
+      // A caller may pre-set X-Namespace-Id to target a specific namespace
+      // (e.g. an admin managing another tenant's API keys) — don't clobber it.
       const namespaceData = localStorage.getItem(NAMESPACE_KEY);
-      if (namespaceData && config.headers) {
+      if (namespaceData && config.headers && !config.headers['X-Namespace-Id']) {
         try {
           const namespace = JSON.parse(namespaceData);
           if (namespace?.uuid) {

--- a/opsapi-dashboard/services/apiKeys.service.ts
+++ b/opsapi-dashboard/services/apiKeys.service.ts
@@ -10,6 +10,18 @@ import type { ApiKey, CreateApiKeyDto, CreatedApiKey } from '@/types';
 const JSON_HEADERS = { headers: { 'Content-Type': 'application/json' } };
 
 /**
+ * Build a request config that targets a specific namespace. When `nsId` is
+ * given (e.g. a platform admin managing another tenant), it is sent as an
+ * explicit `X-Namespace-Id`, which the api-client interceptor now respects
+ * instead of the caller's current namespace. Omit it to use the current one.
+ */
+function nsConfig(nsId?: string, extraHeaders?: Record<string, string>) {
+  const headers: Record<string, string> = { ...extraHeaders };
+  if (nsId) headers['X-Namespace-Id'] = nsId;
+  return Object.keys(headers).length ? { headers } : undefined;
+}
+
+/**
  * Surface the backend's own message. axios throws on a 4xx BEFORE we can read the
  * body, and the API answers errors as { error: "..." } — so a raw axios error
  * ("Request failed with status code 403") would otherwise reach the UI. Prefer
@@ -27,19 +39,25 @@ function messageFrom(err: unknown, fallback: string): string {
 }
 
 export const apiKeysService = {
-  /** List the current namespace's keys (never returns the secret or its hash). */
-  async list(): Promise<ApiKey[]> {
-    const res = await apiClient.get<{ success: boolean; data: ApiKey[] }>('/api/v2/api-keys');
+  /**
+   * List a namespace's keys (never returns the secret or its hash).
+   * Pass `nsId` to target a specific namespace (admin), else the current one.
+   */
+  async list(nsId?: string): Promise<ApiKey[]> {
+    const res = await apiClient.get<{ success: boolean; data: ApiKey[] }>(
+      '/api/v2/api-keys',
+      nsConfig(nsId),
+    );
     return res.data?.data || [];
   },
 
   /** Create a key; the raw secret is returned ONCE in `data.key`. */
-  async create(payload: CreateApiKeyDto): Promise<CreatedApiKey> {
+  async create(payload: CreateApiKeyDto, nsId?: string): Promise<CreatedApiKey> {
     try {
       const res = await apiClient.post<{ success: boolean; data: CreatedApiKey; error?: string }>(
         '/api/v2/api-keys',
         payload,
-        JSON_HEADERS,
+        nsConfig(nsId, JSON_HEADERS.headers),
       );
       if (!res.data?.success || !res.data?.data) {
         throw new Error(res.data?.error || 'Failed to create API key');
@@ -51,9 +69,9 @@ export const apiKeysService = {
   },
 
   /** Revoke a key (idempotent). */
-  async revoke(uuid: string): Promise<void> {
+  async revoke(uuid: string, nsId?: string): Promise<void> {
     try {
-      await apiClient.delete(`/api/v2/api-keys/${uuid}`);
+      await apiClient.delete(`/api/v2/api-keys/${uuid}`, nsConfig(nsId));
     } catch (err) {
       throw new Error(messageFrom(err, 'Failed to revoke API key'));
     }


### PR DESCRIPTION
Follow-up dashboard changes requested after the API Keys backend + migration landed.

## What & why

### 1. API Keys are now reachable from the UI
- **Current namespace** (`/dashboard/namespace`): new **API Keys** quick-link card (shown to owners / `api_keys.manage`).
- **Admin namespace detail** (`/dashboard/namespaces/[id]`): new **API Keys** button in the header.

### 2. Admins can manage ANY namespace's keys — without switching context
The api-keys **list** and **create** pages accept an optional `?ns=<uuid>&nsName=<name>` target:
- The service sends it as an explicit `X-Namespace-Id`; the api-client interceptor now **respects a pre-set header** instead of always overwriting it with the current namespace.
- The backend already authorises this (platform admins reach any namespace via `X-Namespace-Id` — `middleware/namespace.lua`).
- A banner makes the cross-tenant context explicit ("managing keys for X as a platform administrator"). `canManage` requires platform-admin for the foreign case; owner/`api_keys.manage` for your own.

### 3. Fix 404 on `/dashboard/namespaces/[id]/edit`
The detail page's **Edit** button pointed at a route that didn't exist. Added the admin edit page: profile + branding + domain + **plan / status / max users / max stores**, saved via `updateNamespaceAdmin`. (Removed the header's other dead route — the `Settings` button that 404'd the same way — and replaced it with API Keys.)

### 4. Settings redesign
- Extracted a shared **`NamespaceFormFields`** (General / Branding / Domain) with a **live logo preview** and cleaner section cards.
- **Sticky action bar** with dirty-state ("unsaved changes"), **Reset**, and a disabled-until-dirty Save.
- The same field set powers the new admin edit page — one source, no duplicated form JSX.

## Checks
- `tsc --noEmit`: 0 errors
- `eslint` on changed files: 0 errors (2 pre-existing `<img>` warnings)
- `next build`: compiled successfully; `/dashboard/namespaces/[id]/edit` present in the route tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)