### PR TITLE
fix(tax-admin): stop CSV header normalization leaking gsub's match count

### DIFF
--- a/lapis/lib/classification-csv.lua
+++ b/lapis/lib/classification-csv.lua
@@ -51,9 +51,14 @@ function M.splitLines(csv_content)
     return lines
 end
 
+--- Lowercase + trim a header cell.
+-- The wrapping parens are load-bearing: `gsub` returns (string, count), and a
+-- bare `return` propagates both. Callers doing `table.insert(t, normalizeHeader(h))`
+-- would then hit the 3-arg `table.insert(list, pos, value)` overload and throw
+-- "bad argument #2 to 'insert' (number expected, got string)".
 function M.normalizeHeader(h)
     if not h then return "" end
-    return tostring(h):lower():gsub("^%s+", ""):gsub("%s+$", "")
+    return (tostring(h):lower():gsub("^%s+", ""):gsub("%s+$", ""))
 end
 
 --- Ordered lowercase headers joined by `|`.

--- a/lapis/spec/classification-csv_spec.lua
+++ b/lapis/spec/classification-csv_spec.lua
@@ -1,0 +1,70 @@
+--[[
+    Regression spec for lib/classification-csv.lua.
+
+    Standalone — no busted/luarocks needed. Run from the repo root with:
+        luajit lapis/spec/classification-csv_spec.lua
+    (plain `lua5.1` works too).
+
+    Guards the multiple-return bug that made every AI-training CSV upload
+    return SYSTEM_500: `normalizeHeader` returned gsub's (string, count) pair,
+    so `table.insert(parts, normalizeHeader(h))` became the 3-arg
+    `table.insert(list, pos, value)` overload and threw
+    "bad argument #2 to 'insert' (number expected, got string)".
+]]
+
+-- The module pulls in cjson at load time; stub it so this runs anywhere.
+package.preload["cjson"] = function()
+    return { encode = function() return "{}" end, decode = function() return {} end }
+end
+package.path = "lapis/?.lua;lapis/?/init.lua;" .. package.path
+
+local CSV = require("lib.classification-csv")
+
+local failures = 0
+
+local function check(name, ok, detail)
+    if ok then
+        print("  ok   - " .. name)
+    else
+        failures = failures + 1
+        print("  FAIL - " .. name .. (detail and ("  (" .. tostring(detail) .. ")") or ""))
+    end
+end
+
+print("classification-csv")
+
+-- The actual defect: one value out, not two.
+check("normalizeHeader returns exactly one value",
+    select("#", CSV.normalizeHeader("Date")) == 1,
+    "got " .. select("#", CSV.normalizeHeader("Date")) .. " values")
+
+check("normalizeHeader lowercases and trims",
+    CSV.normalizeHeader("  Transaction Date  ") == "transaction date",
+    CSV.normalizeHeader("  Transaction Date  "))
+
+check("normalizeHeader tolerates nil",
+    CSV.normalizeHeader(nil) == "")
+
+-- fingerprint() is the crash site (line 63 in the INT traceback).
+local fp_ok, fp = pcall(CSV.fingerprint, { " Date ", "Description", "Amount" })
+check("fingerprint does not throw", fp_ok, fp)
+check("fingerprint joins normalized headers", fp_ok and fp == "date|description|amount", fp)
+
+-- guessMapping() carries the same call shape and would crash next.
+local gm_ok, mapping, amount_mode = pcall(CSV.guessMapping, { "Date", "Description", "Amount", "Category" })
+check("guessMapping does not throw", gm_ok, mapping)
+check("guessMapping finds the date column", gm_ok and mapping and mapping.date == 1,
+    gm_ok and mapping and mapping.date)
+check("guessMapping picks an amount mode", gm_ok and amount_mode ~= nil, amount_mode)
+
+-- Debit/credit layouts should select the two-column mode.
+local _, dc_mapping, dc_mode = pcall(CSV.guessMapping, { "Date", "Narrative", "Money Out", "Money In", "Category" })
+check("guessMapping detects debit/credit layout",
+    dc_mode == "debit_credit" and dc_mapping and dc_mapping.debit and dc_mapping.credit,
+    tostring(dc_mode))
+
+if failures > 0 then
+    print(failures .. " failure(s)")
+    os.exit(1)
+end
+print("all passed")


### PR DESCRIPTION
## The bug

Every bank-statement CSV upload in the admin **AI Training** panel returns `SYSTEM_500`. Reported on INT:

```json
{ "code": "SYSTEM_500", "correlation_id": "938f318e-6c20-ce1e-9a33-8a29d5a77757" }
```

Pulling that occurrence out of `error_occurrences` on the INT database gives the real cause:

| field | value |
|---|---|
| endpoint | `POST /api/v2/tax/admin/profiles/{uuid}/upload-csv` |
| http_status | 500 |
| raw_error | `/app/lib/classification-csv.lua:63: bad argument #2 to 'insert' (number expected, got string)` |
| created_at | 2026-08-24 12:24:39 UTC |

## Root cause

`M.normalizeHeader` ended in a tail-position `return` over a `gsub` chain:

```lua
return tostring(h):lower():gsub("^%s+", ""):gsub("%s+$", "")
```

`gsub` returns **two** values — the new string *and* the substitution count — and a bare `return` propagates both. So `normalizeHeader("Date")` yields `"date", 1`, not `"date"`.

The caller expands both into the argument list:

```lua
table.insert(parts, M.normalizeHeader(h))
--  becomes  table.insert(parts, "date", 1)
```

Three arguments selects the `table.insert(list, pos, value)` overload, so Lua tries to read `"date"` as the position index and throws.

## Blast radius

`fingerprint()` is called unconditionally at `tax-admin-profiles.lua:564` — right after the auth and size checks, before any parsing. So this hit **100% of uploads** with a non-empty header row. The feature has never worked since it landed in 0e0f23d.

`guessMapping()` (line 108) has the identical call shape and would have crashed next; it was unreachable only because `fingerprint()` threw first. Fixing at the source covers both.

## The fix

Wrap the chain in parentheses to truncate to a single value — the convention already used throughout the codebase (`CmsPageQueries.lua:18`, `UserCustomCategoryQueries.lua:62`, `global.lua:313`, and ~15 others). Line 56 was the lone slip.

A comment records why the parens are load-bearing, since removing them looks harmless.

## Verification

Adds a standalone regression spec — no busted/luarocks needed, `cjson` is stubbed via `package.preload`:

```
luajit lapis/spec/classification-csv_spec.lua
```

All 9 checks pass with the fix. Reverting the one-line change turns **7 of 9** red, reproducing the exact INT error string:

```
FAIL - normalizeHeader returns exactly one value  (got 2 values)
FAIL - fingerprint does not throw  (...: bad argument #2 to 'insert' (number expected, got string))
FAIL - guessMapping does not throw  (...: bad argument #2 to 'insert' (number expected, got string))
```

## Notes

- Based on `feat/ai-training-csv-format-mapping` rather than `main`, since the affected code only exists on that branch.
- Two other unparenthesised `return ...gsub(...)` helpers exist (`lib/theme-renderer.lua:50`, `lib/vault-providers/aws.lua:35`). Neither is in this failure path nor currently feeds a `table.insert`, so they are latent rather than broken — deliberately left out of scope.
- INT still runs the broken image; it needs a rebuild/redeploy of `diytaxreturn-lapis` after merge to clear the 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDbwdceu1Zp8ZG5dd1SSE5