### PR TITLE
fix(prod): route cloud003 hosts via traefik-edge (port 80) — :8888 has no listener

### DIFF
--- a/.github/wslproxy/data/rules/prod/opsapi-prod-cloud003.json
+++ b/.github/wslproxy/data/rules/prod/opsapi-prod-cloud003.json
@@ -16,13 +16,13 @@
     },
     "response": {
       "code": 305,
-      "redirect_uri": "origin-uk-003.pop0.uk:8888",
+      "redirect_uri": "origin-uk-003.pop0.uk",
       "strip_path": false,
       "backends": [
         {
-          "address": "origin-uk-003.pop0.uk:8888",
+          "address": "origin-uk-003.pop0.uk",
           "weight": 100,
-          "label": "origin-uk-003.pop0.uk:8888 = cloud003 k3s ingress entry. PROD-ONLY: workstation-opsapi prod runs entirely on cloud003, so its host routes to cloud003 by stable hostname. int/test/acc stay on opsapi-prod-default (193.237.176.232:8888)."
+          "label": "origin-uk-003.pop0.uk (port 80) = traefik-edge on cloud003 (hostNetwork DaemonSet; nothing listens on :8888 there) — same backend the working diytaxreturn prod rules use. Ingresses MUST use className traefik-edge, not wslproxy. PROD-ONLY: workstation-opsapi prod runs entirely on cloud003. int/test/acc stay on opsapi-prod-default (193.237.176.232:8888)."
         }
       ],
       "routing": {

--- a/devops/helm-charts/diytaxreturn-lapis/values-workstation-prod.yaml
+++ b/devops/helm-charts/diytaxreturn-lapis/values-workstation-prod.yaml
@@ -37,11 +37,15 @@ service:
   type: ClusterIP
   port: 80
 
-# Dedicated Ingress — className `wslproxy`, plain HTTP :80 (TLS at the edge,
-# no cert-manager on k3s1). See values-workstation-int.yaml.
+# Dedicated Ingress — plain HTTP :80 (TLS at the edge, no cert-manager on
+# k3s1). className `traefik-edge`, NOT `wslproxy`: prod is pinned to cloud003,
+# whose only ingress entry is the traefik-edge DaemonSet (hostNetwork :80) —
+# it serves ONLY ingressclass traefik-edge, and the opsapi-prod-cloud003 edge
+# rule targets it at origin-uk-003.pop0.uk (port 80). Same pattern as the
+# working diytaxreturn prod ingresses. int/test/acc stay on wslproxy (LAN).
 ingress:
   enabled: true
-  className: wslproxy
+  className: traefik-edge
   annotations: {}
   hosts:
     - host: opsapi.workstation.co.uk

--- a/devops/helm-charts/opsapi-dashboard/values-workstation-prod.yaml
+++ b/devops/helm-charts/opsapi-dashboard/values-workstation-prod.yaml
@@ -19,7 +19,12 @@ host: opsapi-ui.workstation.co.uk
 
 ingress:
   enabled: true
-  className: wslproxy
+  # NOT wslproxy: cloud003's only ingress entry is the traefik-edge DaemonSet
+  # (hostNetwork :80/:443), and it serves ONLY ingressclass traefik-edge —
+  # exactly how the working diytaxreturn prod ingresses on cloud003 route.
+  # The wslproxy-class traefik only answers on the LAN entry (193.237.176.232),
+  # which prod deliberately avoids.
+  className: traefik-edge
   hostname: opsapi-ui.workstation.co.uk
   annotations: {}
   tls: []


### PR DESCRIPTION
## Problem

The prod UI from #595 deployed healthy (pod Running on cloud003, edge TLS issued) but **https://opsapi-ui.workstation.co.uk timed out**. Two mismatches:

1. The `opsapi-prod-cloud003` edge rule targets `origin-uk-003.pop0.uk:8888` — but **nothing listens on :8888 on cloud003** (that ingress entry only exists on the LAN at `193.237.176.232`). Direct test: `curl 77.68.126.63:8888` → timeout.
2. The UI ingress used class `wslproxy`, but cloud003's only ingress entry is the **`traefik-edge` DaemonSet** (hostNetwork :80/:443), which serves **only** ingressclass `traefik-edge`. Test with the right Host against `77.68.126.63:80` → 404 (no route), confirming the controller answers but had no matching ingress.

Every working diytaxreturn prod ingress on cloud003 already uses `traefik-edge` + rules targeting `origin-uk-003.pop0.uk` (port 80) — this PR aligns opsapi with that proven pattern.

## Changes

- `opsapi-prod-cloud003.json`: backend `origin-uk-003.pop0.uk:8888` → `origin-uk-003.pop0.uk` (port 80, traefik-edge)
- dashboard `values-workstation-prod.yaml`: `ingress.className: wslproxy` → `traefik-edge`
- API `diytaxreturn-lapis/values-workstation-prod.yaml`: same class fix, so the (not-yet-deployed) `workstation-opsapi` prod release lands routable instead of repeating this hunt. This also fixes why `opsapi.workstation.co.uk` would have stayed dead after an API deploy.

int/test/acc are untouched — they stay on `wslproxy` + `opsapi-prod-default`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)