### PR TITLE
fix(int): schedule opsapi on any LAN amd64 node, not a single pinned host

### DIFF
--- a/devops/helm-charts/diytaxreturn-lapis/values-workstation-int.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/values-workstation-int.yaml
@@ -68,13 +68,23 @@ ingress:
           pathType: Prefix
   tls: []
 
-# Pin the pod to debian010 (a debian LAN node with pod headroom). Moved off
-# debworker00, which hit its 110/110 pod cap and left the pod Pending. debian010
-# still reaches workstation-db (a ClusterIP on the LAN mesh) fine. Combines with
-# the chart's NotIn-lubuntu001 affinity. Routing is independent of pod placement —
-# traefik-edge on the edge nodes reaches this ClusterIP Service wherever it runs.
+# Schedule on ANY healthy LAN amd64 node, not one pinned host. Single-node pins
+# kept breaking this: debworker00 hit its 110/110 pod cap, then debian010 went
+# NotReady (unreachable) and the pinned pods sat Pending for ~18h. The label set
+# below lets the scheduler pick from the whole LAN amd64 pool and skip
+# tainted/unreachable/full nodes on its own — a node dying no longer needs a
+# manual re-pin.
+#   net-region=home       → on the LAN; reaches workstation-db (a ClusterIP on the
+#                           LAN). Excludes cloud nodes (net-region=manchester),
+#                           which are across the down cloud<->LAN WireGuard mesh.
+#   kubernetes.io/arch=amd64 → excludes the arm64 Pi (rpworker99); the amd64 image
+#                           cannot exec there ("exec docker-entrypoint.sh: no such
+#                           file or directory").
+# Combines with the chart's NotIn-lubuntu001 affinity. Routing is independent of
+# placement — traefik-edge reaches this ClusterIP Service wherever the pod runs.
 nodeSelector:
-  kubernetes.io/hostname: debian010
+  net-region: home
+  kubernetes.io/arch: amd64
 
 # DATABASE — dedicated Postgres on the LAN (moved here 2026-08-19).
 #   `host` points this release at its OWN `workstation-db` Postgres

--- a/devops/helm-charts/opsapi-dashboard/values-workstation-int.yaml
+++ b/devops/helm-charts/opsapi-dashboard/values-workstation-int.yaml
@@ -22,7 +22,9 @@ ingress:
   annotations: {}
   tls: []
 
-# Pinned to debian010 alongside the API pod — debworker00 hit its 110/110 pod
-# cap. The UI talks to the API over HTTPS, so placement is routing-independent.
+# Schedule on ANY healthy LAN amd64 node (see the API chart's note for why).
+# A single-node pin (debian010) went NotReady and left the dashboard Pending for
+# ~18h. net-region=home keeps it on the LAN; arch=amd64 keeps it off the arm64 Pi.
 nodeSelector:
-  kubernetes.io/hostname: debian010
+  net-region: home
+  kubernetes.io/arch: amd64


### PR DESCRIPTION
## Why int-opsapi was down (503)
`debian010` — the node both the opsapi **API** and **dashboard** were pinned to (via #573) — went **NotReady/unreachable**. Kubernetes auto-tainted it `node.kubernetes.io/unreachable:NoSchedule/NoExecute`, so the pinned pods couldn't reschedule anywhere: new pods sat **Pending ~18h**, old pods stuck **Terminating** on the dead node → `int-opsapi` and `int-opsapi-ui` served **503**.

This is the third single-node-pin failure in a day (debworker00 pod-cap → debian010 down), so this replaces the pin with a **pool**, not another single host.

## Fix
Both int charts (`diytaxreturn-lapis` = API, `opsapi-dashboard` = UI) now select:
```yaml
nodeSelector:
  net-region: home          # LAN nodes → reach workstation-db (LAN ClusterIP);
                            # excludes cloud nodes (net-region=manchester, across
                            # the down cloud↔LAN WireGuard mesh)
  kubernetes.io/arch: amd64 # excludes the arm64 Pi (rpworker99) — the amd64 image
                            # can't exec there
```
The scheduler picks any matching node and **skips tainted/unreachable/full nodes on its own**, so a node dying no longer needs a manual re-pin. The pool is ~7 healthy LAN amd64 nodes (debian001-004/006/007 + debworker00).

## Verified live (before this PR)
Patched both live deployments to this selector: pods rescheduled onto **debian002/debian006**, and `int-opsapi/api/v2/system/info` → **200** + `int-opsapi-ui/login` → **200**. Real `system/info` JSON and `public/cms/workstation/posts` → 200 confirmed.

The live deployments already run this selector; merging persists it so the next deploy doesn't revert to the dead debian010.

🤖 Generated with [Claude Code](https://claude.com/claude-code)