### PR TITLE
feat(themes): white-label the dashboard for the academy tenant

### DIFF
--- a/lapis/.sample.env
+++ b/lapis/.sample.env
@@ -37,7 +37,7 @@ OPSAPI_SSL_VERIFY=false
 # MinIO (S3-compatible Object Storage)
 # ============================================
 MINIO_ENDPOINT=http://172.71.0.17:9000
-MINIO_ENDPOINT_WEB_EXTERNAL=http://localhost:9000
+MINIO_ENDPOINT_WEB_EXTERNAL=http://localhost:9900
 MINIO_ACCESS_KEY=minioadmin
 MINIO_SECRET_KEY=minioadmin123
 MINIO_BUCKET=opsapi
@@ -47,7 +47,7 @@ MINIO_REGION=us-east-1
 # Dashboard & API URLs
 # ============================================
 # Automatically updated by start.sh based on environment
-NEXT_PUBLIC_API_URL=http://127.0.0.1:4010
+NEXT_PUBLIC_API_URL=http://127.0.0.1:4020
 
 # ============================================
 # Node API (Optional)
@@ -79,7 +79,7 @@ NODE_API_URL=http://172.71.0.14/api
 # ============================================
 # GOOGLE_CLIENT_ID=your-google-client-id
 # GOOGLE_CLIENT_SECRET=your-google-client-secret
-GOOGLE_REDIRECT_URI=http://127.0.0.1:4010/auth/google/callback
+GOOGLE_REDIRECT_URI=http://127.0.0.1:4020/auth/google/callback
 
 # ============================================
 # Keycloak SSO (Optional)
@@ -89,7 +89,7 @@ GOOGLE_REDIRECT_URI=http://127.0.0.1:4010/auth/google/callback
 # KEYCLOAK_USERINFO_URL=https://your-keycloak/realms/opsapi/protocol/openid-connect/userinfo
 # KEYCLOAK_CLIENT_ID=opsapi
 # KEYCLOAK_CLIENT_SECRET=your-client-secret
-KEYCLOAK_REDIRECT_URI=http://127.0.0.1:4010/auth/callback
+KEYCLOAK_REDIRECT_URI=http://127.0.0.1:4020/auth/callback
 
 # ============================================
 # Stripe (Optional)

--- a/lapis/docker-compose.yml
+++ b/lapis/docker-compose.yml
@@ -21,8 +21,11 @@ services:
   lapis:
     container_name: opsapi
     build: .
+    # Host port moved off 4010 (taken by the separate diy-tax-return-uk stack's
+    # tax_return_opsapi container) so both opsapi stacks coexist. Container port
+    # stays 80. API/Swagger on the host are now at http://127.0.0.1:4020.
     ports:
-      - "4010:80"
+      - "4020:80"
     volumes:
       - .:/app
       - ../projects:/app/projects
@@ -31,7 +34,9 @@ services:
     environment:
       - PROJECT_CODE=${PROJECT_CODE:-all}
       - KAFKA_BROKERS=${KAFKA_BROKERS:-kafka:29092}
