### PR TITLE
feat(crm): Leads inbox, detail modal, message capture + lead notifications

### DIFF
--- a/lapis/helper/telegram.lua
+++ b/lapis/helper/telegram.lua
@@ -1,0 +1,75 @@
+--[[
+    Telegram helper — send HTML messages via the Telegram Bot API.
+
+    Mirrors the Bot API contract used by the monitoring-go beacon notifier:
+    POST https://api.telegram.org/bot<TOKEN>/sendMessage
+      { chat_id, text, parse_mode: "HTML", disable_web_page_preview: true }
+
+    Per-namespace credentials (a bot token + chat id) are configured by the
+    namespace owner (see crm_lead_notification_settings). Non-throwing: returns
+    (ok, err) so callers can surface a helpful message (bad token / wrong chat id)
+    to the owner during "send test", and swallow failures during live capture.
+]]
+
+local cjson = require("cjson")
+
+local Telegram = {}
+
+local function http_client()
+    local ok, http = pcall(require, "resty.http")
+    if not ok then return nil, "resty.http not available" end
+    local httpc = http.new()
+    httpc:set_timeout(10000)
+    return httpc, nil
+end
+
+--- HTML-escape a value for safe insertion into a Telegram HTML message.
+function Telegram.esc(s)
+    if s == nil then return "" end
+    s = tostring(s)
+    return (s:gsub("&", "&amp;"):gsub("<", "&lt;"):gsub(">", "&gt;"))
+end
+
+--- Send an HTML message.
+-- @param bot_token string  Bot token from @BotFather
+-- @param chat_id string     Target chat id (user, group, or channel)
+-- @param text string        HTML body (use Telegram.esc on dynamic values)
+-- @return boolean ok, string|nil err
+function Telegram.send(bot_token, chat_id, text)
+    if not bot_token or bot_token == "" then return false, "Telegram bot token is not configured" end
+    if not chat_id or chat_id == "" then return false, "Telegram chat id is not configured" end
+
+    local httpc, err = http_client()
+    if not httpc then return false, err end
+
+    local body = cjson.encode({
+        chat_id = chat_id,
+        text = text,
+        parse_mode = "HTML",
+        disable_web_page_preview = true,
+    })
+
+    local res, rerr = httpc:request_uri(
+        "https://api.telegram.org/bot" .. bot_token .. "/sendMessage",
+        {
+            method = "POST",
+            body = body,
+            headers = { ["Content-Type"] = "application/json" },
+            ssl_verify = true,
+        }
+    )
+
+    if not res then
+        return false, "Telegram request failed: " .. tostring(rerr)
+    end
+    if res.status ~= 200 then
+        -- Telegram returns { ok=false, description="..." } on errors.
+        local desc
+        local ok, decoded = pcall(cjson.decode, res.body or "")
+        if ok and type(decoded) == "table" then desc = decoded.description end
+        return false, "Telegram API error: " .. (desc or ("HTTP " .. tostring(res.status)))
+    end
+    return true, nil
+end
+
+return Telegram

