### PR TITLE
feat(academy): tier-aware course access (subscription tiers — phase 1)

### DIFF
--- a/lapis/queries/CreatorQueries.lua
+++ b/lapis/queries/CreatorQueries.lua
@@ -94,18 +94,36 @@ function CreatorQueries.effectiveFeePct(user_uuid)
     return CreatorQueries.getDefaultFeePct()
 end
 
--- ---- Community subscription plan (academy-wide, namespace-level) ----------
+-- ---- Community subscription plans (one active plan PER TIER) --------------
 
-function CreatorQueries.getActivePlan(namespace_id)
+-- All active plans for a namespace, entry-level (lowest tier) first.
+function CreatorQueries.getActivePlans(namespace_id)
+    return db.query(
+        "SELECT * FROM creator_subscription_plans WHERE namespace_id = ? AND active = TRUE ORDER BY tier ASC, amount ASC",
+        namespace_id) or {}
+end
+
+-- The active plan for a specific tier, or nil.
+function CreatorQueries.getActivePlanForTier(namespace_id, tier)
     local rows = db.query(
-        "SELECT * FROM creator_subscription_plans WHERE namespace_id = ? AND active = TRUE ORDER BY created_at DESC LIMIT 1",
-        namespace_id)
+        "SELECT * FROM creator_subscription_plans WHERE namespace_id = ? AND tier = ? AND active = TRUE LIMIT 1",
+        namespace_id, math.max(1, math.floor(tonumber(tier) or 1)))
     return rows and rows[1] or nil
 end
 
+-- Backward-compat: the lowest-tier active plan (the entry-level membership).
+function CreatorQueries.getActivePlan(namespace_id)
+    return CreatorQueries.getActivePlans(namespace_id)[1]
+end
+
+-- Create/replace the active plan FOR ITS TIER. Deactivates only the same-tier
+-- active plan, so the other tiers (Basic/Pro/Premium…) stay live — that's what
+-- makes multiple plans coexist. `fields.tier` defaults to 1 (entry level).
 function CreatorQueries.upsertPlan(namespace_id, fields)
-    db.query("UPDATE creator_subscription_plans SET active = FALSE, updated_at = NOW() WHERE namespace_id = ? AND active = TRUE",
-        namespace_id)
+    local tier = math.max(1, math.floor(tonumber(fields.tier) or 1))
+    db.query("UPDATE creator_subscription_plans SET active = FALSE, updated_at = NOW() WHERE namespace_id = ? AND tier = ? AND active = TRUE",
+        namespace_id, tier)
+    fields.tier = tier
     fields.uuid = Global.generateUUID()
     fields.namespace_id = namespace_id
     fields.active = true

--- a/lapis/queries/EntitlementQueries.lua
+++ b/lapis/queries/EntitlementQueries.lua
@@ -43,10 +43,18 @@ function EntitlementQueries.hasCourseAccess(user_uuid, course)
     if not user_uuid then return false end
     -- Instructor / owner.
     if course.owner_user_uuid and course.owner_user_uuid == user_uuid then return true end
-    -- One-time purchase / enrollment.
+    -- One-time purchase / enrollment (à la carte access to a single course).
     if EnrollmentQueries.isEnrolled(course.id, user_uuid) then return true end
-    -- Active community subscription.
-    if EntitlementQueries.hasActiveSubscription(user_uuid, course.namespace_id) then return true end
+    -- Active community subscription whose plan tier covers this course's tier.
+    -- Tolerant of the tier columns not existing yet: a nil `plan_tier`/`tier`
+    -- reads as 1, so a pre-migration database behaves exactly like the old
+    -- "any active subscription unlocks everything" rule (all courses are tier 1).
+    local sub = EntitlementQueries.activeSubscription(user_uuid, course.namespace_id)
+    if sub then
+        local plan_tier = tonumber(sub.plan_tier) or 1
+        local course_tier = tonumber(course.tier) or 1
+        if plan_tier >= course_tier then return true end
+    end
     return false
 end
 

--- a/lapis/queries/SubscriptionQueries.lua
+++ b/lapis/queries/SubscriptionQueries.lua
@@ -45,6 +45,9 @@ function SubscriptionQueries.upsert(params)
         stripe_subscription_id = params.stripe_subscription_id,
         stripe_customer_id = params.stripe_customer_id,
         status = params.status or "active",
