### PR TITLE
feat(workstation-prod): pin prod to cloud003 + prod-only edge route to origin-uk-003.pop0.uk

### DIFF
--- a/.github/wslproxy/data/rules/prod/opsapi-prod-cloud003.json
+++ b/.github/wslproxy/data/rules/prod/opsapi-prod-cloud003.json
@@ -1,0 +1,36 @@
+{
+  "id": "opsapi-prod-cloud003",
+  "name": "opsapi-prod-cloud003",
+  "profile_id": "prod",
+  "priority": 1,
+  "rules_tags": [
+    "opsapi",
+    "workstation",
+    "prod",
+    "cloud003"
+  ],
+  "match": {
+    "rules": {
+      "path": "/",
+      "path_key": "starts_with"
+    },
+    "response": {
+      "code": 305,
+      "redirect_uri": "origin-uk-003.pop0.uk:8888",
+      "strip_path": false,
+      "backends": [
+        {
+          "address": "origin-uk-003.pop0.uk:8888",
+          "weight": 100,
+          "label": "origin-uk-003.pop0.uk:8888 = cloud003 k3s ingress entry. PROD-ONLY: workstation-opsapi prod runs entirely on cloud003, so its host routes to cloud003 by stable hostname. int/test/acc stay on opsapi-prod-default (193.237.176.232:8888)."
+        }
+      ],
+      "routing": {
+        "mode": "least_conn"
+      }
+    }
+  },
+  "servers": [
+    "host:opsapi.workstation.co.uk"
+  ]
+}