--- a/lapis/migrations.lua
+++ b/lapis/migrations.lua
@@ -320,6 +320,8 @@ local config_cmi_namespace_cleanup_migrations = load_if_enabled(ProjectConfig.FE
 -- CRM
 local crm_system_migrations = load_if_enabled(ProjectConfig.FEATURES.CRM, "migrations.crm-system") or {}
 local crm_menu_items_migrations = load_if_enabled(ProjectConfig.FEATURES.CRM, "migrations.crm-menu-items") or {}
+local crm_leads_menu_migrations = load_if_enabled(ProjectConfig.FEATURES.CRM, "migrations.crm-leads-menu-items") or {}
+local crm_lead_notif_migrations = load_if_enabled(ProjectConfig.FEATURES.CRM, "migrations.crm-lead-notifications") or {}
 
 -- Leads are a CORE capability: the crm_leads table is created for EVERY
 -- PROJECT_CODE (lead capture is generic), so this module loads unconditionally.
@@ -1764,6 +1766,9 @@ local _migrations = {
     ['721_seed_crm_modules'] = conditional_array(ProjectConfig.FEATURES.CRM, crm_menu_items_migrations, 2),
     ['722_grant_crm_permissions'] = conditional_array(ProjectConfig.FEATURES.CRM, crm_menu_items_migrations, 3),
     ['723_enable_crm_menu_per_namespace'] = conditional_array(ProjectConfig.FEATURES.CRM, crm_menu_items_migrations, 4),
+    ['724_seed_crm_leads_menu_item'] = conditional_array(ProjectConfig.FEATURES.CRM, crm_leads_menu_migrations, 1),
+    ['725_enable_crm_leads_menu_per_namespace'] = conditional_array(ProjectConfig.FEATURES.CRM, crm_leads_menu_migrations, 2),
+    ['726_create_crm_lead_notification_settings'] = conditional_array(ProjectConfig.FEATURES.CRM, crm_lead_notif_migrations, 1),
 
     -- =========================================================================
     -- TIMESHEET SYSTEM (520-529)

--- a/lapis/migrations/crm-lead-notifications.lua
+++ b/lapis/migrations/crm-lead-notifications.lua
@@ -1,0 +1,47 @@
+--[[
+    CRM Lead Notification Settings
+
+    Per-namespace configuration for what happens when a lead is captured
+    (typically from a public website form). One row per namespace:
+
+      - notify_admin        email the namespace owner/admin "you got a lead"
+      - admin_email         optional override recipient (defaults to owner email)
+      - send_confirmation   email the person who submitted the lead
+      - telegram_enabled    also push a Telegram alert
+      - telegram_bot_token  bot token from @BotFather (owner-provided)
+      - telegram_chat_id    target chat id
+
+    Feature-gated under FEATURES.CRM. Idempotent (CREATE TABLE IF NOT EXISTS).
+    The bot token is a per-namespace credential the owner sets; the API masks it
+    on read (never echoes it back) and only overwrites it when a new value is
+    sent — see CrmLeadNotificationQueries.
+]]
+
+local db = require("lapis.db")
+
+return {
+    [1] = function()
+        db.query([[
+            CREATE TABLE IF NOT EXISTS crm_lead_notification_settings (
+                id BIGSERIAL PRIMARY KEY,
+                uuid TEXT UNIQUE NOT NULL,
+                namespace_id BIGINT NOT NULL UNIQUE REFERENCES namespaces(id) ON DELETE CASCADE,
+
+                notify_admin BOOLEAN DEFAULT TRUE,
+                admin_email TEXT,
+                send_confirmation BOOLEAN DEFAULT TRUE,
+
+                telegram_enabled BOOLEAN DEFAULT FALSE,
+                telegram_bot_token TEXT,
+                telegram_chat_id TEXT,
+
+                created_at TIMESTAMP DEFAULT NOW(),
+                updated_at TIMESTAMP DEFAULT NOW()
+            )
+        ]])
+        pcall(function()
+            db.query([[CREATE INDEX IF NOT EXISTS crm_lead_notif_ns_idx
+                ON crm_lead_notification_settings (namespace_id)]])
+        end)
+    end,
+}

--- a/lapis/migrations/crm-leads-menu-items.lua
+++ b/lapis/migrations/crm-leads-menu-items.lua
@@ -1,0 +1,88 @@
+--[[
+    CRM Leads Menu Item Seeding Migration
+
+    Adds a dedicated "Leads" sidebar entry pointing at the standalone Leads
+    inbox (/dashboard/leads), alongside the existing "CRM" entry
+    (/dashboard/crm) seeded by crm-menu-items. Leads are the highest-churn CRM
+    object (captured from public website forms, API/webhooks, referrals), so
+    they get their own top-level entry for quick triage.
+
+    Feature-gated under FEATURES.CRM. The menu item's `module` is crm_accounts
+    (the CRM entry-point module, already registered + granted by
+    crm-menu-items) so it passes the PROJECT_CODE gate in MenuQueries and
+    inherits the same read permission — no new RBAC module needed (the
+    /api/v2/crm/leads route itself only requires namespace membership).
+
+    Idempotent: both steps guard on existence, so re-runs no-op.
+]]
+
+local db = require("lapis.db")
+
+return {
+    -- [1] Insert the Leads menu item
+    [1] = function()
+        local MigrationUtils = require("helper.migration-utils")
+        local timestamp = MigrationUtils.getCurrentTimestamp()
+
+        local item = {
+            key = "crm_leads",
+            name = "Leads",
+            icon = "UserPlus",
+            path = "/dashboard/leads",
+            module = "crm_accounts",
+            required_action = "read",
+            priority = 45, -- just above "CRM" (46)
+        }
+
+        local existing = db.select("* FROM menu_items WHERE key = ?", item.key)
+        if #existing == 0 then
+            db.insert("menu_items", {
+                uuid = MigrationUtils.generateUUID(),
+                key = item.key,
+                name = item.name,
+                icon = item.icon,
+                path = item.path,
+                module = item.module,
+                required_action = item.required_action,
+                priority = item.priority,
+                is_active = true,
+                is_admin_only = false,
+                always_show = false,
+                settings = "{}",
+                created_at = timestamp,
+                updated_at = timestamp,
+            })
+            print("[CRM] Added menu item: " .. item.key)
+        end
+    end,
+
+    -- [2] Enable the menu item for all existing namespaces.
+    -- (MenuQueries treats a missing config row as enabled via COALESCE, so this
+    -- is belt-and-braces for parity with crm-menu-items.)
+    [2] = function()
+        local MigrationUtils = require("helper.migration-utils")
+        local timestamp = MigrationUtils.getCurrentTimestamp()
+
+        local menu_rows = db.select("* FROM menu_items WHERE key = ?", "crm_leads")
+        if #menu_rows == 0 then return end
+        local menu_item = menu_rows[1]
+
+        local namespaces = db.select("* FROM namespaces")
+        for _, ns in ipairs(namespaces) do
+            local exists = db.select([[
+                * FROM namespace_menu_config
+                WHERE namespace_id = ? AND menu_item_id = ?
+            ]], ns.id, menu_item.id)
+            if #exists == 0 then
+                db.insert("namespace_menu_config", {
+                    uuid = MigrationUtils.generateUUID(),
+                    namespace_id = ns.id,
+                    menu_item_id = menu_item.id,
+                    is_enabled = true,
+                    created_at = timestamp,
+                    updated_at = timestamp,
+                })
+            end
+        end
+    end,
+}

--- a/lapis/queries/CrmLeadNotificationQueries.lua
+++ b/lapis/queries/CrmLeadNotificationQueries.lua
@@ -1,0 +1,239 @@
+--[[
+    CrmLeadNotificationQueries
+
+    Per-namespace lead notification settings + the dispatch that fires when a
+    lead is captured. Three channels:
+      1. confirmation email to the person who submitted the lead
+      2. "you got a lead" email to the namespace owner/admin
+      3. Telegram alert (owner-configured bot token + chat id)
+
+    Settings default to sensible on-by-default behaviour when no row exists:
+    confirmation + admin email ON, Telegram OFF. The Telegram bot token is a
+    secret — getForApi() never returns it (only a masked hint), and upsert()
+    only overwrites it when a fresh value is supplied.
+]]
+
+local db = require("lapis.db")
+local Global = require("helper.global")
+
+local CrmLeadNotificationQueries = {}
+
+local DEFAULTS = {
+    notify_admin = true,
+    admin_email = nil,
+    send_confirmation = true,
+    telegram_enabled = false,
+    telegram_chat_id = nil,
+}
+
+--- Raw settings row for a namespace, or nil.
+function CrmLeadNotificationQueries.get(namespace_id)
+    local rows = db.select("* FROM crm_lead_notification_settings WHERE namespace_id = ? LIMIT 1", namespace_id)
+    return rows and rows[1] or nil
+end
+
+--- Effective settings (row merged over DEFAULTS) — always returns a table.
+function CrmLeadNotificationQueries.getEffective(namespace_id)
+    local row = CrmLeadNotificationQueries.get(namespace_id)
+    if not row then
+        local d = {}
+        for k, v in pairs(DEFAULTS) do d[k] = v end
+        return d
+    end
+    return row
+end
+
+--- API-safe view: masks the bot token (never echo the secret).
+function CrmLeadNotificationQueries.getForApi(namespace_id)
+    local row = CrmLeadNotificationQueries.get(namespace_id)
+    local s = row or DEFAULTS
+    local token = row and row.telegram_bot_token or nil
+    local hint = nil
+    if token and token ~= "" then
+        hint = "•••" .. string.sub(token, -4)
+    end
+    return {
+        notify_admin = s.notify_admin ~= false,
+        admin_email = s.admin_email or "",
+        send_confirmation = s.send_confirmation ~= false,
+        telegram_enabled = s.telegram_enabled == true,
+        telegram_chat_id = s.telegram_chat_id or "",
+        has_telegram_token = token ~= nil and token ~= "",
+        telegram_token_hint = hint or "",
+    }
+end
+
+--- Create or update settings. `data` is already-coerced values from the route.
+-- telegram_bot_token is only written when a fresh non-empty value is supplied
+-- (so the masked round-trip from the UI never clears an existing token).
+function CrmLeadNotificationQueries.upsert(namespace_id, data)
+    local now = db.raw("NOW()")
+    local existing = CrmLeadNotificationQueries.get(namespace_id)
+
+    local fields = {
+        notify_admin = data.notify_admin == true,
+        admin_email = (data.admin_email ~= nil and data.admin_email ~= "") and data.admin_email or nil,
+        send_confirmation = data.send_confirmation == true,
+        telegram_enabled = data.telegram_enabled == true,
+        telegram_chat_id = (data.telegram_chat_id ~= nil and data.telegram_chat_id ~= "") and data.telegram_chat_id or nil,
+        updated_at = now,
+    }
+    -- Only overwrite the token when the caller sent a new, real one.
+    if data.telegram_bot_token ~= nil and data.telegram_bot_token ~= "" then
+        fields.telegram_bot_token = data.telegram_bot_token
+    end
+
+    if existing then
+        db.update("crm_lead_notification_settings", fields, { id = existing.id })
+    else
+        fields.uuid = Global.generateUUID()
+        fields.namespace_id = namespace_id
+        fields.created_at = now
+        db.insert("crm_lead_notification_settings", fields)
+    end
+    return CrmLeadNotificationQueries.getForApi(namespace_id)
+end
+
+--- Resolve the recipient for the admin "you got a lead" email:
+-- explicit admin_email override, else the namespace owner's email.
+function CrmLeadNotificationQueries.resolveAdminEmail(namespace_id, settings)
+    if settings and settings.admin_email and settings.admin_email ~= "" then
+        return settings.admin_email
+    end
+    local rows = db.query([[
+        SELECT u.email FROM users u
+        JOIN namespaces n ON n.owner_user_id = u.id
+        WHERE n.id = ? LIMIT 1
+    ]], namespace_id)
+    if rows and rows[1] and rows[1].email and rows[1].email ~= "" then
+        return rows[1].email
+    end
+    return nil
+end
+
+-- Build the Telegram HTML alert body for a captured lead.
+local function telegram_body(Telegram, namespace, lead)
+    local esc = Telegram.esc
+    local name = ((lead.first_name or "") .. " " .. (lead.last_name or "")):gsub("^%s+", ""):gsub("%s+$", "")
+    local parts = {}
+    parts[#parts + 1] = "🎯 <b>New lead</b>" .. (namespace.name and (" — " .. esc(namespace.name)) or "")
+    parts[#parts + 1] = ""
+    if name ~= "" then parts[#parts + 1] = "<b>" .. esc(name) .. "</b>" end
+    if lead.company_name and lead.company_name ~= "" then parts[#parts + 1] = "🏢 " .. esc(lead.company_name) end
+    if lead.email and lead.email ~= "" then parts[#parts + 1] = "📧 " .. esc(lead.email) end
+    if lead.phone and lead.phone ~= "" then parts[#parts + 1] = "📞 " .. esc(lead.phone) end
+    if lead.source and lead.source ~= "" then parts[#parts + 1] = "🔖 " .. esc(lead.source) end
+    if lead.notes and lead.notes ~= "" then
+        parts[#parts + 1] = ""
+        parts[#parts + 1] = "💬 " .. esc(lead.notes)
+    end
+    return table.concat(parts, "\n")
+end
+
+-- Pure network sends (no DB). Runs inside an ngx.timer so Mail (sync SMTP) and
+-- the Telegram cosocket never hold the HTTP response. `p` is a self-contained
+-- payload built in request context by notify(). Never throws.
+local function do_sends(p)
+    local Mail = require("helper.mail")
+    local lead, s = p.lead, p.settings
+
+    -- 1) Confirmation to the submitter
+    if s.send_confirmation ~= false and lead.email and lead.email ~= "" then
+        pcall(function()
+            if not Mail.isConfigured() then return end
+            Mail.send({
+                to = lead.email,
+                subject = "We got your enquiry — thanks for getting in touch",
+                template = "lead_confirmation",
+                sync = true,
+                data = { first_name = lead.first_name, company_name = lead.company_name, notes = lead.notes },
+            })
+        end)
+    end
+
+    -- 2) "You got a lead" to the namespace owner/admin
+    if s.notify_admin ~= false and p.admin_email and p.admin_email ~= "" then
+        pcall(function()
+            if not Mail.isConfigured() then return end
+            Mail.send({
+                to = p.admin_email,
+                subject = "New lead: " .. ((lead.first_name or "") .. " " .. (lead.last_name or "")):gsub("%s+$", ""),
+                template = "lead_admin_notification",
+                sync = true,
+                data = {
+                    first_name = lead.first_name, last_name = lead.last_name, email = lead.email,
+                    phone = lead.phone, company_name = lead.company_name, job_title = lead.job_title,
+                    source = lead.source, notes = lead.notes, namespace_name = p.namespace.name,
+                },
+            })
+        end)
+    end
+
+    -- 3) Telegram alert
+    if s.telegram_enabled == true then
+        pcall(function()
+            local Telegram = require("helper.telegram")
+            local ok, err = Telegram.send(s.telegram_bot_token, s.telegram_chat_id,
+                telegram_body(Telegram, p.namespace, lead))
+            if not ok then
+                ngx.log(ngx.WARN, "[lead-notify] telegram failed for namespace ", p.namespace.id, ": ", tostring(err))
+            end
+        end)
+    end
+end
+
+--- Fire all configured notifications for a freshly-captured lead.
+-- Call from a request handler: DB reads (settings + owner email) happen now, in
+-- request context; the actual sends are deferred to an ngx.timer so the caller's
+-- HTTP response returns immediately. Never throws.
+function CrmLeadNotificationQueries.notify(namespace, lead)
+    local ok, err = pcall(function()
+        local settings = CrmLeadNotificationQueries.getEffective(namespace.id)
+        local admin_email = nil
+        if settings.notify_admin ~= false then
+            admin_email = CrmLeadNotificationQueries.resolveAdminEmail(namespace.id, settings)
+        end
+        -- Snapshot into a plain payload — no ngx.var / DB access inside the timer.
+        local payload = {
+            namespace = { id = namespace.id, name = namespace.name },
+            admin_email = admin_email,
+            settings = {
+                notify_admin = settings.notify_admin ~= false,
+                send_confirmation = settings.send_confirmation ~= false,
+                telegram_enabled = settings.telegram_enabled == true,
+                telegram_bot_token = settings.telegram_bot_token,
+                telegram_chat_id = settings.telegram_chat_id,
+            },
+            lead = {
+                first_name = lead.first_name, last_name = lead.last_name, email = lead.email,
+                phone = lead.phone, company_name = lead.company_name, job_title = lead.job_title,
+                source = lead.source, notes = lead.notes,
+            },
+        }
+        local tok, terr = ngx.timer.at(0, function(premature)
+            if premature then return end
+            do_sends(payload)
+        end)
+        if not tok then
+            ngx.log(ngx.WARN, "[lead-notify] failed to schedule notifications: ", tostring(terr))
+        end
+    end)
+    if not ok then
+        ngx.log(ngx.WARN, "[lead-notify] notify() error: ", tostring(err))
+    end
+end
+
+--- Send a test Telegram message for the "Send test" button. Returns (ok, err).
+function CrmLeadNotificationQueries.sendTestTelegram(namespace_id, override)
+    local settings = CrmLeadNotificationQueries.get(namespace_id) or {}
+    -- Allow testing with values from the form before they're saved.
+    local token = (override and override.telegram_bot_token ~= nil and override.telegram_bot_token ~= "")
+        and override.telegram_bot_token or settings.telegram_bot_token
+    local chat = (override and override.telegram_chat_id ~= nil and override.telegram_chat_id ~= "")
+        and override.telegram_chat_id or settings.telegram_chat_id
+    local Telegram = require("helper.telegram")
+    return Telegram.send(token, chat,
+        "✅ <b>OpsAPI</b>\nTelegram lead alerts are connected. You'll get a message here whenever a new lead comes in.")
+end
+
+return CrmLeadNotificationQueries

--- a/lapis/routes/crm-leads-public.lua
+++ b/lapis/routes/crm-leads-public.lua
@@ -8,54 +8,22 @@
     Endpoints:
     - POST /api/v2/public/leads/:namespace_slug - Submit a lead (no auth required)
 
-    Confirmation email:
-    On successful capture with a valid email, a "we got your enquiry"
-    confirmation is sent to the submitter via helper.mail. The send is
-    fire-and-forget (Mail.send default is async via ngx.timer.at) so the
-    HTTP response never waits on SMTP. If SMTP isn't configured, Mail.send
-    logs a warning and returns false — the lead is still stored, only the
-    email side-effect is skipped. Duplicates (same email in same namespace
-    within 5 minutes) do not re-send the email — the earlier submission
-    already produced one.
+    Notifications:
+    On a fresh capture, CrmLeadNotificationQueries.notify() fires the configured
+    channels for the namespace (see crm_lead_notification_settings): a
+    confirmation email to the submitter, a "you got a lead" email to the
+    namespace owner/admin, and an optional Telegram alert. It reads settings in
+    request context and defers the actual sends to an ngx.timer, so the HTTP
+    response never waits on SMTP / Telegram. Duplicates (same email in the same
+    namespace within 5 minutes) do NOT re-notify — the earlier submission
+    already did.
 ]]
 
 local cjson = require("cjson")
 local db = require("lapis.db")
 local RateLimit = require("middleware.rate-limit")
 local CrmLeadQueries = require("queries.CrmLeadQueries")
-local Mail = require("helper.mail")
-
---- Fire the "thanks for reaching out" confirmation to the submitter.
--- Non-blocking (Mail.send is async by default) and non-throwing: any
--- SMTP problem is logged and swallowed so a mail-side-effect never
--- fails a lead capture that already succeeded database-side.
--- @param lead_data table  Parsed request body (first_name, company_name, notes, ...)
--- @param recipient string Verified email from the request
-local function send_lead_confirmation(lead_data, recipient)
-    if not recipient or recipient == "" then return end
-    if not Mail.isConfigured() then
-        ngx.log(ngx.NOTICE, "[crm-leads-public] SMTP not configured — skipping confirmation email to ", recipient)
-        return
-    end
-
-    local ok, err = pcall(Mail.send, {
-        to = recipient,
-        subject = "We got your enquiry — thanks for getting in touch",
-        template = "lead_confirmation",
-        data = {
-            first_name = lead_data.first_name,
-            company_name = lead_data.company_name,
-            notes = lead_data.comments or lead_data.notes,
-            -- app_name / current_year are auto-populated by render_template.
-        },
-    })
-    if not ok then
-        ngx.log(ngx.WARN, "[crm-leads-public] confirmation email send raised: ", tostring(err))
-    elseif err then
-        -- Mail.send returns (false, "reason") on non-fatal failures.
-        ngx.log(ngx.WARN, "[crm-leads-public] confirmation email not sent: ", tostring(err))
-    end
-end
+local CrmLeadNotificationQueries = require("queries.CrmLeadNotificationQueries")
 
 return function(app)
     -- POST /api/v2/public/leads/:namespace_slug - Public lead submission
@@ -63,7 +31,7 @@ return function(app)
         RateLimit.wrap({ rate = 10, window = 60, prefix = "public_lead" }, function(self)
             -- Resolve namespace from slug
             local namespaces = db.query([[
-                SELECT id, slug FROM namespaces
+                SELECT id, slug, name FROM namespaces
                 WHERE slug = ?
                 LIMIT 1
             ]], self.params.namespace_slug)
@@ -105,10 +73,18 @@ return function(app)
                 campaign = data.campaign,
                 referrer_url = referrer,
                 landing_page_url = data.landing_page_url,
-                notes = data.comments or data.notes,
+                -- The enquiry text a visitor types. Public forms name this
+                -- field inconsistently (`message` is the most common, then
+                -- `comments`/`notes`) — accept all three so the message is
+                -- never silently dropped. It lands in `notes` (shown + editable
+                -- in the lead detail view).
+                notes = data.message or data.comments or data.notes,
                 metadata = cjson.encode({
                     user_agent = user_agent,
-                    ip = RateLimit.getClientIP()
+                    ip = RateLimit.getClientIP(),
+                    -- Keep the ORIGINAL submitted message verbatim so a later
+                    -- edit to `notes` can never lose the visitor's own words.
+                    message = data.message or data.comments or data.notes,
                 })
             })
 
@@ -123,8 +99,10 @@ return function(app)
                 return { status = 500, json = { success = false, error = "Submission failed" } }
             end
 
-            -- Fresh capture succeeded — fire the confirmation. Non-blocking, non-throwing.
-            send_lead_confirmation(data, data.email)
+            -- Fresh capture succeeded — fire configured notifications (confirmation
+            -- to submitter, admin email, Telegram). Deferred to a timer internally,
+            -- so this never blocks the response; failures are logged, not fatal.
+            CrmLeadNotificationQueries.notify(namespace, lead)
 
             return { status = 201, json = { success = true, message = "Thank you for your submission" } }
         end)

--- a/lapis/routes/crm-leads.lua
+++ b/lapis/routes/crm-leads.lua
@@ -18,6 +18,7 @@ local cjson = require("cjson")
 local AuthMiddleware = require("middleware.auth")
 local NamespaceMiddleware = require("middleware.namespace")
 local CrmLeadQueries = require("queries.CrmLeadQueries")
+local CrmLeadNotificationQueries = require("queries.CrmLeadNotificationQueries")
 
 return function(app)
     -- Helper to parse JSON body
@@ -108,6 +109,54 @@ return function(app)
         NamespaceMiddleware.requireNamespace(function(self)
             local stats = CrmLeadQueries.getLeadStats(self.namespace.id)
             return api_response(200, stats)
+        end)
+    ))
+
+    -- ── Lead notification settings (per namespace) ─────────────────────────
+    -- Registered BEFORE /:uuid so the literal path isn't captured as a :uuid.
+
+    -- GET settings (any namespace member; bot token is masked, never returned)
+    app:get("/api/v2/crm/leads/notification-settings", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requireNamespace(function(self)
+            return api_response(200, CrmLeadNotificationQueries.getForApi(self.namespace.id))
+        end)
+    ))
+
+    -- PUT settings (namespace owner / platform admin only)
+    app:put("/api/v2/crm/leads/notification-settings", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requireNamespace(function(self)
+            if not (self.is_namespace_owner or self.is_platform_admin) then
+                return api_response(403, nil, "Only the namespace owner can change notification settings")
+            end
+            local body = parse_json_body()
+            local saved = CrmLeadNotificationQueries.upsert(self.namespace.id, {
+                notify_admin = body.notify_admin == true,
+                admin_email = body.admin_email,
+                send_confirmation = body.send_confirmation == true,
+                telegram_enabled = body.telegram_enabled == true,
+                telegram_bot_token = body.telegram_bot_token,
+                telegram_chat_id = body.telegram_chat_id,
+            })
+            return api_response(200, saved)
+        end)
+    ))
+
+    -- POST test Telegram (owner / admin) — verifies the bot token + chat id.
+    -- Accepts optional token/chat in the body so the owner can test BEFORE saving.
+    app:post("/api/v2/crm/leads/notification-settings/test-telegram", AuthMiddleware.requireAuth(
+        NamespaceMiddleware.requireNamespace(function(self)
+            if not (self.is_namespace_owner or self.is_platform_admin) then
+                return api_response(403, nil, "Only the namespace owner can send a test alert")
+            end
+            local body = parse_json_body()
+            local ok, err = CrmLeadNotificationQueries.sendTestTelegram(self.namespace.id, {
+                telegram_bot_token = body.telegram_bot_token,
+                telegram_chat_id = body.telegram_chat_id,
+            })
+            if not ok then
+                return api_response(400, nil, err or "Telegram test failed")
+            end
+            return api_response(200, { sent = true })
         end)
     ))
 