-      - OLLAMA_URL=${OLLAMA_URL:-http://ollama:11434}
+      # The opsapi-ollama container was removed — Ollama runs natively on the
+      # host Mac. Reach it via host.docker.internal (mapped in extra_hosts below).
+      - OLLAMA_URL=${OLLAMA_URL:-http://host.docker.internal:11434}
       - OLLAMA_MODEL=${OLLAMA_MODEL:-mistral}
     depends_on:
       postgres:
@@ -66,7 +71,7 @@ services:
       context: ../opsapi-dashboard
       dockerfile: Dockerfile
       args:
-        - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://127.0.0.1:4010}
+        - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://127.0.0.1:4020}
     ports:
       - "8039:8039"
     environment:
@@ -87,8 +92,12 @@ services:
     container_name: opsapi-postgres-dev-db
     restart: unless-stopped
     image: pgvector/pgvector:pg14
+    # Host port moved off 5439 (taken by another local Postgres container).
+    # Container-internal port stays 5432, so POSTGRES_HOST=172.71.0.10:5432
+    # and Adminer (which connects over the network) are unaffected — this
+    # only changes host access, e.g. psql -h 127.0.0.1 -p 5440.
     ports:
-      - "5439:5432"
+      - "5440:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     env_file: ".env"
@@ -159,9 +168,13 @@ services:
     image: minio/minio:latest
     container_name: opsapi-minio
     restart: unless-stopped
+    # Host ports moved off 9000/9001 — those are taken by another local MinIO
+    # (another Docker stack). Container-internal ports stay 9000/9001, so the
+    # network alias minio:9000 and MINIO_ENDPOINT (172.71.0.17:9000) are
+    # unchanged; only host access moves. Console: http://127.0.0.1:9901
     ports:
-      - "9000:9000"
-      - "9001:9001"
+      - "9900:9000"
+      - "9901:9001"
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin123
@@ -246,40 +259,14 @@ services:
   #     - ../node/opsapi-node:/usr/src/app
   #   env_file: "../node/opsapi-node/.env"
 
-  # Ollama - Local AI/LLM for bookkeeping assistance
-  ollama:
-    image: ollama/ollama:latest
-    container_name: opsapi-ollama
-    restart: unless-stopped
-    ports:
-      - "11434:11434"
-    volumes:
-      - ollama_data:/root/.ollama
-    networks:
-      opsapi-network:
-        ipv4_address: 172.71.0.22
-    deploy:
-      resources:
-        limits:
-          memory: 4G
+  # Ollama runs natively on the host Mac (reached via host.docker.internal),
+  # so the in-compose ollama container was removed.
 
-  # Kafka - Event streaming (Zookeeper + Kafka broker)
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.5.0
-    container_name: opsapi-zookeeper
-    restart: unless-stopped
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-    networks:
-      opsapi-network:
-        ipv4_address: 172.71.0.20
-    healthcheck:
-      test: ["CMD", "nc", "-z", "localhost", "2181"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-
+  # Kafka - Event streaming, single-node KRaft mode (no Zookeeper).
+  # Zookeeper was removed; Kafka 3.x / cp-kafka 7.5.0 self-manages metadata
+  # via the KRaft controller quorum, so this one container is the whole
+  # cluster. CLUSTER_ID is fixed so the storage format is stable across
+  # restarts (the confluent entrypoint auto-formats on first boot).
   kafka:
     image: confluentinc/cp-kafka:7.5.0
     container_name: opsapi-kafka
@@ -287,23 +274,26 @@ services:
     ports:
       - "9092:9092"
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:29093
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://0.0.0.0:9092,CONTROLLER://kafka:29093
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,CONTROLLER:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
-    depends_on:
-      zookeeper:
-        condition: service_healthy
     networks:
       opsapi-network:
         ipv4_address: 172.71.0.21
     healthcheck:
-      test: ["CMD", "kafka-topics", "--bootstrap-server", "localhost:29092", "--list"]
+      # kafka-topics --list can hang under single-node KRaft; api-versions is a
+      # fast, reliable "is the broker accepting connections?" probe.
+      test: ["CMD", "kafka-broker-api-versions", "--bootstrap-server", "localhost:29092"]
       interval: 30s
-      timeout: 10s
+      timeout: 15s
       retries: 5
 
   # Prometheus - Metrics collection and alerting
@@ -380,4 +370,3 @@ volumes:
   prometheus_data:
   grafana_data:
   minio_data:
-  ollama_data:

--- a/lapis/helper/theme-presets.lua
+++ b/lapis/helper/theme-presets.lua
@@ -301,6 +301,42 @@ ThemePresets.LIST = {
             "*:focus-visible { outline: var(--focus-ring-width) solid var(--focus-ring-color); outline-offset: 2px; }",
         }, "\n"),
     },
+    -- Tenant-branded preset. A preset whose slug equals a project_code becomes
+    -- that project's default look (see ThemeQueries.getDefaultPreset), so an
+    -- academy tenant gets this palette with no activation step. Mirrors the
+    -- learner site's --color-brand-* scale in workstation-academy/app/globals.css.
+    {
+        slug         = "academy",
+        name         = "Workstation Academy",
+        description  = "The Workstation Academy look — indigo on warm neutral, matching the learner site.",
+        project_code = "academy",
+        tokens = build_tokens({
+            primary = {
+                ["50"]  = "#eef2ff", ["100"] = "#e0e7ff", ["200"] = "#c7d2fe",
+                ["300"] = "#a5b4fc", ["400"] = "#818cf8", ["500"] = "#6366f1",
+                ["600"] = "#4f46e5", ["700"] = "#4338ca", ["800"] = "#3730a3",
+                ["900"] = "#312e81",
+            },
+            -- Tailwind `neutral`, which is what the learner site's chrome uses.
+            secondary = {
+                ["50"]  = "#fafafa", ["100"] = "#f5f5f5", ["200"] = "#e5e5e5",
+                ["300"] = "#d4d4d4", ["400"] = "#a3a3a3", ["500"] = "#737373",
+                ["600"] = "#525252", ["700"] = "#404040", ["800"] = "#262626",
+                ["900"] = "#171717",
+            },
+            accent           = "#6366f1",
+            background       = "#ffffff",
+            foreground       = "#171717",
+            surface          = "#ffffff",
+            surface_elevated = "#fafafa",
+            success          = "#10b981",
+            warning          = "#f59e0b",
+            danger           = "#ef4444",
+            info             = "#6366f1",
+        }, {
+            branding = { brand_name = "Workstation Academy", logo_text = "Academy" },
+        }),
+    },
 }
 
 --- Get the full preset list