--- a/.github/wslproxy/data/rules/prod/opsapi-prod-default.json
+++ b/.github/wslproxy/data/rules/prod/opsapi-prod-default.json
@@ -30,7 +30,6 @@
     }
   },
   "servers": [
-    "host:opsapi.workstation.co.uk",
     "host:int-opsapi.workstation.co.uk",
     "host:test-opsapi.workstation.co.uk",
     "host:acc-opsapi.workstation.co.uk",

--- a/.github/wslproxy/data/servers/prod/host:opsapi.workstation.co.uk.json
+++ b/.github/wslproxy/data/servers/prod/host:opsapi.workstation.co.uk.json
@@ -8,7 +8,7 @@
   "error_log": "logs/opsapi.workstation.co.uk.error.log",
   "config_status": false,
   "profile_id": "prod",
-  "rules": "opsapi-prod-default",
+  "rules": "opsapi-prod-cloud003",
   "listens": [
     {
       "listen": "80"

--- a/devops/helm-charts/diytaxreturn-lapis/templates/cronjob.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/templates/cronjob.yaml
@@ -13,6 +13,19 @@ spec:
       template:
         spec:
           restartPolicy: Never
+          # Backups pg_dump the release's own DB (POSTGRES_HOST below), so they
+          # must run where that DB is reachable. Follow the release's placement:
+          # the prod release pins app + workstation-db to cloud003 (an edge node),
+          # so the backup pod must land there too and tolerate the edge taint.
+          # Values-driven → no effect for releases that set neither.
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           containers:
             - name: "opsapi-db-backup-{{ .Release.Namespace }}-hourly"
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -157,6 +170,19 @@ spec:
       template:
         spec:
           restartPolicy: Never
+          # Backups pg_dump the release's own DB (POSTGRES_HOST below), so they
+          # must run where that DB is reachable. Follow the release's placement:
+          # the prod release pins app + workstation-db to cloud003 (an edge node),
+          # so the backup pod must land there too and tolerate the edge taint.
+          # Values-driven → no effect for releases that set neither.
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           containers:
             - name: opsapi-db-backup-{{ .Release.Namespace }}-daily
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/devops/helm-charts/diytaxreturn-lapis/templates/deployment.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/templates/deployment.yaml
@@ -49,8 +49,17 @@ spec:
       {{- with .Values.nodeSelector }}
       # Optional hard node pin (per-release, via values). Combines with the
       # NotIn-lubuntu001 affinity above. Used by workstation-opsapi to keep the
-      # pod on a debian node with disk headroom (debworker00).
+      # pod on a specific node (a LAN debian node, or a cloud edge node like
+      # cloud003 for the prod release).
       nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      # Optional tolerations (per-release, via values). Required to schedule on
+      # tainted nodes — e.g. the workstation-opsapi PROD release pins to cloud003
+      # (node-role.kubernetes.io/edge=true:NoSchedule), so it must tolerate that
+      # taint. Empty/unset for LAN releases, which need no toleration.
+      tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/devops/helm-charts/diytaxreturn-lapis/values-workstation-prod.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/values-workstation-prod.yaml
@@ -96,6 +96,16 @@ autoscaling:
   maxReplicas: 3
   targetCPUUtilizationPercentage: 80
 
-# Pin to debworker00 (debian node, disk headroom) — see values-workstation-int.yaml.
+# PROD runs ENTIRELY on cloud003 (the london edge node) — same segment as the
+# dedicated workstation-db (devops/k8s/workstation-db-prod.yaml, also pinned to
+# cloud003) and where diytaxreturn's own prod stack already lives. Co-locating
+# app + DB on one node keeps prod off the down cloud<->LAN WireGuard mesh
+# entirely (nothing it needs crosses segments). cloud003 carries the edge taint
+# node-role.kubernetes.io/edge=true:NoSchedule, so the toleration below is
+# REQUIRED or the pod sits Pending (untolerated taint).
 nodeSelector:
-  kubernetes.io/hostname: debworker00
+  kubernetes.io/hostname: cloud003
+tolerations:
+  - key: node-role.kubernetes.io/edge
+    operator: Exists
+    effect: NoSchedule

--- a/devops/k8s/workstation-db-prod.yaml
+++ b/devops/k8s/workstation-db-prod.yaml
@@ -99,10 +99,17 @@ spec:
       labels:
         app: workstation-db
     spec:
-      # Pin to the same LAN node as the app + ingress so the DB is never on the
-      # far side of the cloud<->LAN partition.
+      # Pin to cloud003 — the SAME node as the prod app (values-workstation-prod
+      # .yaml nodeSelector) — so app + DB are co-located on the london edge node
+      # and nothing prod needs crosses the down cloud<->LAN WireGuard mesh.
+      # cloud003 carries node-role.kubernetes.io/edge=true:NoSchedule, so the
+      # toleration is REQUIRED. local-path binds the PVC to cloud003.
       nodeSelector:
-        kubernetes.io/hostname: debworker00
+        kubernetes.io/hostname: cloud003
+      tolerations:
+        - key: node-role.kubernetes.io/edge
+          operator: Exists
+          effect: NoSchedule
       containers:
         - name: postgres
           image: pgvector/pgvector:pg15


### PR DESCRIPTION
Prepares **opsapi.workstation.co.uk** to go live **entirely on cloud003** (the london edge node, where diytaxreturn prod already runs), keeping prod off the down cloud↔LAN WireGuard mesh.

## Chart (additive; affects prod only — verified no other release sets these)
- **deployment.yaml**: render optional `.Values.tolerations`. Required to schedule on cloud003 (`node-role.kubernetes.io/edge=true:NoSchedule`).
- **cronjob.yaml**: backup jobs now follow the release's `nodeSelector` + `tolerations`, so `pg_dump` runs where the DB is (prod → cloud003; int → its LAN node — a co-location improvement for int too). diytaxreturn values set neither, so its backups are unchanged.

## values-workstation-prod.yaml
`nodeSelector: kubernetes.io/hostname=cloud003` + edge toleration. (Was `debworker00`, which is at its 110/110 pod cap — a pinned pod sat `Pending`, caught during go-live prep.)

## devops/k8s/workstation-db-prod.yaml
Pin the dedicated Postgres to cloud003 + edge toleration, co-located with the app; local-path binds the PVC on cloud003. **Applied live:** `workstation-db-0` Running 1/1 on cloud003, the app's Vault credentials verified to connect (`pguser` → `workstation_opsapi`), pgvector present via the initdb self-heal.

## wslproxy — prod-only, int/test/acc untouched
- New rule **`opsapi-prod-cloud003`** → **`origin-uk-003.pop0.uk:8888`** (cloud003's k3s ingress entry, by stable hostname), `servers: [opsapi.workstation.co.uk]`.
- `host:opsapi.workstation.co.uk` now references `opsapi-prod-cloud003`.
- `opsapi-prod-default` keeps `int/test/acc-opsapi` + `int-opsapi-ui` on `193.237.176.232:8888`.

## Verified
`helm template` (prod) renders cloud003 + toleration; int render carries **0** edge-tolerations; all wslproxy JSON valid and routing consistent.

## Go-live prereqs (already satisfied / done)
- ✅ Prod Vault path `secret/diytaxreturnuk/opsapi/prod/config` populated (all keys incl. `ADMIN_EMAIL`/`ADMIN_PASSWORD`, `POSTGRES_*`, `MINIO_*`).
- ✅ Dedicated prod DB applied and Running on cloud003.
- After merge: run deploy-k3s.yml → `prod` / `build-and-deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)