--- a/lapis/views/emails/lead_admin_notification.etlua
+++ b/lapis/views/emails/lead_admin_notification.etlua
@@ -1,0 +1,21 @@
+<h2>You've got a new lead<% if namespace_name and namespace_name ~= "" then %> — <%= namespace_name %><% end %></h2>
+
+<p>A new enquiry has just come in. The details are below — log in to your dashboard and open <strong>Leads</strong> to follow up.</p>
+
+<div class="info-box">
+  <p><strong>Name:</strong> <%= first_name %><% if last_name and last_name ~= "" then %> <%= last_name %><% end %></p>
+  <% if company_name and company_name ~= "" then %><p><strong>Company:</strong> <%= company_name %></p><% end %>
+  <% if job_title and job_title ~= "" then %><p><strong>Job title:</strong> <%= job_title %></p><% end %>
+  <% if email and email ~= "" then %><p><strong>Email:</strong> <%= email %></p><% end %>
+  <% if phone and phone ~= "" then %><p><strong>Phone:</strong> <%= phone %></p><% end %>
+  <% if source and source ~= "" then %><p><strong>Source:</strong> <%= source %></p><% end %>
+</div>
+
+<% if notes and notes ~= "" then %>
+  <p><strong>Message:</strong></p>
+  <div class="info-box">
+    <%= notes %>
+  </div>
+<% end %>
+
+<p>This is an automated notification from <%= app_name %>. You can turn these off or add a Telegram alert under Leads → Notifications.</p>

