### PR TITLE
fix(workstation-opsapi): allow workstation.academy CORS origins

### DIFF
--- a/devops/helm-charts/diytaxreturn-lapis/values-workstation-acc.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/values-workstation-acc.yaml
@@ -51,6 +51,12 @@ setup:
   adminPassword: ""
   namespaceSlug: ""
 
+# Browser CORS allow-list (consumed by middleware/cors.lua) — git-owned here.
+# workstation.academy lets the Academy tenant's instructor dashboard
+# (acc-teach.workstation.academy) call this shared API cross-origin;
+# workstation.co.uk covers the opsapi admin UI. Additive; matches int.
+corsAllowedDomains: "workstation.co.uk,workstation.academy"
+
 autoscaling:
   enabled: false
   minReplicas: 1

--- a/devops/helm-charts/diytaxreturn-lapis/values-workstation-int.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/values-workstation-int.yaml
@@ -131,7 +131,12 @@ setup:
 # Access-Control-Allow-Origin and the browser blocks every call. The bare
 # domain matches the apex AND every subdomain (http/https, any port), so it
 # covers int-opsapi-ui.workstation.co.uk and the other env UI hosts.
-corsAllowedDomains: "workstation.co.uk"
+#
+# workstation.academy is added because the Workstation Academy is now a tenant
+# of this shared opsapi: its instructor dashboard (int-teach.workstation.academy)
+# is a cross-origin browser client of this API. Additive — the existing
+# workstation.co.uk origins are unaffected.
+corsAllowedDomains: "workstation.co.uk,workstation.academy"
 
 autoscaling:
   enabled: false

--- a/devops/helm-charts/diytaxreturn-lapis/values-workstation-prod.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/values-workstation-prod.yaml
@@ -57,6 +57,12 @@ setup:
   adminPassword: ""
   namespaceSlug: ""
 
+# Browser CORS allow-list (consumed by middleware/cors.lua) — git-owned here.
+# workstation.academy lets the Academy tenant's instructor dashboard
+# (teach.workstation.academy) call this shared API cross-origin;
+# workstation.co.uk covers the opsapi admin UI. Additive; matches int.
+corsAllowedDomains: "workstation.co.uk,workstation.academy"
+
 autoscaling:
   enabled: false
   minReplicas: 1

--- a/devops/helm-charts/diytaxreturn-lapis/values-workstation-test.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/values-workstation-test.yaml
@@ -51,6 +51,12 @@ setup:
   adminPassword: ""
   namespaceSlug: ""
 
+# Browser CORS allow-list (consumed by middleware/cors.lua) — git-owned here.
+# workstation.academy lets the Academy tenant's instructor dashboard
+# (test-teach.workstation.academy) call this shared API cross-origin;
+# workstation.co.uk covers the opsapi admin UI. Additive; matches int.
+corsAllowedDomains: "workstation.co.uk,workstation.academy"
+
 autoscaling:
   enabled: false
   minReplicas: 1


### PR DESCRIPTION
## Why

Workstation Academy is being consolidated onto the shared `workstation-opsapi` as a tenant (academy repo PR #18). Its **instructor dashboard** (`<env>-teach.workstation.academy`) is a cross-origin **browser** client of this API, but `corsAllowedDomains` only listed `workstation.co.uk`, so `middleware/cors.lua` emits no `Access-Control-Allow-Origin` and every dashboard XHR fails at preflight.

Verified against int: a preflight from `Origin: https://int-teach.workstation.academy` to `int-opsapi.workstation.co.uk` returns `204` with **no** allow-origin header.

## Change

Add `workstation.academy` to `corsAllowedDomains` in all `values-workstation-*.yaml`:
- **int** — live (academy going live here): `workstation.co.uk` → `workstation.co.uk,workstation.academy`
- **acc/test/prod** — pre-wired (no `workstation-opsapi` deployed there yet), so no code change is needed when those envs come up.

**Additive** — existing `workstation.co.uk` origins (opsapi admin UI, etc.) are unaffected. The academy **learner** site is server-side and needs no CORS. `helm template` confirms `CORS_ALLOWED_DOMAINS="workstation.co.uk,workstation.academy"` renders for all four envs.

## Deploy note

This is the one shared-opsapi prerequisite for academy PR #18. Merge + deploy `workstation-opsapi` (int) before/with the academy teach dashboard rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)