--- a/lapis/queries/ThemeQueries.lua
+++ b/lapis/queries/ThemeQueries.lua
@@ -240,8 +240,13 @@ function ThemeQueries.getActive(namespace_id, project_code)
 end
 
 --------------------------------------------------------------------------------
--- Fallback for namespaces with no active theme: the first platform preset.
--- Used by the renderer to always have something to serve at /active/styles.css.
+-- Fallback for namespaces with no active theme.
+--
+-- A preset whose slug equals the project_code is that project's own look, so it
+-- wins; otherwise the first-seeded preset (OpsAPI Bright) does. That is how a
+-- white-labelled tenant gets its palette out of the box with no activation
+-- step: project_code "academy" resolves the "academy" preset. An explicitly
+-- activated theme still takes precedence: callers try getActive() first.
 --------------------------------------------------------------------------------
 function ThemeQueries.getDefaultPreset(project_code)
     local rows = db.query([[
@@ -255,9 +260,9 @@ function ThemeQueries.getDefaultPreset(project_code)
           AND t.is_system = true
           AND t.project_code = ?
           AND t.deleted_at IS NULL
-        ORDER BY t.id ASC
+        ORDER BY (t.slug = ?) DESC, t.id ASC
         LIMIT 1
-    ]], project_code)
+    ]], project_code, project_code)
     return rows and rows[1] or nil
 end
 

--- a/lapis/routes/themes.lua
+++ b/lapis/routes/themes.lua
@@ -98,8 +98,25 @@ return function(app)
         return api_err(result.status or 500, result.error or "unknown error", extras)
     end
 