+        -- The tier this subscription grants (EntitlementQueries compares it to the
+        -- course tier). Defaults to 1 so a legacy single-plan checkout still works.
+        plan_tier = math.max(1, math.floor(tonumber(params.plan_tier) or 1)),
         current_period_end = cpe and db.raw("to_timestamp(" .. cpe .. ")") or nil,
         created_at = db.raw("NOW()"),
         updated_at = db.raw("NOW()"),

--- a/lapis/routes/academy-billing.lua
+++ b/lapis/routes/academy-billing.lua
@@ -115,7 +115,10 @@ return function(app)
             -- Account, fee and earnings are per-instructor (user_uuid); the
             -- community subscription plan stays academy-wide (namespace-level).
             local acc = CreatorQueries.getAccount(uid)
-            local plan = CreatorQueries.getActivePlan(ns.id)
+            local plans_out = {}
+            for _, p in ipairs(CreatorQueries.getActivePlans(ns.id)) do
+                plans_out[#plans_out + 1] = { tier = p.tier, amount = p.amount, currency = p.currency, interval = p.interval }
+            end
             local earnings = PayoutQueries.earningsForInstructor(uid)
             local bank = {}
             if acc then
@@ -125,7 +128,8 @@ return function(app)
                 bank = bank,
                 bank_details_complete = acc and acc.bank_details_complete or false,
                 fee_pct = CreatorQueries.effectiveFeePct(uid),
-                plan = plan and { amount = plan.amount, currency = plan.currency, interval = plan.interval } or nil,
+                plan = plans_out[1],
+                plans = plans_out,
                 earnings = {
                     total_net = tonumber(earnings.total_net) or 0,
                     owed = tonumber(earnings.owed) or 0,
@@ -189,14 +193,17 @@ return function(app)
             if not amount or amount <= 0 then
                 return api_response(400, nil, "amount (in minor units, e.g. 999 = $9.99) is required")
             end
+            -- Which tier this plan unlocks (1 = entry level). A course is
+            -- accessible to a subscription whose plan tier >= the course tier.
+            local tier = math.max(1, math.floor(tonumber(body.tier) or 1))
             local interval = (body.interval == "year") and "year" or "month"
             local currency, cur_err = normalize_currency(body.currency)
             if not currency then return api_response(400, nil, cur_err) end
 
             local stripe = Stripe.new()
             local product, perr = stripe:create_product({
-                name = (ns.name or ns.slug) .. " membership",
-                metadata = { namespace_id = tostring(ns.id) },
+                name = (ns.name or ns.slug) .. " membership · tier " .. tier,
+                metadata = { namespace_id = tostring(ns.id), tier = tostring(tier) },
             })
             if not product then return api_response(502, nil, "Stripe product failed: " .. tostring(perr)) end
 
@@ -213,8 +220,9 @@ return function(app)
                 interval = interval,
                 amount = math.floor(amount),
                 currency = currency,
+                tier = tier,
             })
-            return { status = 200, json = { amount = plan.amount, currency = plan.currency, interval = plan.interval } }
+            return { status = 200, json = { tier = plan.tier, amount = plan.amount, currency = plan.currency, interval = plan.interval } }
         end)))
 
     ---------------------------------------------------------------------------
@@ -274,8 +282,16 @@ return function(app)
             return { status = 200, json = { already_subscribed = true } }
         end
 
-        local plan = CreatorQueries.getActivePlan(ns.id)
-        if not plan or not plan.stripe_price_id then return api_response(400, nil, "This community has no subscription plan") end
+        -- Which tier to subscribe to. Default: the entry-level (lowest) plan, so a
+        -- single-plan community keeps working with no `tier` in the request.
+        local body = parse_body()
+        local plan = body.tier
+            and CreatorQueries.getActivePlanForTier(ns.id, body.tier)
+            or CreatorQueries.getActivePlan(ns.id)
+        if not plan or not plan.stripe_price_id then
+            return api_response(400, nil, "No subscription plan available for that tier")
+        end
+        local tier = tostring(plan.tier or 1)
 
         local base = learner_base()
         local stripe = Stripe.new()
@@ -285,8 +301,10 @@ return function(app)
             cancel_url = base .. "/courses?subscribe=cancel",
             client_reference_id = uuid,
             line_items = { { price = plan.stripe_price_id, quantity = 1 } },
