### PR TITLE
feat(rbac): platform admins can list + switch into any namespace

### DIFF
--- a/lapis/queries/NamespaceQueries.lua
+++ b/lapis/queries/NamespaceQueries.lua
@@ -340,6 +340,54 @@ function NamespaceQueries.getForUser(user_id)
     return db.query(query, tostring(user_id), user_id_num or 0)
 end
 
+--- All active namespaces, in the same shape as getForUser, for a PLATFORM ADMIN.
+-- A platform admin (global `administrative` role) has access to every namespace
+-- without being a member, so the switcher must list them all. Each row is marked
+-- is_owner=true and carries that namespace's `owner` role permissions, so the
+-- dashboard grants full control on switch. Namespaces the admin is NOT a member
+-- of therefore appear alongside any they do belong to.
+-- @return table list of namespaces (switcher shape)
+function NamespaceQueries.getAllForPlatformAdmin()
+    local query = [[
+        SELECT
+            n.id, n.uuid, n.name, n.slug, n.description, n.logo_url,
+            n.status, n.plan, n.settings,
+            true as is_owner, 'active' as member_status, NULL as joined_at,
+            (
+                SELECT json_agg(json_build_object(
+                    'id', nr.id,
+                    'uuid', nr.uuid,
+                    'role_name', nr.role_name,
+                    'display_name', nr.display_name,
+                    'permissions', nr.permissions
+                ))
+                FROM namespace_roles nr
+                WHERE nr.namespace_id = n.id AND nr.role_name = 'owner'
+            ) as roles
+        FROM namespaces n
+        WHERE n.status = 'active'
+        ORDER BY n.name ASC
+    ]]
+    return db.query(query)
+end
+
+--- The `owner` role row for a namespace (id + permissions), used to build a
+-- namespace-scoped token when a platform admin switches into a namespace they
+-- are not a member of. Returns nil if the namespace has no owner role defined.
+-- @param namespace_id string|number Namespace ID or UUID
+-- @return table|nil
+function NamespaceQueries.getOwnerRole(namespace_id)
+    local namespace_id_num = tonumber(namespace_id)
+    local rows = db.query([[
+        SELECT nr.id, nr.uuid, nr.role_name, nr.display_name, nr.permissions
+        FROM namespace_roles nr
+        JOIN namespaces n ON n.id = nr.namespace_id
+        WHERE (n.uuid = ? OR n.id = ?) AND nr.role_name = 'owner'
+        LIMIT 1
+    ]], tostring(namespace_id), namespace_id_num or 0)
+    return rows and rows[1]
+end
+
 --- Check if user is member of namespace
 -- @param user_id string|number User ID or UUID
 -- @param namespace_id string|number Namespace ID or UUID

--- a/lapis/routes/namespaces.lua
+++ b/lapis/routes/namespaces.lua
@@ -122,7 +122,16 @@ return function(app)
             return error_response(404, "User not found")
         end
 
-        local namespaces = NamespaceQueries.getForUser(self.current_user.uuid)
+        -- Platform admins (global `administrative` role) have access to every
+        -- namespace without being a member, so the switcher must list them ALL —
+        -- consistent with the /admin/namespaces page. Regular users still see only
+        -- the namespaces they belong to.
+        local namespaces
+        if check_platform_admin(self.current_user) then
+            namespaces = NamespaceQueries.getAllForPlatformAdmin()
+        else
+            namespaces = NamespaceQueries.getForUser(self.current_user.uuid)
+        end
 
         -- Parse roles JSON for each namespace
         for _, ns in ipairs(namespaces or {}) do
@@ -158,12 +167,13 @@ return function(app)
         })
     end))
 
