### PR TITLE
chore(workstation-prod): full opsapi product + fresh isolated DB, super-admin from Vault

### DIFF
--- a/devops/helm-charts/diytaxreturn-lapis/values-workstation-prod.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/values-workstation-prod.yaml
@@ -12,7 +12,12 @@ app: workstation-opsapi
 # ingress.hosts[0].host below.
 host: opsapi.workstation.co.uk
 
-projectCode: tax_copilot
+# Full opsapi product on prod's OWN isolated DB (see `database` below), so
+# `all` is safe: every migration runs against the dedicated workstation_opsapi
+# DB and cannot touch diytaxreturn's data. `all` enables every feature module
+# (incl. SERVICES/Domains) so the live product is the complete one — matching
+# the int build that was verified end-to-end before go-live.
+projectCode: all
 
 frontendUrl: "https://app.diytaxreturn.co.uk"
 
@@ -45,17 +50,39 @@ ingress:
           pathType: Prefix
   tls: []
 
-# Empty map (NOT unset) so the ExternalSecret's `.Values.database.host` lookup
-# resolves to nil and falls back to Vault's POSTGRES_HOST. See -int for detail.
-database: {}
+# DATABASE — dedicated Postgres on the LAN for prod (mirrors -int). Points this
+# release at its OWN `workstation-db` in the `prod` namespace
+# (devops/k8s/workstation-db-prod.yaml — pgvector/pgvector:pg15 on debworker00),
+# NOT the shared Vault POSTGRES_HOST. A fresh isolated DB: the app's postStart
+# bootstrap migrates it and auto-creates the super admin (credentials from Vault
+# — see `setup` below). The chart bakes `host` into config.lua (externalsecret
+# .yaml) and `name` into a POSTGRES_DB env override (deployment.yaml). Apply the
+# manifest BEFORE the first prod deploy so the DB is up when the migrate hook runs.
+database:
+  name: workstation_opsapi
+  host: workstation-db.prod.svc.cluster.local
+
+# workstation-db is plain Postgres with NO TLS — force pgmoon SSL off (the chart
+# default "true" was for the TLS-enforcing Zalando DB). See -int for detail.
+postgresSsl: "false"
 
 externalSecret:
   enabled: true
 
+# Bootstrap super-admin for the fresh prod workstation_opsapi DB, seeded on
+# first boot by scripts/setup-namespace. The CREDENTIALS come from Vault, not
+# git: adminEmail + adminPassword are left BLANK here so the chart does NOT emit
+# explicit ADMIN_* container env — instead the pod's `envFrom` pulls ADMIN_EMAIL
+# / ADMIN_PASSWORD out of the ESO-synced `workstation-opsapi-secrets` (Vault path
+# secret/diytaxreturnuk/opsapi/prod/config). Add those two keys to that Vault
+# path BEFORE deploying; without them setup-namespace falls back to its built-in
+# defaults (admin@opsapi.com / Admin@123). setup-namespace is idempotent — once
+# the admin exists it never rewrites the password, so redeploys are safe.
+# namespaceSlug is not a secret, so it stays git-owned here.
 setup:
   adminEmail: ""
   adminPassword: ""
-  namespaceSlug: ""
+  namespaceSlug: "workstation"
 
 # Browser CORS allow-list (consumed by middleware/cors.lua) — git-owned here.
 # workstation.academy lets the Academy tenant's instructor dashboard

