### PR TITLE
feat(dashboard): prod deployment — opsapi-ui.workstation.co.uk on cloud003

### DIFF
--- a/.github/workflows/deploy-workstation-dashboard.yml
+++ b/.github/workflows/deploy-workstation-dashboard.yml
@@ -4,6 +4,11 @@ name: Deploy Workstation Dashboard
 # https://int-opsapi-ui.workstation.co.uk, fully from GitHub. The UI calls the
 # workstation-opsapi API at https://int-opsapi.workstation.co.uk.
 #
+# PROD: dispatch with TARGET_ENV=prod → https://opsapi-ui.workstation.co.uk
+# (namespace prod, pinned to cloud003 next to the prod API + DB, edge vhost
+# host:opsapi-ui.workstation.co.uk via the opsapi-prod-cloud003 rule). Pushes
+# to main only ever auto-deploy int.
+#
 # Mirrors deploy-k3s.yml (which deploys the API): same k3s1 cluster
 # (KUBE_CONFIG_DATA_K3S), same WSL Proxy edge (DNS CNAME -> lon1.pop0.uk +
 # a stub vhost/rule registered on the control plane), same Docker Hub registry.
@@ -23,7 +28,8 @@ on:
       - "opsapi-dashboard/**"
       - "devops/helm-charts/opsapi-dashboard/**"
       - ".github/workflows/deploy-workstation-dashboard.yml"
-      - ".github/wslproxy/data/servers/prod/host:*-opsapi-ui.workstation.co.uk.json"
+      # matches both int-opsapi-ui... and the bare prod host opsapi-ui...
+      - ".github/wslproxy/data/servers/prod/host:*opsapi-ui.workstation.co.uk.json"
   workflow_dispatch:
     inputs:
       TARGET_ENV:

--- a/.github/wslproxy/data/rules/prod/opsapi-prod-cloud003.json
+++ b/.github/wslproxy/data/rules/prod/opsapi-prod-cloud003.json
@@ -31,6 +31,7 @@
     }
   },
   "servers": [
-    "host:opsapi.workstation.co.uk"
+    "host:opsapi.workstation.co.uk",
+    "host:opsapi-ui.workstation.co.uk"
   ]
 }

--- a/.github/wslproxy/data/servers/prod/host:opsapi-ui.workstation.co.uk.json
+++ b/.github/wslproxy/data/servers/prod/host:opsapi-ui.workstation.co.uk.json
@@ -1,0 +1,25 @@
+{
+  "id": "host:opsapi-ui.workstation.co.uk",
+  "server_name": "opsapi-ui.workstation.co.uk",
+  "proxy_server_name": "opsapi-ui.workstation.co.uk",
+  "root": "/var/www/html",
+  "index": "index.html",
+  "access_log": "logs/opsapi-ui.workstation.co.uk.access.log",
+  "error_log": "logs/opsapi-ui.workstation.co.uk.error.log",
+  "config_status": false,
+  "profile_id": "prod",
+  "rules": "opsapi-prod-cloud003",
+  "listens": [
+    {
+      "listen": "80"
+    }
+  ],
+  "ssl_enabled": true,
+  "ssl_force_https": true,
+  "ssl_staging": false,
+  "ssl_auto_renew": true,
+  "ssl_email": "admin@workstation.co.uk",
+  "cache_enabled": false,
+  "match_cases": {},
+  "custom_headers": []
+}