-    -- Get details of a specific namespace (if user is member)
+    -- Get details of a specific namespace (member, or any namespace for a platform admin)
     app:get("/api/v2/user/namespaces/:id", AuthMiddleware.requireAuth(function(self)
         local namespace_id = self.params.id
 
-        -- Check user is member
-        if not NamespaceQueries.isUserMember(self.current_user.uuid, namespace_id) then
+        -- Check user is member (platform admins have access to every namespace)
+        if not check_platform_admin(self.current_user)
+            and not NamespaceQueries.isUserMember(self.current_user.uuid, namespace_id) then
             return error_response(403, "You don't have access to this namespace")
         end
 
@@ -195,8 +205,10 @@ return function(app)
     app:post("/api/v2/user/namespaces/:id/switch", RateLimit.wrap(NS_SWITCH_LIMIT, AuthMiddleware.requireAuth(function(self)
         local namespace_id = self.params.id
 
-        -- Check user is member
-        if not NamespaceQueries.isUserMember(self.current_user.uuid, namespace_id) then
+        -- Members switch into their own namespace; platform admins into ANY.
+        local is_platform_admin = check_platform_admin(self.current_user)
+        if not is_platform_admin
+            and not NamespaceQueries.isUserMember(self.current_user.uuid, namespace_id) then
             return error_response(403, "You don't have access to this namespace")
         end
 
@@ -227,6 +239,18 @@ return function(app)
         local raw_is_owner = membership and membership.is_owner
         local is_owner = raw_is_owner == true or raw_is_owner == 't' or raw_is_owner == 1
 
+        -- Platform admin switching into a namespace they don't belong to: grant
+        -- owner-level context using that namespace's `owner` role, so the scoped
+        -- token carries full permissions without needing a membership row.
+        local pa_owner_role = nil
+        if not membership and is_platform_admin then
+            is_owner = true
+            pa_owner_role = NamespaceQueries.getOwnerRole(namespace_id)
+            if pa_owner_role then
+                permissions = pa_owner_role.permissions
+            end
+        end
+
         -- Fetch platform roles from DB for accurate JWT
         local platform_roles = db.query([[
             SELECT r.id, r.role_name, r.role_name as name FROM roles r
@@ -242,6 +266,15 @@ return function(app)
                 local ok, parsed = pcall(cjson.decode, ns_roles)
                 if ok then ns_roles = parsed end
             end
+        elseif pa_owner_role then
+            -- Platform admin (non-member): present as the namespace owner role.
+            ns_roles = { {
+                id = pa_owner_role.id,
+                uuid = pa_owner_role.uuid,
+                role_name = pa_owner_role.role_name,
+                display_name = pa_owner_role.display_name,
+                permissions = pa_owner_role.permissions
+            } }
         end
 
         -- Generate proper JWT via centralized helper


### PR DESCRIPTION
## The 3-tier RBAC model (as intended)

1. **Super admin** — global `administrative` role → access to **all** namespaces & everything.
2. **Namespace owner** — full control of **their** namespace only (add members, create roles); no access to others unless added.
3. **Member** — the namespace-scoped role(s) the owner defines and assigns.

## What already works (verified live)

- Tier 2/3 are correct: `POST /namespace/members` and `POST /namespace/roles` are gated by `NamespaceMiddleware.requirePermission(...)` on `self.namespace`, so an owner manages only their own namespace. A regular instructor gets **403** on `/admin/namespaces` and sees only their own namespace in the switcher — **no leak**.

## The gap (tier 1)

The workspace switcher `GET /api/v2/user/namespaces` and `POST /api/v2/user/namespaces/:id/switch` were **membership-only**. So a platform admin who can manage every tenant from the `/admin/namespaces` page still couldn't **switch into** namespaces they weren't a member of — inconsistent with "super admin has access to all namespaces".

## Fix (additive, platform-admin-only)

- `GET /api/v2/user/namespaces`: platform admins receive **all active namespaces** (`NamespaceQueries.getAllForPlatformAdmin`, same shape, owner-level roles).
- `GET /api/v2/user/namespaces/:id` and `.../switch`: a platform admin may enter **any active namespace**; the scoped token is built from that namespace's `owner` role (`NamespaceQueries.getOwnerRole`) so it carries full permissions **without** a membership row.

**Blast radius:** non-admin users take the exact same code paths as before — regular users and other tenants (e.g. diy-tax) are unaffected. `luac`-checked. Only the `administrative` global role gets the new behavior.

## After deploy

- Super admin sees & can switch into every namespace from the dashboard switcher (no per-namespace membership needed).
- The temporary DB membership added to let the super admin reach Academy can then be removed (redundant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)