--- a/opsapi-dashboard/app/dashboard/crm/page.tsx
+++ b/opsapi-dashboard/app/dashboard/crm/page.tsx
@@ -39,6 +39,17 @@ import {
 import { formatDate, formatCurrency } from '@/lib/utils';
 import type { TableColumn } from '@/types';
 import toast from 'react-hot-toast';
+import {
+  LEAD_STATUS_OPTIONS,
+  LEAD_SOURCE_OPTIONS,
+  LEAD_PRIORITY_OPTIONS,
+  leadStatusColors,
+  leadSourceLabels,
+  leadPriorityColors,
+  CreateLeadModal,
+  ConvertLeadModal,
+  LeadDetailModal,
+} from '@/components/crm/leads-shared';
 
 // ============================================================
 // Tab type
@@ -109,31 +120,8 @@ const ACTIVITY_TYPE_OPTIONS = [
   { value: 'task', label: 'Task' },
 ];
 
-const LEAD_STATUS_OPTIONS = [
-  { value: 'all', label: 'All Status' },
-  { value: 'new', label: 'New' },
-  { value: 'contacted', label: 'Contacted' },
-  { value: 'qualified', label: 'Qualified' },
-  { value: 'converted', label: 'Converted' },
-  { value: 'lost', label: 'Lost' },
-];
-
-const LEAD_SOURCE_OPTIONS = [
-  { value: 'all', label: 'All Sources' },
-  { value: 'website_form', label: 'Website Form' },
-  { value: 'email', label: 'Email' },
-  { value: 'social_media', label: 'Social Media' },
-  { value: 'manual', label: 'Manual Entry' },
-  { value: 'api', label: 'API / Webhook' },
-  { value: 'referral', label: 'Referral' },
-];
-
-const LEAD_PRIORITY_OPTIONS = [
-  { value: 'low', label: 'Low' },
-  { value: 'medium', label: 'Medium' },
-  { value: 'high', label: 'High' },
-  { value: 'urgent', label: 'Urgent' },
-];
+// LEAD_STATUS_OPTIONS / LEAD_SOURCE_OPTIONS / LEAD_PRIORITY_OPTIONS are imported
+// from components/crm/leads-shared (shared with the /dashboard/leads inbox).
 
 // ============================================================
 // Create Account Modal
@@ -525,232 +513,6 @@ const CreateActivityModal: React.FC<CreateActivityModalProps> = ({ isOpen, onClo
   );
 };
 
-// ============================================================
-// Create Lead Modal
-// ============================================================
-
-interface CreateLeadModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  onSuccess: () => void;
-}
-
-const CreateLeadModal: React.FC<CreateLeadModalProps> = ({ isOpen, onClose, onSuccess }) => {
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [formData, setFormData] = useState({
-    first_name: '',
-    last_name: '',
-    email: '',
-    phone: '',
-    company_name: '',
-    job_title: '',
-    source: 'manual',
-    channel: '',
-    campaign: '',
-    priority: 'medium',
-    notes: '',
-  });
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
-    setFormData((prev) => ({ ...prev, [e.target.name]: e.target.value }));
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!formData.first_name.trim() && !formData.email.trim()) {
-      toast.error('First name or email is required');
-      return;
-    }
-
-    setIsSubmitting(true);
-    try {
-      await crmService.createLead(formData);
-      toast.success('Lead created successfully');
-      setFormData({ first_name: '', last_name: '', email: '', phone: '', company_name: '', job_title: '', source: 'manual', channel: '', campaign: '', priority: 'medium', notes: '' });
-      onSuccess();
-      onClose();
-    } catch (error) {
-      console.error('Failed to create lead:', error);
-      toast.error('Failed to create lead');
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  return (
-    <Modal isOpen={isOpen} onClose={onClose} title="Create Lead">
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <div className="grid grid-cols-2 gap-4">
-          <div>
-            <label className="block text-sm font-medium text-secondary-700 mb-1">First Name *</label>
-            <input name="first_name" value={formData.first_name} onChange={handleChange} className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500" placeholder="First name" />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-secondary-700 mb-1">Last Name</label>
-            <input name="last_name" value={formData.last_name} onChange={handleChange} className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500" placeholder="Last name" />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-secondary-700 mb-1">Email *</label>
-            <input name="email" type="email" value={formData.email} onChange={handleChange} className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500" placeholder="email@example.com" />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-secondary-700 mb-1">Phone</label>
-            <input name="phone" value={formData.phone} onChange={handleChange} className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500" placeholder="+44 7700 000000" />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-secondary-700 mb-1">Company</label>
-            <input name="company_name" value={formData.company_name} onChange={handleChange} className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500" placeholder="Company name" />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-secondary-700 mb-1">Job Title</label>
-            <input name="job_title" value={formData.job_title} onChange={handleChange} className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500" placeholder="e.g. Marketing Director" />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-secondary-700 mb-1">Source</label>
-            <div className="relative">
-              <select name="source" value={formData.source} onChange={handleChange} className="w-full appearance-none px-3 py-2 pr-10 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 bg-surface cursor-pointer">
-                {LEAD_SOURCE_OPTIONS.filter((o) => o.value !== 'all').map((opt) => (
-                  <option key={opt.value} value={opt.value}>{opt.label}</option>
-                ))}
-              </select>
-              <ChevronDown className="w-4 h-4 absolute right-3 top-1/2 -translate-y-1/2 text-secondary-400 pointer-events-none" />
-            </div>
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-secondary-700 mb-1">Priority</label>
-            <div className="relative">
-              <select name="priority" value={formData.priority} onChange={handleChange} className="w-full appearance-none px-3 py-2 pr-10 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 bg-surface cursor-pointer">
-                {LEAD_PRIORITY_OPTIONS.map((opt) => (
-                  <option key={opt.value} value={opt.value}>{opt.label}</option>
-                ))}
-              </select>
-              <ChevronDown className="w-4 h-4 absolute right-3 top-1/2 -translate-y-1/2 text-secondary-400 pointer-events-none" />
-            </div>
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-secondary-700 mb-1">Channel</label>
-            <input name="channel" value={formData.channel} onChange={handleChange} className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500" placeholder="e.g. organic, paid, social" />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-secondary-700 mb-1">Campaign</label>
-            <input name="campaign" value={formData.campaign} onChange={handleChange} className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500" placeholder="Campaign name" />
-          </div>
-          <div className="col-span-2">
-            <label className="block text-sm font-medium text-secondary-700 mb-1">Notes</label>
-            <textarea name="notes" value={formData.notes} onChange={handleChange} rows={3} className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 resize-none" placeholder="Additional notes about this lead..." />
-          </div>
-        </div>
-        <div className="flex justify-end gap-3 pt-4 border-t border-secondary-200">
-          <button type="button" onClick={onClose} className="px-4 py-2 text-sm font-medium text-secondary-700 bg-surface border border-secondary-300 rounded-lg hover:bg-secondary-50 transition-colors">Cancel</button>
-          <button type="submit" disabled={isSubmitting} className="px-4 py-2 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 transition-colors disabled:opacity-50">{isSubmitting ? 'Creating...' : 'Create Lead'}</button>
-        </div>
-      </form>
-    </Modal>
-  );
-};
-
-// ============================================================
-// Convert Lead Modal
-// ============================================================
-
-interface ConvertLeadModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  onSuccess: () => void;
-  lead: CrmLead | null;
-}
-
-const ConvertLeadModal: React.FC<ConvertLeadModalProps> = ({ isOpen, onClose, onSuccess, lead }) => {
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [createDeal, setCreateDeal] = useState(false);
-  const [dealData, setDealData] = useState({ name: '', value: '', currency: 'GBP', stage: 'new' });
-
-  const handleDealChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
-    setDealData((prev) => ({ ...prev, [e.target.name]: e.target.value }));
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!lead) return;
-
-    setIsSubmitting(true);
-    try {
-      const deal = createDeal && dealData.name.trim() ? {
-        name: dealData.name,
-        value: dealData.value ? parseFloat(dealData.value) : 0,
-        currency: dealData.currency,
-        stage: dealData.stage,
-      } : undefined;
-
-      await crmService.convertLead(lead.uuid, deal);
-      toast.success('Lead converted to contact successfully');
-      setCreateDeal(false);
-      setDealData({ name: '', value: '', currency: 'GBP', stage: 'new' });
-      onSuccess();
-      onClose();
-    } catch (error) {
-      console.error('Failed to convert lead:', error);
-      toast.error('Failed to convert lead');
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  if (!lead) return null;
-
-  return (
-    <Modal isOpen={isOpen} onClose={onClose} title="Convert Lead">
-      <form onSubmit={handleSubmit} className="space-y-4">
-        {/* Lead summary */}
-        <div className="bg-secondary-50 rounded-lg p-4 space-y-1">
-          <p className="text-sm font-medium text-secondary-900">{lead.first_name} {lead.last_name}</p>
-          {lead.email && <p className="text-sm text-secondary-600">{lead.email}</p>}
-          {lead.company_name && <p className="text-sm text-secondary-600">{lead.company_name}</p>}
-          {lead.phone && <p className="text-sm text-secondary-600">{lead.phone}</p>}
-        </div>
-
-        <p className="text-sm text-secondary-600">
-          This will create a new <strong>CRM Contact</strong> from this lead&apos;s information.
-        </p>
-
-        {/* Optional deal creation */}
-        <div className="border border-secondary-200 rounded-lg p-4 space-y-3">
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={createDeal}
-              onChange={(e) => setCreateDeal(e.target.checked)}
-              className="w-4 h-4 rounded border-secondary-300 text-primary-600 focus:ring-primary-500"
-            />
-            <span className="text-sm font-medium text-secondary-700">Also create a deal</span>
-          </label>
-
-          {createDeal && (
-            <div className="grid grid-cols-2 gap-3 pt-2">
-              <div className="col-span-2">
-                <label className="block text-sm font-medium text-secondary-700 mb-1">Deal Name *</label>
-                <input name="name" value={dealData.name} onChange={handleDealChange} className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500" placeholder="Deal name" />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-secondary-700 mb-1">Value</label>
-                <input name="value" type="number" step="0.01" value={dealData.value} onChange={handleDealChange} className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500" placeholder="0.00" />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-secondary-700 mb-1">Currency</label>
-                <input name="currency" value={dealData.currency} onChange={handleDealChange} className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500" placeholder="GBP" />
-              </div>
-            </div>
-          )}
-        </div>
-
-        <div className="flex justify-end gap-3 pt-4 border-t border-secondary-200">
-          <button type="button" onClick={onClose} className="px-4 py-2 text-sm font-medium text-secondary-700 bg-surface border border-secondary-300 rounded-lg hover:bg-secondary-50 transition-colors">Cancel</button>
-          <button type="submit" disabled={isSubmitting} className="px-4 py-2 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 transition-colors disabled:opacity-50">{isSubmitting ? 'Converting...' : 'Convert Lead'}</button>
-        </div>
-      </form>
-    </Modal>
-  );
-};
 
 // ============================================================
 // Main CRM Page Content