+    -- The project a namespace is pinned to, or nil when it isn't pinned to one.
+    --
+    -- `namespaces.project_code` defaults to "all", which means "not assigned to a
+    -- specific product" — those fall through to the pod's PROJECT_CODE, exactly as
+    -- before. A namespace pinned to a real product (academy, tax_copilot) gets that
+    -- product's presets instead, which is what lets a white-labelled tenant have its
+    -- own default look. (Read `project_code`: `default_project_code` was a typo for a
+    -- column that has never existed, so this branch was dead and every namespace
+    -- silently resolved to the pod's code.)
+    local function namespace_project_code(ns)
+        local code = ns and ns.project_code
+        if type(code) == "string" and code ~= "" and code ~= "all" then
+            return code
+        end
+        return nil
+    end
+
     -- Pick the project_code for this request. Precedence:
-    --   explicit ?project_code=... query/body > namespace default > first enabled feature
+    --   explicit ?project_code=... query/body > namespace's product > first enabled feature
     local function resolve_project_code(self, body)
         if body and body.project_code and body.project_code ~= "" then
             return body.project_code
@@ -107,9 +124,8 @@ return function(app)
         if self.params and self.params.project_code and self.params.project_code ~= "" then
             return self.params.project_code
         end
-        if self.namespace and self.namespace.default_project_code and self.namespace.default_project_code ~= "" then
-            return self.namespace.default_project_code
-        end
+        local ns_code = namespace_project_code(self.namespace)
+        if ns_code then return ns_code end
         local ok_cfg, ProjectConfig = pcall(require, "helper.project-config")
         if ok_cfg then
             local codes = ProjectConfig.parseProjectCodes()
@@ -193,9 +209,10 @@ return function(app)
         local project_code
         if self.params and self.params.project_code and self.params.project_code ~= "" then
             project_code = self.params.project_code
-        elseif ns and ns.default_project_code and ns.default_project_code ~= "" then
-            project_code = ns.default_project_code
         else
+            project_code = namespace_project_code(ns)
+        end
+        if not project_code then
             local ok_cfg, ProjectConfig = pcall(require, "helper.project-config")
             project_code = (ok_cfg and ProjectConfig.parseProjectCodes()[1]) or "default"
         end

--- a/lapis/spec/theme-branding_spec.lua
+++ b/lapis/spec/theme-branding_spec.lua
@@ -1,0 +1,103 @@
+--[[
+    Regression spec for tenant white-labelling.
+
+    Standalone — no busted/luarocks needed. Run from the repo root with:
+        luajit lapis/spec/theme-branding_spec.lua
+    (plain `lua5.1` works too).
+
+    Guards the two pieces that make an academy instructor see academy branding
+    on the shared opsapi dashboard:
+
+      1. the "academy" preset exists, is scoped to project_code "academy", and
+         renders the learner site's indigo scale as CSS variables;
+      2. ThemeQueries.getDefaultPreset prefers a preset whose slug equals the
+         project_code — without that ORDER BY, a namespace with no explicitly
+         activated theme falls back to "OpsAPI Bright" (pink) instead.
+]]
+
+package.path = "lapis/?.lua;lapis/?/init.lua;" .. package.path
+
+local failures = 0
+
+local function check(name, ok, detail)
+    if ok then
+        print("  ok   - " .. name)
+    else
+        failures = failures + 1
+        print("  FAIL - " .. name .. (detail and ("  (" .. tostring(detail) .. ")") or ""))
+    end
+end
+
+-- ---------------------------------------------------------------------------
+-- 1. The academy preset
+-- ---------------------------------------------------------------------------
+local ThemePresets = require("helper.theme-presets")
+local ThemeTokenSchema = require("helper.theme-token-schema")
+
+local academy = ThemePresets.getBySlug("academy")
+check("academy preset exists", academy ~= nil)
+
+if academy then
+    check("scoped to the academy project_code", academy.project_code == "academy", academy.project_code)
+    check("brand name is set", (academy.tokens.branding or {}).brand_name == "Workstation Academy")
+
+    -- A partial scale renders half a palette: the dashboard uses every step.
+    local missing = {}
+    for _, key in ipairs(ThemeTokenSchema.COLOR_SCALE_KEYS) do
+        if academy.tokens.colors.primary[key] == nil then missing[#missing + 1] = key end
+        if academy.tokens.colors.secondary[key] == nil then missing[#missing + 1] = "s" .. key end
+    end
+    check("primary + secondary scales are complete (50-900)", #missing == 0, table.concat(missing, ","))
+    check("primary 500 is the learner site's indigo", academy.tokens.colors.primary["500"] == "#6366f1")
+end
+
+-- ---------------------------------------------------------------------------
+-- 2. Rendering: tokens actually reach the browser as CSS variables
+-- ---------------------------------------------------------------------------
+package.preload["cjson"] = function()
+    return { encode = function() return "{}" end, decode = function() return {} end }
+end
+
+local ThemeRenderer = require("lib.theme-renderer")
+local css = ThemeRenderer.render({ tokens = academy and academy.tokens or {} })
+
+check("renders --color-primary-500", css:find("--color-primary-500: #6366f1", 1, true) ~= nil)
+check("renders --color-secondary-900", css:find("--color-secondary-900: #171717", 1, true) ~= nil)
+check("renders --brand-name", css:find("--brand-name: Workstation Academy", 1, true) ~= nil)
+
+-- ---------------------------------------------------------------------------
+-- 3. A project's own preset wins the "no theme activated" fallback
+-- ---------------------------------------------------------------------------
+-- ThemeQueries pulls in lapis.db, which needs a live config; assert on the
+-- source instead. Cheap, but it is exactly the one line that can silently
+-- regress to "first preset by id".
+local fh = assert(io.open("lapis/queries/ThemeQueries.lua"))
+local src = fh:read("*a")
+fh:close()
+local fallback = src:match("function ThemeQueries%.getDefaultPreset.-\nend")
+check("getDefaultPreset prefers slug == project_code",
+    fallback ~= nil and fallback:find("ORDER BY (t.slug = ?) DESC", 1, true) ~= nil)
+
+-- ---------------------------------------------------------------------------
+-- 4. The namespace's own project_code is what selects its presets
+-- ---------------------------------------------------------------------------
+-- routes/themes.lua read `default_project_code` — a column that has never
+-- existed — so every namespace silently resolved to the pod's PROJECT_CODE and
+-- no tenant could ever get its own look. Guard against the typo returning.
+local rh = assert(io.open("lapis/routes/themes.lua"))
+local routes_src = rh:read("*a")
+rh:close()
+
+check("no read of the non-existent default_project_code column",
+    routes_src:find("%.default_project_code") == nil)
+check("resolves the namespace's own project_code",
+    routes_src:find("local code = ns and ns.project_code", 1, true) ~= nil)
+check("treats 'all' as unpinned so existing tenants keep the pod's code",
+    routes_src:find('code ~= "all"', 1, true) ~= nil)
+
+print("")
+if failures > 0 then
+    print(failures .. " failure(s)")
+    os.exit(1)
+end
+print("all checks passed")

--- a/opsapi-dashboard/app/auth/sso/page.tsx
+++ b/opsapi-dashboard/app/auth/sso/page.tsx
@@ -63,6 +63,7 @@ export default function SsoAcceptPage(): React.ReactElement {
       const token = params.get('token');
       const ns = params.get('ns');
       const next = params.get('next') || '/dashboard/academy';
+      const academyUrl = params.get('academyUrl');
 
       if (!token) {
         setError('Missing sign-in token. Please sign in.');
@@ -77,6 +78,17 @@ export default function SsoAcceptPage(): React.ReactElement {
 
       // Clear the token from the address bar as soon as we've read it.
       window.history.replaceState(null, '', window.location.pathname);
+
+      // Remember where to send the instructor "back to" — set ONLY on a handoff
+      // from the academy site, so the Back-to-Academy button never shows for a
+      // direct dashboard login. Sanity-check the scheme to avoid javascript: etc.
+      try {
+        if (academyUrl && /^https?:\/\//i.test(academyUrl)) {
+          window.sessionStorage.setItem('academy_return_url', academyUrl);
+        }
+      } catch {
+        // sessionStorage can throw in private/blocked contexts — non-fatal.
+      }
 
       // 1. Adopt the session.
       useAuthStore.getState().setToken(token);

--- a/opsapi-dashboard/app/dashboard/academy/page.tsx
+++ b/opsapi-dashboard/app/dashboard/academy/page.tsx
@@ -7,6 +7,7 @@ import { Table, Badge, Pagination, Modal, Button, ConfirmDialog, Select, Searcha
 import { ProtectedPage } from '@/components/permissions';
 import { usePermissions } from '@/contexts/PermissionsContext';
 import { useAuthStore } from '@/store/auth.store';
+import { BackToAcademy } from '@/components/academy';
 import {
   academyService,
   getCourseStatusVariant,
@@ -683,6 +684,8 @@ function AcademyCoursesPage() {
           </div>
         </div>
         <div className="flex items-center gap-2">
+          {/* Only shown to instructors who arrived via the academy site handoff. */}
+          <BackToAcademy />
           {isAdmin && (
             <Button variant="outline" leftIcon={<Banknote size={16} />} onClick={() => router.push('/dashboard/academy/admin')}>Payouts</Button>
           )}

--- a/opsapi-dashboard/components/academy/BackToAcademy.tsx
+++ b/opsapi-dashboard/components/academy/BackToAcademy.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import React, { useSyncExternalStore } from 'react';
+import { ArrowLeft } from 'lucide-react';
+import { Button } from '@/components/ui';
+
+/**
+ * "Back to Academy" — a return link for instructors who reached the creator
+ * dashboard through the academy site's SSO handoff.
+ *
+ * The academy origin is stashed in sessionStorage by /auth/sso ONLY on that
+ * handoff (it rides in the SSO fragment as `academyUrl`). So this renders nothing
+ * for a direct dashboard login, or any other way of arriving here — the button
+ * appears strictly when the user came from academy. Session-scoped: it clears
+ * when the tab closes.
+ *
+ * Read via useSyncExternalStore so the client-only value never causes a
+ * hydration mismatch (server snapshot is always null → nothing rendered).
+ */
+const NO_SUBSCRIBE = (): (() => void) => () => {};
+
+function readReturnUrl(): string | null {
+  try {
+    const v = window.sessionStorage.getItem('academy_return_url');
+    return v && /^https?:\/\//i.test(v) ? v : null;
+  } catch {
+    // sessionStorage can be unavailable (private mode) — just hide the button.
+    return null;
+  }
+}
+
+export const BackToAcademy: React.FC = () => {
+  const url = useSyncExternalStore(NO_SUBSCRIBE, readReturnUrl, () => null);
+
+  if (!url) return null;
+
+  return (
+    <Button
+      variant="outline"
+      leftIcon={<ArrowLeft size={16} />}
+      onClick={() => {
+        window.location.href = url;
+      }}
+    >
+      Back to Academy
+    </Button>
+  );
+};
+
+export default BackToAcademy;

--- a/opsapi-dashboard/components/academy/index.ts
+++ b/opsapi-dashboard/components/academy/index.ts
@@ -1,2 +1,3 @@
 export { default as RichTextEditor } from './RichTextEditor';
 export type { RichTextEditorProps } from './RichTextEditor';
+export { BackToAcademy } from './BackToAcademy';

--- a/opsapi-dashboard/components/auth/AuthShell.tsx
+++ b/opsapi-dashboard/components/auth/AuthShell.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { motion, useReducedMotion } from 'framer-motion';
 import { ShieldCheck, Boxes, GitBranch } from 'lucide-react';
 import ParticleField from '@/components/auth/ParticleField';
-import { Logo } from '@/components/brand/Logo';
+import { Logo, useBrand } from '@/components/brand/Logo';
 import PublicThemeStyles from '@/components/layout/PublicThemeStyles';
 
 const EASE = [0.16, 1, 0.3, 1] as const;
@@ -23,6 +23,7 @@ const FEATURES = [
  */
 export default function AuthShell({ children }: { children: React.ReactNode }) {
   const reduce = useReducedMotion();
+  const brand = useBrand();
 
   const container = {
     hidden: {},
@@ -95,7 +96,7 @@ export default function AuthShell({ children }: { children: React.ReactNode }) {
           </div>
 
           <motion.p variants={item} className="text-xs text-white/40">
-            © {new Date().getFullYear()} OpsAPI · Secure multi-tenant SaaS platform
+            © {new Date().getFullYear()} {brand.name} · Secure multi-tenant SaaS platform
           </motion.p>
         </motion.div>
       </div>

--- a/opsapi-dashboard/components/auth/LoginPanel.tsx
+++ b/opsapi-dashboard/components/auth/LoginPanel.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { Eye, EyeOff, Lock, User } from 'lucide-react';
 import { Button, Input } from '@/components/ui';
 import { useAuthStore } from '@/store/auth.store';
+import { useBrand } from '@/components/brand/Logo';
 import toast from 'react-hot-toast';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://127.0.0.1:4010';
@@ -16,6 +17,7 @@ const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://127.0.0.1:4010';
  */
 export default function LoginPanel() {
   const router = useRouter();
+  const brand = useBrand();
   const { login, isLoading, error, clearError } = useAuthStore();
   const [formData, setFormData] = useState({ username: '', password: '' });
   const [showPassword, setShowPassword] = useState(false);
@@ -65,7 +67,7 @@ export default function LoginPanel() {
     <div className="w-full max-w-sm">
       <div className="mb-8">
         <h1 className="text-2xl font-bold text-secondary-900">Welcome back</h1>
-        <p className="mt-1.5 text-sm text-secondary-500">Sign in to your OpsAPI workspace</p>
+        <p className="mt-1.5 text-sm text-secondary-500">Sign in to your {brand.name} workspace</p>
       </div>
 
       {/* Google */}

--- a/opsapi-dashboard/components/brand/Logo.tsx
+++ b/opsapi-dashboard/components/brand/Logo.tsx
@@ -1,16 +1,49 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
+import { useNamespaceStore } from '@/store/namespace.store';
 
 /**
- * OpsAPI brand mark.
+ * Brand mark for the dashboard chrome.
  *
- * The glyph reads as an "O" (Ops) built from an orbit ring around a core, with a
- * single API-endpoint node sitting on the ring — "operations orbiting an API".
- * Pure inline SVG so it scales crisply and can be animated / themed.
+ * OpsAPI is white-labelled per tenant: a namespace that sets `logo_url` takes
+ * over the mark AND the wordmark (its own `name`), so an academy instructor
+ * handed off from the learner site sees Academy branding, not OpsAPI. Colors,
+ * fonts and radii come from the tenant's active theme (ThemeStyles), so this
+ * is the only hard-coded piece of identity left.
+ *
+ * No logo_url set => the OpsAPI house brand below.
  */
 
-export function LogoMark({ size = 40, className = '' }: { size?: number; className?: string }) {
+export interface Brand {
+  name: string;
+  logoUrl?: string;
+}
+
+/**
+ * Current tenant's brand. Reads the namespace *store* rather than
+ * NamespaceContext so it also works on pre-auth pages (login, /auth/sso), which
+ * render outside the provider — the store is persisted, so a returning tenant
+ * user keeps their branding on the login screen.
+ */
+export function useBrand(): Brand {
+  const current = useNamespaceStore((s) => s.currentNamespace);
+  const all = useNamespaceStore((s) => s.namespaces);
+  // The namespace baked into the JWT carries only id/name/slug, so fall back to
+  // the full row from the list when it's loaded.
+  const logoUrl =
+    current?.logo_url || all.find((n) => n.uuid === current?.uuid)?.logo_url || undefined;
+
+  if (!logoUrl) return { name: 'OpsAPI' };
+  return { name: current?.name || 'OpsAPI', logoUrl };
+}
+
+/**
+ * OpsAPI house glyph — an "O" (Ops) built from an orbit ring around a core, with
+ * a single API-endpoint node sitting on the ring. Pure inline SVG so it scales
+ * crisply and can be animated / themed.
+ */
+function OpsApiMark({ size, className }: { size: number; className: string }) {
   return (
     <svg
       width={size}
@@ -41,8 +74,34 @@ export function LogoMark({ size = 40, className = '' }: { size?: number; classNa
   );
 }
 
+export function LogoMark({ size = 40, className = '' }: { size?: number; className?: string }) {
+  const { name, logoUrl } = useBrand();
+  // A tenant's logo_url points at an asset on THEIR site, which we don't control
+  // and which may be missing (a namespace branded before its site deployed, a
+  // moved file, an outage). Fall back to the house mark rather than leaving a
+  // broken image in the chrome.
+  // Keyed by URL, not a boolean, so switching namespace retries the new logo.
+  const [failedUrl, setFailedUrl] = useState<string | null>(null);
+
+  if (logoUrl && logoUrl !== failedUrl) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={logoUrl}
+        alt={name}
+        width={size}
+        height={size}
+        style={{ width: size, height: size }}
+        className={`rounded-xl object-contain ${className}`}
+        onError={() => setFailedUrl(logoUrl)}
+      />
+    );
+  }
+  return <OpsApiMark size={size} className={className} />;
+}
+
 /**
- * Full lockup: mark + "OpsAPI" wordmark. `tone` controls the wordmark color for
+ * Full lockup: mark + wordmark. `tone` controls the wordmark color for
  * placement on dark ("light" text) or light ("dark" text) surfaces.
  */
 export function Logo({
@@ -56,13 +115,14 @@ export function Logo({
   showWordmark?: boolean;
   className?: string;
 }) {
+  const { name, logoUrl } = useBrand();
   const base = tone === 'light' ? 'text-white' : 'text-secondary-900';
   return (
     <span className={`inline-flex items-center gap-2.5 ${className}`}>
       <LogoMark size={size} />
       {showWordmark && (
         <span className={`font-semibold tracking-tight ${base}`} style={{ fontSize: size * 0.6 }}>
-          Ops<span className="text-primary-500">API</span>
+          {logoUrl ? name : <>Ops<span className="text-primary-500">API</span></>}
         </span>
       )}
     </span>

--- a/opsapi-dashboard/components/layout/Sidebar.tsx
+++ b/opsapi-dashboard/components/layout/Sidebar.tsx
@@ -30,7 +30,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useAuthStore } from "@/store/auth.store";
 import { useMenu, type MenuItemWithIcon } from "@/hooks";
-import { LogoMark } from "@/components/brand/Logo";
+import { LogoMark, useBrand } from "@/components/brand/Logo";
 
 interface SidebarProps {
   isOpen: boolean;
@@ -156,6 +156,7 @@ const Sidebar: React.FC<SidebarProps> = memo(function Sidebar({
 }) {
   const pathname = usePathname();
   const logout = useAuthStore((state) => state.logout);
+  const brand = useBrand();
 
   // Use the backend-driven menu hook
   const {
@@ -224,16 +225,16 @@ const Sidebar: React.FC<SidebarProps> = memo(function Sidebar({
             <LogoMark size={40} className="shrink-0" />
             {!isCollapsed && (
               <div className="hidden lg:block">
-                <span className="text-lg font-bold text-secondary-900">
-                  OpsAPI
+                <span className="text-lg font-bold text-secondary-900 line-clamp-1">
+                  {brand.name}
                 </span>
                 <p className="text-xs text-secondary-400">Dashboard</p>
               </div>
             )}
             {/* Always show title on mobile */}
             <div className="lg:hidden">
-              <span className="text-lg font-bold text-secondary-900">
-                OpsAPI
+              <span className="text-lg font-bold text-secondary-900 line-clamp-1">
+                {brand.name}
               </span>
               <p className="text-xs text-secondary-400">Dashboard</p>
             </div>

--- a/opsapi-dashboard/components/layout/ThemeStyles.tsx
+++ b/opsapi-dashboard/components/layout/ThemeStyles.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useNamespace } from '@/contexts/NamespaceContext';
+import { useBrand } from '@/components/brand/Logo';
 import { themesService } from '@/services/themes.service';
 
 const LINK_ID = 'ops-active-theme-css';
@@ -21,6 +22,7 @@ function buildHref(slug: string | undefined, version: string): string {
 
 export default function ThemeStyles() {
   const { currentNamespace } = useNamespace();
+  const { logoUrl } = useBrand();
   const slug = currentNamespace?.slug;
   const [version, setVersion] = useState<string>('0');
 
@@ -84,6 +86,18 @@ export default function ThemeStyles() {
       link.href = href;
     }
   }, [slug, version]);
+
+  // White-labelled tenants get their own favicon too; the OpsAPI one (declared
+  // in app/layout.tsx metadata) stands when the namespace has no logo.
+  useEffect(() => {
+    if (typeof document === 'undefined' || !logoUrl) return;
+    document.querySelectorAll<HTMLLinkElement>('link[rel~="icon"]').forEach((el) => el.remove());
+    const icon = document.createElement('link');
+    icon.rel = 'icon';
+    icon.href = logoUrl;
+    document.head.appendChild(icon);
+    return () => icon.remove();
+  }, [logoUrl]);
 
   return null;
 }

--- a/start.sh
+++ b/start.sh
@@ -45,7 +45,7 @@ show_help() {
     echo "  -h, --help            Show this help message"
     echo ""
     echo -e "${BLUE}Preset Environments:${NC}"
-    echo "  local    - http://127.0.0.1:4010 (default for local development)"
+    echo "  local    - http://127.0.0.1:4020 (default for local development)"
     echo "  dev      - https://dev-api.${BASE_DOMAIN}"
     echo "  test     - https://test-api.${BASE_DOMAIN}"
     echo "  acc      - https://acc-api.${BASE_DOMAIN}"
@@ -292,7 +292,7 @@ get_api_url() {
         local)
             # Local always uses http unless explicitly overridden
             local local_proto="${proto:-http}"
-            echo "${local_proto}://127.0.0.1:4010"
+            echo "${local_proto}://127.0.0.1:4020"
             ;;
         prod)
             # Production uses api.domain.com (no prefix)
@@ -508,7 +508,7 @@ prompt_protocol() {
 # Function to prompt for environment selection
 prompt_environment() {
     echo -e "${CYAN}Select target environment:${NC}" >&2
-    echo "  1) local   - http://127.0.0.1:4010" >&2
+    echo "  1) local   - http://127.0.0.1:4020" >&2
     echo "  2) dev     - https://dev-api.${BASE_DOMAIN}" >&2
     echo "  3) test    - https://test-api.${BASE_DOMAIN}" >&2
     echo "  4) acc     - https://acc-api.${BASE_DOMAIN}" >&2


### PR DESCRIPTION
## Why

An instructor who registers on workstation.academy is handed straight to this dashboard (`/auth/sso`), where they landed on the OpsAPI house brand — pink palette, OpsAPI mark, "Sign in to your OpsAPI workspace" — with nothing to say they were still inside the product they just signed up for.

Pairs with bwalia/workstation-academy#30, which points the academy namespace's `logo_url` at the learner site's `/logo.svg`. Both halves have to land before an instructor actually sees Academy branding.

## What

**Branding (`opsapi-dashboard`)**
- `Logo.tsx` grows `useBrand()`: a namespace that carries a `logo_url` takes over both the mark and the wordmark (its own `name`). It reads the namespace **store** rather than `NamespaceContext`, so it also works on pre-auth pages (login, `/auth/sso`) which render outside the provider — a returning tenant user keeps their branding on the login screen.
- Falls back to the house mark if the tenant's image fails to load. The asset lives on *their* site, so a namespace branded before its site deployed, a moved file or an outage would otherwise leave a broken image in the chrome. Keyed by URL, not a boolean, so switching namespace retries the new logo.
- `Sidebar`, `AuthShell`, `LoginPanel` take the brand name instead of a hard-coded "OpsAPI"; `ThemeStyles` swaps the favicon to match. No `logo_url` set ⇒ everything is exactly as before.

**Palette (`lapis`)**
- New `academy` preset carrying the learner site's indigo/neutral scale, so the dashboard matches workstation.academy rather than approximating it.
- `getDefaultPreset` now prefers a preset whose slug equals the `project_code`. Without that `ORDER BY`, a namespace with no explicitly activated theme falls back to "OpsAPI Bright" (pink). An explicitly activated theme still wins — callers try `getActive()` first.

**Bug found along the way**
`themes.lua` resolved the project code from `ns.default_project_code` — a column that has **never existed**. The branch was dead, so every namespace silently fell through to the pod's `PROJECT_CODE`. It now reads `project_code`, treating the default `"all"` as "not pinned to a product" so existing tenants keep their current resolution.

**Tests**
`lapis/spec/theme-branding_spec.lua` — standalone, no busted/luarocks: `luajit lapis/spec/theme-branding_spec.lua`. Covers the preset's shape and completeness, the `getDefaultPreset` ordering, and that nothing reads the non-existent column. Green.

## ⚠️ One thing to verify before merge

The `default_project_code` fix changes theme resolution for **every** tenant, not just academy. Default *looks* are safe (the `"*"` presets fan out per enabled project code, so preset rows exist either way), but `getActive(namespace_id, project_code)` uses the same resolution — a namespace that had explicitly activated a theme under the pod's old code would now look it up under its own product code, miss, and drop back to a default.

Worth a query against prod for activated themes whose `project_code` differs from their namespace's. **tax_copilot is the one that matters** — this API is shared with diy-tax-return production.

## Second commit — local dev only

Host ports move off the diy-tax-return stack's (4010→4020, 5439→5440, 9000/9001→9900/9901); both opsapi stacks run on the same machine and collided. Container ports and network aliases are unchanged, so nothing deployed is affected. Also drops the `ollama` container — Ollama runs natively on the host now, reached via `host.docker.internal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