-            subscription_data = { metadata = { kind = "subscription", namespace_id = tostring(ns.id), user_uuid = uuid } },
-            metadata = { kind = "subscription", namespace_id = tostring(ns.id), user_uuid = uuid },
+            -- `tier` rides in the metadata so the webhook records plan_tier on the
+            -- academy_subscriptions row (EntitlementQueries reads it for access).
+            subscription_data = { metadata = { kind = "subscription", namespace_id = tostring(ns.id), user_uuid = uuid, tier = tier } },
+            metadata = { kind = "subscription", namespace_id = tostring(ns.id), user_uuid = uuid, tier = tier },
         })
         if not session then return api_response(502, nil, "Checkout failed: " .. tostring(err)) end
         return { status = 200, json = { url = session.url } }
@@ -320,11 +338,13 @@ return function(app)
     app:get("/api/v2/public/academy/:namespace/plan", function(self)
         local ns = NamespaceQueries.findBySlug(self.params.namespace)
         if not ns then return api_response(404, nil, "Namespace not found") end
-        local plan = CreatorQueries.getActivePlan(ns.id)
-        if not plan then return { status = 200, json = { has_plan = false } } end
-        return { status = 200, json = {
-            has_plan = true,
-            plan = { amount = plan.amount, currency = plan.currency, interval = plan.interval },
-        } }
+        local out = {}
+        for _, p in ipairs(CreatorQueries.getActivePlans(ns.id)) do
+            out[#out + 1] = { tier = p.tier, amount = p.amount, currency = p.currency, interval = p.interval }
+        end
+        if #out == 0 then return { status = 200, json = { has_plan = false } } end
+        -- `plan` = the entry-level plan (backward-compat); `plans` = every tier,
+        -- entry level first, for the pricing UI.
+        return { status = 200, json = { has_plan = true, plan = out[1], plans = out } }
     end)
 end

--- a/lapis/routes/academy-stripe-webhook.lua
+++ b/lapis/routes/academy-stripe-webhook.lua
@@ -131,6 +131,9 @@ return function(app)
                         user_uuid = md.user_uuid, namespace_id = ns_id,
                         stripe_subscription_id = obj.subscription, stripe_customer_id = obj.customer,
                         status = subobj and subobj.status or "active",
+                        -- Which tier the learner bought (rides in the checkout metadata);
+                        -- EntitlementQueries compares this to each course's tier.
+                        plan_tier = tonumber(md.tier) or 1,
                         current_period_end_unix = subobj and subobj.current_period_end or nil,
                     })
                     -- First payment: record the ledger entry here (renewals come via invoice.paid).

--- a/lapis/routes/academy.lua
+++ b/lapis/routes/academy.lua
@@ -430,6 +430,9 @@ return function(app)
                 is_free = is_free,
                 price = price,
                 currency = body.currency or "USD",
+                -- Membership tier a subscriber needs to unlock this course (paid
+                -- only; harmless on free). Clamp to >= 1; default entry level.
+                tier = math.max(1, math.floor(tonumber(body.tier) or 1)),
                 status = status,
                 owner_user_uuid = self.current_user.uuid,
             })
@@ -472,6 +475,7 @@ return function(app)
             end
             if body.is_free ~= nil then fields.is_free = to_bool(body.is_free, true) end
             if body.price ~= nil then fields.price = tonumber(body.price) or 0 end
+            if body.tier ~= nil then fields.tier = math.max(1, math.floor(tonumber(body.tier) or 1)) end
             -- Present-but-empty ([]) clears the tags; absent leaves them untouched.
             if body.tags ~= nil then fields.tags = coerce_tags(body.tags) end
 

--- a/lapis/routes/academy.lua
+++ b/lapis/routes/academy.lua
@@ -273,6 +273,9 @@ return function(app)
             is_free = row.is_free,
             price = row.price,
             currency = row.currency,
+            -- Membership tier a subscriber needs to unlock this course (1 = entry
+            -- level). nil when the tier column predates the migration -> defaults 1.
+            tier = row.tier and tonumber(row.tier) or 1,
             rating = row.rating and tonumber(row.rating) or 0,
             rating_count = row.rating_count,
             duration_minutes = row.duration_minutes,

