### PR TITLE
fix(academy): close paywall bypass in the /enroll endpoint

### DIFF
--- a/lapis/routes/academy.lua
+++ b/lapis/routes/academy.lua
@@ -848,6 +848,14 @@ return function(app)
             if not course or course.status ~= "published" then
                 return api_response(404, nil, "Course not found")
             end
+            -- PAYWALL: self-enrollment is for FREE courses only. Paid access is
+            -- granted EXCLUSIVELY by the Stripe webhook (academy-stripe-webhook),
+            -- which calls EnrollmentQueries.enroll after payment settles. Without
+            -- this gate any authenticated user could enroll into a paid course and
+            -- unlock its content/video for free, bypassing checkout entirely.
+            if not pg_true(course.is_free) then
+                return api_response(403, nil, "This course must be purchased")
+            end
             local ok = pcall(EnrollmentQueries.enroll, ns.id, course.id, self.current_user.uuid)
             if not ok then
                 ngx.log(ngx.ERR, "[academy] enroll failed for course ", course.uuid)


### PR DESCRIPTION
## Blocker (found in the pre-payment audit)
`POST /api/v2/public/academy/:namespace/courses/:slug/enroll` (lapis/routes/academy.lua) wrote an **active** enrollment for **any** published course — no `is_free` check, no payment verification (only `requireAuth`).

`EntitlementQueries.hasCourseAccess` treats any active enrollment as access, and the Stripe webhook grants paid access through the **same** `EnrollmentQueries.enroll`. So any logged-in user could POST to a **paid** course's enroll URL → active enrollment → `hasCourseAccess` = true → they get every lesson's content_html/s3_key + signed video, **skipping checkout entirely**.

## Fix
Reject paid courses at the enroll handler (403); paid access comes **only** from the Stripe webhook after payment settles. Free courses are unaffected. Academy-namespace-scoped; no tax_copilot impact. `luac -p` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
