### PR TITLE
feat(academy-dashboard): clean up Create/Edit Course form (instructor, category, tags)

### DIFF
--- a/opsapi-dashboard/app/dashboard/academy/page.tsx
+++ b/opsapi-dashboard/app/dashboard/academy/page.tsx
@@ -3,9 +3,10 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { Search, Plus, Trash2, Edit, BookOpen, RefreshCw, Layers, CreditCard, Banknote, GraduationCap, ArrowRight, User, X, ClipboardCheck, CheckCircle2, XCircle, Send } from 'lucide-react';
-import { Table, Badge, Pagination, Modal, Button, ConfirmDialog, Select } from '@/components/ui';
+import { Table, Badge, Pagination, Modal, Button, ConfirmDialog, Select, SearchableSelect } from '@/components/ui';
 import { ProtectedPage } from '@/components/permissions';
 import { usePermissions } from '@/contexts/PermissionsContext';
+import { useAuthStore } from '@/store/auth.store';
 import {
   academyService,
   getCourseStatusVariant,
@@ -73,6 +74,16 @@ const CourseModal: React.FC<CourseModalProps> = ({ isOpen, course, canPublishDir
   const [categories, setCategories] = useState<string[]>([]);
   const [tagDraft, setTagDraft] = useState('');
 
+  const { user } = useAuthStore();
+  // The creator is the instructor — no free-text field. Derive a display name
+  // (full name → username → email local-part) for the read-only credit and as
+  // the default `instructor` value on a new course.
+  const currentUserName =
+    [user?.first_name, user?.last_name].filter(Boolean).join(' ').trim() ||
+    user?.username ||
+    (user?.email ? user.email.split('@')[0] : '') ||
+    'You';
+
   useEffect(() => {
     if (course) {
       setForm({
@@ -91,10 +102,10 @@ const CourseModal: React.FC<CourseModalProps> = ({ isOpen, course, canPublishDir
         status: course.status,
       });
     } else {
-      setForm(EMPTY_FORM);
+      setForm({ ...EMPTY_FORM, instructor: currentUserName });
     }
     setTagDraft('');
-  }, [course, isOpen]);
+  }, [course, isOpen, currentUserName]);
 
   // Fetch the existing category values whenever the modal opens, so the
   // create-or-select control can offer them (falls back to none on error).
@@ -188,23 +199,27 @@ const CourseModal: React.FC<CourseModalProps> = ({ isOpen, course, canPublishDir
           </div>
           <div>
             <label className="block text-sm font-medium text-secondary-700 mb-1">Instructor</label>
-            <input className={inputClass} value={form.instructor} onChange={(e) => set('instructor', e.target.value)} placeholder="Instructor name" />
+            {/* The creator IS the instructor (backend sets owner_user_uuid to the
+                current user; the public page credits their profile name). So this
+                is a read-only credit, not a field to fill in. */}
+            <div className="w-full px-3 py-2 border border-secondary-200 rounded-lg text-sm bg-secondary-50 text-secondary-700 truncate">
+              {form.instructor?.trim() || currentUserName}
+            </div>
+            <p className="mt-1 text-xs text-secondary-500">You&apos;re the instructor. Change your public name in My Profile.</p>
           </div>
           <div>
             <label className="block text-sm font-medium text-secondary-700 mb-1">Category</label>
-            {/* Create-or-select: pick an existing category or type a brand-new one. */}
-            <input
-              className={inputClass}
-              list="course-category-options"
+            {/* Searchable combobox: pick an existing namespace category or create a new one. */}
+            <SearchableSelect
+              options={categories.map((c) => ({ value: c, label: c }))}
               value={form.category}
-              onChange={(e) => set('category', e.target.value)}
-              placeholder="Pick existing or type a new one"
+              onChange={(v) => set('category', v)}
+              creatable
+              clearable
+              placeholder="Pick existing or create new"
+              searchPlaceholder="Search or type a new category…"
+              emptyMessage="No categories yet — type to create one"
             />
-            <datalist id="course-category-options">
-              {categories.map((c) => (
-                <option key={c} value={c} />
-              ))}
-            </datalist>
           </div>
           <div>
             <label className="block text-sm font-medium text-secondary-700 mb-1">Level</label>
@@ -253,32 +268,36 @@ const CourseModal: React.FC<CourseModalProps> = ({ isOpen, course, canPublishDir
           </div>
           <div className="col-span-2">
             <label className="block text-sm font-medium text-secondary-700 mb-1">Tags</label>
-            <div className={`${inputClass} flex flex-wrap items-center gap-1.5 min-h-[42px] h-auto`}>
-              {(form.tags ?? []).map((tag) => (
-                <span
-                  key={tag}
-                  className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-primary-50 text-primary-700 text-xs font-medium"
-                >
-                  {tag}
-                  <button
-                    type="button"
-                    onClick={() => removeTag(tag)}
-                    className="text-primary-500 hover:text-primary-700"
-                    aria-label={`Remove ${tag}`}
+            {/* Input stays full-width on top; added tags wrap as chips BELOW it so
+                typing never gets pushed around by existing chips. */}
+            <input
+              className={inputClass}
+              value={tagDraft}
+              onChange={(e) => setTagDraft(e.target.value)}
+              onKeyDown={handleTagKeyDown}
+              onBlur={() => addTag(tagDraft)}
+              placeholder="Add tags (Enter or comma)…"
+            />
+            {(form.tags ?? []).length > 0 && (
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {(form.tags ?? []).map((tag) => (
+                  <span
+                    key={tag}
+                    className="inline-flex items-center gap-1 pl-2.5 pr-1.5 py-1 rounded-full bg-primary-50 text-primary-700 text-xs font-medium"
                   >
-                    <X className="w-3 h-3" />
-                  </button>
-                </span>
-              ))}
-              <input
-                className="flex-1 min-w-[8rem] border-none outline-none bg-transparent text-sm p-0 focus:ring-0"
-                value={tagDraft}
-                onChange={(e) => setTagDraft(e.target.value)}
-                onKeyDown={handleTagKeyDown}
-                onBlur={() => addTag(tagDraft)}
-                placeholder={(form.tags ?? []).length === 0 ? 'Add tags (Enter or comma)…' : ''}
-              />
-            </div>
+                    {tag}
+                    <button
+                      type="button"
+                      onClick={() => removeTag(tag)}
+                      className="rounded-full p-0.5 text-primary-400 hover:bg-primary-100 hover:text-primary-700"
+                      aria-label={`Remove ${tag}`}
+                    >
+                      <X className="w-3 h-3" />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
             <p className="mt-1 text-xs text-secondary-500">Press Enter or comma to add. Used for sorting and filtering. Up to 20 tags.</p>
           </div>
           <div className="col-span-2 flex items-center gap-3">

--- a/opsapi-dashboard/components/ui/SearchableSelect.tsx
+++ b/opsapi-dashboard/components/ui/SearchableSelect.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
-import { ChevronDown, Search, Check, X } from 'lucide-react';
+import { ChevronDown, Search, Check, X, Plus } from 'lucide-react';
 
 export interface SearchableSelectOption {
   value: string;
@@ -28,6 +28,9 @@ export interface SearchableSelectProps {
   autoFocus?: boolean;
   // Called when the dropdown closes without a selection (e.g. on blur/escape).
   onClose?: () => void;
+  // Allow selecting a typed value that isn't in `options` (offers a "Create …"
+  // row and accepts it on Enter). Turns the select into a create-or-pick combobox.
+  creatable?: boolean;
   // Optional server-side search. When provided, the typed query is forwarded
   // (debounced) so the parent can fetch matching options — letting the dropdown
   // reach records beyond a server-side result cap instead of only filtering the
@@ -50,6 +53,7 @@ const SearchableSelect: React.FC<SearchableSelectProps> = ({
   autoFocus = false,
   onClose,
   onSearch,
+  creatable = false,
 }) => {
   const [open, setOpen] = useState(autoFocus);
   const [query, setQuery] = useState('');
@@ -71,6 +75,13 @@ const SearchableSelect: React.FC<SearchableSelectProps> = ({
         o.hint?.toLowerCase().includes(q)
     );
   }, [options, query]);
+
+  // Offer to create the typed value when it matches no existing option.
+  const trimmedQuery = query.trim();
+  const showCreate =
+    creatable &&
+    trimmedQuery.length > 0 &&
+    !options.some((o) => o.value.toLowerCase() === trimmedQuery.toLowerCase());
 
   // Debounced server-side search: forward the typed query to the parent so it
   // can refetch options. Only active when an onSearch handler is supplied.
@@ -130,6 +141,7 @@ const SearchableSelect: React.FC<SearchableSelectProps> = ({
       e.preventDefault();
       const opt = filtered[highlight];
       if (opt) pick(opt.value);
+      else if (showCreate) pick(trimmedQuery);
     }
   };
 
@@ -155,11 +167,11 @@ const SearchableSelect: React.FC<SearchableSelectProps> = ({
           triggerPad
         )}
       >
-        <span className={cn('truncate', !selected && 'text-secondary-400')}>
-          {selected ? selected.label : placeholder}
+        <span className={cn('truncate', !selected && !value && 'text-secondary-400')}>
+          {selected ? selected.label : value ? value : placeholder}
         </span>
         <span className="flex items-center gap-1">
-          {clearable && selected && !disabled && (
+          {clearable && (selected || value) && !disabled && (
             <X
               className="h-3.5 w-3.5 text-secondary-400 hover:text-secondary-600"
               onClick={(e) => {
@@ -189,7 +201,7 @@ const SearchableSelect: React.FC<SearchableSelectProps> = ({
             />
           </div>
           <ul className="max-h-60 overflow-y-auto py-1" role="listbox">
-            {filtered.length === 0 ? (
+            {filtered.length === 0 && !showCreate ? (
               <li className="px-3 py-2 text-sm text-secondary-400">{emptyMessage}</li>
             ) : (
               filtered.map((opt, i) => {
@@ -216,6 +228,18 @@ const SearchableSelect: React.FC<SearchableSelectProps> = ({
                   </li>
                 );
               })
+            )}
+            {showCreate && (
+              <li role="option" aria-selected={false}>
+                <button
+                  type="button"
+                  onClick={() => pick(trimmedQuery)}
+                  className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-primary-600 hover:bg-primary-50"
+                >
+                  <Plus className="h-4 w-4 shrink-0" />
+                  <span className="min-w-0 truncate">Create &ldquo;{trimmedQuery}&rdquo;</span>
+                </button>
+              </li>
             )}
           </ul>
         </div>


### PR DESCRIPTION
Fixes three UX issues on the course create/edit modal (reported from the Create Course screen), plus a reusable combobox enhancement. Dashboard-only, no backend change.

### 1. Instructor field removed
The creator **is** the instructor — the backend sets `owner_user_uuid` to the current user and the public page credits their profile name. The free-text "Instructor name" box was redundant and confusing. Replaced with a **read-only credit** (the current user), defaulted as the instructor on new courses; existing values preserved on edit. To change how the name appears publicly, the instructor edits **My Profile**.

### 2. Category is now a real searchable dropdown
The native `<datalist>` barely surfaces on many browsers ("I can't list the categories"). Replaced with the existing **`SearchableSelect`** combobox in **create-or-pick** mode: lists the namespace's existing categories and lets you **create a new one inline**. Namespace-scoped (the categories endpoint already scopes by namespace).

### 3. Tags input redesigned
The input now stays **full-width on top** and added tags wrap as chips **below** it, so typing is never pushed around by existing chips. Cleaner chip + remove-button styling.

### Reusable: `SearchableSelect` `creatable`
Added a small `creatable` mode — offers a "Create …" row and accepts the typed value on Enter; created values display and clear correctly. Usable anywhere a pick-or-create field is needed.

### Scope check ("other similar cases")
Swept the whole dashboard: the only `<datalist>` was this one, and the instructor/category/tags inputs exist only in this modal (the lesson form and other pages just *display* instructor). So all instances are covered.

### Validation
`tsc --noEmit` clean, `eslint` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)