### PR TITLE
fix(security): reject API keys used with a foreign namespace header

### DIFF
--- a/lapis/helper/auth.lua
+++ b/lapis/helper/auth.lua
@@ -99,6 +99,26 @@ function _M.authenticate()
             ngx.exit(403)
         end
 
+        -- An API key is bound to exactly ONE namespace. Reject any request that
+        -- names a DIFFERENT namespace via header — centrally, here, so it also
+        -- covers routes that resolve the namespace OUTSIDE requireNamespace
+        -- (optionalNamespace, raw X-Namespace-Id reads) and any route added
+        -- later. requireNamespace has its own equivalent check; this closes the
+        -- gap for everything else (fail-closed, same as permits_uri above).
+        local ns = principal.namespace or {}
+        local req_headers = ngx.req.get_headers()
+        local hdr_id = req_headers["x-namespace-id"]
+        local hdr_slug = req_headers["x-namespace-slug"]
+        if (hdr_id and hdr_id ~= "" and hdr_id ~= tostring(ns.id) and hdr_id ~= ns.uuid)
+            or (hdr_slug and hdr_slug ~= "" and hdr_slug ~= ns.slug) then
+            ngx.log(ngx.WARN, "API key ", principal.key_uuid,
+                " used with a namespace it does not belong to")
+            ngx.status = 403
+            ngx.header.content_type = "application/json"
+            ngx.say('{"error":"API key is not valid for the requested namespace"}')
+            ngx.exit(403)
+        end
+
         ngx.ctx.user = principal
         ngx.ctx.api_key_auth = true
         ngx.log(ngx.NOTICE, "API key authentication successful: ", principal.key_uuid,


### PR DESCRIPTION
## Vulnerability
An API key is bound to exactly one namespace, but that binding was **only** enforced inside `NamespaceMiddleware.requireNamespace`. Routes that resolve the namespace another way — `optionalNamespace`, or a raw `X-Namespace-Id` header read — trusted the header. So a key scoped for a module could reach **another tenant's data** on those routes by sending `X-Namespace-Id: <other-ns>`.

`permits_uri` gates only the *module*, not the tenant, so it didn't stop this. `validate_scopes` only blocks the `namespace` module, so a key *can* be granted `users`/`roles`/etc.

**Blast radius today is low** (the only `optionalNamespace` routes are public read-only `stores`/`products`), but it becomes exploitable the moment a key is scoped for a module whose routes read `X-Namespace-Id` directly (several do). Fixing before that ships.

## Fix
One central guard in the global before_filter (`helper/auth.lua`), right after the `permits_uri` scope check: if the request carries `X-Namespace-Id` / `X-Namespace-Slug` and it doesn't equal the key's own namespace (`id`/`uuid`/`slug`), **403**.

This covers `optionalNamespace`, raw-header reads, and any route added later — same fail-closed spirit as `permits_uri`. `requireNamespace` keeps its own equivalent check (belt and suspenders).

luajit syntax-checked. Mirrors the existing `requireNamespace` api-key namespace check.

## Context
Found in a full API-key security audit. Everything else checked out: SHA-256 storage (unique-indexed, once-only reveal), 192-bit CSPRNG entropy, revocation/expiry enforced per-request, no injection, no key/hash leakage, keys can't manage keys. Two lower items noted for follow-up (scope *actions* advisory on `requireAuth`-only routes; weak-RNG fallback; unanchored `expires_at` regex).

🤖 Generated with [Claude Code](https://claude.com/claude-code)