--- a/opsapi-dashboard/app/dashboard/academy/creator/page.tsx
+++ b/opsapi-dashboard/app/dashboard/academy/creator/page.tsx
@@ -38,6 +38,7 @@ function CreatorMonetization(): React.ReactElement {
   const [bank, setBank] = useState<CreatorBank>(EMPTY_BANK);
   const [savingBank, setSavingBank] = useState(false);
 
+  const [tier, setTier] = useState('1');
   const [price, setPrice] = useState('');
   const [interval, setInterval] = useState<'month' | 'year'>('month');
   const [savingPlan, setSavingPlan] = useState(false);
@@ -97,18 +98,27 @@ function CreatorMonetization(): React.ReactElement {
       toast.error('Enter a valid price');
       return;
     }
+    const tierNum = Math.max(1, Math.floor(Number(tier) || 1));
     setSavingPlan(true);
     try {
-      await academyService.setSubscriptionPlan({ amount: Math.round(dollars * 100), interval });
-      toast.success('Community membership price saved');
+      await academyService.setSubscriptionPlan({ tier: tierNum, amount: Math.round(dollars * 100), interval });
+      toast.success(`Tier ${tierNum} membership saved`);
       load();
     } catch (err) {
       console.error('Save plan failed:', err);
-      toast.error('Failed to save price');
+      toast.error('Failed to save tier');
     } finally {
       setSavingPlan(false);
     }
   };
+
+  // Existing tiers, entry level first. Falls back to the single `plan` for a
+  // backend that predates the multi-tier response.
+  const plans = (account?.plans && account.plans.length > 0)
+    ? [...account.plans].sort((a, b) => (a.tier ?? 1) - (b.tier ?? 1))
+    : account?.plan
+      ? [account.plan]
+      : [];
 
   const e = account?.earnings;
 
