### PR TITLE
feat(academy): paid-video stream URL + delayed-payment webhook guard

### DIFF
--- a/lapis/routes/academy-stripe-webhook.lua
+++ b/lapis/routes/academy-stripe-webhook.lua
@@ -6,7 +6,8 @@
     Source of truth for granting access + recording the earnings ledger. All
     charges are on the PLATFORM account (no Connect); the creator's cut/net is
     computed by PayoutQueries.recordSale using their effective fee %.
-      - checkout.session.completed (course)       -> enroll + ledger entry
+      - checkout.session.completed (course)       -> enroll + ledger entry (only if paid)
+      - checkout.session.async_payment_succeeded  -> enroll + ledger for a delayed course payment
       - checkout.session.completed (subscription) -> create sub + first ledger entry
       - invoice.paid (subscription_cycle)         -> extend sub + renewal ledger entry
       - customer.subscription.updated/deleted     -> update status/period
@@ -105,6 +106,23 @@ return function(app)
             if ok_fetch then subobj = res end
         end
 
+        -- Enroll the buyer + record the instructor's earnings, atomically (a
+        -- failed ledger write rolls the enrollment back too, so access is never
+        -- granted without a sale row). Shared by the instant-payment path
+        -- (checkout.session.completed, payment_status "paid") and the delayed one
+        -- (checkout.session.async_payment_succeeded), so both grant identically.
+        local function grant_course_purchase(md, ns_id, session)
+            EnrollmentQueries.enroll(ns_id, tonumber(md.course_id), md.user_uuid)
+            -- Attribute the sale to the course owner (the instructor). Legacy /
+            -- admin-owned courses may have no owner -> platform revenue.
+            local course = CourseQueries.findById(ns_id, tonumber(md.course_id))
+            PayoutQueries.recordSale({
+                user_uuid = md.user_uuid, namespace_id = ns_id, course_id = tonumber(md.course_id),
+                seller_user_uuid = course and course.owner_user_uuid or nil,
+                kind = "course", stripe_ref = session.payment_intent, amount = session.amount_total, currency = session.currency,
+            })
+        end
+
         -- All persistent side effects run inside ONE transaction, and the
         -- idempotency marker is written as its LAST statement. Any failure rolls
         -- back the marker together with the partial side effects, so nothing is
@@ -114,18 +132,14 @@ return function(app)
                 local md = obj.metadata or {}
                 local ns_id = tonumber(md.namespace_id)
                 if md.kind == "course" and ns_id and tonumber(md.course_id) and md.user_uuid then
-                    -- Enroll + ledger are now atomic: if the ledger write fails the
-                    -- enrollment rolls back too, so the buyer is never granted access
-                    -- without the instructor's earnings row being recorded.
-                    EnrollmentQueries.enroll(ns_id, tonumber(md.course_id), md.user_uuid)
-                    -- Attribute the sale to the course owner (the instructor). Legacy /
-                    -- admin-owned courses may have no owner -> platform revenue.
-                    local course = CourseQueries.findById(ns_id, tonumber(md.course_id))
-                    PayoutQueries.recordSale({
-                        user_uuid = md.user_uuid, namespace_id = ns_id, course_id = tonumber(md.course_id),
-                        seller_user_uuid = course and course.owner_user_uuid or nil,
-                        kind = "course", stripe_ref = obj.payment_intent, amount = obj.amount_total, currency = obj.currency,
-                    })
+                    -- Only grant once the money is actually captured. Card and other
+                    -- instant methods arrive here already "paid"; asynchronous methods
+                    -- (some bank debits, vouchers) arrive "unpaid" and are granted
+                    -- later by async_payment_succeeded — NOT here, or the buyer would
+                    -- get the course before Stripe confirms the funds.
+                    if obj.payment_status == "paid" or obj.payment_status == "no_payment_required" then
+                        grant_course_purchase(md, ns_id, obj)
+                    end
                 elseif md.kind == "subscription" and ns_id and md.user_uuid and obj.subscription then
                     SubscriptionQueries.upsert({
                         user_uuid = md.user_uuid, namespace_id = ns_id,
@@ -141,6 +155,18 @@ return function(app)
                         user_uuid = md.user_uuid, namespace_id = ns_id, kind = "subscription",
                         stripe_ref = obj.subscription, amount = obj.amount_total, currency = obj.currency,
                     })