--- a/devops/k8s/workstation-db-prod.yaml
+++ b/devops/k8s/workstation-db-prod.yaml
@@ -1,0 +1,160 @@
+# workstation-db (PROD) — dedicated Postgres owned by the WORKSTATION opsapi
+# product in the `prod` namespace. Prod copy of devops/k8s/workstation-db.yaml
+# (which is the `int` one) — see that file's header for the full rationale.
+#
+# Why a dedicated DB (not the shared diy-tax-db)
+# ----------------------------------------------
+# `opsapi.workstation.co.uk` (Helm release `workstation-opsapi`, namespace
+# `prod`) runs the FULL opsapi product (projectCode: all). It gets its OWN
+# Postgres ON THE LAN (debworker00), co-located with the app and the wslproxy
+# ingress, so nothing it needs crosses the (currently down) cloud<->LAN
+# WireGuard mesh. Fully data-isolated from diytaxreturn AND partition-
+# independent. The app is repointed at it by `database.host` in
+# values-workstation-prod.yaml.
+#
+# Image: pgvector/pgvector:pg15 — the tax-classifier migration
+# (classification_reference_data) uses the `vector(384)` type. The initdb
+# ConfigMap self-heals `CREATE EXTENSION vector` on a FRESH volume, so a wipe
+# recovers on its own (the app's postStart bootstrap then migrates + seeds it,
+# auto-creating the super admin from the Vault-provided ADMIN_* env).
+#
+# Credentials: pguser REUSES the app's Vault password so the app connects with
+# no change. The `workstation-db-auth` Secret is provisioned by the
+# ExternalSecret below from the prod Vault path the app reads
+# (secret/diytaxreturnuk/opsapi/prod/config, property POSTGRES_PASSWORD) — no
+# plaintext in git.
+#
+# Apply (one-time, BEFORE the first prod deploy so the DB is up when the app's
+# migrate hook runs; the StatefulSet's PVC persists across app redeploys):
+#   kubectl create namespace prod --dry-run=client -o yaml | kubectl apply -f -
+#   kubectl apply -f devops/k8s/workstation-db-prod.yaml
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: workstation-db-auth
+  namespace: prod
+  labels:
+    app: workstation-db
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: workstation-db-auth
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: POSTGRES_PASSWORD
+      remoteRef:
+        key: secret/diytaxreturnuk/opsapi/prod/config
+        property: POSTGRES_PASSWORD
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: workstation-db-initdb
+  namespace: prod
+  labels:
+    app: workstation-db
+data:
+  # Runs ONLY on a fresh (empty) data volume, against POSTGRES_DB
+  # (workstation_opsapi). Makes the pgvector type available before the app's
+  # first `lapis migrate`, so a wiped/rebuilt volume self-heals.
+  01-extensions.sql: |
+    CREATE EXTENSION IF NOT EXISTS vector;
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: workstation-db
+  namespace: prod
+  labels:
+    app: workstation-db
+spec:
+  type: ClusterIP
+  selector:
+    app: workstation-db
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: workstation-db
+  namespace: prod
+  labels:
+    app: workstation-db
+spec:
+  serviceName: workstation-db
+  replicas: 1
+  selector:
+    matchLabels:
+      app: workstation-db
+  template:
+    metadata:
+      labels:
+        app: workstation-db
+    spec:
+      # Pin to the same LAN node as the app + ingress so the DB is never on the
+      # far side of the cloud<->LAN partition.
+      nodeSelector:
+        kubernetes.io/hostname: debworker00
+      containers:
+        - name: postgres
+          image: pgvector/pgvector:pg15
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              value: pguser
+            - name: POSTGRES_DB
+              value: workstation_opsapi
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: workstation-db-auth
+                  key: POSTGRES_PASSWORD
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "pg_isready -U pguser -d workstation_opsapi -h 127.0.0.1"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "pg_isready -U pguser -h 127.0.0.1"]
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            - name: initdb
+              mountPath: /docker-entrypoint-initdb.d
+      volumes:
+        - name: initdb
+          configMap:
+            name: workstation-db-initdb
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: local-path
+        resources:
+          requests:
+            storage: 5Gi


### PR DESCRIPTION
Prepares **opsapi.workstation.co.uk** (release `workstation-opsapi`, namespace `prod`) for go-live as the **full opsapi product**, mirroring the `int` build verified end-to-end. Follows the decisions: *full product (projectCode `all`)* + *fresh dedicated prod DB with the super-admin password coming from Vault*.

## Changes
**`values-workstation-prod.yaml`**
- `projectCode: tax_copilot → all` — this is opsapi itself; enables every module (namespaces, SERVICES/Domains, CRM, …), matching int.
- `database: {} →` dedicated LAN `workstation-db.prod.svc.cluster.local` + `postgresSsl: "false"` — its own isolated DB, partition-independent like int (plain PG, no TLS).
- `setup.adminEmail` / `adminPassword` **stay blank** → the chart emits **no** explicit `ADMIN_*` container env, so the pod's `envFrom` pulls `ADMIN_EMAIL` / `ADMIN_PASSWORD` from the ESO-synced `workstation-opsapi-secrets` (Vault). Super-admin is auto-created on first boot **from Vault, never from git**. `namespaceSlug: "workstation"` stays git-owned (not a secret).

**`devops/k8s/workstation-db-prod.yaml`** (new) — prod copy of the int `workstation-db` manifest: namespace `prod`, prod Vault path for pguser's password, `pgvector/pgvector:pg15` on debworker00, initdb self-heal (`CREATE EXTENSION vector`), local-path 5Gi PVC. One-time `kubectl apply`.

## Verified
`helm template` with prod values renders clean — `POSTGRES_SSL=false`, `POSTGRES_DB=workstation_opsapi`, config.lua `host=workstation-db.prod…`, `ADMIN_*` absent from explicit env (Vault-sourced), `NAMESPACE_SLUG=workstation`.

## ⚠️ Manual prerequisites before dispatching the prod deploy (cannot be in git)
1. **Vault** — at `secret/diytaxreturnuk/opsapi/prod/config` ensure `POSTGRES_PASSWORD` (used by both the app and the new DB) exists, and **add `ADMIN_EMAIL` + `ADMIN_PASSWORD`** for the super-admin.
2. **Create the prod DB first** (so it's up when the app's migrate hook runs):
   `kubectl create ns prod --dry-run=client -o yaml | kubectl apply -f -`
   `kubectl apply -f devops/k8s/workstation-db-prod.yaml`
3. **Deploy** — GitHub → Actions → *Build and Deploy OpsAPI to K3s* → Run workflow → `TARGET_ENV=prod`, `DEPLOYMENT_TYPE=build-and-deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)