@@ -793,6 +555,8 @@ function CrmPageContent() {
   const [isCreateLeadOpen, setIsCreateLeadOpen] = useState(false);
   const [isConvertLeadOpen, setIsConvertLeadOpen] = useState(false);
   const [convertTarget, setConvertTarget] = useState<CrmLead | null>(null);
+  const [detailLead, setDetailLead] = useState<CrmLead | null>(null);
+  const [isLeadDetailOpen, setIsLeadDetailOpen] = useState(false);
 
   // Delete
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -977,29 +741,8 @@ function CrmPageContent() {
 
   // ---- Table columns ----
 
-  const leadStatusColors: Record<string, string> = {
-    new: 'bg-blue-100 text-blue-800',
-    contacted: 'bg-amber-100 text-amber-800',
-    qualified: 'bg-green-100 text-green-800',
-    converted: 'bg-purple-100 text-purple-800',
-    lost: 'bg-red-100 text-red-800',
-  };
-
-  const leadSourceLabels: Record<string, string> = {
-    website_form: 'Website',
-    email: 'Email',
-    social_media: 'Social',
-    manual: 'Manual',
-    api: 'API',
-    referral: 'Referral',
-  };
-
-  const leadPriorityColors: Record<string, string> = {
-    low: 'bg-secondary-100 text-secondary-700',
-    medium: 'bg-blue-100 text-blue-700',
-    high: 'bg-amber-100 text-amber-700',
-    urgent: 'bg-red-100 text-red-700',
-  };
+  // leadStatusColors / leadSourceLabels / leadPriorityColors imported from
+  // components/crm/leads-shared (shared with the /dashboard/leads inbox).
 
   const leadColumns: TableColumn<CrmLead>[] = useMemo(() => [
     {
@@ -1612,6 +1355,7 @@ function CrmPageContent() {
             columns={leadColumns}
             data={leads}
             keyExtractor={(l) => l.uuid}
+            onRowClick={(lead) => { setDetailLead(lead); setIsLeadDetailOpen(true); }}
             sortColumn={sortColumn}
             sortDirection={sortDirection}
             onSort={handleSort}
@@ -1689,6 +1433,16 @@ function CrmPageContent() {
       <CreateDealModal isOpen={isCreateDealOpen} onClose={() => setIsCreateDealOpen(false)} onSuccess={fetchData} />
       <CreateActivityModal isOpen={isCreateActivityOpen} onClose={() => setIsCreateActivityOpen(false)} onSuccess={fetchData} />
       <ConvertLeadModal isOpen={isConvertLeadOpen} onClose={() => { setIsConvertLeadOpen(false); setConvertTarget(null); }} onSuccess={fetchData} lead={convertTarget} />
+
+      {/* Lead detail — opens on clicking a leads row */}
+      <LeadDetailModal
+        isOpen={isLeadDetailOpen}
+        lead={detailLead}
+        onClose={() => setIsLeadDetailOpen(false)}
+        onSaved={fetchData}
+        onConvert={(lead) => { setIsLeadDetailOpen(false); handleConvertLead(lead); }}
+        onDelete={(lead) => { setIsLeadDetailOpen(false); handleDeleteClick(lead.uuid, `${lead.first_name} ${lead.last_name || ''}`, 'leads'); }}
+      />
 
       {/* Delete Confirmation */}
       <ConfirmDialog

--- a/opsapi-dashboard/app/dashboard/leads/page.tsx
+++ b/opsapi-dashboard/app/dashboard/leads/page.tsx
@@ -1,0 +1,441 @@
+'use client';
+
+/**
+ * Leads Inbox — /dashboard/leads
+ *
+ * A focused view of every lead captured for the CURRENT namespace, from any
+ * source (public website form, API/webhook, manual entry, referral). Data is
+ * namespace-scoped by the backend: crmService goes through the axios client
+ * which injects the active namespace headers, and the /api/v2/crm/leads route
+ * filters by the resolved tenant.
+ *
+ * The CRM workspace (/dashboard/crm) has a leads tab for triage alongside
+ * accounts/contacts/deals; this page is the dedicated inbox for reviewing an
+ * individual lead in full (the detail drawer), updating its status, and
+ * converting it. Shared building blocks live in components/crm/leads-shared.
+ */
+
+import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import {
+  Search,
+  Plus,
+  Trash2,
+  UserPlus,
+  Mail,
+  Phone,
+  Briefcase,
+  ArrowRightCircle,
+  ChevronDown,
+  RefreshCw,
+  Star,
+  Bell,
+} from 'lucide-react';
+import { Input, Table, Pagination, Card, Button, ConfirmDialog } from '@/components/ui';
+import { ProtectedPage } from '@/components/permissions';
+import { PageHeader } from '@/components/layout/PageHeader';
+import {
+  crmService,
+  type CrmLead,
+  type CrmLeadStats,
+  type CrmListParams,
+} from '@/services/crm.service';
+import {
+  LEAD_STATUS_OPTIONS,
+  LEAD_SOURCE_OPTIONS,
+  LEAD_PRIORITY_OPTIONS,
+  leadStatusColors,
+  leadSourceLabels,
+  leadPriorityColors,
+  CreateLeadModal,
+  ConvertLeadModal,
+  LeadDetailModal,
+  LeadNotificationsModal,
+} from '@/components/crm/leads-shared';
+import { formatDate } from '@/lib/utils';
+import type { TableColumn } from '@/types';
+import toast from 'react-hot-toast';
+
+const PER_PAGE = 10;
+
+// ============================================================
+// Stat card
+// ============================================================
+
+interface StatCardProps {
+  title: string;
+  value: string | number;
+  icon: React.ReactNode;
+  color: 'primary' | 'success' | 'warning' | 'info' | 'violet';
+}
+
+const StatCard: React.FC<StatCardProps> = ({ title, value, icon, color }) => {
+  const colorClasses: Record<StatCardProps['color'], string> = {
+    primary: 'bg-primary-50 text-primary-600',
+    success: 'bg-green-50 text-green-600',
+    warning: 'bg-amber-50 text-amber-600',
+    info: 'bg-blue-50 text-blue-600',
+    violet: 'bg-violet-50 text-violet-600',
+  };
+  return (
+    <div className="bg-surface rounded-xl border border-secondary-200 p-5 shadow-sm">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm font-medium text-secondary-500">{title}</p>
+          <p className="text-2xl font-bold text-secondary-900 mt-1">{value}</p>
+        </div>
+        <div className={`w-12 h-12 rounded-xl flex items-center justify-center ${colorClasses[color]}`}>
+          {icon}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ============================================================
+// Main content
+// ============================================================
+
+function LeadsPageContent() {
+  const [leads, setLeads] = useState<CrmLead[]>([]);
+  const [stats, setStats] = useState<CrmLeadStats | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState('all');
+  const [sourceFilter, setSourceFilter] = useState('all');
+  const [priorityFilter, setPriorityFilter] = useState('all');
+
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [totalItems, setTotalItems] = useState(0);
+  const [sortColumn, setSortColumn] = useState('created_at');
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc');
+
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [isNotifOpen, setIsNotifOpen] = useState(false);
+  const [isConvertOpen, setIsConvertOpen] = useState(false);
+  const [convertTarget, setConvertTarget] = useState<CrmLead | null>(null);
+  const [detailLead, setDetailLead] = useState<CrmLead | null>(null);
+  const [isDetailOpen, setIsDetailOpen] = useState(false);
+
+  const [deleteTarget, setDeleteTarget] = useState<CrmLead | null>(null);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const fetchIdRef = useRef(0);
+
+  // Debounce the search box so we issue one request after typing settles.
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setDebouncedSearch(searchQuery.trim());
+      setCurrentPage(1);
+    }, 300);
+    return () => clearTimeout(t);
+  }, [searchQuery]);
+
+  const loadStats = useCallback(async () => {
+    const s = await crmService.getLeadStats().catch(() => null);
+    if (s) setStats(s);
+  }, []);
+
+  useEffect(() => { loadStats(); }, [loadStats]);
+
+  const fetchLeads = useCallback(async () => {
+    const fetchId = ++fetchIdRef.current;
+    setIsLoading(true);
+    try {
+      const params: CrmListParams = {
+        page: currentPage,
+        perPage: PER_PAGE,
+        orderBy: sortColumn,
+        orderDir: sortDirection,
+      };
+      if (debouncedSearch) params.search = debouncedSearch;
+      if (statusFilter !== 'all') params.status = statusFilter;
+      if (sourceFilter !== 'all') params.source = sourceFilter;
+      if (priorityFilter !== 'all') params.priority = priorityFilter;
+
+      const response = await crmService.getLeads(params);
+      if (fetchId === fetchIdRef.current) {
+        setLeads(response.data);
+        setTotalPages(response.total_pages);
+        setTotalItems(response.total);
+      }
+    } catch (error) {
+      if (fetchId === fetchIdRef.current) {
+        console.error('Failed to fetch leads:', error);
+        toast.error('Failed to load leads');
+      }
+    } finally {
+      if (fetchId === fetchIdRef.current) setIsLoading(false);
+    }
+  }, [currentPage, sortColumn, sortDirection, debouncedSearch, statusFilter, sourceFilter, priorityFilter]);
+
+  useEffect(() => { fetchLeads(); }, [fetchLeads]);
+
+  const refreshAll = useCallback(() => {
+    fetchLeads();
+    loadStats();
+  }, [fetchLeads, loadStats]);
+
+  const handleSort = useCallback((column: string) => {
+    setSortColumn((prev) => {
+      if (prev === column) {
+        setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'));
+        return prev;
+      }
+      setSortDirection('desc');
+      return column;
+    });
+  }, []);
+
+  const openDetail = useCallback((lead: CrmLead) => {
+    setDetailLead(lead);
+    setIsDetailOpen(true);
+  }, []);
+
+  const handleConvert = useCallback((lead: CrmLead) => {
+    setIsDetailOpen(false);
+    setConvertTarget(lead);
+    setIsConvertOpen(true);
+  }, []);
+
+  const handleDeleteClick = useCallback((lead: CrmLead) => {
+    setIsDetailOpen(false);
+    setDeleteTarget(lead);
+    setDeleteDialogOpen(true);
+  }, []);
+
+  const handleDeleteConfirm = useCallback(async () => {
+    if (!deleteTarget) return;
+    setIsDeleting(true);
+    try {
+      await crmService.deleteLead(deleteTarget.uuid);
+      toast.success('Lead deleted');
+      setDeleteDialogOpen(false);
+      setDeleteTarget(null);
+      refreshAll();
+    } catch (error) {
+      console.error('Failed to delete lead:', error);
+      toast.error('Failed to delete lead');
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [deleteTarget, refreshAll]);
+
+  const columns: TableColumn<CrmLead>[] = useMemo(() => [
+    {
+      key: 'name',
+      header: 'Name',
+      sortable: true,
+      render: (lead) => (
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 bg-violet-100 rounded-lg flex items-center justify-center">
+            <UserPlus className="w-5 h-5 text-violet-600" />
+          </div>
+          <div>
+            <p className="font-medium text-secondary-900">{lead.first_name} {lead.last_name || ''}</p>
+            {lead.company_name && <p className="text-xs text-secondary-500">{lead.company_name}</p>}
+          </div>
+        </div>
+      ),
+    },
+    {
+      key: 'email',
+      header: 'Email',
+      render: (lead) => lead.email ? (
+        <div className="flex items-center gap-2 text-sm text-secondary-600">
+          <Mail className="w-3.5 h-3.5 text-secondary-400" />
+          <span>{lead.email}</span>
+        </div>
+      ) : <span className="text-sm text-secondary-400">--</span>,
+    },
+    {
+      key: 'source',
+      header: 'Source',
+      render: (lead) => (
+        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-secondary-100 text-secondary-700">
+          {leadSourceLabels[lead.source] || lead.source}
+        </span>
+      ),
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      render: (lead) => (
+        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${leadStatusColors[lead.status] || 'bg-secondary-100 text-secondary-600'}`}>
+          {lead.status}
+        </span>
+      ),
+    },
+    {
+      key: 'priority',
+      header: 'Priority',
+      render: (lead) => (
+        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${leadPriorityColors[lead.priority] || 'bg-secondary-100 text-secondary-600'}`}>
+          {lead.priority}
+        </span>
+      ),
+    },
+    {
+      key: 'score',
+      header: 'Score',
+      sortable: true,
+      render: (lead) => <span className="text-sm font-medium text-secondary-700">{lead.score}</span>,
+    },
+    {
+      key: 'created_at',
+      header: 'Created',
+      sortable: true,
+      render: (lead) => <span className="text-sm text-secondary-600">{formatDate(lead.created_at)}</span>,
+    },
+    {
+      key: 'actions',
+      header: '',
+      width: 'w-28',
+      render: (lead) => (
+        <div className="flex items-center gap-1">
+          {lead.status !== 'converted' && (
+            <button
+              onClick={(e) => { e.stopPropagation(); handleConvert(lead); }}
+              className="p-1.5 text-secondary-500 hover:text-primary-500 hover:bg-primary-50 rounded-lg transition-colors"
+              title="Convert to Contact"
+            >
+              <ArrowRightCircle className="w-4 h-4" />
+            </button>
+          )}
+          <button
+            onClick={(e) => { e.stopPropagation(); handleDeleteClick(lead); }}
+            className="p-1.5 text-secondary-500 hover:text-error-500 hover:bg-error-50 rounded-lg transition-colors"
+            title="Delete Lead"
+          >
+            <Trash2 className="w-4 h-4" />
+          </button>
+        </div>
+      ),
+    },
+  ], [handleConvert, handleDeleteClick]);
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Leads"
+        description="Every enquiry captured for this workspace — website forms, API, referrals and manual entries."
+        actions={
+          <>
+            <Button variant="secondary" onClick={refreshAll} title="Refresh">
+              <RefreshCw className="w-4 h-4" />
+            </Button>
+            <Button variant="secondary" onClick={() => setIsNotifOpen(true)}>
+              <Bell className="w-4 h-4 mr-1.5" /> Notifications
+            </Button>
+            <Button onClick={() => setIsCreateOpen(true)}>
+              <Plus className="w-4 h-4 mr-1.5" /> New Lead
+            </Button>
+          </>
+        }
+      />
+
+      {/* Stats */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">
+        <StatCard title="Total" value={stats?.total_leads ?? 0} icon={<UserPlus className="w-6 h-6" />} color="violet" />
+        <StatCard title="New" value={stats?.new_leads ?? 0} icon={<Star className="w-6 h-6" />} color="info" />
+        <StatCard title="Contacted" value={stats?.contacted_leads ?? 0} icon={<Phone className="w-6 h-6" />} color="warning" />
+        <StatCard title="Qualified" value={stats?.qualified_leads ?? 0} icon={<Briefcase className="w-6 h-6" />} color="success" />
+        <StatCard title="Conversion" value={stats ? `${stats.conversion_rate}%` : '0%'} icon={<ArrowRightCircle className="w-6 h-6" />} color="primary" />
+      </div>
+
+      {/* Filters */}
+      <Card padding="md">
+        <div className="flex flex-wrap items-center gap-4">
+          <div className="flex-1 min-w-[250px] max-w-md">
+            <Input
+              placeholder="Search leads..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              leftIcon={<Search className="w-4 h-4" />}
+            />
+          </div>
+          <div className="relative">
+            <select value={statusFilter} onChange={(e) => { setStatusFilter(e.target.value); setCurrentPage(1); }} className="appearance-none px-4 py-2.5 pr-10 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 bg-surface cursor-pointer">
+              {LEAD_STATUS_OPTIONS.map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
+            </select>
+            <ChevronDown className="w-4 h-4 absolute right-3 top-1/2 -translate-y-1/2 text-secondary-400 pointer-events-none" />
+          </div>
+          <div className="relative">
+            <select value={sourceFilter} onChange={(e) => { setSourceFilter(e.target.value); setCurrentPage(1); }} className="appearance-none px-4 py-2.5 pr-10 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 bg-surface cursor-pointer">
+              {LEAD_SOURCE_OPTIONS.map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
+            </select>
+            <ChevronDown className="w-4 h-4 absolute right-3 top-1/2 -translate-y-1/2 text-secondary-400 pointer-events-none" />
+          </div>
+          <div className="relative">
+            <select value={priorityFilter} onChange={(e) => { setPriorityFilter(e.target.value); setCurrentPage(1); }} className="appearance-none px-4 py-2.5 pr-10 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 bg-surface cursor-pointer">
+              <option value="all">All Priority</option>
+              {LEAD_PRIORITY_OPTIONS.map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
+            </select>
+            <ChevronDown className="w-4 h-4 absolute right-3 top-1/2 -translate-y-1/2 text-secondary-400 pointer-events-none" />
+          </div>
+        </div>
+      </Card>
+
+      {/* Table */}
+      <div>
+        <Table
+          columns={columns}
+          data={leads}
+          keyExtractor={(l) => l.uuid}
+          onRowClick={openDetail}
+          sortColumn={sortColumn}
+          sortDirection={sortDirection}
+          onSort={handleSort}
+          isLoading={isLoading}
+          emptyMessage="No leads yet — captured enquiries will appear here."
+        />
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          totalItems={totalItems}
+          perPage={PER_PAGE}
+          onPageChange={setCurrentPage}
+        />
+      </div>
+
+      {/* Modals */}
+      <LeadDetailModal
+        isOpen={isDetailOpen}
+        lead={detailLead}
+        onClose={() => setIsDetailOpen(false)}
+        onSaved={refreshAll}
+        onConvert={handleConvert}
+        onDelete={handleDeleteClick}
+      />
+      <CreateLeadModal isOpen={isCreateOpen} onClose={() => setIsCreateOpen(false)} onSuccess={refreshAll} />
+      <LeadNotificationsModal isOpen={isNotifOpen} onClose={() => setIsNotifOpen(false)} />
+      <ConvertLeadModal
+        isOpen={isConvertOpen}
+        onClose={() => { setIsConvertOpen(false); setConvertTarget(null); }}
+        onSuccess={refreshAll}
+        lead={convertTarget}
+      />
+      <ConfirmDialog
+        isOpen={deleteDialogOpen}
+        onClose={() => setDeleteDialogOpen(false)}
+        onConfirm={handleDeleteConfirm}
+        title="Delete lead"
+        message={`Are you sure you want to delete "${deleteTarget?.first_name || ''} ${deleteTarget?.last_name || ''}"? This action cannot be undone.`}
+        confirmText="Delete"
+        variant="danger"
+        isLoading={isDeleting}
+      />
+    </div>
+  );
+}
+
+export default function LeadsPage() {
+  return (
+    <ProtectedPage module="crm" title="Leads">
+      <LeadsPageContent />
+    </ProtectedPage>
+  );
+}

--- a/opsapi-dashboard/components/crm/leads-shared.tsx
+++ b/opsapi-dashboard/components/crm/leads-shared.tsx
@@ -1,0 +1,695 @@
+'use client';
+
+/**
+ * CRM Leads — shared presentational pieces
+ *
+ * Single source of truth for lead option lists, status/source/priority badge
+ * maps, and the Create/Convert modals — reused by BOTH the CRM workspace
+ * (/dashboard/crm, leads tab) and the dedicated Leads inbox (/dashboard/leads).
+ *
+ * Business logic + API calls live in crmService (namespace-scoped via the axios
+ * client). These are thin display/form components only.
+ */
+
+import React, { useState, useEffect } from 'react';
+import {
+  ChevronDown,
+  UserPlus,
+  Mail,
+  Phone,
+  Building2,
+  Briefcase,
+  Tag,
+  Megaphone,
+  Globe,
+  Link2,
+  Star,
+  CalendarClock,
+  MessageSquare,
+  ArrowRightCircle,
+  Trash2,
+  Bell,
+  Send,
+  Info,
+  ExternalLink,
+} from 'lucide-react';
+import { Modal } from '@/components/ui';
+import { crmService, type CrmLead, type LeadNotificationSettings } from '@/services/crm.service';
+import { formatDate } from '@/lib/utils';
+import toast from 'react-hot-toast';
+
+// A compact on/off toggle switch (no extra dependency).
+const Toggle: React.FC<{ checked: boolean; onChange: (v: boolean) => void; disabled?: boolean }> = ({ checked, onChange, disabled }) => (
+  <button
+    type="button"
+    role="switch"
+    aria-checked={checked}
+    disabled={disabled}
+    onClick={() => onChange(!checked)}
+    className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500/30 disabled:opacity-50 ${checked ? 'bg-primary-600' : 'bg-secondary-300'}`}
+  >
+    <span className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform ${checked ? 'translate-x-5' : 'translate-x-0.5'}`} />
+  </button>
+);
+
+// ============================================================
+// Option lists
+// ============================================================
+
+export const LEAD_STATUS_OPTIONS = [
+  { value: 'all', label: 'All Status' },
+  { value: 'new', label: 'New' },
+  { value: 'contacted', label: 'Contacted' },
+  { value: 'qualified', label: 'Qualified' },
+  { value: 'converted', label: 'Converted' },
+  { value: 'lost', label: 'Lost' },
+];
+
+export const LEAD_SOURCE_OPTIONS = [
+  { value: 'all', label: 'All Sources' },
+  { value: 'website_form', label: 'Website Form' },
+  { value: 'email', label: 'Email' },
+  { value: 'social_media', label: 'Social Media' },
+  { value: 'manual', label: 'Manual Entry' },
+  { value: 'api', label: 'API / Webhook' },
+  { value: 'referral', label: 'Referral' },
+];
+
+export const LEAD_PRIORITY_OPTIONS = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+  { value: 'urgent', label: 'Urgent' },
+];
+
+// ============================================================
+// Badge maps
+// ============================================================
+
+export const leadStatusColors: Record<string, string> = {
+  new: 'bg-blue-100 text-blue-800',
+  contacted: 'bg-amber-100 text-amber-800',
+  qualified: 'bg-green-100 text-green-800',
+  converted: 'bg-purple-100 text-purple-800',
+  lost: 'bg-red-100 text-red-800',
+};
+
+export const leadSourceLabels: Record<string, string> = {
+  website_form: 'Website',
+  email: 'Email',
+  social_media: 'Social',
+  manual: 'Manual',
+  api: 'API',
+  referral: 'Referral',
+};
+
+export const leadPriorityColors: Record<string, string> = {
+  low: 'bg-secondary-100 text-secondary-700',
+  medium: 'bg-blue-100 text-blue-700',
+  high: 'bg-amber-100 text-amber-700',
+  urgent: 'bg-red-100 text-red-700',
+};
+
+// ============================================================
+// Create Lead Modal
+// ============================================================
+
+interface CreateLeadModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export const CreateLeadModal: React.FC<CreateLeadModalProps> = ({ isOpen, onClose, onSuccess }) => {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [formData, setFormData] = useState({
+    first_name: '',
+    last_name: '',
+    email: '',
+    phone: '',
+    company_name: '',
+    job_title: '',
+    source: 'manual',
+    channel: '',
+    campaign: '',
+    priority: 'medium',
+    notes: '',
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
+    setFormData((prev) => ({ ...prev, [e.target.name]: e.target.value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!formData.first_name.trim() && !formData.email.trim()) {
+      toast.error('First name or email is required');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await crmService.createLead(formData);
+      toast.success('Lead created successfully');
+      setFormData({ first_name: '', last_name: '', email: '', phone: '', company_name: '', job_title: '', source: 'manual', channel: '', campaign: '', priority: 'medium', notes: '' });
+      onSuccess();
+      onClose();
+    } catch (error) {
+      console.error('Failed to create lead:', error);
+      toast.error('Failed to create lead');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Create Lead">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-secondary-700 mb-1">First Name *</label>
+            <input name="first_name" value={formData.first_name} onChange={handleChange} className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500" placeholder="First name" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-secondary-700 mb-1">Last Name</label>
+            <input name="last_name" value={formData.last_name} onChange={handleChange} className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500" placeholder="Last name" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-secondary-700 mb-1">Email *</label>
+            <input name="email" type="email" value={formData.email} onChange={handleChange} className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500" placeholder="email@example.com" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-secondary-700 mb-1">Phone</label>
+            <input name="phone" value={formData.phone} onChange={handleChange} className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500" placeholder="+44 7700 000000" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-secondary-700 mb-1">Company</label>
+            <input name="company_name" value={formData.company_name} onChange={handleChange} className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500" placeholder="Company name" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-secondary-700 mb-1">Job Title</label>
+            <input name="job_title" value={formData.job_title} onChange={handleChange} className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500" placeholder="e.g. Marketing Director" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-secondary-700 mb-1">Source</label>
+            <div className="relative">
+              <select name="source" value={formData.source} onChange={handleChange} className="w-full appearance-none px-3 py-2 pr-10 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 bg-surface cursor-pointer">
+                {LEAD_SOURCE_OPTIONS.filter((o) => o.value !== 'all').map((opt) => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+              <ChevronDown className="w-4 h-4 absolute right-3 top-1/2 -translate-y-1/2 text-secondary-400 pointer-events-none" />
+            </div>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-secondary-700 mb-1">Priority</label>
+            <div className="relative">
+              <select name="priority" value={formData.priority} onChange={handleChange} className="w-full appearance-none px-3 py-2 pr-10 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 bg-surface cursor-pointer">
+                {LEAD_PRIORITY_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+              <ChevronDown className="w-4 h-4 absolute right-3 top-1/2 -translate-y-1/2 text-secondary-400 pointer-events-none" />
+            </div>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-secondary-700 mb-1">Channel</label>
+            <input name="channel" value={formData.channel} onChange={handleChange} className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500" placeholder="e.g. organic, paid, social" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-secondary-700 mb-1">Campaign</label>
+            <input name="campaign" value={formData.campaign} onChange={handleChange} className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500" placeholder="Campaign name" />
+          </div>
+          <div className="col-span-2">
+            <label className="block text-sm font-medium text-secondary-700 mb-1">Notes</label>
+            <textarea name="notes" value={formData.notes} onChange={handleChange} rows={3} className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 resize-none" placeholder="Additional notes about this lead..." />
+          </div>
+        </div>
+        <div className="flex justify-end gap-3 pt-4 border-t border-secondary-200">
+          <button type="button" onClick={onClose} className="px-4 py-2 text-sm font-medium text-secondary-700 bg-surface border border-secondary-300 rounded-lg hover:bg-secondary-50 transition-colors">Cancel</button>
+          <button type="submit" disabled={isSubmitting} className="px-4 py-2 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 transition-colors disabled:opacity-50">{isSubmitting ? 'Creating...' : 'Create Lead'}</button>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+// ============================================================
+// Convert Lead Modal
+// ============================================================
+
+interface ConvertLeadModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  lead: CrmLead | null;
+}
+
+export const ConvertLeadModal: React.FC<ConvertLeadModalProps> = ({ isOpen, onClose, onSuccess, lead }) => {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [createDeal, setCreateDeal] = useState(false);
+  const [dealData, setDealData] = useState({ name: '', value: '', currency: 'GBP', stage: 'new' });
+
+  const handleDealChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    setDealData((prev) => ({ ...prev, [e.target.name]: e.target.value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!lead) return;
+
+    setIsSubmitting(true);
+    try {
+      const deal = createDeal && dealData.name.trim() ? {
+        name: dealData.name,
+        value: dealData.value ? parseFloat(dealData.value) : 0,
+        currency: dealData.currency,
+        stage: dealData.stage,
+      } : undefined;
+
+      await crmService.convertLead(lead.uuid, deal);
+      toast.success('Lead converted to contact successfully');
+      setCreateDeal(false);
+      setDealData({ name: '', value: '', currency: 'GBP', stage: 'new' });
+      onSuccess();
+      onClose();
+    } catch (error) {
+      console.error('Failed to convert lead:', error);
+      toast.error('Failed to convert lead');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!lead) return null;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Convert Lead">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {/* Lead summary */}
+        <div className="bg-secondary-50 rounded-lg p-4 space-y-1">
+          <p className="text-sm font-medium text-secondary-900">{lead.first_name} {lead.last_name}</p>
+          {lead.email && <p className="text-sm text-secondary-600">{lead.email}</p>}
+          {lead.company_name && <p className="text-sm text-secondary-600">{lead.company_name}</p>}
+          {lead.phone && <p className="text-sm text-secondary-600">{lead.phone}</p>}
+        </div>
+
+        <p className="text-sm text-secondary-600">
+          This will create a new <strong>CRM Contact</strong> from this lead&apos;s information.
+        </p>
+
+        {/* Optional deal creation */}
+        <div className="border border-secondary-200 rounded-lg p-4 space-y-3">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={createDeal}
+              onChange={(e) => setCreateDeal(e.target.checked)}
+              className="w-4 h-4 rounded border-secondary-300 text-primary-600 focus:ring-primary-500"
+            />
+            <span className="text-sm font-medium text-secondary-700">Also create a deal</span>
+          </label>
+
+          {createDeal && (
+            <div className="grid grid-cols-2 gap-3 pt-2">
+              <div className="col-span-2">
+                <label className="block text-sm font-medium text-secondary-700 mb-1">Deal Name *</label>
+                <input name="name" value={dealData.name} onChange={handleDealChange} className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500" placeholder="Deal name" />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-secondary-700 mb-1">Value</label>
+                <input name="value" type="number" step="0.01" value={dealData.value} onChange={handleDealChange} className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500" placeholder="0.00" />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-secondary-700 mb-1">Currency</label>
+                <input name="currency" value={dealData.currency} onChange={handleDealChange} className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500" placeholder="GBP" />
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-3 pt-4 border-t border-secondary-200">
+          <button type="button" onClick={onClose} className="px-4 py-2 text-sm font-medium text-secondary-700 bg-surface border border-secondary-300 rounded-lg hover:bg-secondary-50 transition-colors">Cancel</button>
+          <button type="submit" disabled={isSubmitting} className="px-4 py-2 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 transition-colors disabled:opacity-50">{isSubmitting ? 'Converting...' : 'Convert Lead'}</button>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+// ============================================================
+// Lead detail drawer — "check the lead" (row click → this)
+// ============================================================
+
+const DetailRow: React.FC<{ icon: React.ReactNode; label: string; value?: React.ReactNode }> = ({ icon, label, value }) => {
+  if (value === undefined || value === null || value === '') return null;
+  return (
+    <div className="flex items-start gap-3 py-2">
+      <div className="w-8 h-8 rounded-lg bg-secondary-100 text-secondary-500 flex items-center justify-center shrink-0">{icon}</div>
+      <div className="min-w-0">
+        <p className="text-xs font-medium text-secondary-500">{label}</p>
+        <p className="text-sm text-secondary-900 break-words">{value}</p>
+      </div>
+    </div>
+  );
+};
+
+interface LeadDetailModalProps {
+  isOpen: boolean;
+  lead: CrmLead | null;
+  onClose: () => void;
+  onSaved: () => void;
+  onConvert: (lead: CrmLead) => void;
+  onDelete: (lead: CrmLead) => void;
+}
+
+export const LeadDetailModal: React.FC<LeadDetailModalProps> = ({ isOpen, lead, onClose, onSaved, onConvert, onDelete }) => {
+  const [status, setStatus] = useState('new');
+  const [priority, setPriority] = useState('medium');
+  const [notes, setNotes] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Sync form fields whenever a different lead is opened.
+  useEffect(() => {
+    if (lead) {
+      setStatus(lead.status);
+      setPriority(lead.priority);
+      setNotes(lead.notes || '');
+    }
+  }, [lead]);
+
+  if (!lead) return null;
+
+  const dirty = status !== lead.status || priority !== lead.priority || (notes || '') !== (lead.notes || '');
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      await crmService.updateLead(lead.uuid, { status, priority, notes });
+      toast.success('Lead updated');
+      onSaved();
+    } catch (error) {
+      console.error('Failed to update lead:', error);
+      toast.error('Failed to update lead');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const fullName = `${lead.first_name} ${lead.last_name || ''}`.trim();
+  const convertedName = lead.converted_contact_first_name
+    ? `${lead.converted_contact_first_name} ${lead.converted_contact_last_name || ''}`.trim()
+    : null;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Lead details" size="2xl">
+      <div className="space-y-5">
+        {/* Header */}
+        <div className="flex items-center gap-3">
+          <div className="w-12 h-12 bg-violet-100 rounded-xl flex items-center justify-center">
+            <UserPlus className="w-6 h-6 text-violet-600" />
+          </div>
+          <div>
+            <p className="text-lg font-semibold text-secondary-900">{fullName || lead.email || 'Unnamed lead'}</p>
+            <div className="flex items-center gap-2 mt-0.5">
+              <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${leadStatusColors[lead.status] || 'bg-secondary-100 text-secondary-600'}`}>{lead.status}</span>
+              <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-secondary-100 text-secondary-700">{leadSourceLabels[lead.source] || lead.source}</span>
+            </div>
+          </div>
+        </div>
+
+        {/* The message the visitor submitted (stored in notes). This is the
+            first thing to read when triaging an inbound enquiry. */}
+        {lead.notes ? (
+          <div className="rounded-lg bg-secondary-50 border border-secondary-200 p-4">
+            <div className="flex items-center gap-2 mb-1.5">
+              <MessageSquare className="w-4 h-4 text-secondary-500" />
+              <p className="text-xs font-semibold uppercase tracking-wide text-secondary-500">Message</p>
+            </div>
+            <p className="text-sm text-secondary-900 whitespace-pre-wrap break-words">{lead.notes}</p>
+          </div>
+        ) : null}
+
+        {/* Captured info */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4">
+          <DetailRow icon={<Mail className="w-4 h-4" />} label="Email" value={lead.email} />
+          <DetailRow icon={<Phone className="w-4 h-4" />} label="Phone" value={lead.phone} />
+          <DetailRow icon={<Building2 className="w-4 h-4" />} label="Company" value={lead.company_name} />
+          <DetailRow icon={<Briefcase className="w-4 h-4" />} label="Job title" value={lead.job_title} />
+          <DetailRow icon={<Tag className="w-4 h-4" />} label="Channel" value={lead.channel} />
+          <DetailRow icon={<Megaphone className="w-4 h-4" />} label="Campaign" value={lead.campaign} />
+          <DetailRow icon={<Globe className="w-4 h-4" />} label="Referrer" value={lead.referrer_url} />
+          <DetailRow icon={<Link2 className="w-4 h-4" />} label="Landing page" value={lead.landing_page_url} />
+          <DetailRow icon={<Star className="w-4 h-4" />} label="Score" value={String(lead.score)} />
+          <DetailRow icon={<CalendarClock className="w-4 h-4" />} label="Captured" value={formatDate(lead.created_at)} />
+        </div>
+
+        {convertedName && (
+          <div className="rounded-lg bg-purple-50 border border-purple-100 p-3 text-sm text-purple-800">
+            Converted to contact <strong>{convertedName}</strong>
+            {lead.converted_deal_name ? <> · deal <strong>{lead.converted_deal_name}</strong></> : null}
+          </div>
+        )}
+
+        {/* Editable triage fields */}
+        <div className="border-t border-secondary-200 pt-4 grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-secondary-700 mb-1">Status</label>
+            <div className="relative">
+              <select value={status} onChange={(e) => setStatus(e.target.value)} className="w-full appearance-none px-3 py-2 pr-10 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 bg-surface cursor-pointer">
+                {LEAD_STATUS_OPTIONS.filter((o) => o.value !== 'all').map((opt) => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+              <ChevronDown className="w-4 h-4 absolute right-3 top-1/2 -translate-y-1/2 text-secondary-400 pointer-events-none" />
+            </div>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-secondary-700 mb-1">Priority</label>
+            <div className="relative">
+              <select value={priority} onChange={(e) => setPriority(e.target.value)} className="w-full appearance-none px-3 py-2 pr-10 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 bg-surface cursor-pointer">
+                {LEAD_PRIORITY_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+              <ChevronDown className="w-4 h-4 absolute right-3 top-1/2 -translate-y-1/2 text-secondary-400 pointer-events-none" />
+            </div>
+          </div>
+          <div className="sm:col-span-2">
+            <label className="block text-sm font-medium text-secondary-700 mb-1">Message / notes</label>
+            <textarea value={notes} onChange={(e) => setNotes(e.target.value)} rows={4} className="w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 resize-none" placeholder="What the lead submitted — edit or append your own notes..." />
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex flex-wrap items-center justify-between gap-3 pt-4 border-t border-secondary-200">
+          <div className="flex items-center gap-2">
+            {lead.status !== 'converted' && (
+              <button type="button" onClick={() => onConvert(lead)} className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-primary-600 bg-primary-50 rounded-lg hover:bg-primary-100 transition-colors">
+                <ArrowRightCircle className="w-4 h-4" /> Convert
+              </button>
+            )}
+            <button type="button" onClick={() => onDelete(lead)} className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-error-600 bg-error-50 rounded-lg hover:bg-error-100 transition-colors">
+              <Trash2 className="w-4 h-4" /> Delete
+            </button>
+          </div>
+          <div className="flex items-center gap-2">
+            <button type="button" onClick={onClose} className="px-4 py-2 text-sm font-medium text-secondary-700 bg-surface border border-secondary-300 rounded-lg hover:bg-secondary-50 transition-colors">Close</button>
+            <button type="button" onClick={handleSave} disabled={!dirty || isSaving} className="px-4 py-2 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 transition-colors disabled:opacity-50">{isSaving ? 'Saving...' : 'Save changes'}</button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+// ============================================================
+// Lead notifications settings modal
+// ============================================================
+
+interface LeadNotificationsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const Field: React.FC<{ label: string; hint?: string; children: React.ReactNode }> = ({ label, hint, children }) => (
+  <div className="flex items-center justify-between gap-4 py-3">
+    <div className="min-w-0">
+      <p className="text-sm font-medium text-secondary-900">{label}</p>
+      {hint ? <p className="text-xs text-secondary-500 mt-0.5">{hint}</p> : null}
+    </div>
+    <div className="shrink-0">{children}</div>
+  </div>
+);
+
+export const LeadNotificationsModal: React.FC<LeadNotificationsModalProps> = ({ isOpen, onClose }) => {
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [showGuide, setShowGuide] = useState(false);
+
+  const [notifyAdmin, setNotifyAdmin] = useState(true);
+  const [adminEmail, setAdminEmail] = useState('');
+  const [sendConfirmation, setSendConfirmation] = useState(true);
+  const [telegramEnabled, setTelegramEnabled] = useState(false);
+  const [telegramChatId, setTelegramChatId] = useState('');
+  const [telegramToken, setTelegramToken] = useState('');
+  const [tokenHint, setTokenHint] = useState('');
+  const [hasToken, setHasToken] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    let cancelled = false;
+    setLoading(true);
+    setTelegramToken('');
+    crmService.getLeadNotificationSettings()
+      .then((s: LeadNotificationSettings) => {
+        if (cancelled) return;
+        setNotifyAdmin(s.notify_admin);
+        setAdminEmail(s.admin_email || '');
+        setSendConfirmation(s.send_confirmation);
+        setTelegramEnabled(s.telegram_enabled);
+        setTelegramChatId(s.telegram_chat_id || '');
+        setHasToken(s.has_telegram_token);
+        setTokenHint(s.telegram_token_hint || '');
+      })
+      .catch(() => { if (!cancelled) toast.error('Failed to load notification settings'); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [isOpen]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const saved = await crmService.updateLeadNotificationSettings({
+        notify_admin: notifyAdmin,
+        admin_email: adminEmail,
+        send_confirmation: sendConfirmation,
+        telegram_enabled: telegramEnabled,
+        telegram_chat_id: telegramChatId,
+        telegram_bot_token: telegramToken || undefined,
+      });
+      setHasToken(saved.has_telegram_token);
+      setTokenHint(saved.telegram_token_hint || '');
+      setTelegramToken('');
+      toast.success('Notification settings saved');
+      onClose();
+    } catch {
+      toast.error('Failed to save — only the namespace owner can change these');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleTest = async () => {
+    setTesting(true);
+    try {
+      await crmService.testTelegram({
+        telegram_bot_token: telegramToken || undefined,
+        telegram_chat_id: telegramChatId || undefined,
+      });
+      toast.success('Test message sent — check Telegram');
+    } catch (e) {
+      const msg = (e as { response?: { data?: { error?: string } } })?.response?.data?.error;
+      toast.error(msg || 'Telegram test failed — check the token and chat id');
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const inputCls = 'w-full px-3 py-2 border border-secondary-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500';
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Lead notifications" size="2xl">
+      {loading ? (
+        <div className="py-10 text-center text-sm text-secondary-500">Loading settings…</div>
+      ) : (
+        <div className="space-y-6">
+          {/* Email */}
+          <section>
+            <div className="flex items-center gap-2 mb-1">
+              <Mail className="w-4 h-4 text-secondary-500" />
+              <h3 className="text-sm font-semibold text-secondary-900">Email</h3>
+            </div>
+            <div className="divide-y divide-secondary-100 border border-secondary-200 rounded-xl px-4">
+              <Field label="Email me on a new lead" hint="Sends to the namespace owner (or the override below).">
+                <Toggle checked={notifyAdmin} onChange={setNotifyAdmin} />
+              </Field>
+              {notifyAdmin && (
+                <div className="py-3">
+                  <label className="block text-xs font-medium text-secondary-500 mb-1">Send to (optional override)</label>
+                  <input type="email" value={adminEmail} onChange={(e) => setAdminEmail(e.target.value)} placeholder="Defaults to the namespace owner's email" className={inputCls} />
+                </div>
+              )}
+              <Field label="Confirmation to the person" hint="Sends a “we got your enquiry” email to the lead.">
+                <Toggle checked={sendConfirmation} onChange={setSendConfirmation} />
+              </Field>
+            </div>
+          </section>
+
+          {/* Telegram */}
+          <section>
+            <div className="flex items-center gap-2 mb-1">
+              <Send className="w-4 h-4 text-secondary-500" />
+              <h3 className="text-sm font-semibold text-secondary-900">Telegram</h3>
+            </div>
+            <div className="border border-secondary-200 rounded-xl px-4">
+              <Field label="Telegram alerts" hint="Push a message to a chat whenever a lead arrives.">
+                <Toggle checked={telegramEnabled} onChange={setTelegramEnabled} />
+              </Field>
+
+              {telegramEnabled && (
+                <div className="pb-4 space-y-3 border-t border-secondary-100 pt-3">
+                  <div>
+                    <label className="block text-xs font-medium text-secondary-500 mb-1">Bot token</label>
+                    <input
+                      type="password"
+                      value={telegramToken}
+                      onChange={(e) => setTelegramToken(e.target.value)}
+                      placeholder={hasToken ? `Saved (${tokenHint}) — leave blank to keep` : 'Paste the token from @BotFather'}
+                      className={inputCls}
+                      autoComplete="off"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-secondary-500 mb-1">Chat ID</label>
+                    <input value={telegramChatId} onChange={(e) => setTelegramChatId(e.target.value)} placeholder="e.g. 123456789 or -1001234567890" className={inputCls} />
+                  </div>
+
+                  <div className="flex items-center gap-3">
+                    <button type="button" onClick={handleTest} disabled={testing} className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-primary-600 bg-primary-50 rounded-lg hover:bg-primary-100 transition-colors disabled:opacity-50">
+                      <Send className="w-4 h-4" /> {testing ? 'Sending…' : 'Send test message'}
+                    </button>
+                    <button type="button" onClick={() => setShowGuide((v) => !v)} className="inline-flex items-center gap-1.5 text-sm text-secondary-500 hover:text-secondary-700">
+                      <Info className="w-4 h-4" /> How do I set this up?
+                    </button>
+                  </div>
+
+                  {showGuide && (
+                    <ol className="text-sm text-secondary-600 space-y-2 bg-secondary-50 rounded-lg p-4 list-decimal list-inside">
+                      <li>In Telegram, message <strong>@BotFather</strong> → send <code>/newbot</code> → follow the prompts. It gives you a <strong>bot token</strong> — paste it above.</li>
+                      <li>Start a chat with your new bot (tap <em>Start</em>), or add it to a group/channel where you want the alerts.</li>
+                      <li>Get your <strong>Chat ID</strong>: message <strong>@userinfobot</strong> for a personal chat, or add <strong>@RawDataBot</strong> to a group. Paste the id above (group ids start with <code>-100</code>).</li>
+                      <li>Click <strong>Send test message</strong> — you should receive it instantly. Then Save.</li>
+                      <li className="flex items-center gap-1">
+                        <a href="https://core.telegram.org/bots#how-do-i-create-a-bot" target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-primary-600 hover:underline">Telegram bot docs <ExternalLink className="w-3 h-3" /></a>
+                      </li>
+                    </ol>
+                  )}
+                </div>
+              )}
+            </div>
+          </section>
+
+          <div className="flex items-center justify-between gap-3 pt-2 border-t border-secondary-200">
+            <p className="text-xs text-secondary-400 flex items-center gap-1"><Bell className="w-3.5 h-3.5" /> Applies to leads captured for this namespace.</p>
+            <div className="flex items-center gap-2">
+              <button type="button" onClick={onClose} className="px-4 py-2 text-sm font-medium text-secondary-700 bg-surface border border-secondary-300 rounded-lg hover:bg-secondary-50 transition-colors">Cancel</button>
+              <button type="button" onClick={handleSave} disabled={saving} className="px-4 py-2 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 transition-colors disabled:opacity-50">{saving ? 'Saving…' : 'Save settings'}</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </Modal>
+  );
+};

--- a/opsapi-dashboard/hooks/useMenu.ts
+++ b/opsapi-dashboard/hooks/useMenu.ts
@@ -57,6 +57,7 @@ async function loadIconMap(): Promise<Record<string, LucideIcon>> {
     Clock: icons.Clock,
     BookOpen: icons.BookOpen,
     Contact: icons.Contact,
+    UserPlus: icons.UserPlus,
     Landmark: icons.Landmark,
     FileUp: icons.FileUp,
     ArrowLeftRight: icons.ArrowLeftRight,

--- a/opsapi-dashboard/services/crm.service.ts
+++ b/opsapi-dashboard/services/crm.service.ts
@@ -133,6 +133,25 @@ export interface CrmLeadStats {
   leads_by_source: { source: string; count: number }[];
 }
 
+export interface LeadNotificationSettings {
+  notify_admin: boolean;
+  admin_email: string;
+  send_confirmation: boolean;
+  telegram_enabled: boolean;
+  telegram_chat_id: string;
+  has_telegram_token: boolean;
+  telegram_token_hint: string;
+}
+
+export interface LeadNotificationSettingsInput {
+  notify_admin: boolean;
+  admin_email?: string;
+  send_confirmation: boolean;
+  telegram_enabled: boolean;
+  telegram_chat_id?: string;
+  telegram_bot_token?: string; // only sent when changed (never echoed back)
+}
+
 export interface CrmLeadConvertResult {
   lead: CrmLead;
   contact: CrmContact;
@@ -400,6 +419,31 @@ export const crmService = {
     const response = await apiClient.get('/api/v2/crm/leads/stats');
     const d = response.data as Record<string, unknown>;
     return (d?.data || d) as CrmLeadStats;
+  },
+
+  // ----------------------------------------------------------
+  // Lead notification settings (per namespace)
+  // ----------------------------------------------------------
+
+  async getLeadNotificationSettings(): Promise<LeadNotificationSettings> {
+    const response = await apiClient.get('/api/v2/crm/leads/notification-settings');
+    return (response.data?.data ?? response.data) as LeadNotificationSettings;
+  },
+
+  // Sent as JSON (these routes parse a JSON body, unlike the form-encoded CRUD).
+  async updateLeadNotificationSettings(data: LeadNotificationSettingsInput): Promise<LeadNotificationSettings> {
+    const response = await apiClient.put('/api/v2/crm/leads/notification-settings', data, {
+      headers: { 'Content-Type': 'application/json' },
+    });
+    return (response.data?.data ?? response.data) as LeadNotificationSettings;
+  },
+
+  // Send a test Telegram alert. Optional token/chat_id let the owner test
+  // before saving. Throws (rejected promise) with the API error on failure.
+  async testTelegram(input: { telegram_bot_token?: string; telegram_chat_id?: string } = {}): Promise<void> {
+    await apiClient.post('/api/v2/crm/leads/notification-settings/test-telegram', input, {
+      headers: { 'Content-Type': 'application/json' },
+    });
   },
 };
 


### PR DESCRIPTION
## What

A first-class **Leads** experience on top of the existing CRM leads data, plus a configurable **notification pipeline** for captured leads (email + Telegram).

### Sidebar + Leads inbox
- Seeds a dedicated **"Leads"** sidebar item (CRM-gated migration) → `/dashboard/leads`.
- New **Leads inbox** page: stats, search + status/source/priority filters, paginated table, and **click-a-row → detail modal** (all captured fields, inline status/priority/notes edit, convert, delete).
- Extracted shared lead UI (option lists, badge maps, Create/Convert/**Detail** modals) into `components/crm/leads-shared` and refactored the CRM page to consume it — single source of truth. The detail modal is wired into the **CRM → Leads tab** too. Detail modal widened (`md → 2xl`).

### Public capture — don't drop the visitor's message
- The public lead route only read `comments`/`notes`; it now also accepts **`message`** (the most common contact-form field) and preserves the original verbatim in `metadata.message` so a later notes edit can't lose it.

### Lead notifications (per namespace)
- New `crm_lead_notification_settings` table (CRM-gated migration).
- On capture, `CrmLeadNotificationQueries.notify()` fires the configured channels — **confirmation email** to the submitter, **"you got a lead" email** to the namespace owner/admin, and an optional **Telegram alert** — deferred to an `ngx.timer` so the HTTP response never waits on SMTP/Telegram.
- `helper/telegram.lua`: Telegram Bot API sender (mirrors the monitoring-go beacon notifier). Bot token is **masked on read** and only overwritten when a new value is sent.
- Owner/admin routes: `GET`/`PUT /api/v2/crm/leads/notification-settings` + `POST .../test-telegram`.
- Frontend: **"Notifications"** config modal — email toggles + owner-email override, confirmation toggle, and a Telegram section (token/chat/**send test** + collapsible **@BotFather** setup guide).

**Defaults with no config:** save + confirmation email + admin email **ON**, Telegram **OFF**. Manual (authenticated) lead creation does **not** notify (only public captures do).

## Scope / safety
- All changes are generic and **CRM feature-gated** — they reach every opsapi deployment (int/test/acc/prod) on deploy. Migrations are idempotent.
- No consumer-specific migrations; no local port/env tweaks; `projects/academy/` excluded.

## Validation
- Lua: syntax-checked via the opsapi container; migrations applied locally (menu item + settings table created).
- Routes load (401 unauth on the new settings routes); public capture returns 201 and the notify path runs clean.
- **Telegram helper proven** against the real `api.telegram.org` (correct round-trip).
- Frontend: `tsc --noEmit`, `eslint`, and `next build` all green; `/dashboard/leads` compiles.

## Deploy note
Menu item + settings table come from the CRM-gated migrations (run on the app's postStart). The page/menu icon/detail modal come from the dashboard build. Email sending requires SMTP configured (already in int/prod Vault); if unset, emails are skipped and the lead still saves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)