@@ -223,19 +233,44 @@ function CreatorMonetization(): React.ReactElement {
         </CardContent>
       </Card>
 
-      {/* Community membership price */}
+      {/* Membership tiers */}
       <Card>
         <CardHeader>
-          <h2 className="text-sm font-semibold text-secondary-800">Community membership price</h2>
+          <h2 className="text-sm font-semibold text-secondary-800">Membership tiers</h2>
         </CardHeader>
         <CardContent>
+          {plans.length > 0 ? (
+            <div className="mb-5 overflow-hidden rounded-lg border border-secondary-200">
+              <table className="w-full text-sm">
+                <thead className="bg-secondary-50 text-left text-xs uppercase tracking-wide text-secondary-500">
+                  <tr>
+                    <th className="px-3 py-2 font-medium">Tier</th>
+                    <th className="px-3 py-2 font-medium">Price</th>
+                    <th className="px-3 py-2 font-medium">Billing</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-secondary-100">
+                  {plans.map((p) => (
+                    <tr key={p.tier ?? 1}>
+                      <td className="px-3 py-2 font-medium text-secondary-900">Tier {p.tier ?? 1}</td>
+                      <td className="px-3 py-2 text-secondary-700">{money(p.amount, p.currency)}</td>
+                      <td className="px-3 py-2 text-secondary-500">/ {p.interval}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p className="mb-5 text-sm text-secondary-500">No membership tiers yet. Add one below.</p>
+          )}
+
           <form onSubmit={handleSavePlan} className="space-y-4">
-            {account?.plan ? (
-              <p className="text-sm text-secondary-600">
-                Current: <span className="font-medium text-secondary-900">{money(account.plan.amount, account.plan.currency)}</span> / {account.plan.interval}
-              </p>
-            ) : null}
-            <div className="grid grid-cols-2 gap-4">
+            <p className="text-sm font-medium text-secondary-700">Add or update a tier</p>
+            <div className="grid grid-cols-3 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-secondary-700 mb-1">Tier</label>
+                <input className={inputClass} type="number" min={1} step={1} value={tier} onChange={(ev) => setTier(ev.target.value)} placeholder="1" />
+              </div>
               <div>
                 <label className="block text-sm font-medium text-secondary-700 mb-1">Price</label>
                 <input className={inputClass} type="number" min={1} step="0.01" value={price} onChange={(ev) => setPrice(ev.target.value)} placeholder="9.99" />
@@ -248,8 +283,8 @@ function CreatorMonetization(): React.ReactElement {
                 </select>
               </div>
             </div>
-            <p className="text-xs text-secondary-400">Members who subscribe get access to all of your courses.</p>
-            <Button type="submit" isLoading={savingPlan}>Save price</Button>
+            <p className="text-xs text-secondary-400">A subscriber unlocks every course at their tier and below. Tier 1 is your entry-level plan. Saving a tier that already exists updates its price.</p>
+            <Button type="submit" isLoading={savingPlan}>Save tier</Button>
           </form>
         </CardContent>
       </Card>

--- a/opsapi-dashboard/app/dashboard/academy/page.tsx
+++ b/opsapi-dashboard/app/dashboard/academy/page.tsx
@@ -52,6 +52,7 @@ const EMPTY_FORM: CourseInput = {
   is_free: true,
   price: 0,
   currency: 'USD',
+  tier: 1,
   status: 'draft',
 };
 
@@ -100,6 +101,7 @@ const CourseModal: React.FC<CourseModalProps> = ({ isOpen, course, canPublishDir
         // Stored in minor units (pence/cents); edit in major units.
         price: (course.price ?? 0) / 100,
         currency: course.currency,
+        tier: course.tier ?? 1,
         status: course.status,
       });
     } else {
@@ -319,6 +321,11 @@ const CourseModal: React.FC<CourseModalProps> = ({ isOpen, course, canPublishDir
                     <option key={c} value={c}>{c}</option>
                   ))}
                 </select>
+              </div>
+              <div className="col-span-2">
+                <label className="block text-sm font-medium text-secondary-700 mb-1">Membership tier</label>
+                <input className={inputClass} type="number" min={1} step={1} value={form.tier ?? 1} onChange={(e) => set('tier', Math.max(1, Math.floor(Number(e.target.value) || 1)))} />
+                <p className="mt-1 text-xs text-secondary-500">A subscriber can watch this course if their membership tier is this number or higher. Tier 1 = your entry-level plan. Buyers always get access regardless of tier.</p>
               </div>
             </>
           )}

--- a/opsapi-dashboard/services/academy.service.ts
+++ b/opsapi-dashboard/services/academy.service.ts
@@ -24,6 +24,8 @@ export interface AcademyCourse {
   is_free: boolean;
   price: number;
   currency: string;
+  /** Membership tier a subscriber needs to unlock this course (1 = entry level). */
+  tier?: number;
   rating?: number;
   rating_count?: number;
   duration_minutes?: number;
@@ -132,6 +134,8 @@ export interface CourseInput {
   is_free?: boolean;
   price?: number;
   currency?: string;
+  /** Membership tier a subscriber needs to unlock this course (1 = entry level). */
+  tier?: number;
   status?: CourseStatus;
 }
 
@@ -148,6 +152,8 @@ export interface LessonInput {
 }
 
 export interface CommunityPlan {
+  /** Membership tier (1 = entry level). A plan unlocks its tier and below. */
+  tier?: number;
   amount: number; // minor units (e.g. 999 = $9.99)
   currency: string;
   interval: string; // month|year
@@ -177,7 +183,8 @@ export interface CreatorAccount {
   bank: CreatorBank;
   bank_details_complete: boolean;
   fee_pct: number; // effective cut % applied to this creator
-  plan?: CommunityPlan | null;
+  plan?: CommunityPlan | null; // entry-level plan (back-compat)
+  plans?: CommunityPlan[]; // every active membership tier
   earnings: CreatorEarnings;
 }
 
@@ -195,6 +202,8 @@ export interface SubscriptionPlanInput {
   amount: number; // minor units
   interval: 'month' | 'year';
   currency?: string;
+  /** Which tier this plan unlocks (1 = entry level). Omitted -> tier 1. */
+  tier?: number;
 }
 
 // ============================================================


### PR DESCRIPTION
**Phase 1 of tiered subscription plans** — the access rule. (Schema is a companion academy consumer migration; checkout/webhook/UI are later phases.)

## Change
`EntitlementQueries.hasCourseAccess` grants a paid course to an active subscriber only when `plan_tier >= course.tier` (was: any active subscription → all courses).

**Safe / no behaviour change on its own:** tolerant of the tier columns not existing yet — a nil `plan_tier`/`tier` reads as `1`, every course defaults to tier `1`, so a pre-migration DB (or a namespace with no tiers configured) behaves exactly like today's single all-access plan.

## Companion
Schema lands via `workstation-academy` migration `20260828_001_subscription_tiers` (additive columns `academy_courses.tier`, `creator_subscription_plans.tier`, `academy_subscriptions.plan_tier`; the one-active-plan index becomes one-per-tier; existing active subscribers grandfathered to all-access).

## Not yet done (later phases)
- Checkout to a *specific* plan tier + webhook recording `plan_tier`
- `CreatorQueries` multi-plan helpers
- Creator dashboard (manage tiers + set course tiers) and learner pricing UI

⚠️ **Not live-tested** — the local Docker daemon was unavailable this session. Verify the access matrix (Basic sub → tier-1 only; Pro → tier ≤ 2; à-la-carte purchase still unlocks any single course; grandfathered subs keep all-access) before merge. `luac -p` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