--- a/devops/helm-charts/opsapi-dashboard/values-workstation-prod.yaml
+++ b/devops/helm-charts/opsapi-dashboard/values-workstation-prod.yaml
@@ -1,0 +1,40 @@
+# ── OpsAPI Dashboard on workstation.co.uk — PRODUCTION ──────────────────────
+# Helm RELEASE: workstation-opsapi-dashboard   Namespace: prod   Cluster: k3s1
+# Public host: https://opsapi-ui.workstation.co.uk   (bare host = prod)
+#   → calls the API at https://opsapi.workstation.co.uk (workstation-opsapi)
+#
+# Layered on top of values.yaml by deploy-workstation-dashboard.yml — run it
+# with workflow_dispatch TARGET_ENV=prod (pushes to main only auto-deploy int).
+# Only the fields that differ from the base defaults (or that other jobs read)
+# live here.
+env: prod
+
+# The API this UI calls. Baked into the browser bundle at BUILD time
+# (--build-arg NEXT_PUBLIC_API_URL) by the deploy workflow.
+apiUrl: https://opsapi.workstation.co.uk
+
+# Single source of truth for the DNS + wslproxy jobs (read via awk). MUST equal
+# ingress.hostname below.
+host: opsapi-ui.workstation.co.uk
+
+ingress:
+  enabled: true
+  className: wslproxy
+  hostname: opsapi-ui.workstation.co.uk
+  annotations: {}
+  tls: []
+
+# PROD runs ENTIRELY on cloud003 (the london edge node) — same placement as the
+# workstation-opsapi prod API and its dedicated workstation-db (see the API
+# chart's values-workstation-prod.yaml for the full rationale: keeps prod off
+# the cloud<->LAN WireGuard mesh). The matching edge vhost
+# host:opsapi-ui.workstation.co.uk routes via the opsapi-prod-cloud003 rule to
+# cloud003's own ingress entry, so requests never leave the node. cloud003
+# carries the taint node-role.kubernetes.io/edge=true:NoSchedule, so the
+# toleration below is REQUIRED or the pod sits Pending.
+nodeSelector:
+  kubernetes.io/hostname: cloud003
+tolerations:
+  - key: node-role.kubernetes.io/edge
+    operator: Exists
+    effect: NoSchedule


### PR DESCRIPTION
## What

Creates the **production** deployment of the OpsAPI dashboard at **https://opsapi-ui.workstation.co.uk**, mirroring the int deployment (https://int-opsapi-ui.workstation.co.uk) and following the prod-on-cloud003 topology from #594.

## Changes

- **`values-workstation-prod.yaml`** (new): namespace `prod`, `apiUrl: https://opsapi.workstation.co.uk` (baked into the browser bundle at build time), pinned to **cloud003** with the `node-role.kubernetes.io/edge` taint toleration — same placement as the prod API + dedicated `workstation-db`, so nothing crosses the cloud↔LAN WireGuard mesh.
- **`host:opsapi-ui.workstation.co.uk.json`** (new edge vhost): routed via the **`opsapi-prod-cloud003`** rule (→ `origin-uk-003.pop0.uk:8888`, cloud003's own k3s ingress entry), unlike the int UI which rides `opsapi-prod-default`. Added to that rule's `servers` list.
- **`deploy-workstation-dashboard.yml`**: path glob widened (`host:*opsapi-ui...`) so the bare prod vhost file also triggers the workflow; header documents the prod dispatch. **Pushes to main still only auto-deploy int.**

## How to deploy prod

```bash
gh workflow run deploy-workstation-dashboard.yml -f TARGET_ENV=prod
```

The workflow builds the image with the prod API URL baked in, ensures the Cloudflare CNAME (`opsapi-ui` → `lon1.pop0.uk`), pushes the edge vhost/rule, and helm-upgrades `workstation-opsapi-dashboard` into the `prod` namespace.

## Heads-up

1. **The prod API is not live yet**: `opsapi.workstation.co.uk` has an edge vhost but no `workstation-opsapi` release exists in the `prod` namespace (only `workstation-db-0` is running on cloud003). The UI will deploy and serve `/login`, but sign-in will fail until the API is deployed (deploy-k3s.yml with the prod values from #594).
2. A prod build overwrites the shared `bwalia/opsapi-dashboard:latest` tag with a prod-API-baked image. The int helm release pins an explicit tag so it is unaffected, but anything pulling `:latest` directly would get the prod bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)