+                end
+
+            elseif t == "checkout.session.async_payment_succeeded" then
+                -- A delayed payment method finally cleared. The checkout.session.completed
+                -- for this session arrived "unpaid" and granted nothing; now that the funds
+                -- are confirmed we grant the course (a different event id, so it is not a
+                -- duplicate of the earlier no-op). Courses only — subscription first
+                -- payments settle through invoice.paid.
+                local md = obj.metadata or {}
+                local ns_id = tonumber(md.namespace_id)
+                if md.kind == "course" and ns_id and tonumber(md.course_id) and md.user_uuid then
+                    grant_course_purchase(md, ns_id, obj)
                 end
 
             elseif t == "invoice.paid" then

--- a/lapis/routes/academy.lua
+++ b/lapis/routes/academy.lua
@@ -26,6 +26,7 @@
 local cJson = require("cjson")
 local CourseQueries = require "queries.CourseQueries"
 local LessonQueries = require "queries.LessonQueries"
+local MinioClient = require "helper.minio"
 local InstructorQueries = require "queries.InstructorQueries"
 local EnrollmentQueries = require "queries.EnrollmentQueries"
 local EntitlementQueries = require "queries.EntitlementQueries"
@@ -967,6 +968,45 @@ return function(app)
                 completed_count = count,
                 total = #lessons,
             } }
+        end))
+
+    -- A short-lived signed URL to stream a PAID lesson's video. Free lessons
+    -- never reach here — the learner site signs those itself from its SQLite
+    -- cache (golden rule). This re-checks entitlement before handing out a key:
+    -- a preview lesson is watchable by anyone, otherwise the caller must have
+    -- access to the parent course (free / owner / enrolled / tier subscriber).
+    app:get("/api/v2/public/academy/:namespace/lessons/:uuid/stream-url",
+        AuthMiddleware.requireAuth(function(self)
+            local ns = resolve_namespace(self)
+            if not ns then return api_response(404, nil, "Namespace not found") end
+            local user_uuid = self.current_user and self.current_user.uuid
+            if not user_uuid then return api_response(401, nil, "Authentication required") end
+
+            local lesson = LessonQueries.getByUuid(ns.id, self.params.uuid)
+            if not lesson then return api_response(404, nil, "Lesson not found") end
+
+            local key = lesson.s3_key
+            if not key or key == "" then
+                return api_response(404, nil, "This lesson has no video")
+            end
+
+            if not pg_true(lesson.is_preview) then
+                local course = CourseQueries.findById(ns.id, lesson.course_id)
+                if not course then return api_response(404, nil, "Course not found") end
+                if not EntitlementQueries.hasCourseAccess(user_uuid, course) then
+                    return api_response(403, nil, "You need access to this course to watch it")
+                end
+            end
+
+            local expires_in = 3600
+            local url, err = MinioClient.getDefault():getPresignedUrl(key, expires_in)
+            if not url then
+                ngx.log(ngx.ERR, "[academy] presign failed for lesson ",
+                    tostring(self.params.uuid), ": ", tostring(err))
+                return api_response(500, nil, "Could not generate a playback URL")
+            end
+
+            return api_response(200, { url = url, expires_in = expires_in })
         end))
 
     -- Which lessons of a course the current learner has completed.


### PR DESCRIPTION
## Close the paid-course loop: video playback + delayed-payment safety

### 1. Paid video stream URL (was missing entirely)
New authed route **`GET /api/v2/public/academy/:namespace/lessons/:uuid/stream-url`**:
- Re-checks entitlement before signing — a **preview** lesson is watchable by anyone, otherwise the caller must have access to the parent course (`EntitlementQueries.hasCourseAccess`: free / owner / enrolled / tier subscriber).
- Returns a short-lived **presigned MinIO URL** for the lesson's `s3_key`.
- `404` when the lesson has no video, `403` without entitlement.

Mirrors the existing lesson-progress route's namespace + entitlement pattern; the presign reuses `helper.minio` exactly as `tax-upload` does. The learner app (`workstation-academy`) is updated to call this namespaced path (companion PR).

### 2. Delayed-payment guard in the Stripe webhook
`checkout.session.completed` now grants a course **only when `payment_status` is `paid`/`no_payment_required`** (instant methods). Asynchronous methods (some bank debits, vouchers) arrive `unpaid` and are granted by a new **`checkout.session.async_payment_succeeded`** handler once funds clear. The enroll + ledger write is factored into one helper both paths call — so a buyer is **never enrolled before Stripe confirms the money**, and the two events (different ids) can't double-grant.

### Verification
Local `:4020`: module parses (opsapi healthy), the route is auth-gated (`401` unauth), and the presign chain returns a valid signed URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
